### PR TITLE
chore: release v1.4.0rc1 website update

### DIFF
--- a/website/api/index.html
+++ b/website/api/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <title>PixlStash API Reference</title>
-    <meta http-equiv="refresh" content="0; url=./v1.3/" />
-    <link rel="canonical" href="./v1.3/" />
+    <meta http-equiv="refresh" content="0; url=./v1.4/" />
+    <link rel="canonical" href="./v1.4/" />
   </head>
   <body>
     <p>Redirecting to the latest API reference
-       (<a href="./v1.3/">v1.3</a>)…</p>
+       (<a href="./v1.4/">v1.4</a>)…</p>
   </body>
 </html>

--- a/website/api/v1.4/index.html
+++ b/website/api/v1.4/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <title>PixlStash API Reference</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <redoc spec-url="openapi.json"></redoc>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  </body>
+</html>

--- a/website/api/v1.4/openapi.json
+++ b/website/api/v1.4/openapi.json
@@ -1,0 +1,9813 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "PixlStash API",
+    "description": "PixlStash backend API for picture management, tagging, stacks, sets, character workflows and ComfyUI integration.",
+    "version": "1.4.0rc1"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "Read Root",
+        "operationId": "read_root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/version": {
+      "get": {
+        "summary": "Read Version",
+        "operationId": "read_version_version_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/favicon.ico": {
+      "get": {
+        "summary": "Favicon",
+        "operationId": "favicon_favicon_ico_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/config": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get current user config",
+        "description": "Returns the authenticated user's UI and behavior configuration payload.",
+        "operationId": "get_me_config_api_v1_users_me_config_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Update current user config",
+        "description": "Applies a partial config patch for the authenticated user and returns updated settings.",
+        "operationId": "patch_me_config_api_v1_users_me_config_patch",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/penalised-tags": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get penalised tags",
+        "description": "Returns the smart-score penalised tags for the authenticated user. Accessible to READ-scoped tokens.",
+        "operationId": "get_me_penalised_tags_api_v1_users_me_penalised_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/auth": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get auth state",
+        "description": "Returns authentication and session-related information for the current request.",
+        "operationId": "get_me_auth_api_v1_users_me_auth_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Change current user password",
+        "description": "Changes the authenticated user's password according to auth policy.",
+        "operationId": "change_me_password_api_v1_users_me_auth_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/token": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "List API tokens",
+        "description": "Lists personal access tokens owned by the authenticated user.",
+        "operationId": "list_me_tokens_api_v1_users_me_token_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Create API token",
+        "description": "Creates a personal access token for the authenticated user.",
+        "operationId": "create_me_token_api_v1_users_me_token_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/token/{token_id}": {
+      "delete": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Delete API token",
+        "description": "Deletes one personal access token by id for the authenticated user.",
+        "operationId": "delete_me_token_api_v1_users_me_token__token_id__delete",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Token Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Update API token",
+        "description": "Updates mutable fields on a personal access token (currently: watermark).",
+        "operationId": "patch_me_token_api_v1_users_me_token__token_id__patch",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Token Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTokenRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/watermark": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get watermark image",
+        "description": "Returns the user's watermark as a PNG. Returns the default if no custom watermark is set.",
+        "operationId": "get_me_watermark_api_v1_users_me_watermark_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Upload custom watermark",
+        "description": "Uploads a PNG/JPEG/WebP image to use as the user's watermark.",
+        "operationId": "post_me_watermark_api_v1_users_me_watermark_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_post_me_watermark_api_v1_users_me_watermark_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Remove custom watermark",
+        "description": "Removes the user's custom watermark; the default will be used for new shares.",
+        "operationId": "delete_me_watermark_api_v1_users_me_watermark_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/shared-resource-ids": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get shared resource IDs",
+        "description": "Returns the IDs of resources of the given type that have at least one active READ share token. Accepts ?resource_type= (character, picture_set, project, picture).",
+        "operationId": "get_shared_resource_ids_api_v1_users_me_shared_resource_ids_get",
+        "parameters": [
+          {
+            "name": "resource_type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Resource Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/shared-picture-ids/batch": {
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Batch check shared picture IDs",
+        "description": "Given a list of picture IDs, returns which ones have active READ share tokens.",
+        "operationId": "batch_shared_picture_ids_api_v1_users_me_shared_picture_ids_batch_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchSharedPictureIdsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/tokens/by-resource": {
+      "delete": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Revoke all tokens for a resource",
+        "description": "Deletes all READ tokens scoped to a specific resource (by type and id).",
+        "operationId": "revoke_tokens_for_resource_api_v1_users_me_tokens_by_resource_delete",
+        "parameters": [
+          {
+            "name": "resource_type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Resource Type"
+            }
+          },
+          {
+            "name": "resource_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Resource Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/session/context": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get session access context",
+        "description": "Returns the access scope for the current session or token. Accepts ?token= query parameter so unauthenticated share-link recipients can discover what the token grants before loading the UI.",
+        "operationId": "get_session_context_api_v1_session_context_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/progress": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get worker progress",
+        "description": "Returns background worker progress plus process CPU, RAM, and VRAM usage metrics.",
+        "operationId": "get_workers_progress_api_v1_workers_progress_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/server-config/watch-folders": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "List watch folders",
+        "description": "Returns watch-folder paths from import-folder records in the database.",
+        "operationId": "get_watch_folders_api_v1_server_config_watch_folders_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/server-config/filesystem-roots": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "List filesystem browser roots",
+        "description": "Returns the configured filesystem browser root paths. When non-empty, the filesystem browser is restricted to these directories. An empty list means the browser is unrestricted.",
+        "operationId": "get_filesystem_roots_api_v1_server_config_filesystem_roots_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/server-config/open": {
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Open server config location",
+        "description": "Opens the server config path in the operating system file browser.",
+        "operationId": "open_server_config_api_v1_server_config_open_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/characters/{id}/summary": {
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Get character category summary",
+        "description": "Returns summary counts and thumbnail reference for ALL, UNASSIGNED, SCRAPHEAP, or a specific character id.",
+        "operationId": "get_characters_summary_api_v1_characters__id__summary_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/characters/{id}/reference_pictures": {
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "List reference pictures",
+        "description": "Returns picture ids selected as reference faces for the given character.",
+        "operationId": "get_character_reference_pictures_api_v1_characters__id__reference_pictures_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/characters/{id}": {
+      "patch": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Update character",
+        "description": "Updates character fields and clears dependent picture text embeddings when identity data changes.",
+        "operationId": "patch_character_api_v1_characters__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Delete character",
+        "description": "Deletes a character, clears character assignment from faces, and removes its reference set when present.",
+        "operationId": "delete_character_api_v1_characters__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Get character by id",
+        "description": "Returns a single character record by id.",
+        "operationId": "get_character_by_id_api_v1_characters__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/characters/membership": {
+      "post": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Batch character membership lookup",
+        "description": "Given a list of picture IDs, returns character_assignments (character_id \u2192 [picture_ids]) and pictures_with_faces ([picture_ids]). Used by the AddToCharacter menu to load membership in a single request.",
+        "operationId": "get_batch_character_membership_api_v1_characters_membership_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_get_batch_character_membership_api_v1_characters_membership_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_name}/characters/{character_name}": {
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Get character by project name and character name",
+        "description": "Returns a character record by name within a named project.",
+        "operationId": "get_character_by_project_and_name_api_v1_projects__project_name__characters__character_name__get",
+        "parameters": [
+          {
+            "name": "project_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Name"
+            }
+          },
+          {
+            "name": "character_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Character Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/characters/{id}/{field}": {
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Get character field",
+        "description": "Returns one character field value, including generated thumbnail handling for field=thumbnail.",
+        "operationId": "get_character_field_by_id_api_v1_characters__id___field__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Field"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/characters": {
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "List characters",
+        "description": "Lists characters, optionally filtered by exact name or project. Pass ``project_id`` as a numeric ID to restrict to one project, or ``UNASSIGNED`` for characters with no project.",
+        "operationId": "get_characters_api_v1_characters_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Create character",
+        "description": "Creates a character and its linked reference picture set.",
+        "operationId": "create_character_api_v1_characters_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/characters/{character_id}/faces": {
+      "post": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Assign faces to character",
+        "description": "Assigns provided face ids or largest faces from picture ids to a character.",
+        "operationId": "assign_face_to_character_api_v1_characters__character_id__faces_post",
+        "parameters": [
+          {
+            "name": "character_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Character Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Unassign faces from character",
+        "description": "Removes character assignment from provided face ids or from faces in provided picture ids.",
+        "operationId": "remove_character_from_faces_api_v1_characters__character_id__faces_delete",
+        "parameters": [
+          {
+            "name": "character_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Character Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/characters/likeness-search": {
+      "post": {
+        "tags": [
+          "characters",
+          "characters"
+        ],
+        "summary": "Search characters by face likeness",
+        "description": "Upload one or more images and retrieve vault characters ranked by face similarity (softmax-weighted cosine similarity on InsightFace ArcFace embeddings).\n\nWhen multiple query images are provided, per-character scores from each image are combined using the ``combine`` strategy before ranking.\n\n**Combine modes**\n- `mean` (default): arithmetic mean across query images.\n- `max`: best match to any query image.\n- `min`: must match all query images.\n- `harmonic_mean`: emphasises the worst-matching query.\n- `geometric_mean`: product-like balance.\n\n**Random modes**\n- `random=false` (default): returns the top `top_n` most similar characters.\n- `random=true`: selects `top_n` characters at random from the `pool_m` most similar candidates.\n\nResults are ordered by descending similarity score. Only characters with at least one pre-computed face embedding are considered. The most prominent face (largest bounding box) in each uploaded image is used as the query. Images with no detectable face are skipped; returns 422 when no face is detected in any image.",
+        "operationId": "search_by_character_likeness_api_v1_characters_likeness_search_post",
+        "parameters": [
+          {
+            "name": "top_n",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Maximum number of results to return.",
+              "default": 20,
+              "title": "Top N"
+            },
+            "description": "Maximum number of results to return."
+          },
+          {
+            "name": "pool_m",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 2000,
+              "minimum": 0,
+              "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`.",
+              "default": 0,
+              "title": "Pool M"
+            },
+            "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`."
+          },
+          {
+            "name": "random",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "When true, return a random sample from the top-M pool.",
+              "default": false,
+              "title": "Random"
+            },
+            "description": "When true, return a random sample from the top-M pool."
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "description": "Minimum similarity score required to include a result.",
+              "default": 0.0,
+              "title": "Threshold"
+            },
+            "description": "Minimum similarity score required to include a result."
+          },
+          {
+            "name": "combine",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean.",
+              "default": "mean",
+              "title": "Combine"
+            },
+            "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_search_by_character_likeness_api_v1_characters_likeness_search_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/picture_sets": {
+      "get": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "List picture sets",
+        "description": "Returns picture sets with visible member counts, top pictures, and thumbnail URLs.",
+        "operationId": "get_picture_sets_api_v1_picture_sets_get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Create picture set",
+        "description": "Creates a new picture set with name and optional description.",
+        "operationId": "create_picture_set_api_v1_picture_sets_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_name}/picture_sets/{picture_set_name}": {
+      "get": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Get picture set by project name and set name",
+        "description": "Returns picture set metadata for a named set within a named project.",
+        "operationId": "get_picture_set_by_name_api_v1_projects__project_name__picture_sets__picture_set_name__get",
+        "parameters": [
+          {
+            "name": "project_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Name"
+            }
+          },
+          {
+            "name": "picture_set_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Picture Set Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/picture_sets/membership": {
+      "post": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Batch set membership lookup",
+        "description": "Given a list of picture IDs, returns a map of set_id \u2192 [picture_ids] for every set that contains at least one of the requested pictures. Also expands stack siblings so all stack members are considered. Used by the AddToSet menu to load membership in a single request.",
+        "operationId": "get_batch_membership_api_v1_picture_sets_membership_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_get_batch_membership_api_v1_picture_sets_membership_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/picture_sets/{id}/thumbnail": {
+      "get": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Get picture set thumbnail",
+        "description": "Returns or generates a cached composite thumbnail representing top-scoring pictures in a set.",
+        "operationId": "get_picture_set_thumbnail_api_v1_picture_sets__id__thumbnail_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/picture_sets/{id}": {
+      "get": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Get picture set",
+        "description": "Returns set metadata or member pictures with optional sort, format, and character-likeness/smart-score modes. By default only the stack leader picture is returned for each stack. Pass expand_stacks=true to receive every picture in every stack.",
+        "operationId": "get_picture_set_api_v1_picture_sets__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "info",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Info"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Sort"
+            }
+          },
+          {
+            "name": "descending",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Descending"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Format"
+            }
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Character Id"
+            }
+          },
+          {
+            "name": "reference_character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Character Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Fields"
+            }
+          },
+          {
+            "name": "min_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Min Score"
+            }
+          },
+          {
+            "name": "max_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Max Score"
+            }
+          },
+          {
+            "name": "smart_score_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Smart Score Bucket"
+            }
+          },
+          {
+            "name": "resolution_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Resolution Bucket"
+            }
+          },
+          {
+            "name": "expand_stacks",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Expand Stacks"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Update picture set",
+        "description": "Updates picture set name and/or description.",
+        "operationId": "update_picture_set_api_v1_picture_sets__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Delete picture set",
+        "description": "Deletes a picture set and all its membership links.",
+        "operationId": "delete_picture_set_api_v1_picture_sets__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/picture_sets/{id}/members": {
+      "get": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "List picture set members",
+        "description": "Returns unique picture ids that belong to a set, with optional deleted inclusion. By default only explicitly stored members are returned. Pass expand_stacks=true to also include all stack siblings of any member, which is useful for checking whether a stack is part of the set.",
+        "operationId": "get_picture_set_pictures_api_v1_picture_sets__id__members_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "include_deleted",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Deleted"
+            }
+          },
+          {
+            "name": "expand_stacks",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Expand Stacks"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Bulk add pictures to set",
+        "description": "Adds a batch of pictures to a set (non-destructive). Skips pictures already in the set.",
+        "operationId": "bulk_add_pictures_to_set_api_v1_picture_sets__id__members_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Bulk replace picture set members",
+        "description": "Atomically replaces the entire member list of a set. All existing members are removed and the provided picture ids become the new members.",
+        "operationId": "bulk_replace_pictures_in_set_api_v1_picture_sets__id__members_put",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/picture_sets/{id}/members/{picture_id}": {
+      "post": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Add picture to set",
+        "description": "Adds one picture to a set when the set and picture are valid and membership does not already exist.",
+        "operationId": "add_picture_to_set_api_v1_picture_sets__id__members__picture_id__post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "picture_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Picture Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "picture_sets"
+        ],
+        "summary": "Remove picture from set",
+        "description": "Removes one picture membership from a picture set.",
+        "operationId": "remove_picture_from_set_api_v1_picture_sets__id__members__picture_id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "picture_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Picture Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "List all projects",
+        "operationId": "list_projects_api_v1_projects_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectResponse"
+                  },
+                  "type": "array",
+                  "title": "Response List Projects Api V1 Projects Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Create a project",
+        "operationId": "create_project_api_v1_projects_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/membership": {
+      "post": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Batch project membership lookup",
+        "description": "Given a list of picture IDs, returns project_assignments (project_id \u2192 [picture_ids]) and unassigned_picture_ids ([picture_ids with no project membership]). Used by the AddToProject menu to load membership in a single request.",
+        "operationId": "get_batch_project_membership_api_v1_projects_membership_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_get_batch_project_membership_api_v1_projects_membership_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{id_or_name}/picture_sets": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "List picture sets for a project",
+        "description": "Returns all picture sets that belong to the given project. ``id_or_name`` may be a numeric ID or a project name (case-insensitive).",
+        "operationId": "list_project_picture_sets_api_v1_projects__id_or_name__picture_sets_get",
+        "parameters": [
+          {
+            "name": "id_or_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id Or Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{id_or_name}": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Get a project by ID or name",
+        "description": "Returns the project matching the given numeric ID or name (case-insensitive).",
+        "operationId": "get_project_api_v1_projects__id_or_name__get",
+        "parameters": [
+          {
+            "name": "id_or_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id Or Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}": {
+      "put": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Update a project",
+        "operationId": "update_project_api_v1_projects__project_id__put",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Delete a project",
+        "description": "Delete a project.\n\nCharacters and picture sets belonging to the project have their\nproject_id nulled (they become unassigned).  Attachments and their\nfiles are permanently removed.",
+        "operationId": "delete_project_api_v1_projects__project_id__delete",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectDeleteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/summary": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Get project picture count",
+        "description": "Returns the number of pictures assigned to a project. Use 'UNASSIGNED' as project_id to count pictures with no project.",
+        "operationId": "get_project_summary_api_v1_projects__project_id__summary_get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectSummaryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/export": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Export project as ZIP",
+        "description": "Download a ZIP archive of the project: metadata, attachment files, and optionally all pictures belonging to its characters and picture sets.",
+        "operationId": "export_project_api_v1_projects__project_id__export_get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "include_pictures",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Include Pictures"
+            }
+          },
+          {
+            "name": "include_attachments",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Include Attachments"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/attachments": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "List attachments for a project",
+        "operationId": "list_attachments_api_v1_projects__project_id__attachments_get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectAttachmentResponse"
+                  },
+                  "title": "Response List Attachments Api V1 Projects  Project Id  Attachments Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Upload an attachment to a project",
+        "operationId": "upload_attachment_api_v1_projects__project_id__attachments_post",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_attachment_api_v1_projects__project_id__attachments_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectAttachmentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/attachments/url": {
+      "post": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Add a URL bookmark to a project",
+        "operationId": "add_url_attachment_api_v1_projects__project_id__attachments_url_post",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectUrlAttachmentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectAttachmentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/attachments/{attachment_id}": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Download a project attachment",
+        "operationId": "download_attachment_api_v1_projects__project_id__attachments__attachment_id__get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "attachment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Attachment Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "Delete a project attachment",
+        "operationId": "delete_attachment_api_v1_projects__project_id__attachments__attachment_id__delete",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "attachment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Attachment Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectDeleteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tags": {
+      "post": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Add tag to picture",
+        "description": "Adds a tag to a picture and removes empty-tag sentinel when appropriate.",
+        "operationId": "add_tag_to_picture_api_v1_pictures__id__tags_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "List picture tags",
+        "description": "Returns all tags currently attached to a picture.",
+        "operationId": "list_picture_tags_api_v1_pictures__id__tags_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Clear all tags on picture",
+        "description": "Removes all tags from a picture in a single operation and restores the empty-tag sentinel.",
+        "operationId": "clear_all_tags_on_picture_api_v1_pictures__id__tags_delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tags/{tag_id}": {
+      "delete": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Remove picture tag",
+        "description": "Removes one tag from a picture by numeric tag id and restores empty-tag sentinel when needed.",
+        "operationId": "remove_tag_from_picture_api_v1_pictures__id__tags__tag_id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tag Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tags/remove_all": {
+      "post": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Remove tag everywhere on picture",
+        "description": "Removes a tag value from the picture and its face/hand associations for that picture.",
+        "operationId": "remove_tag_from_picture_everywhere_api_v1_pictures__id__tags_remove_all_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tags": {
+      "get": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "List all tags",
+        "description": "Returns all unique tag values with their usage count, sorted by count descending then alphabetically.",
+        "operationId": "list_all_tags_api_v1_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/tags/bulk_fetch": {
+      "post": {
+        "tags": [
+          "tags"
+        ],
+        "summary": "Fetch tags for multiple pictures",
+        "description": "Returns tags for each requested picture id. At most 200 ids accepted per call.",
+        "operationId": "bulk_fetch_tags_api_v1_pictures_tags_bulk_fetch_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkFetchTagsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stacks/{stack_id}": {
+      "get": {
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Get stack details",
+        "description": "Returns stack metadata and ordered picture ids for a stack.",
+        "operationId": "get_stack_api_v1_stacks__stack_id__get",
+        "parameters": [
+          {
+            "name": "stack_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stack Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stacks/{stack_id}/pictures": {
+      "get": {
+        "tags": [
+          "stacks"
+        ],
+        "summary": "List pictures in stack",
+        "description": "Returns ordered picture payloads for a stack using grid or metadata field sets.",
+        "operationId": "get_stack_pictures_api_v1_stacks__stack_id__pictures_get",
+        "parameters": [
+          {
+            "name": "stack_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stack Id"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "grid",
+              "title": "Fields"
+            }
+          },
+          {
+            "name": "include_deleted",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Deleted"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Sort"
+            }
+          },
+          {
+            "name": "descending",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Descending"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{picture_id}/stack": {
+      "get": {
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Get picture's stack",
+        "description": "Returns the stack containing a picture, or null stack information when unstacked.",
+        "operationId": "get_stack_for_picture_api_v1_pictures__picture_id__stack_get",
+        "parameters": [
+          {
+            "name": "picture_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Picture Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stacks": {
+      "post": {
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Create stack",
+        "description": "Creates a new stack or reuses an existing compatible one and assigns provided pictures to it.",
+        "operationId": "create_stack_api_v1_stacks_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stacks/{stack_id}/order": {
+      "patch": {
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Reorder stack",
+        "description": "Sets explicit order for all members in a stack using a complete ordered id list.",
+        "operationId": "reorder_stack_api_v1_stacks__stack_id__order_patch",
+        "parameters": [
+          {
+            "name": "stack_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stack Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stacks/{stack_id}/members": {
+      "post": {
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Add stack members",
+        "description": "Adds pictures to an existing stack while preventing cross-stack membership conflicts.",
+        "operationId": "add_stack_members_api_v1_stacks__stack_id__members_post",
+        "parameters": [
+          {
+            "name": "stack_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stack Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Remove stack members",
+        "description": "Removes pictures from a stack and deletes the stack when one or fewer members remain.",
+        "operationId": "remove_stack_members_api_v1_stacks__stack_id__members_delete",
+        "parameters": [
+          {
+            "name": "stack_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stack Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/stacks/{stack_id}/members/{picture_id}": {
+      "patch": {
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Set member position",
+        "description": "Moves a single stack member to the given 0-based position, shifting all other members as needed.",
+        "operationId": "set_member_position_api_v1_stacks__stack_id__members__picture_id__patch",
+        "parameters": [
+          {
+            "name": "stack_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stack Id"
+            }
+          },
+          {
+            "name": "picture_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Picture Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tag_predictions": {
+      "get": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Get tag predictions for a picture",
+        "description": "Returns all stored tag predictions for the given picture, ordered by confidence descending.  Use the ``status`` query param to filter by ``PENDING``, ``CONFIRMED``, or ``REJECTED``.",
+        "operationId": "get_tag_predictions_api_v1_pictures__id__tag_predictions_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "include_meta",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Meta"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tag_predictions/{tag}/confirm": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Confirm a tag prediction",
+        "description": "Marks the prediction as CONFIRMED and ensures a corresponding row exists in the Tag table.  Emits a CHANGED_PICTURES event.",
+        "operationId": "confirm_tag_prediction_api_v1_pictures__id__tag_predictions__tag__confirm_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tag"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tag_predictions/{tag}/reject": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Reject a tag prediction",
+        "description": "Marks the prediction as REJECTED.  Does not modify the Tag table.",
+        "operationId": "reject_tag_prediction_api_v1_pictures__id__tag_predictions__tag__reject_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tag"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tag_predictions/delete": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Delete tag predictions for a picture",
+        "description": "Deletes all TagPrediction rows for the picture except those with model_version='manual' (user-rejected tags), so the background tagger treats it as never seen and rebuilds predictions from scratch.",
+        "operationId": "delete_tag_predictions_api_v1_pictures__id__tag_predictions_delete_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/reset_tags": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Reset tags and predictions for a picture",
+        "description": "Atomically deletes all non-manual TagPrediction rows and all Tag rows for the picture, then restores the pending-retag sentinel.  This is the single-round-trip equivalent of calling tag_predictions/delete followed by DELETE tags \u2014 it avoids the intermediate state where predictions are gone but tags still exist, which otherwise tricks the background MissingTagFinder into running a wasted inference pass.",
+        "operationId": "reset_picture_tags_api_v1_pictures__id__reset_tags_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ResetTagsRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/reset_description": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Reset description for a picture",
+        "description": "Clears the picture's description field and queues a new description inference pass.  Pass a 'model' field in the request body to override which description plugin to use for this specific picture.",
+        "operationId": "reset_picture_description_api_v1_pictures__id__reset_description_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ResetTagsRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tagger/label-thresholds": {
+      "get": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Get per-label thresholds for the PixlStash tagger",
+        "description": "Returns each label's base threshold and the effective threshold after applying the current user offset. Results are sorted alphabetically.",
+        "operationId": "get_label_thresholds_api_v1_tagger_label_thresholds_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/guest-scores": {
+      "get": {
+        "tags": [
+          "guest_scores"
+        ],
+        "summary": "Get Guest Scores",
+        "description": "Return all scores submitted by this guest session.\n\nRequires a READ-scoped token.  The guest_session cookie must be present\nand valid (resolved by auth_middleware into request.state.guest_session_id).\n\nReturns:\n    A JSON object ``{\"scores\": {\"<picture_id>\": <score>, ...}}``.",
+        "operationId": "get_guest_scores_api_v1_pictures_guest_scores_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "guest_scores"
+        ],
+        "summary": "Submit Guest Scores",
+        "description": "Submit or update star scores for one or more pictures.\n\nThis is the sole write endpoint accessible to READ-scoped tokens.\n\nRequest body (JSON):\n    session_id (str): Client-generated UUID (max 64 chars, ``[A-Za-z0-9_-]``).\n    set_cookie (bool): When True the server sets persistent cookies.\n    scores (dict[str, int]): Mapping of picture_id \u2192 score (0-5).\n        At most 500 entries per request.\n\nReturns:\n    ``{\"ok\": true}`` on success.\n\nRaises:\n    400: Validation error (bad session_id, bad score value, too many entries).\n    503: Too many concurrent active guest sessions (new session refused).",
+        "operationId": "submit_guest_scores_api_v1_pictures_guest_scores_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/guest-scores/session": {
+      "delete": {
+        "tags": [
+          "guest_scores"
+        ],
+        "summary": "Clear Guest Session",
+        "description": "Clear the guest session cookies for this browser.\n\nRemoves the ``guest_session`` and ``guest_session_active`` cookies so\nthe browser starts a fresh anonymous session on the next page load.\nThe scores stored in the database are retained (they may still be used\nfor aggregate statistics); we simply sever the link between this browser\nand those scores.\n\nRequires a READ-scoped token.\n\nReturns:\n    ``{\"ok\": true}``",
+        "operationId": "clear_guest_session_api_v1_pictures_guest_scores_session_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/sort_mechanisms": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List picture sort mechanisms",
+        "description": "Returns all available sorting keys and direction semantics supported by picture listing and search endpoints.",
+        "operationId": "get_pictures_sort_mechanisms_api_v1_sort_mechanisms_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/plugins": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List image plugins",
+        "description": "Lists available image plugins and their parameter schemas.",
+        "operationId": "list_picture_plugins_api_v1_pictures_plugins_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/plugins/{name}": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Run image plugin",
+        "description": "Runs a named image plugin on selected pictures and imports outputs into stacks.",
+        "operationId": "run_picture_plugin_api_v1_pictures_plugins__name__post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/comfyui_models": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List distinct ComfyUI model names",
+        "operationId": "get_comfyui_models_api_v1_pictures_comfyui_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/comfyui_loras": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List distinct ComfyUI LoRA names",
+        "operationId": "get_comfyui_loras_api_v1_pictures_comfyui_loras_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/likeness-groups": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List computed likeness groups",
+        "description": "Builds groups from likeness edges using filtering options such as character, set, format, and threshold.",
+        "operationId": "get_likeness_groups_api_v1_pictures_likeness_groups_get",
+        "parameters": [
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "default": 0.0,
+              "title": "Threshold"
+            }
+          },
+          {
+            "name": "min_group_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 2,
+              "title": "Min Group Size"
+            }
+          },
+          {
+            "name": "set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Set Id"
+            }
+          },
+          {
+            "name": "set_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "title": "Set Ids"
+            }
+          },
+          {
+            "name": "set_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "union",
+              "title": "Set Mode"
+            }
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Character Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Format"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Tag"
+            }
+          },
+          {
+            "name": "rejected_tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Rejected Tag"
+            }
+          },
+          {
+            "name": "tag_confidence_above",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Tag Confidence Above"
+            }
+          },
+          {
+            "name": "tag_confidence_below",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Tag Confidence Below"
+            }
+          },
+          {
+            "name": "comfyui_model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Comfyui Model"
+            }
+          },
+          {
+            "name": "comfyui_lora",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Comfyui Lora"
+            }
+          },
+          {
+            "name": "min_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Min Score"
+            }
+          },
+          {
+            "name": "max_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Max Score"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/open-location": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Open picture location",
+        "description": "Opens the containing folder of a reference picture in the OS file manager.",
+        "operationId": "open_picture_location_api_v1_pictures__id__open_location_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/stats": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get picture statistics",
+        "description": "Returns tag statistics for the current view filter, cached for 60 seconds.",
+        "operationId": "get_picture_stats_api_v1_pictures_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/thumbnails/{id}.webp": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get picture thumbnail image",
+        "description": "Returns a WebP thumbnail for a picture id, generating and caching it on demand when needed.",
+        "operationId": "get_thumbnail_api_v1_pictures_thumbnails__id__webp_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/thumbnails": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get batch thumbnail metadata",
+        "description": "Returns thumbnail URLs and mapped face/hand overlays for a list of picture ids, including penalised-tag hints.",
+        "operationId": "get_thumbnails_api_v1_pictures_thumbnails_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/export": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Start picture export job",
+        "description": "Queues an asynchronous export task and returns a task id for polling status and downloading the generated archive.",
+        "operationId": "export_pictures_zip_api_v1_pictures_export_get",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
+          },
+          {
+            "name": "set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Set Id"
+            }
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "default": 0.0,
+              "title": "Threshold"
+            }
+          },
+          {
+            "name": "caption_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "description",
+              "title": "Caption Mode"
+            }
+          },
+          {
+            "name": "include_character_name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Character Name"
+            }
+          },
+          {
+            "name": "use_original_file_names",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Use Original File Names"
+            }
+          },
+          {
+            "name": "resolution",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "original",
+              "title": "Resolution"
+            }
+          },
+          {
+            "name": "export_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "full",
+              "title": "Export Type"
+            }
+          },
+          {
+            "name": "tag_format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "spaces",
+              "title": "Tag Format"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/export/status": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get export job status",
+        "description": "Returns current progress for an export task id, including completion state and download URL when ready.",
+        "operationId": "export_status_api_v1_pictures_export_status_get",
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Task Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/export/download/{task_id}": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Download completed export",
+        "description": "Downloads the generated export file for a completed task id.",
+        "operationId": "download_export_api_v1_pictures_export_download__task_id__get",
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Task Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/search": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Search pictures by text",
+        "description": "Performs semantic text search across pictures with optional sort, filtering, and candidate scoping.",
+        "operationId": "search_pictures_api_v1_pictures_search_get",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 9223372036854775807,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "default": 0.5,
+              "title": "Threshold"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/likeness-search": {
+      "post": {
+        "tags": [
+          "pictures",
+          "pictures"
+        ],
+        "summary": "Search by image likeness",
+        "description": "Upload one or more images and retrieve vault pictures ranked by visual similarity (cosine similarity on CLIP embeddings).\n\nWhen multiple query images are provided, per-candidate scores from each image are combined using the ``combine`` strategy before ranking.\n\n**Combine modes**\n- `mean` (default): arithmetic mean across query images.\n- `max`: best match to any query image.\n- `min`: must match all query images.\n- `harmonic_mean`: emphasises the worst-matching query.\n- `geometric_mean`: product-like balance.\n\n**Random modes**\n- `random=false` (default): returns the top `top_n` most similar pictures.\n- `random=true`: selects `top_n` pictures at random from the `pool_m` most similar candidates.\n\nResults are ordered by descending similarity score. Only pictures with a pre-computed image embedding are considered.",
+        "operationId": "search_by_image_likeness_api_v1_pictures_likeness_search_post",
+        "parameters": [
+          {
+            "name": "source_picture_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Use the stored embedding of this picture ID as the query (single ID, kept for backward compatibility).",
+              "title": "Source Picture Id"
+            },
+            "description": "Use the stored embedding of this picture ID as the query (single ID, kept for backward compatibility)."
+          },
+          {
+            "name": "source_picture_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "description": "Use the stored embeddings of these picture IDs as the query. When multiple IDs are supplied results are ranked by the minimum similarity across all sources.",
+              "default": [],
+              "title": "Source Picture Ids"
+            },
+            "description": "Use the stored embeddings of these picture IDs as the query. When multiple IDs are supplied results are ranked by the minimum similarity across all sources."
+          },
+          {
+            "name": "top_n",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Maximum number of results to return.",
+              "default": 20,
+              "title": "Top N"
+            },
+            "description": "Maximum number of results to return."
+          },
+          {
+            "name": "pool_m",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 2000,
+              "minimum": 0,
+              "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`.",
+              "default": 0,
+              "title": "Pool M"
+            },
+            "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`."
+          },
+          {
+            "name": "random",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "When true, return a random sample from the top-M pool.",
+              "default": false,
+              "title": "Random"
+            },
+            "description": "When true, return a random sample from the top-M pool."
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "description": "Minimum cosine similarity required to include a result.",
+              "default": 0.0,
+              "title": "Threshold"
+            },
+            "description": "Minimum cosine similarity required to include a result."
+          },
+          {
+            "name": "combine",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean.",
+              "default": "mean",
+              "title": "Combine"
+            },
+            "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean."
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to pictures in a specific project (numeric ID or 'UNASSIGNED').",
+              "title": "Project Id"
+            },
+            "description": "Filter to pictures in a specific project (numeric ID or 'UNASSIGNED')."
+          },
+          {
+            "name": "set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to pictures in a specific set.",
+              "title": "Set Id"
+            },
+            "description": "Filter to pictures in a specific set."
+          },
+          {
+            "name": "set_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter to pictures in multiple sets.",
+              "default": [],
+              "title": "Set Ids"
+            },
+            "description": "Filter to pictures in multiple sets."
+          },
+          {
+            "name": "set_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "How to combine set filters: union, intersection, difference, xor.",
+              "default": "union",
+              "title": "Set Mode"
+            },
+            "description": "How to combine set filters: union, intersection, difference, xor."
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to pictures containing a specific character (numeric ID).",
+              "title": "Character Id"
+            },
+            "description": "Filter to pictures containing a specific character (numeric ID)."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_search_by_image_likeness_api_v1_pictures_likeness_search_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/face-search": {
+      "post": {
+        "tags": [
+          "pictures",
+          "pictures"
+        ],
+        "summary": "Search by face likeness",
+        "description": "Upload one or more images and retrieve vault pictures ranked by face similarity (cosine similarity on InsightFace ArcFace embeddings).\n\nThe most prominent face (largest bounding box) in each uploaded image is used as the query.  For each candidate picture the score is the **best-matching face** it contains, so pictures where the queried person appears alongside others are still found accurately.\n\nWhen multiple query images are provided, per-picture scores from each image are combined using the ``combine`` strategy before ranking.  Images with no detectable face are skipped; returns 422 when no face is detected in any image.\n\n**Combine modes**\n- `mean` (default): arithmetic mean across query images.\n- `max`: best match to any query image.\n- `min`: must match all query images.\n- `harmonic_mean`: emphasises the worst-matching query.\n- `geometric_mean`: product-like balance.\n\n**Random modes**\n- `random=false` (default): returns the top `top_n` most similar pictures.\n- `random=true`: selects `top_n` pictures at random from the `pool_m` most similar candidates.\n\nResults are ordered by descending similarity score. Only pictures that contain at least one pre-computed face embedding are considered.",
+        "operationId": "search_by_face_likeness_api_v1_pictures_face_search_post",
+        "parameters": [
+          {
+            "name": "source_picture_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Use the stored ArcFace embedding(s) of this picture ID as the query instead of uploading a file.",
+              "title": "Source Picture Id"
+            },
+            "description": "Use the stored ArcFace embedding(s) of this picture ID as the query instead of uploading a file."
+          },
+          {
+            "name": "source_face_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Use the stored ArcFace embedding of this specific face ID as the query.",
+              "title": "Source Face Id"
+            },
+            "description": "Use the stored ArcFace embedding of this specific face ID as the query."
+          },
+          {
+            "name": "top_n",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Maximum number of results to return.",
+              "default": 20,
+              "title": "Top N"
+            },
+            "description": "Maximum number of results to return."
+          },
+          {
+            "name": "pool_m",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 2000,
+              "minimum": 0,
+              "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`.",
+              "default": 0,
+              "title": "Pool M"
+            },
+            "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`."
+          },
+          {
+            "name": "random",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "When true, return a random sample from the top-M pool.",
+              "default": false,
+              "title": "Random"
+            },
+            "description": "When true, return a random sample from the top-M pool."
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "description": "Minimum similarity score required to include a result.",
+              "default": 0.0,
+              "title": "Threshold"
+            },
+            "description": "Minimum similarity score required to include a result."
+          },
+          {
+            "name": "combine",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean.",
+              "default": "mean",
+              "title": "Combine"
+            },
+            "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean."
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to pictures in a specific project (numeric ID or 'UNASSIGNED').",
+              "title": "Project Id"
+            },
+            "description": "Filter to pictures in a specific project (numeric ID or 'UNASSIGNED')."
+          },
+          {
+            "name": "set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to pictures in a specific set.",
+              "title": "Set Id"
+            },
+            "description": "Filter to pictures in a specific set."
+          },
+          {
+            "name": "set_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter to pictures in multiple sets.",
+              "default": [],
+              "title": "Set Ids"
+            },
+            "description": "Filter to pictures in multiple sets."
+          },
+          {
+            "name": "set_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "How to combine set filters: union, intersection, difference, xor.",
+              "default": "union",
+              "title": "Set Mode"
+            },
+            "description": "How to combine set filters: union, intersection, difference, xor."
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to pictures containing a specific character (numeric ID).",
+              "title": "Character Id"
+            },
+            "description": "Filter to pictures containing a specific character (numeric ID)."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_search_by_face_likeness_api_v1_pictures_face_search_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/import": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Import media files",
+        "description": "Starts an asynchronous import of uploaded image/video files (or zip contents) and returns a task id.",
+        "operationId": "import_pictures_api_v1_pictures_import_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_import_pictures_api_v1_pictures_import_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/import/status": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get import job status",
+        "description": "Returns progress and result information for a previously started import task.",
+        "operationId": "import_status_api_v1_pictures_import_status_get",
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Task Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/project": {
+      "patch": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Set project for pictures",
+        "description": "Assigns, removes, or clears project association for a batch of pictures.",
+        "operationId": "set_project_for_pictures_api_v1_pictures_project_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/apply-scores": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Batch apply manual scores",
+        "description": "Applies 0-5 manual scores to multiple pictures in one request while optionally enforcing only-unscored updates.",
+        "operationId": "apply_scores_for_pictures_api_v1_pictures_apply_scores_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}.{ext}": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get original picture file",
+        "description": "Streams the original media file for a picture id when the requested extension matches the stored format.",
+        "operationId": "get_picture_api_v1_pictures__id___ext__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "ext",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Ext"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/metadata": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get picture metadata",
+        "description": "Returns metadata, tags, and optional smart score for a single picture, including embedded file metadata when available.",
+        "operationId": "get_picture_metadata_api_v1_pictures__id__metadata_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "smart_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Smart Score"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/face": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Create manual face entry",
+        "description": "Adds a face bounding box to a picture and frame index, updating sentinel/ordering behavior for manual annotations.",
+        "operationId": "create_picture_face_api_v1_pictures__id__face_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/face/{index}": {
+      "delete": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Delete face by index",
+        "description": "Deletes a face at frame 0 by index and reindexes remaining faces for stable ordering.",
+        "operationId": "delete_picture_face_api_v1_pictures__id__face__index__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "index",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Index"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/character_likeness": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get picture character likeness",
+        "description": "Computes max character-likeness score for faces in a picture against a reference character.",
+        "operationId": "get_picture_character_likeness_api_v1_pictures__id__character_likeness_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "reference_character_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Reference Character Id"
+            }
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Character Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/{field}": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get raw picture field",
+        "description": "Returns a single picture field value; large binary fields are base64 encoded and thumbnail returns image bytes.",
+        "operationId": "get_picture_field_api_v1_pictures__id___field__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Field"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}": {
+      "patch": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Patch picture fields",
+        "description": "Updates mutable picture fields from query/body parameters, including tag replacement when provided.",
+        "operationId": "patch_picture_api_v1_pictures__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Move picture to scrapheap",
+        "description": "Soft-deletes a picture by marking it deleted, making it appear in scrapheap views.",
+        "operationId": "delete_picture_api_v1_pictures__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/scrapheap/restore": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Restore deleted pictures",
+        "description": "Restores deleted pictures from scrapheap, either all deleted pictures or a provided picture id subset.",
+        "operationId": "restore_scrapheap_api_v1_pictures_scrapheap_restore_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/scrapheap": {
+      "delete": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Permanently delete scrapheap pictures",
+        "description": "Permanently removes deleted pictures from database and disk for provided ids or for all scrapheap items when omitted.",
+        "operationId": "delete_scrapheap_selection_api_v1_pictures_scrapheap_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List pictures",
+        "description": "Lists pictures with filtering, sort, pagination, and optional grid field projection.",
+        "operationId": "list_pictures_api_v1_pictures_get",
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Sort mechanism. One of: DATE, IMPORTED_AT, SCORE, SMART_SCORE, IMAGE_SIZE, TEXT_CONTENT, CHARACTER_LIKENESS. Omit for natural (id) order.",
+              "examples": [
+                "DATE"
+              ],
+              "title": "Sort"
+            },
+            "description": "Sort mechanism. One of: DATE, IMPORTED_AT, SCORE, SMART_SCORE, IMAGE_SIZE, TEXT_CONTENT, CHARACTER_LIKENESS. Omit for natural (id) order."
+          },
+          {
+            "name": "descending",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Sort direction; true = newest/highest first.",
+              "default": true,
+              "title": "Descending"
+            },
+            "description": "Sort direction; true = newest/highest first."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Number of rows to skip (pagination).",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of rows to skip (pagination)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Maximum rows to return.",
+              "examples": [
+                200
+              ],
+              "default": 9223372036854775807,
+              "title": "Limit"
+            },
+            "description": "Maximum rows to return."
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Field projection: 'grid' for the minimal grid set, a comma-separated field list, or omit for full metadata.",
+              "examples": [
+                "grid"
+              ],
+              "title": "Fields"
+            },
+            "description": "Field projection: 'grid' for the minimal grid set, a comma-separated field list, or omit for full metadata."
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by project id or 'UNASSIGNED'",
+              "examples": [
+                "UNASSIGNED"
+              ],
+              "title": "Project Id"
+            },
+            "description": "Filter by project id or 'UNASSIGNED'"
+          },
+          {
+            "name": "only_deleted",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP.",
+              "default": false,
+              "title": "Only Deleted"
+            },
+            "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP."
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Character filter: a character id, or 'UNASSIGNED'.",
+              "examples": [
+                "42"
+              ],
+              "title": "Character Id"
+            },
+            "description": "Character filter: a character id, or 'UNASSIGNED'."
+          },
+          {
+            "name": "character_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multi-character filter (repeatable).",
+              "default": [],
+              "title": "Character Ids"
+            },
+            "description": "Multi-character filter (repeatable)."
+          },
+          {
+            "name": "character_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "union | intersection | difference | xor",
+              "title": "Character Mode"
+            },
+            "description": "union | intersection | difference | xor"
+          },
+          {
+            "name": "set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Single picture-set filter.",
+              "title": "Set Id"
+            },
+            "description": "Single picture-set filter."
+          },
+          {
+            "name": "set_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multi-set filter (repeatable).",
+              "default": [],
+              "title": "Set Ids"
+            },
+            "description": "Multi-set filter (repeatable)."
+          },
+          {
+            "name": "set_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "union | intersection | difference",
+              "title": "Set Mode"
+            },
+            "description": "union | intersection | difference"
+          },
+          {
+            "name": "base_set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Base set for set_mode=difference.",
+              "title": "Base Set Id"
+            },
+            "description": "Base set for set_mode=difference."
+          },
+          {
+            "name": "reference_character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Required reference for sort=CHARACTER_LIKENESS.",
+              "title": "Reference Character Id"
+            },
+            "description": "Required reference for sort=CHARACTER_LIKENESS."
+          },
+          {
+            "name": "min_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Minimum star score.",
+              "examples": [
+                3
+              ],
+              "title": "Min Score"
+            },
+            "description": "Minimum star score."
+          },
+          {
+            "name": "max_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum star score.",
+              "examples": [
+                5
+              ],
+              "title": "Max Score"
+            },
+            "description": "Maximum star score."
+          },
+          {
+            "name": "smart_score_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5",
+              "title": "Smart Score Bucket"
+            },
+            "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5"
+          },
+          {
+            "name": "resolution_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus",
+              "title": "Resolution Bucket"
+            },
+            "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus"
+          },
+          {
+            "name": "file_path_prefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict to file paths starting with this prefix.",
+              "title": "File Path Prefix"
+            },
+            "description": "Restrict to file paths starting with this prefix."
+          },
+          {
+            "name": "face_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "with_face | without_face",
+              "examples": [
+                "with_face"
+              ],
+              "title": "Face Filter"
+            },
+            "description": "with_face | without_face"
+          },
+          {
+            "name": "shared_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Only pictures shared with the current user.",
+              "default": false,
+              "title": "Shared Only"
+            },
+            "description": "Only pictures shared with the current user."
+          },
+          {
+            "name": "apply_tag_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Apply the user's hidden-tag filter.",
+              "default": false,
+              "title": "Apply Tag Filter"
+            },
+            "description": "Apply the user's hidden-tag filter."
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by file format (repeatable).",
+              "default": [],
+              "title": "Format"
+            },
+            "description": "Filter by file format (repeatable)."
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Require these tags (repeatable).",
+              "examples": [
+                "sunset"
+              ],
+              "default": [],
+              "title": "Tag"
+            },
+            "description": "Require these tags (repeatable)."
+          },
+          {
+            "name": "rejected_tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Exclude these tags (repeatable).",
+              "default": [],
+              "title": "Rejected Tag"
+            },
+            "description": "Exclude these tags (repeatable)."
+          },
+          {
+            "name": "tag_confidence_above",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
+              "title": "Tag Confidence Above"
+            },
+            "description": "'tag:threshold' prediction filter (repeatable)."
+          },
+          {
+            "name": "tag_confidence_below",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
+              "title": "Tag Confidence Below"
+            },
+            "description": "'tag:threshold' prediction filter (repeatable)."
+          },
+          {
+            "name": "comfyui_model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by ComfyUI model (repeatable).",
+              "default": [],
+              "title": "Comfyui Model"
+            },
+            "description": "Filter by ComfyUI model (repeatable)."
+          },
+          {
+            "name": "comfyui_lora",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by ComfyUI LoRA (repeatable).",
+              "default": [],
+              "title": "Comfyui Lora"
+            },
+            "description": "Filter by ComfyUI LoRA (repeatable)."
+          },
+          {
+            "name": "reference_folder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by reference-folder id.",
+              "title": "Reference Folder Id"
+            },
+            "description": "Filter by reference-folder id."
+          },
+          {
+            "name": "import_source_folder",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by import source folder.",
+              "title": "Import Source Folder"
+            },
+            "description": "Filter by import source folder."
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Restrict to specific picture ids (repeatable).",
+              "default": [],
+              "title": "Id"
+            },
+            "description": "Restrict to specific picture ids (repeatable)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching pictures (field set depends on `fields`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GridPicture"
+                  },
+                  "title": "Response 200 List Pictures Api V1 Pictures Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid sort mechanism."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/stream": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Stream pictures in batches",
+        "description": "Fetches a single batch of pictures and reports completion via an explicit `done` flag derived from the underlying SQL row count (not the post-filter row count). Callers paginate by passing the returned `next_offset` until `done` is true.",
+        "operationId": "stream_pictures_api_v1_pictures_stream_get",
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Sort mechanism (see /pictures). Omit for natural order.",
+              "examples": [
+                "DATE"
+              ],
+              "title": "Sort"
+            },
+            "description": "Sort mechanism (see /pictures). Omit for natural order."
+          },
+          {
+            "name": "descending",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Sort direction; true = newest/highest first.",
+              "default": true,
+              "title": "Descending"
+            },
+            "description": "Sort direction; true = newest/highest first."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Row offset for this batch (use next_offset).",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Row offset for this batch (use next_offset)."
+          },
+          {
+            "name": "batch_limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 5000,
+              "minimum": 1,
+              "description": "Rows per batch (1-5000).",
+              "examples": [
+                1000
+              ],
+              "default": 1000,
+              "title": "Batch Limit"
+            },
+            "description": "Rows per batch (1-5000)."
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Field projection: 'grid', a comma list, or omit.",
+              "examples": [
+                "grid"
+              ],
+              "title": "Fields"
+            },
+            "description": "Field projection: 'grid', a comma list, or omit."
+          },
+          {
+            "name": "grid_lite",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "When `fields=grid`, omit high-cardinality string fields such as `file_path` to reduce payload size for streaming.",
+              "default": false,
+              "title": "Grid Lite"
+            },
+            "description": "When `fields=grid`, omit high-cardinality string fields such as `file_path` to reduce payload size for streaming."
+          },
+          {
+            "name": "stack_leaders_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Collapse stacks to their leader only.",
+              "default": false,
+              "title": "Stack Leaders Only"
+            },
+            "description": "Collapse stacks to their leader only."
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by project id or 'UNASSIGNED'",
+              "examples": [
+                "UNASSIGNED"
+              ],
+              "title": "Project Id"
+            },
+            "description": "Filter by project id or 'UNASSIGNED'"
+          },
+          {
+            "name": "only_deleted",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP.",
+              "default": false,
+              "title": "Only Deleted"
+            },
+            "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP."
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Character filter: a character id, or 'UNASSIGNED'.",
+              "examples": [
+                "42"
+              ],
+              "title": "Character Id"
+            },
+            "description": "Character filter: a character id, or 'UNASSIGNED'."
+          },
+          {
+            "name": "character_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multi-character filter (repeatable).",
+              "default": [],
+              "title": "Character Ids"
+            },
+            "description": "Multi-character filter (repeatable)."
+          },
+          {
+            "name": "character_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "union | intersection | difference | xor",
+              "title": "Character Mode"
+            },
+            "description": "union | intersection | difference | xor"
+          },
+          {
+            "name": "set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Single picture-set filter.",
+              "title": "Set Id"
+            },
+            "description": "Single picture-set filter."
+          },
+          {
+            "name": "set_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multi-set filter (repeatable).",
+              "default": [],
+              "title": "Set Ids"
+            },
+            "description": "Multi-set filter (repeatable)."
+          },
+          {
+            "name": "set_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "union | intersection | difference",
+              "title": "Set Mode"
+            },
+            "description": "union | intersection | difference"
+          },
+          {
+            "name": "base_set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Base set for set_mode=difference.",
+              "title": "Base Set Id"
+            },
+            "description": "Base set for set_mode=difference."
+          },
+          {
+            "name": "reference_character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Required reference for sort=CHARACTER_LIKENESS.",
+              "title": "Reference Character Id"
+            },
+            "description": "Required reference for sort=CHARACTER_LIKENESS."
+          },
+          {
+            "name": "min_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Minimum star score.",
+              "examples": [
+                3
+              ],
+              "title": "Min Score"
+            },
+            "description": "Minimum star score."
+          },
+          {
+            "name": "max_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum star score.",
+              "examples": [
+                5
+              ],
+              "title": "Max Score"
+            },
+            "description": "Maximum star score."
+          },
+          {
+            "name": "smart_score_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5",
+              "title": "Smart Score Bucket"
+            },
+            "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5"
+          },
+          {
+            "name": "resolution_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus",
+              "title": "Resolution Bucket"
+            },
+            "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus"
+          },
+          {
+            "name": "file_path_prefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict to file paths starting with this prefix.",
+              "title": "File Path Prefix"
+            },
+            "description": "Restrict to file paths starting with this prefix."
+          },
+          {
+            "name": "face_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "with_face | without_face",
+              "examples": [
+                "with_face"
+              ],
+              "title": "Face Filter"
+            },
+            "description": "with_face | without_face"
+          },
+          {
+            "name": "shared_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Only pictures shared with the current user.",
+              "default": false,
+              "title": "Shared Only"
+            },
+            "description": "Only pictures shared with the current user."
+          },
+          {
+            "name": "apply_tag_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Apply the user's hidden-tag filter.",
+              "default": false,
+              "title": "Apply Tag Filter"
+            },
+            "description": "Apply the user's hidden-tag filter."
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by file format (repeatable).",
+              "default": [],
+              "title": "Format"
+            },
+            "description": "Filter by file format (repeatable)."
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Require these tags (repeatable).",
+              "examples": [
+                "sunset"
+              ],
+              "default": [],
+              "title": "Tag"
+            },
+            "description": "Require these tags (repeatable)."
+          },
+          {
+            "name": "rejected_tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Exclude these tags (repeatable).",
+              "default": [],
+              "title": "Rejected Tag"
+            },
+            "description": "Exclude these tags (repeatable)."
+          },
+          {
+            "name": "tag_confidence_above",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
+              "title": "Tag Confidence Above"
+            },
+            "description": "'tag:threshold' prediction filter (repeatable)."
+          },
+          {
+            "name": "tag_confidence_below",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
+              "title": "Tag Confidence Below"
+            },
+            "description": "'tag:threshold' prediction filter (repeatable)."
+          },
+          {
+            "name": "comfyui_model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by ComfyUI model (repeatable).",
+              "default": [],
+              "title": "Comfyui Model"
+            },
+            "description": "Filter by ComfyUI model (repeatable)."
+          },
+          {
+            "name": "comfyui_lora",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by ComfyUI LoRA (repeatable).",
+              "default": [],
+              "title": "Comfyui Lora"
+            },
+            "description": "Filter by ComfyUI LoRA (repeatable)."
+          },
+          {
+            "name": "reference_folder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by reference-folder id.",
+              "title": "Reference Folder Id"
+            },
+            "description": "Filter by reference-folder id."
+          },
+          {
+            "name": "import_source_folder",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by import source folder.",
+              "title": "Import Source Folder"
+            },
+            "description": "Filter by import source folder."
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Restrict to specific picture ids (repeatable).",
+              "default": [],
+              "title": "Id"
+            },
+            "description": "Restrict to specific picture ids (repeatable)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StreamPicturesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid sort mechanism."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/count": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Total picture count for a listing filter",
+        "description": "Returns the total number of pictures matching the same filter set used by `/pictures` and `/pictures/stream`.",
+        "operationId": "count_pictures_api_v1_pictures_count_get",
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Sort mechanism; only affects whether a count is computable (CHARACTER_LIKENESS returns null).",
+              "examples": [
+                "DATE"
+              ],
+              "title": "Sort"
+            },
+            "description": "Sort mechanism; only affects whether a count is computable (CHARACTER_LIKENESS returns null)."
+          },
+          {
+            "name": "descending",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Unused for counting; accepted for parity with /pictures.",
+              "default": true,
+              "title": "Descending"
+            },
+            "description": "Unused for counting; accepted for parity with /pictures."
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Unused for counting; accepted for parity.",
+              "title": "Fields"
+            },
+            "description": "Unused for counting; accepted for parity."
+          },
+          {
+            "name": "stack_leaders_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Count stacks as one (their leader).",
+              "default": false,
+              "title": "Stack Leaders Only"
+            },
+            "description": "Count stacks as one (their leader)."
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by project id or 'UNASSIGNED'",
+              "examples": [
+                "UNASSIGNED"
+              ],
+              "title": "Project Id"
+            },
+            "description": "Filter by project id or 'UNASSIGNED'"
+          },
+          {
+            "name": "only_deleted",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP.",
+              "default": false,
+              "title": "Only Deleted"
+            },
+            "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP."
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Character filter: a character id, or 'UNASSIGNED'.",
+              "examples": [
+                "42"
+              ],
+              "title": "Character Id"
+            },
+            "description": "Character filter: a character id, or 'UNASSIGNED'."
+          },
+          {
+            "name": "character_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multi-character filter (repeatable).",
+              "default": [],
+              "title": "Character Ids"
+            },
+            "description": "Multi-character filter (repeatable)."
+          },
+          {
+            "name": "character_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "union | intersection | difference | xor",
+              "title": "Character Mode"
+            },
+            "description": "union | intersection | difference | xor"
+          },
+          {
+            "name": "set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Single picture-set filter.",
+              "title": "Set Id"
+            },
+            "description": "Single picture-set filter."
+          },
+          {
+            "name": "set_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multi-set filter (repeatable).",
+              "default": [],
+              "title": "Set Ids"
+            },
+            "description": "Multi-set filter (repeatable)."
+          },
+          {
+            "name": "set_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "union | intersection | difference",
+              "title": "Set Mode"
+            },
+            "description": "union | intersection | difference"
+          },
+          {
+            "name": "base_set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Base set for set_mode=difference.",
+              "title": "Base Set Id"
+            },
+            "description": "Base set for set_mode=difference."
+          },
+          {
+            "name": "reference_character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Required reference for sort=CHARACTER_LIKENESS.",
+              "title": "Reference Character Id"
+            },
+            "description": "Required reference for sort=CHARACTER_LIKENESS."
+          },
+          {
+            "name": "min_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Minimum star score.",
+              "examples": [
+                3
+              ],
+              "title": "Min Score"
+            },
+            "description": "Minimum star score."
+          },
+          {
+            "name": "max_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum star score.",
+              "examples": [
+                5
+              ],
+              "title": "Max Score"
+            },
+            "description": "Maximum star score."
+          },
+          {
+            "name": "smart_score_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5",
+              "title": "Smart Score Bucket"
+            },
+            "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5"
+          },
+          {
+            "name": "resolution_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus",
+              "title": "Resolution Bucket"
+            },
+            "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus"
+          },
+          {
+            "name": "file_path_prefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict to file paths starting with this prefix.",
+              "title": "File Path Prefix"
+            },
+            "description": "Restrict to file paths starting with this prefix."
+          },
+          {
+            "name": "face_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "with_face | without_face",
+              "examples": [
+                "with_face"
+              ],
+              "title": "Face Filter"
+            },
+            "description": "with_face | without_face"
+          },
+          {
+            "name": "shared_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Only pictures shared with the current user.",
+              "default": false,
+              "title": "Shared Only"
+            },
+            "description": "Only pictures shared with the current user."
+          },
+          {
+            "name": "apply_tag_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Apply the user's hidden-tag filter.",
+              "default": false,
+              "title": "Apply Tag Filter"
+            },
+            "description": "Apply the user's hidden-tag filter."
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by file format (repeatable).",
+              "default": [],
+              "title": "Format"
+            },
+            "description": "Filter by file format (repeatable)."
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Require these tags (repeatable).",
+              "examples": [
+                "sunset"
+              ],
+              "default": [],
+              "title": "Tag"
+            },
+            "description": "Require these tags (repeatable)."
+          },
+          {
+            "name": "rejected_tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Exclude these tags (repeatable).",
+              "default": [],
+              "title": "Rejected Tag"
+            },
+            "description": "Exclude these tags (repeatable)."
+          },
+          {
+            "name": "tag_confidence_above",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
+              "title": "Tag Confidence Above"
+            },
+            "description": "'tag:threshold' prediction filter (repeatable)."
+          },
+          {
+            "name": "tag_confidence_below",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
+              "title": "Tag Confidence Below"
+            },
+            "description": "'tag:threshold' prediction filter (repeatable)."
+          },
+          {
+            "name": "comfyui_model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by ComfyUI model (repeatable).",
+              "default": [],
+              "title": "Comfyui Model"
+            },
+            "description": "Filter by ComfyUI model (repeatable)."
+          },
+          {
+            "name": "comfyui_lora",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by ComfyUI LoRA (repeatable).",
+              "default": [],
+              "title": "Comfyui Lora"
+            },
+            "description": "Filter by ComfyUI LoRA (repeatable)."
+          },
+          {
+            "name": "reference_folder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by reference-folder id.",
+              "title": "Reference Folder Id"
+            },
+            "description": "Filter by reference-folder id."
+          },
+          {
+            "name": "import_source_folder",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by import source folder.",
+              "title": "Import Source Folder"
+            },
+            "description": "Filter by import source folder."
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Restrict to specific picture ids (repeatable).",
+              "default": [],
+              "title": "Id"
+            },
+            "description": "Restrict to specific picture ids (repeatable)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PictureCountResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/workflows": {
+      "get": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "List ComfyUI workflows",
+        "description": "Lists discovered built-in and user workflows with placeholder validation metadata.",
+        "operationId": "list_comfyui_workflows_api_v1_comfyui_workflows_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/workflows/{workflow_name}": {
+      "delete": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Delete user workflow",
+        "description": "Deletes a workflow JSON from the user workflow directory.",
+        "operationId": "delete_comfyui_workflow_api_v1_comfyui_workflows__workflow_name__delete",
+        "parameters": [
+          {
+            "name": "workflow_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/abort": {
+      "post": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Abort ComfyUI execution",
+        "description": "Interrupts the currently running ComfyUI prompt and clears the pending queue.",
+        "operationId": "abort_comfyui_api_v1_comfyui_abort_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/run_i2i": {
+      "post": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Run ComfyUI image-to-image",
+        "description": "Submits i2i prompts for one or more picture ids and imports generated outputs back into PixlStash.",
+        "operationId": "run_comfyui_i2i_api_v1_comfyui_run_i2i_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/run_t2i": {
+      "post": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Run ComfyUI text-to-image",
+        "description": "Submits a t2i prompt using only a caption and imports generated outputs back into PixlStash.",
+        "operationId": "run_comfyui_t2i_api_v1_comfyui_run_t2i_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/workflows/import": {
+      "post": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Import ComfyUI workflow",
+        "description": "Saves a workflow JSON into the user workflow directory, optionally overwriting an existing file.",
+        "operationId": "import_comfyui_workflow_api_v1_comfyui_workflows_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/pictures/{picture_id}/workflow": {
+      "get": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Get ComfyUI workflow for a picture",
+        "description": "Extracts and returns the ComfyUI workflow embedded in a picture's file metadata, if present.",
+        "operationId": "get_picture_comfyui_workflow_api_v1_comfyui_pictures__picture_id__workflow_get",
+        "parameters": [
+          {
+            "name": "picture_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Picture Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/reference-folders": {
+      "get": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "List reference folders",
+        "description": "Returns all reference folders and metadata about the current runtime mode.",
+        "operationId": "list_reference_folders_api_v1_reference_folders_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenceFoldersListResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Add a reference folder",
+        "description": "Adds a new reference folder. The path must be absolute and must not point to a restricted system directory. In Docker mode the folder is created with status 'pending_mount' and requires a server restart to mount-verify the path. Outside Docker the path is verified immediately and the folder becomes 'active' (or 'mount_error') right away.",
+        "operationId": "create_reference_folder_api_v1_reference_folders_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferenceFolderCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenceFolderResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/reference-folders/{folder_id}": {
+      "patch": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Update a reference folder",
+        "description": "Updates editable fields for a reference folder.",
+        "operationId": "update_reference_folder_api_v1_reference_folders__folder_id__patch",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferenceFolderUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenceFolderResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Remove a reference folder",
+        "description": "Removes a reference folder record. Pictures indexed from this folder are de-associated but not deleted from the database or disk.",
+        "operationId": "delete_reference_folder_api_v1_reference_folders__folder_id__delete",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/server/restart": {
+      "post": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Restart the PixlStash server",
+        "description": "Gracefully terminates the server process. The process manager (systemd, Docker, etc.) is expected to restart it automatically. Use this after adding reference folders to apply pending mount changes.",
+        "operationId": "restart_server_api_v1_server_restart_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/reference-folders/{folder_id}/open": {
+      "post": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Open reference folder in file manager",
+        "description": "Opens the reference folder (or an optional subdirectory within it) in the OS file manager.",
+        "operationId": "open_reference_folder_api_v1_reference_folders__folder_id__open_post",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          },
+          {
+            "name": "subpath",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Subpath"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/import-folders": {
+      "get": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "List import folders",
+        "description": "Returns all folders used by the automatic import watcher.",
+        "operationId": "list_import_folders_api_v1_import_folders_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportFoldersListResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Add an import folder",
+        "description": "Adds a folder watched for automatic imports.",
+        "operationId": "create_import_folder_api_v1_import_folders_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportFolderCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportFolderResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/import-folders/{folder_id}": {
+      "patch": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Update an import folder",
+        "description": "Updates label and import behavior for an import folder.",
+        "operationId": "update_import_folder_api_v1_import_folders__folder_id__patch",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportFolderUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportFolderResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Remove an import folder",
+        "description": "Removes an import folder from automatic monitoring.",
+        "operationId": "delete_import_folder_api_v1_import_folders__folder_id__delete",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/filesystem/browse": {
+      "get": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Browse server filesystem",
+        "description": "Returns immediate child entries of the requested directory. Available in native (non-Docker) installs only. Requires authentication.",
+        "operationId": "browse_filesystem_api_v1_filesystem_browse_get",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Absolute directory path to list. Defaults to home directory.",
+              "title": "Path"
+            },
+            "description": "Absolute directory path to list. Defaults to home directory."
+          },
+          {
+            "name": "show_hidden",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Include hidden (dot-prefixed) entries.",
+              "default": false,
+              "title": "Show Hidden"
+            },
+            "description": "Include hidden (dot-prefixed) entries."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilesystemBrowseResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/taggers": {
+      "get": {
+        "tags": [
+          "taggers",
+          "taggers"
+        ],
+        "summary": "List tagger plugins and current settings",
+        "description": "Return every registered tagger/captioner plugin together with\nthe current user's ``tagger_settings``.\n\nResponse shape::\n\n    {\n      \"plugins\": [\n        {\n          \"name\": \"pixlstash_tagger\",\n          \"display_name\": \"PixlStash Tagger\",\n          \"description\": \"...\",\n          \"supports_tags\": true,\n          \"supports_descriptions\": false,\n          \"requires_download\": true,\n          \"default_enabled\": true,\n          \"parameter_schema\": [...],\n          \"downloaded_artifacts\": [],\n          \"is_loaded\": false,\n          \"load_error\": null\n        },\n        ...\n      ],\n      \"settings\": { ... }\n    }",
+        "operationId": "list_taggers_api_v1_taggers_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/taggers/{name}/download": {
+      "post": {
+        "tags": [
+          "taggers",
+          "taggers"
+        ],
+        "summary": "Start artifact download for a tagger plugin",
+        "description": "Kick off a background download for the named plugin.\n\nReturns immediately with ``{\"status\": \"started\"}`` or\n``{\"status\": \"not_required\"}`` when no download is needed.\nDownload progress is logged to the server console.\n\nRaises 404 if the plugin is not registered.",
+        "operationId": "download_plugin_api_v1_taggers__name__download_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/taggers/{name}/artifacts/{artifact_id}": {
+      "delete": {
+        "tags": [
+          "taggers",
+          "taggers"
+        ],
+        "summary": "Delete a downloaded artifact for a tagger plugin",
+        "description": "Remove a downloaded artifact and unload the plugin if currently loaded.\n\nRaises 404 if the plugin or artifact is not found.",
+        "operationId": "delete_artifact_api_v1_taggers__name__artifacts__artifact_id__delete",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Artifact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/check-session": {
+      "get": {
+        "summary": "Check Session",
+        "operationId": "check_session_api_v1_check_session_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/network/info": {
+      "get": {
+        "summary": "Network Info",
+        "operationId": "network_info_api_v1_network_info_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/login": {
+      "get": {
+        "summary": "Check Registration",
+        "operationId": "check_registration_api_v1_login_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Login",
+        "operationId": "login_api_v1_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/logout": {
+      "post": {
+        "summary": "Logout",
+        "operationId": "logout_api_v1_logout_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/protected": {
+      "get": {
+        "summary": "Protected",
+        "operationId": "protected_api_v1_protected_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{full_path}": {
+      "get": {
+        "summary": "Frontend Fallback",
+        "operationId": "frontend_fallback__full_path__get",
+        "parameters": [
+          {
+            "name": "full_path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Full Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BatchSharedPictureIdsRequest": {
+        "properties": {
+          "picture_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Picture Ids"
+          }
+        },
+        "type": "object",
+        "title": "BatchSharedPictureIdsRequest"
+      },
+      "Body_get_batch_character_membership_api_v1_characters_membership_post": {
+        "properties": {
+          "picture_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Picture Ids",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "Body_get_batch_character_membership_api_v1_characters_membership_post"
+      },
+      "Body_get_batch_membership_api_v1_picture_sets_membership_post": {
+        "properties": {
+          "picture_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Picture Ids",
+            "default": []
+          },
+          "include_deleted": {
+            "type": "boolean",
+            "title": "Include Deleted",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "Body_get_batch_membership_api_v1_picture_sets_membership_post"
+      },
+      "Body_get_batch_project_membership_api_v1_projects_membership_post": {
+        "properties": {
+          "picture_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Picture Ids",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "Body_get_batch_project_membership_api_v1_projects_membership_post"
+      },
+      "Body_import_pictures_api_v1_pictures_import_post": {
+        "properties": {
+          "file": {
+            "items": {
+              "type": "string",
+              "contentMediaType": "application/octet-stream"
+            },
+            "type": "array",
+            "title": "File"
+          },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Id"
+          }
+        },
+        "type": "object",
+        "title": "Body_import_pictures_api_v1_pictures_import_post"
+      },
+      "Body_post_me_watermark_api_v1_users_me_watermark_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_post_me_watermark_api_v1_users_me_watermark_post"
+      },
+      "Body_search_by_character_likeness_api_v1_characters_likeness_search_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "type": "string",
+              "contentMediaType": "application/octet-stream"
+            },
+            "type": "array",
+            "title": "Files",
+            "description": "One or more query images containing a face to search against."
+          }
+        },
+        "type": "object",
+        "required": [
+          "files"
+        ],
+        "title": "Body_search_by_character_likeness_api_v1_characters_likeness_search_post"
+      },
+      "Body_search_by_face_likeness_api_v1_pictures_face_search_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "type": "string",
+              "contentMediaType": "application/octet-stream"
+            },
+            "type": "array",
+            "title": "Files",
+            "description": "One or more query images containing a face to search against.",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "Body_search_by_face_likeness_api_v1_pictures_face_search_post"
+      },
+      "Body_search_by_image_likeness_api_v1_pictures_likeness_search_post": {
+        "properties": {
+          "files": {
+            "items": {
+              "type": "string",
+              "contentMediaType": "application/octet-stream"
+            },
+            "type": "array",
+            "title": "Files",
+            "description": "One or more query images to search against.",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "Body_search_by_image_likeness_api_v1_pictures_likeness_search_post"
+      },
+      "Body_upload_attachment_api_v1_projects__project_id__attachments_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_attachment_api_v1_projects__project_id__attachments_post"
+      },
+      "BulkFetchTagsRequest": {
+        "properties": {
+          "picture_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Picture Ids",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "BulkFetchTagsRequest"
+      },
+      "ChangePasswordRequest": {
+        "properties": {
+          "current_password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Password"
+          },
+          "new_password": {
+            "type": "string",
+            "minLength": 8,
+            "title": "New Password",
+            "description": "Password must be at least 8 characters long"
+          }
+        },
+        "type": "object",
+        "required": [
+          "new_password"
+        ],
+        "title": "ChangePasswordRequest"
+      },
+      "CreateTokenRequest": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": "ALL"
+          },
+          "resource_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource Type"
+          },
+          "resource_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource Id"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "include_attachments": {
+            "type": "boolean",
+            "title": "Include Attachments",
+            "default": false
+          },
+          "watermark": {
+            "type": "boolean",
+            "title": "Watermark",
+            "default": true
+          }
+        },
+        "type": "object",
+        "title": "CreateTokenRequest"
+      },
+      "FilesystemBrowseResponse": {
+        "properties": {
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent"
+          },
+          "image_count": {
+            "type": "integer",
+            "title": "Image Count"
+          },
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/FilesystemEntry"
+            },
+            "type": "array",
+            "title": "Entries"
+          }
+        },
+        "type": "object",
+        "required": [
+          "path",
+          "parent",
+          "image_count",
+          "entries"
+        ],
+        "title": "FilesystemBrowseResponse"
+      },
+      "FilesystemEntry": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "is_dir": {
+            "type": "boolean",
+            "title": "Is Dir"
+          },
+          "image_count": {
+            "type": "integer",
+            "title": "Image Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "path",
+          "is_dir"
+        ],
+        "title": "FilesystemEntry"
+      },
+      "GridPicture": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id",
+            "description": "Picture id (primary key)."
+          },
+          "width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Width",
+            "description": "Image width in pixels."
+          },
+          "height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Height",
+            "description": "Image height in pixels."
+          },
+          "format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Format",
+            "description": "File format, e.g. PNG, JPEG, MP4."
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score",
+            "description": "Manual star rating (0-5)."
+          },
+          "smart_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Smart Score",
+            "description": "Model-predicted aesthetic score."
+          },
+          "smartScore": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Smartscore",
+            "description": "camelCase alias of smart_score (legacy clients)."
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "When the source file was created."
+          },
+          "imported_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imported At",
+            "description": "When the picture was imported into the vault."
+          },
+          "stack_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stack Id",
+            "description": "Id of the stack this picture belongs to, if any."
+          },
+          "stack_position": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stack Position",
+            "description": "Position within its stack; 0 is the stack leader."
+          },
+          "stack_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stack Count",
+            "description": "Number of pictures in the stack (only set on stack leaders when stack_leaders_only is used)."
+          },
+          "tag_uncertainty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Uncertainty",
+            "description": "Aggregate tag-prediction uncertainty."
+          },
+          "anomaly_tag_uncertainty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Anomaly Tag Uncertainty",
+            "description": "Uncertainty restricted to anomaly/problem tags."
+          },
+          "text_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text Score",
+            "description": "Relevance score for the active text search, if any."
+          },
+          "reference_folder_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Folder Id",
+            "description": "Source reference-folder id for externally-referenced files."
+          },
+          "file_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Path",
+            "description": "Path relative to the image root (omitted when grid_lite=true)."
+          }
+        },
+        "type": "object",
+        "title": "GridPicture",
+        "description": "A single picture row as returned by the grid listing endpoints.\n\nFields are the projection used when ``fields=grid``; all are optional\nbecause the exact set returned depends on the requested ``fields`` and on\nserver-side enrichment (stack counts, guest-score overlay, thumbnail/face\ndata added by ``POST /pictures/thumbnails``). Documented for the OpenAPI\nschema only \u2014 responses are not filtered against this model, so additional\nfields may be present.",
+        "example": {
+          "created_at": "2026-01-14T09:30:00",
+          "file_path": "01a43b7e-dda4-45bb-a912-2ed4b786260d.png",
+          "format": "PNG",
+          "height": 1536,
+          "id": 12345,
+          "imported_at": "2026-01-15T18:02:11",
+          "score": 4,
+          "smart_score": 3.87,
+          "stack_count": 5,
+          "stack_id": 87,
+          "stack_position": 0,
+          "width": 1024
+        }
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ImportFolderCreateRequest": {
+        "properties": {
+          "folder": {
+            "type": "string",
+            "title": "Folder"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "host_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Path"
+          },
+          "delete_after_import": {
+            "type": "boolean",
+            "title": "Delete After Import",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "folder"
+        ],
+        "title": "ImportFolderCreateRequest"
+      },
+      "ImportFolderResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "folder": {
+            "type": "string",
+            "title": "Folder"
+          },
+          "host_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Path"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "delete_after_import": {
+            "type": "boolean",
+            "title": "Delete After Import"
+          },
+          "last_checked": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Checked"
+          },
+          "picture_count": {
+            "type": "integer",
+            "title": "Picture Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "folder",
+          "host_path",
+          "label",
+          "delete_after_import",
+          "last_checked"
+        ],
+        "title": "ImportFolderResponse"
+      },
+      "ImportFolderUpdateRequest": {
+        "properties": {
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "host_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Path"
+          },
+          "delete_after_import": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delete After Import"
+          }
+        },
+        "type": "object",
+        "title": "ImportFolderUpdateRequest"
+      },
+      "ImportFoldersListResponse": {
+        "properties": {
+          "folders": {
+            "items": {
+              "$ref": "#/components/schemas/ImportFolderResponse"
+            },
+            "type": "array",
+            "title": "Folders"
+          }
+        },
+        "type": "object",
+        "required": [
+          "folders"
+        ],
+        "title": "ImportFoldersListResponse"
+      },
+      "LoginRequest": {
+        "properties": {
+          "username": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username",
+            "description": "Username is required"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 8
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Password",
+            "description": "Password must be at least 8 characters long"
+          },
+          "token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token",
+            "description": "API token for authentication"
+          }
+        },
+        "type": "object",
+        "title": "LoginRequest"
+      },
+      "PictureCountResponse": {
+        "properties": {
+          "count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Count",
+            "description": "Total matching pictures, or null when not cheaply computable."
+          }
+        },
+        "type": "object",
+        "title": "PictureCountResponse",
+        "description": "Total number of pictures matching the listing filters.\n\n``count`` is ``null`` for sorts where a total cannot be computed cheaply\n(e.g. CHARACTER_LIKENESS).",
+        "example": {
+          "count": 28259
+        }
+      },
+      "ProjectAttachmentResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "original_filename": {
+            "type": "string",
+            "title": "Original Filename"
+          },
+          "mime_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mime Type"
+          },
+          "file_size": {
+            "type": "integer",
+            "title": "File Size"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "original_filename",
+          "file_size"
+        ],
+        "title": "ProjectAttachmentResponse"
+      },
+      "ProjectCreateRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "cover_image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Image Path"
+          },
+          "extra_metadata": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "ProjectCreateRequest"
+      },
+      "ProjectDeleteResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "id"
+        ],
+        "title": "ProjectDeleteResponse"
+      },
+      "ProjectResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "cover_image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Image Path"
+          },
+          "extra_metadata": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra Metadata"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "ProjectResponse"
+      },
+      "ProjectSummaryResponse": {
+        "properties": {
+          "image_count": {
+            "type": "integer",
+            "title": "Image Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "image_count"
+        ],
+        "title": "ProjectSummaryResponse"
+      },
+      "ProjectUpdateRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "cover_image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Image Path"
+          },
+          "extra_metadata": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra Metadata"
+          }
+        },
+        "type": "object",
+        "title": "ProjectUpdateRequest"
+      },
+      "ProjectUrlAttachmentRequest": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "ProjectUrlAttachmentRequest"
+      },
+      "ReferenceFolderCreateRequest": {
+        "properties": {
+          "folder": {
+            "type": "string",
+            "title": "Folder"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "host_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Path"
+          }
+        },
+        "type": "object",
+        "required": [
+          "folder"
+        ],
+        "title": "ReferenceFolderCreateRequest"
+      },
+      "ReferenceFolderResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "folder": {
+            "type": "string",
+            "title": "Folder"
+          },
+          "host_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Path"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "allow_delete_file": {
+            "type": "boolean",
+            "title": "Allow Delete File"
+          },
+          "sync_captions": {
+            "type": "boolean",
+            "title": "Sync Captions"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "last_scanned": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Scanned"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "folder",
+          "host_path",
+          "label",
+          "allow_delete_file",
+          "sync_captions",
+          "status",
+          "last_scanned"
+        ],
+        "title": "ReferenceFolderResponse"
+      },
+      "ReferenceFolderUpdateRequest": {
+        "properties": {
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "allow_delete_file": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allow Delete File"
+          },
+          "sync_captions": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Captions"
+          },
+          "host_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Path"
+          }
+        },
+        "type": "object",
+        "title": "ReferenceFolderUpdateRequest"
+      },
+      "ReferenceFoldersListResponse": {
+        "properties": {
+          "in_docker": {
+            "type": "boolean",
+            "title": "In Docker"
+          },
+          "has_pending": {
+            "type": "boolean",
+            "title": "Has Pending"
+          },
+          "image_root": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Root"
+          },
+          "folders": {
+            "items": {
+              "$ref": "#/components/schemas/ReferenceFolderResponse"
+            },
+            "type": "array",
+            "title": "Folders"
+          }
+        },
+        "type": "object",
+        "required": [
+          "in_docker",
+          "has_pending",
+          "image_root",
+          "folders"
+        ],
+        "title": "ReferenceFoldersListResponse"
+      },
+      "ResetTagsRequest": {
+        "properties": {
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          }
+        },
+        "type": "object",
+        "title": "ResetTagsRequest",
+        "description": "Request body for reset_tags and reset_description endpoints."
+      },
+      "StreamPicturesResponse": {
+        "properties": {
+          "pictures": {
+            "items": {
+              "$ref": "#/components/schemas/GridPicture"
+            },
+            "type": "array",
+            "title": "Pictures",
+            "description": "Pictures in this batch, in sort order."
+          },
+          "done": {
+            "type": "boolean",
+            "title": "Done",
+            "description": "True when the underlying SQL row count for this batch was <= batch_limit, i.e. there are no further rows to fetch."
+          },
+          "next_offset": {
+            "type": "integer",
+            "title": "Next Offset",
+            "description": "Offset to pass on the next request to continue paginating."
+          }
+        },
+        "type": "object",
+        "required": [
+          "pictures",
+          "done",
+          "next_offset"
+        ],
+        "title": "StreamPicturesResponse",
+        "description": "One batch of the streaming listing plus pagination state.",
+        "example": {
+          "done": false,
+          "next_offset": 1000,
+          "pictures": [
+            {
+              "created_at": "2026-01-14T09:30:00",
+              "file_path": "01a43b7e-dda4-45bb-a912-2ed4b786260d.png",
+              "format": "PNG",
+              "height": 1536,
+              "id": 12345,
+              "imported_at": "2026-01-15T18:02:11",
+              "score": 4,
+              "smart_score": 3.87,
+              "stack_count": 5,
+              "stack_id": 87,
+              "stack_position": 0,
+              "width": 1024
+            }
+          ]
+        }
+      },
+      "UpdateTokenRequest": {
+        "properties": {
+          "watermark": {
+            "type": "boolean",
+            "title": "Watermark"
+          }
+        },
+        "type": "object",
+        "required": [
+          "watermark"
+        ],
+        "title": "UpdateTokenRequest"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "config",
+      "description": "User configuration, auth helpers, worker progress and server config utilities."
+    },
+    {
+      "name": "characters",
+      "description": "Character CRUD, summaries, reference pictures and face assignment endpoints."
+    },
+    {
+      "name": "picture_sets",
+      "description": "Picture set CRUD and picture membership management."
+    },
+    {
+      "name": "tags",
+      "description": "Tag management for pictures, faces"
+    },
+    {
+      "name": "stacks",
+      "description": "Stack creation, ordering and membership operations."
+    },
+    {
+      "name": "pictures",
+      "description": "Picture listing, metadata, thumbnails, import/export and media operations."
+    },
+    {
+      "name": "comfyui",
+      "description": "ComfyUI workflow management and image-to-image execution."
+    },
+    {
+      "name": "projects",
+      "description": "Project management, including character/set scoping and file attachments."
+    },
+    {
+      "name": "taggers",
+      "description": "Tagger plugin registry, artifact downloads and deletion."
+    }
+  ]
+}


### PR DESCRIPTION
Automated website update triggered by release **v1.4.0rc1**.

Changes included:
- `website/api/v{major}.{minor}/` — versioned OpenAPI docs generated
  from the release tag's own backend code.
- `website/latest-version.json` — updated to this release (if it is
  strictly newer than the currently published version; skipped otherwise).
  The `[Security: ...]` tag was taken from the release tag's own `CHANGELOG.md`.