### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Pikselkroken/pixlstash/security/code-scanning/1](https://github.com/Pikselkroken/pixlstash/security/code-scanning/1)

In general, the problem is fixed by explicitly defining a `permissions` block either at the top level of the workflow (applying to all jobs) or within the specific job, restricting `GITHUB_TOKEN` to the minimal scopes it needs. For a CI pipeline that only checks out code, caches dependencies, installs, and runs tests, read-only `contents` permissions are sufficient; no write-level or extra scopes are required.

The best minimally invasive fix here is to add a top-level `permissions` block (just under `name: CI` and before `on:`) to apply to all jobs. None of the listed steps perform actions that require write access to the repository or other GitHub resources. Therefore, specifying `permissions: contents: read` documents the intent and ensures the token cannot be used to modify repository contents even if defaults elsewhere are broad. Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` line and the `on:` block. No additional imports or methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
