### PR TITLE
chore: release v1.4.2 website update

### DIFF
--- a/website/api/index.html
+++ b/website/api/index.html
@@ -3,14 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>PixlStash API Reference</title>
+    <meta http-equiv="refresh" content="0; url=./v1.4/" />
     <link rel="canonical" href="./v1.4/" />
-    <script>
-      // Preserve any deep-link hash (e.g. #tag/pictures) through the redirect.
-      location.replace("./v1.4/" + (location.hash || ""));
-    </script>
-    <noscript>
-      <meta http-equiv="refresh" content="0; url=./v1.4/" />
-    </noscript>
   </head>
   <body>
     <p>Redirecting to the latest API reference

--- a/website/api/v1.4/index.html
+++ b/website/api/v1.4/index.html
@@ -1,90 +1,12 @@
 <!doctype html>
-<html lang="en">
+<html>
   <head>
     <title>PixlStash API Reference</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
-    <style>
-      /* With the developer-tools toolbar disabled the top header strip is
-         empty, but Scalar still reserves its height — collapse it so the
-         content title sits at the top of the page. */
-      :root,
-      .scalar-app,
-      .dark-mode {
-        --scalar-header-height: 0px !important;
-      }
-      /* Every Scalar ``.section`` carries generous vertical padding to space
-         sections apart; on the first one (the introduction) that top padding
-         becomes ~90px of dead space above the title. Trim it to 12px for the
-         intro only (matching the sidebar's top inset; other sections keep
-         their spacing), and tighten the section's ``gap-12`` flex gap. */
-      .scalar-app section.introduction-section {
-        padding-top: 12px !important;
-        gap: 1rem !important;
-      }
-      .scalar-app section.introduction-section > .section-content {
-        padding-top: 0 !important;
-        margin-top: 0 !important;
-      }
-      /* The main column wrapper ships ``padding: 0 60px``, leaving a wide gap
-         between the sidebar and the content. Tighten the horizontal inset. */
-      .scalar-app .section-container {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-      }
-      .dark-mode {
-        --scalar-font: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif !important;
-        --scalar-font-code: 'IBM Plex Mono', ui-monospace, monospace !important;
-        --scalar-background-1: #2a2f36 !important;
-        --scalar-background-2: #2b3138 !important;
-        --scalar-background-3: #313337 !important;
-        --scalar-background-accent: rgba(142, 166, 4, 0.16) !important;
-        --scalar-color-1: #f2e5da !important;
-        --scalar-color-2: rgba(242, 229, 218, 0.72) !important;
-        --scalar-color-3: rgba(242, 229, 218, 0.5) !important;
-        --scalar-color-accent: #8ea604 !important;
-        --scalar-border-color: #3a4047 !important;
-      }
-      .dark-mode .sidebar {
-        --scalar-sidebar-background-1: #1f2328 !important;
-        --scalar-sidebar-color-1: #f2e5da !important;
-        --scalar-sidebar-color-2: rgba(242, 229, 218, 0.7) !important;
-        --scalar-sidebar-border-color: #3a4047 !important;
-        --scalar-sidebar-item-hover-background: rgba(255, 255, 255, 0.06) !important;
-        --scalar-sidebar-item-hover-color: #f2e5da !important;
-        --scalar-sidebar-item-active-background: rgba(142, 166, 4, 0.16) !important;
-        --scalar-sidebar-color-active: #8ea604 !important;
-        --scalar-sidebar-search-background: #2b3138 !important;
-        --scalar-sidebar-search-border-color: #3a4047 !important;
-        --scalar-sidebar-search--color: rgba(242, 229, 218, 0.6) !important;
-      }
-      /* Float the logo (rendered from the OpenAPI description) so the intro
-         heading and paragraphs flow around it — Scalar's markdown sanitizer
-         strips inline style attributes, so we target the image by src here. */
-      img[src$="scalar-assets/logo.png"] {
-        float: right !important;
-        margin: 0 0 16px 24px !important;
-        max-width: 120px;
-      }
-      /* Make the markdown divider (`---`) end the logo's float so the Quick
-         start block never wraps beside it. */
-      hr {
-        clear: both !important;
-      }
-    </style>
   </head>
   <body>
-    <script
-      id="api-reference"
-      data-url="openapi.json"
-      data-configuration='{"forceDarkModeState": "dark", "hideDarkModeToggle": true, "hideModels": true, "persistAuth": true, "showDeveloperTools": "never", "authentication": {"preferredSecurityScheme": "bearerAuth", "securitySchemes": {"bearerAuth": {"token": "MWPcUXbn2pRCt-RKYsRsDnkaC6EANar794qXaLwlQwE"}}}, "servers": [{"url": "https://demo.pixlstash.dev", "description": "PixlStash demo server"}]}'
-    ></script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <redoc spec-url="openapi.json"></redoc>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
   </body>
 </html>

--- a/website/api/v1.4/openapi.json
+++ b/website/api/v1.4/openapi.json
@@ -2,578 +2,160 @@
   "openapi": "3.1.0",
   "info": {
     "title": "PixlStash API",
-    "description": "<a href=\"https://pixlstash.dev\" target=\"_blank\" rel=\"noopener\">\n  <img\n    src=\"scalar-assets/logo.png\"\n    alt=\"PixlStash\"\n    width=\"120\"\n    style=\"float: right; margin: 0 0 16px 24px\"\n  />\n</a>\n\n# Simplify your image workflow\n\n**PixlStash is a self-hosted, open-source image library for creators.** It imports your\npictures and videos, auto-tags and captions them with local AI models, recognises\ncharacters and faces, scores image quality, runs natural-language semantic search and\ndrives ComfyUI workflows \u2014 all on your own hardware, with no cloud and no lock-in.\n\n**Integrate with scripts, pipelines and external tools** \u2014 fetch images, metadata, tags and\nmore. This REST API exposes everything the app can do \u2014 **pictures, tags, stacks, sets,\ncharacters and projects** \u2014 so you can script imports, build integrations and automate your pipeline.\n\n### \u2192 Learn more and download at **[pixlstash.dev](https://pixlstash.dev)**\n\n<div style=\"clear: both\"></div>\n\n---\n\n## What can you do with this?\n\nDrive any tool or pipeline you can script. For a worked example, see the\n[**PixlStash LM Studio plugin**](https://github.com/pikselkroken/pixlstash-lmstudio) \u2014\nit uses this API to let a locally-running LLM illustrate its chat replies with\nmatching pictures from your PixlStash library.\n\n## Quick start\n\nCreate an API token (steps below), then fetch your first 50 pictures \u2014 replace\n`your-pixlstash-host` with your server's address:\n\n```bash\ncurl \"https://your-pixlstash-host/api/v1/pictures?limit=50\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n```\n\n## Authentication\n\nEvery request authenticates with a personal **API token**, sent as a Bearer header:\n\n```http\nAuthorization: Bearer YOUR_TOKEN\n```\n\nTokens have one of two access types:\n\n| Access type | Can do | Notes |\n| --- | --- | --- |\n| **Full access** | Read **and** write \u2014 everything your account can do | Never put a full-access token in a URL |\n| **Read-only** | `GET` requests only | May also be passed as a `?token=\u2026` query parameter (handy for share links) |\n\n## Creating a token\n\n**1. Open Settings** \u2014 click the gear icon in the top toolbar.\n\n![Open Settings from the top toolbar](scalar-assets/WhereIsUserSettings.jpg)\n\n**2. Open the *Account Settings* tab.**\n\n![The Account Settings tab](scalar-assets/ScreenshotsUserSettings.jpg)\n\n**3. Create the token** \u2014 in the **API Tokens** section, type a description, choose an\naccess type (*Full access* or *Read-only*), optionally tick *Apply watermark*, then click\n**Create Token**.\n\n![The API Tokens section in Account Settings](scalar-assets/ScreenshotTokens.jpg)\n\n**4. Copy it now** \u2014 the token is shown **only once**. Copy it and store it somewhere safe;\nyou won't be able to see it again.\n\n![Copy the newly created token](scalar-assets/ScreenshotToken.jpg)\n\n## Using the token\n\nThe API is served under `/api/v1`. Send your token in the `Authorization` header on every\nrequest, replacing `your-pixlstash-host` with the address of your PixlStash server. To\nconfirm a token is valid:\n\n```bash\ncurl https://your-pixlstash-host/api/v1/check-session \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n```\n\nA **read-only** token may instead be passed in the query string for quick read requests\n(never do this with a full-access token):\n\n```bash\ncurl \"https://your-pixlstash-host/api/v1/pictures?limit=50&token=YOUR_READ_TOKEN\"\n```\n\nBrowse the endpoints below for full request and response details.\n",
-    "version": "1.4.1"
+    "description": "PixlStash backend API for picture management, tagging, stacks, sets, character workflows and ComfyUI integration.",
+    "version": "1.4.2"
   },
   "paths": {
-    "/api/v1/pictures": {
+    "/": {
       "get": {
-        "tags": [
-          "pictures"
-        ],
-        "summary": "List pictures",
-        "description": "Lists pictures with filtering, sort, pagination, and optional grid field projection.",
-        "operationId": "list_pictures_api_v1_pictures_get",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Sort mechanism. One of: DATE, IMPORTED_AT, SCORE, SMART_SCORE, IMAGE_SIZE, TEXT_CONTENT, CHARACTER_LIKENESS. Omit for natural (id) order.",
-              "examples": [
-                "DATE"
-              ],
-              "title": "Sort"
-            },
-            "description": "Sort mechanism. One of: DATE, IMPORTED_AT, SCORE, SMART_SCORE, IMAGE_SIZE, TEXT_CONTENT, CHARACTER_LIKENESS. Omit for natural (id) order."
-          },
-          {
-            "name": "descending",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Sort direction; true = newest/highest first.",
-              "title": "Descending"
-            },
-            "description": "Sort direction; true = newest/highest first."
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "description": "Number of rows to skip (pagination).",
-              "title": "Offset"
-            },
-            "description": "Number of rows to skip (pagination)."
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "description": "Maximum rows to return.",
-              "examples": [
-                200
-              ],
-              "title": "Limit"
-            },
-            "description": "Maximum rows to return."
-          },
-          {
-            "name": "fields",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Field projection: 'grid' for the minimal grid set, a comma-separated field list, or omit for full metadata.",
-              "examples": [
-                "grid"
-              ],
-              "title": "Fields"
-            },
-            "description": "Field projection: 'grid' for the minimal grid set, a comma-separated field list, or omit for full metadata."
-          },
-          {
-            "name": "project_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by project id or 'UNASSIGNED'",
-              "examples": [
-                "UNASSIGNED"
-              ],
-              "title": "Project Id"
-            },
-            "description": "Filter by project id or 'UNASSIGNED'"
-          },
-          {
-            "name": "only_deleted",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP.",
-              "title": "Only Deleted"
-            },
-            "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP."
-          },
-          {
-            "name": "character_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Character filter: a character id, or 'UNASSIGNED'.",
-              "examples": [
-                "42"
-              ],
-              "title": "Character Id"
-            },
-            "description": "Character filter: a character id, or 'UNASSIGNED'."
-          },
-          {
-            "name": "character_ids",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Multi-character filter (repeatable).",
-              "title": "Character Ids"
-            },
-            "description": "Multi-character filter (repeatable)."
-          },
-          {
-            "name": "character_mode",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "union | intersection | difference | xor",
-              "title": "Character Mode"
-            },
-            "description": "union | intersection | difference | xor"
-          },
-          {
-            "name": "set_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Single picture-set filter.",
-              "title": "Set Id"
-            },
-            "description": "Single picture-set filter."
-          },
-          {
-            "name": "set_ids",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Multi-set filter (repeatable).",
-              "title": "Set Ids"
-            },
-            "description": "Multi-set filter (repeatable)."
-          },
-          {
-            "name": "set_mode",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "union | intersection | difference",
-              "title": "Set Mode"
-            },
-            "description": "union | intersection | difference"
-          },
-          {
-            "name": "base_set_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Base set for set_mode=difference.",
-              "title": "Base Set Id"
-            },
-            "description": "Base set for set_mode=difference."
-          },
-          {
-            "name": "reference_character_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Required reference for sort=CHARACTER_LIKENESS.",
-              "title": "Reference Character Id"
-            },
-            "description": "Required reference for sort=CHARACTER_LIKENESS."
-          },
-          {
-            "name": "min_score",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Minimum star score.",
-              "examples": [
-                3
-              ],
-              "title": "Min Score"
-            },
-            "description": "Minimum star score."
-          },
-          {
-            "name": "max_score",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Maximum star score.",
-              "examples": [
-                5
-              ],
-              "title": "Max Score"
-            },
-            "description": "Maximum star score."
-          },
-          {
-            "name": "smart_score_bucket",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5",
-              "title": "Smart Score Bucket"
-            },
-            "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5"
-          },
-          {
-            "name": "resolution_bucket",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus",
-              "title": "Resolution Bucket"
-            },
-            "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus"
-          },
-          {
-            "name": "file_path_prefix",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Restrict to file paths starting with this prefix.",
-              "title": "File Path Prefix"
-            },
-            "description": "Restrict to file paths starting with this prefix."
-          },
-          {
-            "name": "face_filter",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "with_face | without_face",
-              "examples": [
-                "with_face"
-              ],
-              "title": "Face Filter"
-            },
-            "description": "with_face | without_face"
-          },
-          {
-            "name": "shared_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Only pictures shared with the current user.",
-              "title": "Shared Only"
-            },
-            "description": "Only pictures shared with the current user."
-          },
-          {
-            "name": "apply_tag_filter",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "Apply the user's hidden-tag filter.",
-              "title": "Apply Tag Filter"
-            },
-            "description": "Apply the user's hidden-tag filter."
-          },
-          {
-            "name": "format",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Filter by file format (repeatable).",
-              "title": "Format"
-            },
-            "description": "Filter by file format (repeatable)."
-          },
-          {
-            "name": "tag",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Require these tags (repeatable).",
-              "examples": [
-                "sunset"
-              ],
-              "title": "Tag"
-            },
-            "description": "Require these tags (repeatable)."
-          },
-          {
-            "name": "rejected_tag",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Exclude these tags (repeatable).",
-              "title": "Rejected Tag"
-            },
-            "description": "Exclude these tags (repeatable)."
-          },
-          {
-            "name": "tag_confidence_above",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "'tag:threshold' prediction filter (repeatable).",
-              "title": "Tag Confidence Above"
-            },
-            "description": "'tag:threshold' prediction filter (repeatable)."
-          },
-          {
-            "name": "tag_confidence_below",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "'tag:threshold' prediction filter (repeatable).",
-              "title": "Tag Confidence Below"
-            },
-            "description": "'tag:threshold' prediction filter (repeatable)."
-          },
-          {
-            "name": "comfyui_model",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Filter by ComfyUI model (repeatable).",
-              "title": "Comfyui Model"
-            },
-            "description": "Filter by ComfyUI model (repeatable)."
-          },
-          {
-            "name": "comfyui_lora",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Filter by ComfyUI LoRA (repeatable).",
-              "title": "Comfyui Lora"
-            },
-            "description": "Filter by ComfyUI LoRA (repeatable)."
-          },
-          {
-            "name": "reference_folder_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by reference-folder id.",
-              "title": "Reference Folder Id"
-            },
-            "description": "Filter by reference-folder id."
-          },
-          {
-            "name": "import_source_folder",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by import source folder.",
-              "title": "Import Source Folder"
-            },
-            "description": "Filter by import source folder."
-          },
-          {
-            "name": "id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Restrict to specific picture ids (repeatable).",
-              "title": "Id"
-            },
-            "description": "Restrict to specific picture ids (repeatable)."
-          }
-        ],
+        "summary": "Read Root",
+        "operationId": "read_root__get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/GridPicture"
-                  },
-                  "title": "Response List Pictures Api V1 Pictures Get"
-                },
-                "example": [
-                  {
-                    "created_at": "2026-01-14T09:30:00",
-                    "file_path": "01a43b7e-dda4-45bb-a912-2ed4b786260d.png",
-                    "format": "PNG",
-                    "height": 1536,
-                    "id": 12345,
-                    "imported_at": "2026-01-15T18:02:11",
-                    "score": 4,
-                    "smart_score": 3.87,
-                    "stack_count": 5,
-                    "stack_id": 87,
-                    "stack_position": 0,
-                    "width": 1024
-                  }
-                ]
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/version": {
+      "get": {
+        "summary": "Read Version",
+        "operationId": "read_version_version_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/favicon.ico": {
+      "get": {
+        "summary": "Favicon",
+        "operationId": "favicon_favicon_ico_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/config": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get current user config",
+        "description": "Returns the authenticated user's UI and behavior configuration payload.",
+        "operationId": "get_me_config_api_v1_users_me_config_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Update current user config",
+        "description": "Applies a partial config patch for the authenticated user and returns updated settings.",
+        "operationId": "patch_me_config_api_v1_users_me_config_patch",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/penalised-tags": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get penalised tags",
+        "description": "Returns the smart-score penalised tags for the authenticated user. Accessible to READ-scoped tokens.",
+        "operationId": "get_me_penalised_tags_api_v1_users_me_penalised_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/auth": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get auth state",
+        "description": "Returns authentication and session-related information for the current request.",
+        "operationId": "get_me_auth_api_v1_users_me_auth_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Change current user password",
+        "description": "Changes the authenticated user's password according to auth policy.",
+        "operationId": "change_me_password_api_v1_users_me_auth_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
               }
             }
           },
-          "400": {
-            "description": "Invalid sort mechanism."
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
@@ -585,35 +167,458 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
-    "/version": {
+    "/api/v1/users/me/token": {
       "get": {
         "tags": [
-          "server"
+          "config"
         ],
-        "summary": "Read Version",
-        "operationId": "read_version_version_get",
+        "summary": "List API tokens",
+        "description": "Lists personal access tokens owned by the authenticated user.",
+        "operationId": "list_me_tokens_api_v1_users_me_token_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Create API token",
+        "description": "Creates a personal access token for the authenticated user.",
+        "operationId": "create_me_token_api_v1_users_me_token_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VersionResponse"
-                },
-                "example": {
-                  "message": "string",
-                  "version": "string",
-                  "install_type": "string",
-                  "docker_variant": "string"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/token/{token_id}": {
+      "delete": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Delete API token",
+        "description": "Deletes one personal access token by id for the authenticated user.",
+        "operationId": "delete_me_token_api_v1_users_me_token__token_id__delete",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Token Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Update API token",
+        "description": "Updates mutable fields on a personal access token (currently: watermark).",
+        "operationId": "patch_me_token_api_v1_users_me_token__token_id__patch",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Token Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTokenRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/watermark": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get watermark image",
+        "description": "Returns the user's watermark as a PNG. Returns the default if no custom watermark is set.",
+        "operationId": "get_me_watermark_api_v1_users_me_watermark_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Upload custom watermark",
+        "description": "Uploads a PNG/JPEG/WebP image to use as the user's watermark.",
+        "operationId": "post_me_watermark_api_v1_users_me_watermark_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_post_me_watermark_api_v1_users_me_watermark_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Remove custom watermark",
+        "description": "Removes the user's custom watermark; the default will be used for new shares.",
+        "operationId": "delete_me_watermark_api_v1_users_me_watermark_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/shared-resource-ids": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get shared resource IDs",
+        "description": "Returns the IDs of resources of the given type that have at least one active READ share token. Accepts ?resource_type= (character, picture_set, project, picture).",
+        "operationId": "get_shared_resource_ids_api_v1_users_me_shared_resource_ids_get",
+        "parameters": [
+          {
+            "name": "resource_type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Resource Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/shared-picture-ids/batch": {
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Batch check shared picture IDs",
+        "description": "Given a list of picture IDs, returns which ones have active READ share tokens.",
+        "operationId": "batch_shared_picture_ids_api_v1_users_me_shared_picture_ids_batch_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchSharedPictureIdsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me/tokens/by-resource": {
+      "delete": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Revoke all tokens for a resource",
+        "description": "Deletes all READ tokens scoped to a specific resource (by type and id).",
+        "operationId": "revoke_tokens_for_resource_api_v1_users_me_tokens_by_resource_delete",
+        "parameters": [
+          {
+            "name": "resource_type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Resource Type"
+            }
+          },
+          {
+            "name": "resource_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Resource Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/session/context": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get session access context",
+        "description": "Returns the access scope for the current session or token. Accepts ?token= query parameter so unauthenticated share-link recipients can discover what the token grants before loading the UI.",
+        "operationId": "get_session_context_api_v1_session_context_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workers/progress": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get worker progress",
+        "description": "Returns background worker progress plus process CPU, RAM, and VRAM usage metrics.",
+        "operationId": "get_workers_progress_api_v1_workers_progress_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/server-config/watch-folders": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "List watch folders",
+        "description": "Returns watch-folder paths from import-folder records in the database.",
+        "operationId": "get_watch_folders_api_v1_server_config_watch_folders_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/server-config/filesystem-roots": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "List filesystem browser roots",
+        "description": "Returns the configured filesystem browser root paths. When non-empty, the filesystem browser is restricted to these directories. An empty list means the browser is unrestricted.",
+        "operationId": "get_filesystem_roots_api_v1_server_config_filesystem_roots_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/server-config/open": {
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Open server config location",
+        "description": "Opens the server config path in the operating system file browser.",
+        "operationId": "open_server_config_api_v1_server_config_open_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
               }
             }
           }
@@ -635,12 +640,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           },
           {
             "name": "project_id",
@@ -664,14 +665,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterSummaryResponse"
-                },
-                "example": {
-                  "character_id": 0,
-                  "image_count": 0,
-                  "thumbnail_url": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -685,12 +679,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/characters/{id}/reference_pictures": {
@@ -708,12 +697,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "responses": {
@@ -721,12 +706,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterReferencePicturesResponse"
-                },
-                "example": {
-                  "reference_picture_ids": []
-                }
+                "schema": {}
               }
             }
           },
@@ -740,12 +720,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/characters/{id}": {
@@ -763,12 +738,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "responses": {
@@ -776,20 +747,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterMutationResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "character": {
-                    "id": 0,
-                    "name": "string",
-                    "description": "string",
-                    "extra_metadata": "string",
-                    "reference_picture_set_id": 0,
-                    "project_id": 0
-                  }
-                }
+                "schema": {}
               }
             }
           },
@@ -803,12 +761,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -824,12 +777,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "responses": {
@@ -837,13 +786,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterDeleteResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "deleted_id": 0
-                }
+                "schema": {}
               }
             }
           },
@@ -857,12 +800,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "get": {
         "tags": [
@@ -878,12 +816,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "responses": {
@@ -891,25 +825,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/CharacterResponse"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "title": "Response Get Character By Id Api V1 Characters  Id  Get"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "description": "string",
-                  "extra_metadata": "string",
-                  "reference_picture_set_id": 0,
-                  "project_id": 0
-                }
+                "schema": {}
               }
             }
           },
@@ -923,12 +839,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/characters/membership": {
@@ -953,13 +864,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterMembershipResponse"
-                },
-                "example": {
-                  "character_assignments": {},
-                  "pictures_with_faces": []
-                }
+                "schema": {}
               }
             }
           },
@@ -973,12 +878,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{project_name}/characters/{character_name}": {
@@ -996,12 +896,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Project Name",
-              "examples": [
-                "example"
-              ]
-            },
-            "example": "example"
+              "title": "Project Name"
+            }
           },
           {
             "name": "character_name",
@@ -1009,12 +905,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Character Name",
-              "examples": [
-                "example"
-              ]
-            },
-            "example": "example"
+              "title": "Character Name"
+            }
           }
         ],
         "responses": {
@@ -1022,17 +914,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "description": "string",
-                  "extra_metadata": "string",
-                  "reference_picture_set_id": 0,
-                  "project_id": 0
-                }
+                "schema": {}
               }
             }
           },
@@ -1046,12 +928,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/characters/{id}/{field}": {
@@ -1069,12 +946,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           },
           {
             "name": "field",
@@ -1082,12 +955,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Field",
-              "examples": [
-                "example"
-              ]
-            },
-            "example": "example"
+              "title": "Field"
+            }
           }
         ],
         "responses": {
@@ -1095,13 +964,8 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                },
-                "example": {}
-              },
-              "image/png": {}
+                "schema": {}
+              }
             }
           },
           "422": {
@@ -1114,12 +978,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/characters": {
@@ -1162,24 +1021,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CharacterListItemResponse"
-                  },
-                  "title": "Response Get Characters Api V1 Characters Get"
-                },
-                "example": [
-                  {
-                    "id": 0,
-                    "name": "string",
-                    "description": "string",
-                    "extra_metadata": "string",
-                    "reference_picture_set_id": 0,
-                    "project_id": 0,
-                    "has_reference_faces": false
-                  }
-                ]
+                "schema": {}
               }
             }
           },
@@ -1193,12 +1035,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -1224,20 +1061,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterMutationResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "character": {
-                    "id": 0,
-                    "name": "string",
-                    "description": "string",
-                    "extra_metadata": "string",
-                    "reference_picture_set_id": 0,
-                    "project_id": 0
-                  }
-                }
+                "schema": {}
               }
             }
           },
@@ -1251,12 +1075,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/characters/{character_id}/faces": {
@@ -1274,12 +1093,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Character Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Character Id"
+            }
           }
         ],
         "requestBody": {
@@ -1299,19 +1114,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterFaceAssignmentResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "face_ids": [
-                    0
-                  ],
-                  "character_id": 0,
-                  "already_assigned_ids": [
-                    0
-                  ]
-                }
+                "schema": {}
               }
             }
           },
@@ -1325,12 +1128,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -1346,12 +1144,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Character Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Character Id"
+            }
           }
         ],
         "requestBody": {
@@ -1371,19 +1165,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CharacterFaceAssignmentResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "face_ids": [
-                    0
-                  ],
-                  "character_id": 0,
-                  "already_assigned_ids": [
-                    0
-                  ]
-                }
+                "schema": {}
               }
             }
           },
@@ -1397,17 +1179,13 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/characters/likeness-search": {
       "post": {
         "tags": [
+          "characters",
           "characters"
         ],
         "summary": "Search characters by face likeness",
@@ -1423,6 +1201,7 @@
               "maximum": 500,
               "minimum": 1,
               "description": "Maximum number of results to return.",
+              "default": 20,
               "title": "Top N"
             },
             "description": "Maximum number of results to return."
@@ -1436,6 +1215,7 @@
               "maximum": 2000,
               "minimum": 0,
               "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`.",
+              "default": 0,
               "title": "Pool M"
             },
             "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`."
@@ -1447,6 +1227,7 @@
             "schema": {
               "type": "boolean",
               "description": "When true, return a random sample from the top-M pool.",
+              "default": false,
               "title": "Random"
             },
             "description": "When true, return a random sample from the top-M pool."
@@ -1460,6 +1241,7 @@
               "maximum": 1.0,
               "minimum": 0.0,
               "description": "Minimum similarity score required to include a result.",
+              "default": 0.0,
               "title": "Threshold"
             },
             "description": "Minimum similarity score required to include a result."
@@ -1471,6 +1253,7 @@
             "schema": {
               "type": "string",
               "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean.",
+              "default": "mean",
               "title": "Combine"
             },
             "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean."
@@ -1491,19 +1274,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CharacterLikenessResultResponse"
-                  },
-                  "title": "Response Search By Character Likeness Api V1 Characters Likeness Search Post"
-                },
-                "example": [
-                  {
-                    "character_id": 0,
-                    "likeness": 0.0
-                  }
-                ]
+                "schema": {}
               }
             }
           },
@@ -1517,12 +1288,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/picture_sets": {
@@ -1556,28 +1322,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PictureSetResponse"
-                  },
-                  "title": "Response Get Picture Sets Api V1 Picture Sets Get"
-                },
-                "example": [
-                  {
-                    "id": 0,
-                    "name": "string",
-                    "description": "string",
-                    "project_id": 0,
-                    "set_icon": "string",
-                    "set_color": "string",
-                    "picture_count": 0,
-                    "top_picture_ids": [
-                      0
-                    ],
-                    "thumbnail_url": "string"
-                  }
-                ]
+                "schema": {}
               }
             }
           },
@@ -1591,12 +1336,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -1622,13 +1362,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetCreateResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "picture_set": {}
-                }
+                "schema": {}
               }
             }
           },
@@ -1642,12 +1376,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{project_name}/picture_sets/{picture_set_name}": {
@@ -1665,12 +1394,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Project Name",
-              "examples": [
-                "example"
-              ]
-            },
-            "example": "example"
+              "title": "Project Name"
+            }
           },
           {
             "name": "picture_set_name",
@@ -1678,12 +1403,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Picture Set Name",
-              "examples": [
-                "example"
-              ]
-            },
-            "example": "example"
+              "title": "Picture Set Name"
+            }
           }
         ],
         "responses": {
@@ -1691,22 +1412,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "description": "string",
-                  "project_id": 0,
-                  "set_icon": "string",
-                  "set_color": "string",
-                  "picture_count": 0,
-                  "top_picture_ids": [
-                    0
-                  ],
-                  "thumbnail_url": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -1720,12 +1426,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/picture_sets/membership": {
@@ -1750,12 +1451,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Batch Membership Api V1 Picture Sets Membership Post"
-                },
-                "example": {}
+                "schema": {}
               }
             }
           },
@@ -1769,12 +1465,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/picture_sets/{id}/thumbnail": {
@@ -1792,19 +1483,17 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
-              "image/png": {}
+              "application/json": {
+                "schema": {}
+              }
             }
           },
           "422": {
@@ -1817,12 +1506,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/picture_sets/{id}": {
@@ -1840,12 +1524,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           },
           {
             "name": "info",
@@ -1853,6 +1533,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": false,
               "title": "Info"
             }
           },
@@ -1871,6 +1552,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": true,
               "title": "Descending"
             }
           },
@@ -2013,6 +1695,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": false,
               "title": "Expand Stacks"
             }
           }
@@ -2022,34 +1705,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetPicturesResponse"
-                },
-                "example": {
-                  "pictures": [
-                    {}
-                  ],
-                  "set": {
-                    "id": 0,
-                    "name": "string",
-                    "description": "string",
-                    "project_id": 0,
-                    "set_icon": "string",
-                    "set_color": "string",
-                    "picture_count": 0,
-                    "top_picture_ids": [
-                      0
-                    ],
-                    "thumbnail_url": "string"
-                  },
-                  "id": 0,
-                  "name": "string",
-                  "description": "string",
-                  "project_id": 0,
-                  "set_icon": "string",
-                  "set_color": "string",
-                  "picture_count": 0
-                }
+                "schema": {}
               }
             }
           },
@@ -2063,12 +1719,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "patch": {
         "tags": [
@@ -2084,12 +1735,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "requestBody": {
@@ -2109,12 +1756,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetUpdateResponse"
-                },
-                "example": {
-                  "status": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -2128,12 +1770,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -2149,12 +1786,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "responses": {
@@ -2162,13 +1795,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetDeleteResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "deleted_id": 0
-                }
+                "schema": {}
               }
             }
           },
@@ -2182,12 +1809,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/picture_sets/{id}/members": {
@@ -2205,12 +1827,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           },
           {
             "name": "include_deleted",
@@ -2218,6 +1836,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": false,
               "title": "Include Deleted"
             }
           },
@@ -2227,6 +1846,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": false,
               "title": "Expand Stacks"
             }
           }
@@ -2236,14 +1856,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetMembersResponse"
-                },
-                "example": {
-                  "picture_ids": [
-                    0
-                  ]
-                }
+                "schema": {}
               }
             }
           },
@@ -2257,12 +1870,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -2278,12 +1886,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "requestBody": {
@@ -2303,13 +1907,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetBulkAddResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "added": 0
-                }
+                "schema": {}
               }
             }
           },
@@ -2323,12 +1921,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -2344,12 +1937,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "requestBody": {
@@ -2369,13 +1958,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetBulkReplaceResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "members": 0
-                }
+                "schema": {}
               }
             }
           },
@@ -2389,12 +1972,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/picture_sets/{id}/members/{picture_id}": {
@@ -2412,12 +1990,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           },
           {
             "name": "picture_id",
@@ -2425,12 +1999,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Picture Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Picture Id"
+            }
           }
         ],
         "responses": {
@@ -2438,12 +2008,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetAddPictureResponse"
-                },
-                "example": {
-                  "status": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -2457,12 +2022,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -2478,12 +2038,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           },
           {
             "name": "picture_id",
@@ -2491,12 +2047,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Picture Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Picture Id"
+            }
           }
         ],
         "responses": {
@@ -2504,12 +2056,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureSetRemovePictureResponse"
-                },
-                "example": {
-                  "status": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -2523,12 +2070,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects": {
@@ -2549,26 +2091,11 @@
                   },
                   "type": "array",
                   "title": "Response List Projects Api V1 Projects Get"
-                },
-                "example": [
-                  {
-                    "id": 0,
-                    "name": "string",
-                    "description": "string",
-                    "cover_image_path": "string",
-                    "extra_metadata": "string",
-                    "created_at": "2026-01-01T00:00:00Z"
-                  }
-                ]
+                }
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -2593,14 +2120,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProjectResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "description": "string",
-                  "cover_image_path": "string",
-                  "extra_metadata": "string",
-                  "created_at": "2026-01-01T00:00:00Z"
                 }
               }
             }
@@ -2615,12 +2134,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/membership": {
@@ -2645,13 +2159,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProjectMembershipResponse"
-                },
-                "example": {
-                  "project_assignments": {},
-                  "unassigned_picture_ids": []
-                }
+                "schema": {}
               }
             }
           },
@@ -2665,12 +2173,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{id_or_name}/picture_sets": {
@@ -2688,12 +2191,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id Or Name",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id Or Name"
+            }
           }
         ],
         "responses": {
@@ -2701,21 +2200,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ProjectPictureSetResponse"
-                  },
-                  "title": "Response List Project Picture Sets Api V1 Projects  Id Or Name  Picture Sets Get"
-                },
-                "example": [
-                  {
-                    "id": 0,
-                    "name": "string",
-                    "description": "string",
-                    "project_id": 0
-                  }
-                ]
+                "schema": {}
               }
             }
           },
@@ -2729,12 +2214,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{id_or_name}": {
@@ -2752,12 +2232,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id Or Name",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id Or Name"
+            }
           }
         ],
         "responses": {
@@ -2767,14 +2243,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProjectResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "description": "string",
-                  "cover_image_path": "string",
-                  "extra_metadata": "string",
-                  "created_at": "2026-01-01T00:00:00Z"
                 }
               }
             }
@@ -2789,12 +2257,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{project_id}": {
@@ -2811,12 +2274,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Project Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Project Id"
+            }
           }
         ],
         "requestBody": {
@@ -2836,14 +2295,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProjectResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "description": "string",
-                  "cover_image_path": "string",
-                  "extra_metadata": "string",
-                  "created_at": "2026-01-01T00:00:00Z"
                 }
               }
             }
@@ -2858,12 +2309,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -2879,12 +2325,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Project Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Project Id"
+            }
           }
         ],
         "responses": {
@@ -2894,10 +2336,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProjectDeleteResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "id": 0
                 }
               }
             }
@@ -2912,12 +2350,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{project_id}/summary": {
@@ -2935,12 +2368,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Project Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Project Id"
+            }
           }
         ],
         "responses": {
@@ -2950,9 +2379,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProjectSummaryResponse"
-                },
-                "example": {
-                  "image_count": 0
                 }
               }
             }
@@ -2967,12 +2393,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{project_id}/export": {
@@ -2990,12 +2411,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Project Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Project Id"
+            }
           },
           {
             "name": "include_pictures",
@@ -3003,6 +2420,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": true,
               "title": "Include Pictures"
             }
           },
@@ -3012,6 +2430,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": true,
               "title": "Include Attachments"
             }
           }
@@ -3020,7 +2439,9 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/zip": {}
+              "application/json": {
+                "schema": {}
+              }
             }
           },
           "422": {
@@ -3033,12 +2454,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{project_id}/attachments": {
@@ -3055,12 +2471,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Project Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Project Id"
+            }
           }
         ],
         "responses": {
@@ -3074,17 +2486,7 @@
                     "$ref": "#/components/schemas/ProjectAttachmentResponse"
                   },
                   "title": "Response List Attachments Api V1 Projects  Project Id  Attachments Get"
-                },
-                "example": [
-                  {
-                    "id": 0,
-                    "original_filename": "string",
-                    "mime_type": "string",
-                    "file_size": 0,
-                    "url": "string",
-                    "created_at": "2026-01-01T00:00:00Z"
-                  }
-                ]
+                }
               }
             }
           },
@@ -3098,12 +2500,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -3118,12 +2515,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Project Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Project Id"
+            }
           }
         ],
         "requestBody": {
@@ -3143,14 +2536,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProjectAttachmentResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "original_filename": "string",
-                  "mime_type": "string",
-                  "file_size": 0,
-                  "url": "string",
-                  "created_at": "2026-01-01T00:00:00Z"
                 }
               }
             }
@@ -3165,12 +2550,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{project_id}/attachments/url": {
@@ -3187,12 +2567,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Project Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Project Id"
+            }
           }
         ],
         "requestBody": {
@@ -3212,14 +2588,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProjectAttachmentResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "original_filename": "string",
-                  "mime_type": "string",
-                  "file_size": 0,
-                  "url": "string",
-                  "created_at": "2026-01-01T00:00:00Z"
                 }
               }
             }
@@ -3234,12 +2602,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/projects/{project_id}/attachments/{attachment_id}": {
@@ -3256,12 +2619,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Project Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Project Id"
+            }
           },
           {
             "name": "attachment_id",
@@ -3269,19 +2628,17 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Attachment Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Attachment Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/octet-stream": {}
+              "application/json": {
+                "schema": {}
+              }
             }
           },
           "422": {
@@ -3294,12 +2651,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -3314,12 +2666,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Project Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Project Id"
+            }
           },
           {
             "name": "attachment_id",
@@ -3327,12 +2675,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Attachment Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Attachment Id"
+            }
           }
         ],
         "responses": {
@@ -3342,10 +2686,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProjectDeleteResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "id": 0
                 }
               }
             }
@@ -3360,12 +2700,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/{id}/tags": {
@@ -3383,12 +2718,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           }
         ],
         "requestBody": {
@@ -3408,13 +2739,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureTagsResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "tags": []
-                }
+                "schema": {}
               }
             }
           },
@@ -3428,12 +2753,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "get": {
         "tags": [
@@ -3449,12 +2769,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           }
         ],
         "responses": {
@@ -3462,13 +2778,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListPictureTagsResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "tags": []
-                }
+                "schema": {}
               }
             }
           },
@@ -3482,12 +2792,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -3503,12 +2808,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           }
         ],
         "responses": {
@@ -3516,13 +2817,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureTagsResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "tags": []
-                }
+                "schema": {}
               }
             }
           },
@@ -3536,12 +2831,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/{id}/tags/{tag_id}": {
@@ -3559,12 +2849,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           },
           {
             "name": "tag_id",
@@ -3572,12 +2858,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Tag Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Tag Id"
+            }
           }
         ],
         "responses": {
@@ -3585,13 +2867,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureTagsResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "tags": []
-                }
+                "schema": {}
               }
             }
           },
@@ -3605,12 +2881,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/{id}/tags/remove_all": {
@@ -3628,12 +2899,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           }
         ],
         "requestBody": {
@@ -3653,13 +2920,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureTagsResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "tags": []
-                }
+                "schema": {}
               }
             }
           },
@@ -3673,12 +2934,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/tags": {
@@ -3694,28 +2950,11 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/TagCountResponse"
-                  },
-                  "type": "array",
-                  "title": "Response List All Tags Api V1 Tags Get"
-                },
-                "example": [
-                  {
-                    "tag": "string",
-                    "count": 0
-                  }
-                ]
+                "schema": {}
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/tags/bulk_fetch": {
@@ -3741,19 +2980,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/BulkPictureTagsResponse"
-                  },
-                  "type": "array",
-                  "title": "Response Bulk Fetch Tags Api V1 Pictures Tags Bulk Fetch Post"
-                },
-                "example": [
-                  {
-                    "id": 0,
-                    "tags": []
-                  }
-                ]
+                "schema": {}
               }
             }
           },
@@ -3767,12 +2994,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/stacks/{stack_id}": {
@@ -3790,12 +3012,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Stack Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Stack Id"
+            }
           }
         ],
         "responses": {
@@ -3803,20 +3021,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StackResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "created_at": "2026-01-01T00:00:00Z",
-                  "updated_at": "2026-01-01T00:00:00Z",
-                  "picture_ids": [
-                    0
-                  ],
-                  "stack_id": 0,
-                  "status": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -3830,12 +3035,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/stacks/{stack_id}/pictures": {
@@ -3853,12 +3053,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Stack Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Stack Id"
+            }
           },
           {
             "name": "fields",
@@ -3866,6 +3062,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "default": "grid",
               "title": "Fields"
             }
           },
@@ -3875,6 +3072,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": false,
               "title": "Include Deleted"
             }
           },
@@ -3900,6 +3098,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": true,
               "title": "Descending"
             }
           }
@@ -3909,17 +3108,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": true
-                  },
-                  "title": "Response Get Stack Pictures Api V1 Stacks  Stack Id  Pictures Get"
-                },
-                "example": [
-                  {}
-                ]
+                "schema": {}
               }
             }
           },
@@ -3933,12 +3122,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/{picture_id}/stack": {
@@ -3956,12 +3140,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Picture Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Picture Id"
+            }
           }
         ],
         "responses": {
@@ -3969,20 +3149,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StackResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "created_at": "2026-01-01T00:00:00Z",
-                  "updated_at": "2026-01-01T00:00:00Z",
-                  "picture_ids": [
-                    0
-                  ],
-                  "stack_id": 0,
-                  "status": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -3996,12 +3163,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/stacks": {
@@ -4029,20 +3191,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StackResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "created_at": "2026-01-01T00:00:00Z",
-                  "updated_at": "2026-01-01T00:00:00Z",
-                  "picture_ids": [
-                    0
-                  ],
-                  "stack_id": 0,
-                  "status": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -4056,12 +3205,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/stacks/{stack_id}/order": {
@@ -4079,12 +3223,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Stack Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Stack Id"
+            }
           }
         ],
         "requestBody": {
@@ -4104,15 +3244,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StackOrderResponse"
-                },
-                "example": {
-                  "stack_id": 0,
-                  "picture_ids": [
-                    0
-                  ]
-                }
+                "schema": {}
               }
             }
           },
@@ -4126,12 +3258,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/stacks/{stack_id}/members": {
@@ -4149,12 +3276,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Stack Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Stack Id"
+            }
           }
         ],
         "requestBody": {
@@ -4174,20 +3297,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StackResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "created_at": "2026-01-01T00:00:00Z",
-                  "updated_at": "2026-01-01T00:00:00Z",
-                  "picture_ids": [
-                    0
-                  ],
-                  "stack_id": 0,
-                  "status": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -4201,12 +3311,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -4222,12 +3327,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Stack Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Stack Id"
+            }
           }
         ],
         "requestBody": {
@@ -4247,20 +3348,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StackResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "name": "string",
-                  "created_at": "2026-01-01T00:00:00Z",
-                  "updated_at": "2026-01-01T00:00:00Z",
-                  "picture_ids": [
-                    0
-                  ],
-                  "stack_id": 0,
-                  "status": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -4274,12 +3362,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/stacks/{stack_id}/members/{picture_id}": {
@@ -4297,12 +3380,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Stack Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Stack Id"
+            }
           },
           {
             "name": "picture_id",
@@ -4310,12 +3389,8 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Picture Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Picture Id"
+            }
           }
         ],
         "requestBody": {
@@ -4335,15 +3410,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StackOrderResponse"
-                },
-                "example": {
-                  "stack_id": 0,
-                  "picture_ids": [
-                    0
-                  ]
-                }
+                "schema": {}
               }
             }
           },
@@ -4357,12 +3424,409 @@
               }
             }
           }
-        },
-        "security": [
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tag_predictions": {
+      "get": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Get tag predictions for a picture",
+        "description": "Returns all stored tag predictions for the given picture, ordered by confidence descending.  Use the ``status`` query param to filter by ``PENDING``, ``CONFIRMED``, or ``REJECTED``.",
+        "operationId": "get_tag_predictions_api_v1_pictures__id__tag_predictions_get",
+        "parameters": [
           {
-            "bearerAuth": []
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "include_meta",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Meta"
+            }
           }
-        ]
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tag_predictions/{tag}/confirm": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Confirm a tag prediction",
+        "description": "Marks the prediction as CONFIRMED and ensures a corresponding row exists in the Tag table.  Emits a CHANGED_PICTURES event.",
+        "operationId": "confirm_tag_prediction_api_v1_pictures__id__tag_predictions__tag__confirm_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tag"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tag_predictions/{tag}/reject": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Reject a tag prediction",
+        "description": "Marks the prediction as REJECTED.  Does not modify the Tag table.",
+        "operationId": "reject_tag_prediction_api_v1_pictures__id__tag_predictions__tag__reject_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tag"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/tag_predictions/delete": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Delete tag predictions for a picture",
+        "description": "Deletes all TagPrediction rows for the picture except those with model_version='manual' (user-rejected tags), so the background tagger treats it as never seen and rebuilds predictions from scratch.",
+        "operationId": "delete_tag_predictions_api_v1_pictures__id__tag_predictions_delete_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/reset_tags": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Reset tags and predictions for a picture",
+        "description": "Atomically deletes all non-manual TagPrediction rows and all Tag rows for the picture, then restores the pending-retag sentinel.  This is the single-round-trip equivalent of calling tag_predictions/delete followed by DELETE tags \u2014 it avoids the intermediate state where predictions are gone but tags still exist, which otherwise tricks the background MissingTagFinder into running a wasted inference pass.",
+        "operationId": "reset_picture_tags_api_v1_pictures__id__reset_tags_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ResetTagsRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/reset_description": {
+      "post": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Reset description for a picture",
+        "description": "Clears the picture's description field and queues a new description inference pass.  Pass a 'model' field in the request body to override which description plugin to use for this specific picture.",
+        "operationId": "reset_picture_description_api_v1_pictures__id__reset_description_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ResetTagsRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tagger/label-thresholds": {
+      "get": {
+        "tags": [
+          "tag_predictions"
+        ],
+        "summary": "Get per-label thresholds for the PixlStash tagger",
+        "description": "Returns each label's base threshold and the effective threshold after applying the current user offset. Results are sorted alphabetically.",
+        "operationId": "get_label_thresholds_api_v1_tagger_label_thresholds_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/guest-scores": {
+      "get": {
+        "tags": [
+          "guest_scores"
+        ],
+        "summary": "Get Guest Scores",
+        "description": "Return all scores submitted by this guest session.\n\nRequires a READ-scoped token.  The guest_session cookie must be present\nand valid (resolved by auth_middleware into request.state.guest_session_id).\n\nReturns:\n    A JSON object ``{\"scores\": {\"<picture_id>\": <score>, ...}}``.",
+        "operationId": "get_guest_scores_api_v1_pictures_guest_scores_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "guest_scores"
+        ],
+        "summary": "Submit Guest Scores",
+        "description": "Submit or update star scores for one or more pictures.\n\nThis is the sole write endpoint accessible to READ-scoped tokens.\n\nRequest body (JSON):\n    session_id (str): Client-generated UUID (max 64 chars, ``[A-Za-z0-9_-]``).\n    set_cookie (bool): When True the server sets persistent cookies.\n    scores (dict[str, int]): Mapping of picture_id \u2192 score (0-5).\n        At most 500 entries per request.\n\nReturns:\n    ``{\"ok\": true}`` on success.\n\nRaises:\n    400: Validation error (bad session_id, bad score value, too many entries).\n    503: Too many concurrent active guest sessions (new session refused).",
+        "operationId": "submit_guest_scores_api_v1_pictures_guest_scores_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/guest-scores/session": {
+      "delete": {
+        "tags": [
+          "guest_scores"
+        ],
+        "summary": "Clear Guest Session",
+        "description": "Clear the guest session cookies for this browser.\n\nRemoves the ``guest_session`` and ``guest_session_active`` cookies so\nthe browser starts a fresh anonymous session on the next page load.\nThe scores stored in the database are retained (they may still be used\nfor aggregate statistics); we simply sever the link between this browser\nand those scores.\n\nRequires a READ-scoped token.\n\nReturns:\n    ``{\"ok\": true}``",
+        "operationId": "clear_guest_session_api_v1_pictures_guest_scores_session_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/sort_mechanisms": {
@@ -4378,29 +3842,386 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/SortMechanismResponse"
-                  },
-                  "type": "array",
-                  "title": "Response Get Pictures Sort Mechanisms Api V1 Sort Mechanisms Get"
-                },
-                "example": [
-                  {
-                    "key": "string",
-                    "field": "string",
-                    "description": "string"
-                  }
-                ]
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/plugins": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List image plugins",
+        "description": "Lists available image plugins and their parameter schemas.",
+        "operationId": "list_picture_plugins_api_v1_pictures_plugins_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/plugins/{name}": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Run image plugin",
+        "description": "Runs a named image plugin on selected pictures and imports outputs into stacks.",
+        "operationId": "run_picture_plugin_api_v1_pictures_plugins__name__post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
               }
             }
           }
         },
-        "security": [
-          {
-            "bearerAuth": []
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
-        ]
+        }
+      }
+    },
+    "/api/v1/pictures/comfyui_models": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List distinct ComfyUI model names",
+        "operationId": "get_comfyui_models_api_v1_pictures_comfyui_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/comfyui_loras": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List distinct ComfyUI LoRA names",
+        "operationId": "get_comfyui_loras_api_v1_pictures_comfyui_loras_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/likeness-groups": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List computed likeness groups",
+        "description": "Builds groups from likeness edges using filtering options such as character, set, format, and threshold.",
+        "operationId": "get_likeness_groups_api_v1_pictures_likeness_groups_get",
+        "parameters": [
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "default": 0.0,
+              "title": "Threshold"
+            }
+          },
+          {
+            "name": "min_group_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 2,
+              "title": "Min Group Size"
+            }
+          },
+          {
+            "name": "set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Set Id"
+            }
+          },
+          {
+            "name": "set_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "title": "Set Ids"
+            }
+          },
+          {
+            "name": "set_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "union",
+              "title": "Set Mode"
+            }
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Character Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Format"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Tag"
+            }
+          },
+          {
+            "name": "rejected_tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Rejected Tag"
+            }
+          },
+          {
+            "name": "tag_confidence_above",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Tag Confidence Above"
+            }
+          },
+          {
+            "name": "tag_confidence_below",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Tag Confidence Below"
+            }
+          },
+          {
+            "name": "comfyui_model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Comfyui Model"
+            }
+          },
+          {
+            "name": "comfyui_lora",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Comfyui Lora"
+            }
+          },
+          {
+            "name": "min_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Min Score"
+            }
+          },
+          {
+            "name": "max_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Max Score"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/open-location": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Open picture location",
+        "description": "Opens the containing folder of a reference picture in the OS file manager.",
+        "operationId": "open_picture_location_api_v1_pictures__id__open_location_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/stats": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get picture statistics",
+        "description": "Returns tag statistics for the current view filter, cached for 60 seconds.",
+        "operationId": "get_picture_stats_api_v1_pictures_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/pictures/thumbnails/{id}.webp": {
@@ -4418,19 +4239,17 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "title": "Id",
-              "examples": [
-                1
-              ]
-            },
-            "example": 1
+              "title": "Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
-              "image/webp": {}
+              "application/json": {
+                "schema": {}
+              }
             }
           },
           "422": {
@@ -4443,12 +4262,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/thumbnails": {
@@ -4476,12 +4290,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Thumbnails Api V1 Pictures Thumbnails Post"
-                },
-                "example": {}
+                "schema": {}
               }
             }
           },
@@ -4495,12 +4304,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/export": {
@@ -4536,6 +4340,7 @@
             "required": false,
             "schema": {
               "type": "number",
+              "default": 0.0,
               "title": "Threshold"
             }
           },
@@ -4545,6 +4350,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "default": "description",
               "title": "Caption Mode"
             }
           },
@@ -4554,6 +4360,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": false,
               "title": "Include Character Name"
             }
           },
@@ -4563,6 +4370,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": false,
               "title": "Use Original File Names"
             }
           },
@@ -4572,6 +4380,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "default": "original",
               "title": "Resolution"
             }
           },
@@ -4581,6 +4390,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "default": "full",
               "title": "Export Type"
             }
           },
@@ -4590,6 +4400,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "default": "spaces",
               "title": "Tag Format"
             }
           }
@@ -4599,12 +4410,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExportStartResponse"
-                },
-                "example": {
-                  "task_id": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -4618,12 +4424,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/export/status": {
@@ -4650,16 +4451,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExportStatusResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "total": 0,
-                  "processed": 0,
-                  "progress": 0.0,
-                  "download_url": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -4673,12 +4465,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/export/download/{task_id}": {
@@ -4696,19 +4483,17 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Task Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Task Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/zip": {}
+              "application/json": {
+                "schema": {}
+              }
             }
           },
           "422": {
@@ -4721,12 +4506,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/search": {
@@ -4753,6 +4533,7 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "default": 0,
               "title": "Offset"
             }
           },
@@ -4762,6 +4543,7 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "default": 9223372036854775807,
               "title": "Limit"
             }
           },
@@ -4771,6 +4553,7 @@
             "required": false,
             "schema": {
               "type": "number",
+              "default": 0.5,
               "title": "Threshold"
             }
           }
@@ -4780,21 +4563,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PictureMetadataResponse"
-                  },
-                  "title": "Response Search Pictures Api V1 Pictures Search Get"
-                },
-                "example": [
-                  {
-                    "id": 0,
-                    "format": "string",
-                    "score": 0,
-                    "likeness_score": 0.0
-                  }
-                ]
+                "schema": {}
               }
             }
           },
@@ -4808,17 +4577,13 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/likeness-search": {
       "post": {
         "tags": [
+          "pictures",
           "pictures"
         ],
         "summary": "Search by image likeness",
@@ -4853,6 +4618,7 @@
                 "type": "integer"
               },
               "description": "Use the stored embeddings of these picture IDs as the query. When multiple IDs are supplied results are ranked by the minimum similarity across all sources.",
+              "default": [],
               "title": "Source Picture Ids"
             },
             "description": "Use the stored embeddings of these picture IDs as the query. When multiple IDs are supplied results are ranked by the minimum similarity across all sources."
@@ -4866,6 +4632,7 @@
               "maximum": 500,
               "minimum": 1,
               "description": "Maximum number of results to return.",
+              "default": 20,
               "title": "Top N"
             },
             "description": "Maximum number of results to return."
@@ -4879,6 +4646,7 @@
               "maximum": 2000,
               "minimum": 0,
               "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`.",
+              "default": 0,
               "title": "Pool M"
             },
             "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`."
@@ -4890,6 +4658,7 @@
             "schema": {
               "type": "boolean",
               "description": "When true, return a random sample from the top-M pool.",
+              "default": false,
               "title": "Random"
             },
             "description": "When true, return a random sample from the top-M pool."
@@ -4903,6 +4672,7 @@
               "maximum": 1.0,
               "minimum": 0.0,
               "description": "Minimum cosine similarity required to include a result.",
+              "default": 0.0,
               "title": "Threshold"
             },
             "description": "Minimum cosine similarity required to include a result."
@@ -4914,6 +4684,7 @@
             "schema": {
               "type": "string",
               "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean.",
+              "default": "mean",
               "title": "Combine"
             },
             "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean."
@@ -4964,6 +4735,7 @@
                 "type": "string"
               },
               "description": "Filter to pictures in multiple sets.",
+              "default": [],
               "title": "Set Ids"
             },
             "description": "Filter to pictures in multiple sets."
@@ -4975,6 +4747,7 @@
             "schema": {
               "type": "string",
               "description": "How to combine set filters: union, intersection, difference, xor.",
+              "default": "union",
               "title": "Set Mode"
             },
             "description": "How to combine set filters: union, intersection, difference, xor."
@@ -5012,19 +4785,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ImageLikenessMatchResponse"
-                  },
-                  "title": "Response Search By Image Likeness Api V1 Pictures Likeness Search Post"
-                },
-                "example": [
-                  {
-                    "picture_id": 0,
-                    "likeness": 0.0
-                  }
-                ]
+                "schema": {}
               }
             }
           },
@@ -5038,17 +4799,13 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/face-search": {
       "post": {
         "tags": [
+          "pictures",
           "pictures"
         ],
         "summary": "Search by face likeness",
@@ -5100,6 +4857,7 @@
               "maximum": 500,
               "minimum": 1,
               "description": "Maximum number of results to return.",
+              "default": 20,
               "title": "Top N"
             },
             "description": "Maximum number of results to return."
@@ -5113,6 +4871,7 @@
               "maximum": 2000,
               "minimum": 0,
               "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`.",
+              "default": 0,
               "title": "Pool M"
             },
             "description": "Pool size for random mode. When >0 and `random=true`, the top `pool_m` matches are collected first and then `top_n` are drawn at random. Ignored when `random=false`."
@@ -5124,6 +4883,7 @@
             "schema": {
               "type": "boolean",
               "description": "When true, return a random sample from the top-M pool.",
+              "default": false,
               "title": "Random"
             },
             "description": "When true, return a random sample from the top-M pool."
@@ -5137,6 +4897,7 @@
               "maximum": 1.0,
               "minimum": 0.0,
               "description": "Minimum similarity score required to include a result.",
+              "default": 0.0,
               "title": "Threshold"
             },
             "description": "Minimum similarity score required to include a result."
@@ -5148,6 +4909,7 @@
             "schema": {
               "type": "string",
               "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean.",
+              "default": "mean",
               "title": "Combine"
             },
             "description": "How to combine scores when multiple query images are uploaded. One of: mean, max, min, harmonic_mean, geometric_mean."
@@ -5198,6 +4960,7 @@
                 "type": "string"
               },
               "description": "Filter to pictures in multiple sets.",
+              "default": [],
               "title": "Set Ids"
             },
             "description": "Filter to pictures in multiple sets."
@@ -5209,6 +4972,7 @@
             "schema": {
               "type": "string",
               "description": "How to combine set filters: union, intersection, difference, xor.",
+              "default": "union",
               "title": "Set Mode"
             },
             "description": "How to combine set filters: union, intersection, difference, xor."
@@ -5246,19 +5010,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FaceLikenessMatchResponse"
-                  },
-                  "title": "Response Search By Face Likeness Api V1 Pictures Face Search Post"
-                },
-                "example": [
-                  {
-                    "picture_id": 0,
-                    "likeness": 0.0
-                  }
-                ]
+                "schema": {}
               }
             }
           },
@@ -5272,12 +5024,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/import": {
@@ -5302,12 +5049,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportStartResponse"
-                },
-                "example": {
-                  "task_id": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -5321,12 +5063,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/import/status": {
@@ -5353,24 +5090,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportStatusResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "stage": "string",
-                  "total": 0,
-                  "processed": 0,
-                  "progress": 0.0,
-                  "results": [
-                    {
-                      "status": "string",
-                      "picture_id": 0,
-                      "file": "string"
-                    }
-                  ],
-                  "error": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -5384,12 +5104,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/project": {
@@ -5417,17 +5132,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SetProjectForPicturesResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "project_id": 0,
-                  "mode": "string",
-                  "updated_ids": [],
-                  "updated_count": 0,
-                  "missing_ids": []
-                }
+                "schema": {}
               }
             }
           },
@@ -5441,12 +5146,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/apply-scores": {
@@ -5474,20 +5174,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApplyScoresResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "only_unscored": true,
-                  "updated_ids": [],
-                  "updated_count": 0,
-                  "skipped_ids": [],
-                  "skipped_count": 0,
-                  "missing_ids": [],
-                  "missing_count": 0,
-                  "reset_triggered": true
-                }
+                "schema": {}
               }
             }
           },
@@ -5501,12 +5188,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/{id}.{ext}": {
@@ -5524,12 +5206,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           },
           {
             "name": "ext",
@@ -5537,19 +5215,17 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Ext",
-              "examples": [
-                "jpg"
-              ]
-            },
-            "example": "jpg"
+              "title": "Ext"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
-              "image/*": {}
+              "application/json": {
+                "schema": {}
+              }
             }
           },
           "422": {
@@ -5562,12 +5238,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/{id}/metadata": {
@@ -5585,12 +5256,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           },
           {
             "name": "smart_score",
@@ -5598,6 +5265,7 @@
             "required": false,
             "schema": {
               "type": "boolean",
+              "default": false,
               "title": "Smart Score"
             }
           }
@@ -5607,17 +5275,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureFullMetadataResponse"
-                },
-                "example": {
-                  "id": 0,
-                  "format": "string",
-                  "score": 0,
-                  "tags": [],
-                  "smartScore": 0.0,
-                  "metadata": {}
-                }
+                "schema": {}
               }
             }
           },
@@ -5631,12 +5289,219 @@
               }
             }
           }
-        },
-        "security": [
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/face": {
+      "post": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Create manual face entry",
+        "description": "Adds a face bounding box to a picture and frame index, updating sentinel/ordering behavior for manual annotations.",
+        "operationId": "create_picture_face_api_v1_pictures__id__face_post",
+        "parameters": [
           {
-            "bearerAuth": []
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/face/{index}": {
+      "delete": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Delete face by index",
+        "description": "Deletes a face at frame 0 by index and reindexes remaining faces for stable ordering.",
+        "operationId": "delete_picture_face_api_v1_pictures__id__face__index__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "index",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Index"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/character_likeness": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get picture character likeness",
+        "description": "Computes max character-likeness score for faces in a picture against a reference character.",
+        "operationId": "get_picture_character_likeness_api_v1_pictures__id__character_likeness_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "reference_character_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Reference Character Id"
+            }
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Character Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pictures/{id}/{field}": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "Get raw picture field",
+        "description": "Returns a single picture field value; large binary fields are base64 encoded and thumbnail returns image bytes.",
+        "operationId": "get_picture_field_api_v1_pictures__id___field__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "field",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Field"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/pictures/{id}": {
@@ -5654,12 +5519,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           }
         ],
         "responses": {
@@ -5667,13 +5528,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PicturePatchResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "picture": {}
-                }
+                "schema": {}
               }
             }
           },
@@ -5687,12 +5542,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -5708,12 +5558,8 @@
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Id",
-              "examples": [
-                "1"
-              ]
-            },
-            "example": "1"
+              "title": "Id"
+            }
           }
         ],
         "responses": {
@@ -5721,13 +5567,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PictureDeleteResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "message": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -5741,12 +5581,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/scrapheap/restore": {
@@ -5780,13 +5615,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ScrapheapRestoreResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "restored_count": 0
-                }
+                "schema": {}
               }
             }
           },
@@ -5800,12 +5629,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/scrapheap": {
@@ -5839,13 +5663,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ScrapheapDeleteResponse"
-                },
-                "example": {
-                  "status": "string",
-                  "deleted_count": 0
-                }
+                "schema": {}
               }
             }
           },
@@ -5859,12 +5677,589 @@
               }
             }
           }
-        },
-        "security": [
+        }
+      }
+    },
+    "/api/v1/pictures": {
+      "get": {
+        "tags": [
+          "pictures"
+        ],
+        "summary": "List pictures",
+        "description": "Lists pictures with filtering, sort, pagination, and optional grid field projection.",
+        "operationId": "list_pictures_api_v1_pictures_get",
+        "parameters": [
           {
-            "bearerAuth": []
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Sort mechanism. One of: DATE, IMPORTED_AT, SCORE, SMART_SCORE, IMAGE_SIZE, TEXT_CONTENT, CHARACTER_LIKENESS. Omit for natural (id) order.",
+              "examples": [
+                "DATE"
+              ],
+              "title": "Sort"
+            },
+            "description": "Sort mechanism. One of: DATE, IMPORTED_AT, SCORE, SMART_SCORE, IMAGE_SIZE, TEXT_CONTENT, CHARACTER_LIKENESS. Omit for natural (id) order."
+          },
+          {
+            "name": "descending",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Sort direction; true = newest/highest first.",
+              "default": true,
+              "title": "Descending"
+            },
+            "description": "Sort direction; true = newest/highest first."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Number of rows to skip (pagination).",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of rows to skip (pagination)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "Maximum rows to return.",
+              "examples": [
+                200
+              ],
+              "default": 9223372036854775807,
+              "title": "Limit"
+            },
+            "description": "Maximum rows to return."
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Field projection: 'grid' for the minimal grid set, a comma-separated field list, or omit for full metadata.",
+              "examples": [
+                "grid"
+              ],
+              "title": "Fields"
+            },
+            "description": "Field projection: 'grid' for the minimal grid set, a comma-separated field list, or omit for full metadata."
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by project id or 'UNASSIGNED'",
+              "examples": [
+                "UNASSIGNED"
+              ],
+              "title": "Project Id"
+            },
+            "description": "Filter by project id or 'UNASSIGNED'"
+          },
+          {
+            "name": "only_deleted",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP.",
+              "default": false,
+              "title": "Only Deleted"
+            },
+            "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP."
+          },
+          {
+            "name": "character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Character filter: a character id, or 'UNASSIGNED'.",
+              "examples": [
+                "42"
+              ],
+              "title": "Character Id"
+            },
+            "description": "Character filter: a character id, or 'UNASSIGNED'."
+          },
+          {
+            "name": "character_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multi-character filter (repeatable).",
+              "default": [],
+              "title": "Character Ids"
+            },
+            "description": "Multi-character filter (repeatable)."
+          },
+          {
+            "name": "character_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "union | intersection | difference | xor",
+              "title": "Character Mode"
+            },
+            "description": "union | intersection | difference | xor"
+          },
+          {
+            "name": "set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Single picture-set filter.",
+              "title": "Set Id"
+            },
+            "description": "Single picture-set filter."
+          },
+          {
+            "name": "set_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multi-set filter (repeatable).",
+              "default": [],
+              "title": "Set Ids"
+            },
+            "description": "Multi-set filter (repeatable)."
+          },
+          {
+            "name": "set_mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "union | intersection | difference",
+              "title": "Set Mode"
+            },
+            "description": "union | intersection | difference"
+          },
+          {
+            "name": "base_set_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Base set for set_mode=difference.",
+              "title": "Base Set Id"
+            },
+            "description": "Base set for set_mode=difference."
+          },
+          {
+            "name": "reference_character_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Required reference for sort=CHARACTER_LIKENESS.",
+              "title": "Reference Character Id"
+            },
+            "description": "Required reference for sort=CHARACTER_LIKENESS."
+          },
+          {
+            "name": "min_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Minimum star score.",
+              "examples": [
+                3
+              ],
+              "title": "Min Score"
+            },
+            "description": "Minimum star score."
+          },
+          {
+            "name": "max_score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum star score.",
+              "examples": [
+                5
+              ],
+              "title": "Max Score"
+            },
+            "description": "Maximum star score."
+          },
+          {
+            "name": "smart_score_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5",
+              "title": "Smart Score Bucket"
+            },
+            "description": "unscored | 1-2 | 2-3 | 3-4 | 4-5"
+          },
+          {
+            "name": "resolution_bucket",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus",
+              "title": "Resolution Bucket"
+            },
+            "description": "unknown | lt1mp | 1-4mp | 4-8mp | 8-16mp | 16plus"
+          },
+          {
+            "name": "file_path_prefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict to file paths starting with this prefix.",
+              "title": "File Path Prefix"
+            },
+            "description": "Restrict to file paths starting with this prefix."
+          },
+          {
+            "name": "face_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "with_face | without_face",
+              "examples": [
+                "with_face"
+              ],
+              "title": "Face Filter"
+            },
+            "description": "with_face | without_face"
+          },
+          {
+            "name": "shared_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Only pictures shared with the current user.",
+              "default": false,
+              "title": "Shared Only"
+            },
+            "description": "Only pictures shared with the current user."
+          },
+          {
+            "name": "apply_tag_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Apply the user's hidden-tag filter.",
+              "default": false,
+              "title": "Apply Tag Filter"
+            },
+            "description": "Apply the user's hidden-tag filter."
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by file format (repeatable).",
+              "default": [],
+              "title": "Format"
+            },
+            "description": "Filter by file format (repeatable)."
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Require these tags (repeatable).",
+              "examples": [
+                "sunset"
+              ],
+              "default": [],
+              "title": "Tag"
+            },
+            "description": "Require these tags (repeatable)."
+          },
+          {
+            "name": "rejected_tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Exclude these tags (repeatable).",
+              "default": [],
+              "title": "Rejected Tag"
+            },
+            "description": "Exclude these tags (repeatable)."
+          },
+          {
+            "name": "tag_confidence_above",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
+              "title": "Tag Confidence Above"
+            },
+            "description": "'tag:threshold' prediction filter (repeatable)."
+          },
+          {
+            "name": "tag_confidence_below",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
+              "title": "Tag Confidence Below"
+            },
+            "description": "'tag:threshold' prediction filter (repeatable)."
+          },
+          {
+            "name": "comfyui_model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by ComfyUI model (repeatable).",
+              "default": [],
+              "title": "Comfyui Model"
+            },
+            "description": "Filter by ComfyUI model (repeatable)."
+          },
+          {
+            "name": "comfyui_lora",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filter by ComfyUI LoRA (repeatable).",
+              "default": [],
+              "title": "Comfyui Lora"
+            },
+            "description": "Filter by ComfyUI LoRA (repeatable)."
+          },
+          {
+            "name": "reference_folder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by reference-folder id.",
+              "title": "Reference Folder Id"
+            },
+            "description": "Filter by reference-folder id."
+          },
+          {
+            "name": "import_source_folder",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by import source folder.",
+              "title": "Import Source Folder"
+            },
+            "description": "Filter by import source folder."
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Restrict to specific picture ids (repeatable).",
+              "default": [],
+              "title": "Id"
+            },
+            "description": "Restrict to specific picture ids (repeatable)."
           }
-        ]
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching pictures (field set depends on `fields`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GridPicture"
+                  },
+                  "title": "Response 200 List Pictures Api V1 Pictures Get"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid sort mechanism."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/pictures/stream": {
@@ -5897,6 +6292,7 @@
             "schema": {
               "type": "boolean",
               "description": "Sort direction; true = newest/highest first.",
+              "default": true,
               "title": "Descending"
             },
             "description": "Sort direction; true = newest/highest first."
@@ -5909,6 +6305,7 @@
               "type": "integer",
               "minimum": 0,
               "description": "Row offset for this batch (use next_offset).",
+              "default": 0,
               "title": "Offset"
             },
             "description": "Row offset for this batch (use next_offset)."
@@ -5925,6 +6322,7 @@
               "examples": [
                 1000
               ],
+              "default": 1000,
               "title": "Batch Limit"
             },
             "description": "Rows per batch (1-5000)."
@@ -5950,6 +6348,7 @@
             "schema": {
               "type": "boolean",
               "description": "When `fields=grid`, omit high-cardinality string fields such as `file_path` to reduce payload size for streaming.",
+              "default": false,
               "title": "Grid Lite"
             },
             "description": "When `fields=grid`, omit high-cardinality string fields such as `file_path` to reduce payload size for streaming."
@@ -5961,6 +6360,7 @@
             "schema": {
               "type": "boolean",
               "description": "Collapse stacks to their leader only.",
+              "default": false,
               "title": "Stack Leaders Only"
             },
             "description": "Collapse stacks to their leader only."
@@ -5993,6 +6393,7 @@
             "schema": {
               "type": "boolean",
               "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP.",
+              "default": false,
               "title": "Only Deleted"
             },
             "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP."
@@ -6028,6 +6429,7 @@
                 "type": "string"
               },
               "description": "Multi-character filter (repeatable).",
+              "default": [],
               "title": "Character Ids"
             },
             "description": "Multi-character filter (repeatable)."
@@ -6078,6 +6480,7 @@
                 "type": "string"
               },
               "description": "Multi-set filter (repeatable).",
+              "default": [],
               "title": "Set Ids"
             },
             "description": "Multi-set filter (repeatable)."
@@ -6260,6 +6663,7 @@
             "schema": {
               "type": "boolean",
               "description": "Only pictures shared with the current user.",
+              "default": false,
               "title": "Shared Only"
             },
             "description": "Only pictures shared with the current user."
@@ -6271,6 +6675,7 @@
             "schema": {
               "type": "boolean",
               "description": "Apply the user's hidden-tag filter.",
+              "default": false,
               "title": "Apply Tag Filter"
             },
             "description": "Apply the user's hidden-tag filter."
@@ -6285,6 +6690,7 @@
                 "type": "string"
               },
               "description": "Filter by file format (repeatable).",
+              "default": [],
               "title": "Format"
             },
             "description": "Filter by file format (repeatable)."
@@ -6302,6 +6708,7 @@
               "examples": [
                 "sunset"
               ],
+              "default": [],
               "title": "Tag"
             },
             "description": "Require these tags (repeatable)."
@@ -6316,6 +6723,7 @@
                 "type": "string"
               },
               "description": "Exclude these tags (repeatable).",
+              "default": [],
               "title": "Rejected Tag"
             },
             "description": "Exclude these tags (repeatable)."
@@ -6330,6 +6738,7 @@
                 "type": "string"
               },
               "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
               "title": "Tag Confidence Above"
             },
             "description": "'tag:threshold' prediction filter (repeatable)."
@@ -6344,6 +6753,7 @@
                 "type": "string"
               },
               "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
               "title": "Tag Confidence Below"
             },
             "description": "'tag:threshold' prediction filter (repeatable)."
@@ -6358,6 +6768,7 @@
                 "type": "string"
               },
               "description": "Filter by ComfyUI model (repeatable).",
+              "default": [],
               "title": "Comfyui Model"
             },
             "description": "Filter by ComfyUI model (repeatable)."
@@ -6372,6 +6783,7 @@
                 "type": "string"
               },
               "description": "Filter by ComfyUI LoRA (repeatable).",
+              "default": [],
               "title": "Comfyui Lora"
             },
             "description": "Filter by ComfyUI LoRA (repeatable)."
@@ -6422,6 +6834,7 @@
                 "type": "string"
               },
               "description": "Restrict to specific picture ids (repeatable).",
+              "default": [],
               "title": "Id"
             },
             "description": "Restrict to specific picture ids (repeatable)."
@@ -6434,26 +6847,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/StreamPicturesResponse"
-                },
-                "example": {
-                  "done": false,
-                  "next_offset": 1000,
-                  "pictures": [
-                    {
-                      "created_at": "2026-01-14T09:30:00",
-                      "file_path": "01a43b7e-dda4-45bb-a912-2ed4b786260d.png",
-                      "format": "PNG",
-                      "height": 1536,
-                      "id": 12345,
-                      "imported_at": "2026-01-15T18:02:11",
-                      "score": 4,
-                      "smart_score": 3.87,
-                      "stack_count": 5,
-                      "stack_id": 87,
-                      "stack_position": 0,
-                      "width": 1024
-                    }
-                  ]
                 }
               }
             }
@@ -6471,12 +6864,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
     "/api/v1/pictures/count": {
@@ -6509,6 +6897,7 @@
             "schema": {
               "type": "boolean",
               "description": "Unused for counting; accepted for parity with /pictures.",
+              "default": true,
               "title": "Descending"
             },
             "description": "Unused for counting; accepted for parity with /pictures."
@@ -6531,6 +6920,7 @@
             "schema": {
               "type": "boolean",
               "description": "Count stacks as one (their leader).",
+              "default": false,
               "title": "Stack Leaders Only"
             },
             "description": "Count stacks as one (their leader)."
@@ -6563,6 +6953,7 @@
             "schema": {
               "type": "boolean",
               "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP.",
+              "default": false,
               "title": "Only Deleted"
             },
             "description": "Return only deleted (scrapheap) pictures. Replaces the deprecated character_id=SCRAPHEAP."
@@ -6598,6 +6989,7 @@
                 "type": "string"
               },
               "description": "Multi-character filter (repeatable).",
+              "default": [],
               "title": "Character Ids"
             },
             "description": "Multi-character filter (repeatable)."
@@ -6648,6 +7040,7 @@
                 "type": "string"
               },
               "description": "Multi-set filter (repeatable).",
+              "default": [],
               "title": "Set Ids"
             },
             "description": "Multi-set filter (repeatable)."
@@ -6830,6 +7223,7 @@
             "schema": {
               "type": "boolean",
               "description": "Only pictures shared with the current user.",
+              "default": false,
               "title": "Shared Only"
             },
             "description": "Only pictures shared with the current user."
@@ -6841,6 +7235,7 @@
             "schema": {
               "type": "boolean",
               "description": "Apply the user's hidden-tag filter.",
+              "default": false,
               "title": "Apply Tag Filter"
             },
             "description": "Apply the user's hidden-tag filter."
@@ -6855,6 +7250,7 @@
                 "type": "string"
               },
               "description": "Filter by file format (repeatable).",
+              "default": [],
               "title": "Format"
             },
             "description": "Filter by file format (repeatable)."
@@ -6872,6 +7268,7 @@
               "examples": [
                 "sunset"
               ],
+              "default": [],
               "title": "Tag"
             },
             "description": "Require these tags (repeatable)."
@@ -6886,6 +7283,7 @@
                 "type": "string"
               },
               "description": "Exclude these tags (repeatable).",
+              "default": [],
               "title": "Rejected Tag"
             },
             "description": "Exclude these tags (repeatable)."
@@ -6900,6 +7298,7 @@
                 "type": "string"
               },
               "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
               "title": "Tag Confidence Above"
             },
             "description": "'tag:threshold' prediction filter (repeatable)."
@@ -6914,6 +7313,7 @@
                 "type": "string"
               },
               "description": "'tag:threshold' prediction filter (repeatable).",
+              "default": [],
               "title": "Tag Confidence Below"
             },
             "description": "'tag:threshold' prediction filter (repeatable)."
@@ -6928,6 +7328,7 @@
                 "type": "string"
               },
               "description": "Filter by ComfyUI model (repeatable).",
+              "default": [],
               "title": "Comfyui Model"
             },
             "description": "Filter by ComfyUI model (repeatable)."
@@ -6942,6 +7343,7 @@
                 "type": "string"
               },
               "description": "Filter by ComfyUI LoRA (repeatable).",
+              "default": [],
               "title": "Comfyui Lora"
             },
             "description": "Filter by ComfyUI LoRA (repeatable)."
@@ -6992,6 +7394,7 @@
                 "type": "string"
               },
               "description": "Restrict to specific picture ids (repeatable).",
+              "default": [],
               "title": "Id"
             },
             "description": "Restrict to specific picture ids (repeatable)."
@@ -7004,9 +7407,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PictureCountResponse"
-                },
-                "example": {
-                  "count": 28259
                 }
               }
             }
@@ -7021,31 +7421,63 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        }
       }
     },
-    "/api/v1/check-session": {
+    "/api/v1/comfyui/workflows": {
       "get": {
         "tags": [
-          "auth"
+          "comfyui"
         ],
-        "summary": "Check Session",
-        "operationId": "check_session_api_v1_check_session_get",
+        "summary": "List ComfyUI workflows",
+        "description": "Lists discovered built-in and user workflows with placeholder validation metadata.",
+        "operationId": "list_comfyui_workflows_api_v1_comfyui_workflows_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/workflows/{workflow_name}": {
+      "delete": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Delete user workflow",
+        "description": "Deletes a workflow JSON from the user workflow directory.",
+        "operationId": "delete_comfyui_workflow_api_v1_comfyui_workflows__workflow_name__delete",
+        "parameters": [
+          {
+            "name": "workflow_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SessionStatusResponse"
-                },
-                "example": {
-                  "status": "string"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7053,23 +7485,209 @@
         }
       }
     },
-    "/api/v1/login": {
+    "/api/v1/comfyui/abort": {
+      "post": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Abort ComfyUI execution",
+        "description": "Interrupts the currently running ComfyUI prompt and clears the pending queue.",
+        "operationId": "abort_comfyui_api_v1_comfyui_abort_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/run_i2i": {
+      "post": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Run ComfyUI image-to-image",
+        "description": "Submits i2i prompts for one or more picture ids and imports generated outputs back into PixlStash.",
+        "operationId": "run_comfyui_i2i_api_v1_comfyui_run_i2i_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/run_t2i": {
+      "post": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Run ComfyUI text-to-image",
+        "description": "Submits a t2i prompt using only a caption and imports generated outputs back into PixlStash.",
+        "operationId": "run_comfyui_t2i_api_v1_comfyui_run_t2i_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/workflows/import": {
+      "post": {
+        "tags": [
+          "comfyui"
+        ],
+        "summary": "Import ComfyUI workflow",
+        "description": "Saves a workflow JSON into the user workflow directory, optionally overwriting an existing file.",
+        "operationId": "import_comfyui_workflow_api_v1_comfyui_workflows_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Payload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/comfyui/pictures/{picture_id}/workflow": {
       "get": {
         "tags": [
-          "auth"
+          "comfyui"
         ],
-        "summary": "Check Registration",
-        "operationId": "check_registration_api_v1_login_get",
+        "summary": "Get ComfyUI workflow for a picture",
+        "description": "Extracts and returns the ComfyUI workflow embedded in a picture's file metadata, if present.",
+        "operationId": "get_picture_comfyui_workflow_api_v1_comfyui_pictures__picture_id__workflow_get",
+        "parameters": [
+          {
+            "name": "picture_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Picture Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/reference-folders": {
+      "get": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "List reference folders",
+        "description": "Returns all reference folders and metadata about the current runtime mode.",
+        "operationId": "list_reference_folders_api_v1_reference_folders_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RegistrationStatusResponse"
-                },
-                "example": {
-                  "needs_registration": true
+                  "$ref": "#/components/schemas/ReferenceFoldersListResponse"
                 }
               }
             }
@@ -7078,8 +7696,604 @@
       },
       "post": {
         "tags": [
-          "auth"
+          "config",
+          "config"
         ],
+        "summary": "Add a reference folder",
+        "description": "Adds a new reference folder. The path must be absolute and must not point to a restricted system directory. In Docker mode the folder is created with status 'pending_mount' and requires a server restart to mount-verify the path. Outside Docker the path is verified immediately and the folder becomes 'active' (or 'mount_error') right away.",
+        "operationId": "create_reference_folder_api_v1_reference_folders_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferenceFolderCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenceFolderResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/reference-folders/{folder_id}": {
+      "patch": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Update a reference folder",
+        "description": "Updates editable fields for a reference folder.",
+        "operationId": "update_reference_folder_api_v1_reference_folders__folder_id__patch",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferenceFolderUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenceFolderResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Remove a reference folder",
+        "description": "Removes a reference folder record. Pictures indexed from this folder are de-associated but not deleted from the database or disk.",
+        "operationId": "delete_reference_folder_api_v1_reference_folders__folder_id__delete",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/server/restart": {
+      "post": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Restart the PixlStash server",
+        "description": "Gracefully terminates the server process. The process manager (systemd, Docker, etc.) is expected to restart it automatically. Use this after adding reference folders to apply pending mount changes.",
+        "operationId": "restart_server_api_v1_server_restart_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/reference-folders/{folder_id}/open": {
+      "post": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Open reference folder in file manager",
+        "description": "Opens the reference folder (or an optional subdirectory within it) in the OS file manager.",
+        "operationId": "open_reference_folder_api_v1_reference_folders__folder_id__open_post",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          },
+          {
+            "name": "subpath",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Subpath"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/import-folders": {
+      "get": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "List import folders",
+        "description": "Returns all folders used by the automatic import watcher.",
+        "operationId": "list_import_folders_api_v1_import_folders_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportFoldersListResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Add an import folder",
+        "description": "Adds a folder watched for automatic imports.",
+        "operationId": "create_import_folder_api_v1_import_folders_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportFolderCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportFolderResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/import-folders/{folder_id}": {
+      "patch": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Update an import folder",
+        "description": "Updates label and import behavior for an import folder.",
+        "operationId": "update_import_folder_api_v1_import_folders__folder_id__patch",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportFolderUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportFolderResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Remove an import folder",
+        "description": "Removes an import folder from automatic monitoring.",
+        "operationId": "delete_import_folder_api_v1_import_folders__folder_id__delete",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Folder Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/filesystem/browse": {
+      "get": {
+        "tags": [
+          "config",
+          "config"
+        ],
+        "summary": "Browse server filesystem",
+        "description": "Returns immediate child entries of the requested directory. Available in native (non-Docker) installs only. Requires authentication.",
+        "operationId": "browse_filesystem_api_v1_filesystem_browse_get",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Absolute directory path to list. Defaults to home directory.",
+              "title": "Path"
+            },
+            "description": "Absolute directory path to list. Defaults to home directory."
+          },
+          {
+            "name": "show_hidden",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Include hidden (dot-prefixed) entries.",
+              "default": false,
+              "title": "Show Hidden"
+            },
+            "description": "Include hidden (dot-prefixed) entries."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilesystemBrowseResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/taggers": {
+      "get": {
+        "tags": [
+          "taggers",
+          "taggers"
+        ],
+        "summary": "List tagger plugins and current settings",
+        "description": "Return every registered tagger/captioner plugin together with\nthe current user's ``tagger_settings``.\n\nResponse shape::\n\n    {\n      \"plugins\": [\n        {\n          \"name\": \"pixlstash_tagger\",\n          \"display_name\": \"PixlStash Tagger\",\n          \"description\": \"...\",\n          \"supports_tags\": true,\n          \"supports_descriptions\": false,\n          \"requires_download\": true,\n          \"default_enabled\": true,\n          \"parameter_schema\": [...],\n          \"downloaded_artifacts\": [],\n          \"is_loaded\": false,\n          \"load_error\": null\n        },\n        ...\n      ],\n      \"settings\": { ... }\n    }",
+        "operationId": "list_taggers_api_v1_taggers_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/taggers/{name}/download": {
+      "post": {
+        "tags": [
+          "taggers",
+          "taggers"
+        ],
+        "summary": "Start artifact download for a tagger plugin",
+        "description": "Kick off a background download for the named plugin.\n\nReturns immediately with ``{\"status\": \"started\"}`` or\n``{\"status\": \"not_required\"}`` when no download is needed.\nDownload progress is logged to the server console.\n\nRaises 404 if the plugin is not registered.",
+        "operationId": "download_plugin_api_v1_taggers__name__download_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/taggers/{name}/artifacts/{artifact_id}": {
+      "delete": {
+        "tags": [
+          "taggers",
+          "taggers"
+        ],
+        "summary": "Delete a downloaded artifact for a tagger plugin",
+        "description": "Remove a downloaded artifact and unload the plugin if currently loaded.\n\nRaises 404 if the plugin or artifact is not found.",
+        "operationId": "delete_artifact_api_v1_taggers__name__artifacts__artifact_id__delete",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Artifact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/check-session": {
+      "get": {
+        "summary": "Check Session",
+        "operationId": "check_session_api_v1_check_session_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/network/info": {
+      "get": {
+        "summary": "Network Info",
+        "operationId": "network_info_api_v1_network_info_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/login": {
+      "get": {
+        "summary": "Check Registration",
+        "operationId": "check_registration_api_v1_login_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
         "summary": "Login",
         "operationId": "login_api_v1_login_post",
         "requestBody": {
@@ -7097,12 +8311,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MessageResponse"
-                },
-                "example": {
-                  "message": "string"
-                }
+                "schema": {}
               }
             }
           },
@@ -7121,9 +8330,6 @@
     },
     "/api/v1/logout": {
       "post": {
-        "tags": [
-          "auth"
-        ],
         "summary": "Logout",
         "operationId": "logout_api_v1_logout_post",
         "responses": {
@@ -7131,11 +8337,59 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/protected": {
+      "get": {
+        "summary": "Protected",
+        "operationId": "protected_api_v1_protected_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{full_path}": {
+      "get": {
+        "summary": "Frontend Fallback",
+        "operationId": "frontend_fallback__full_path__get",
+        "parameters": [
+          {
+            "name": "full_path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Full Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MessageResponse"
-                },
-                "example": {
-                  "message": "string"
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -7146,68 +8400,18 @@
   },
   "components": {
     "schemas": {
-      "ApplyScoresResponse": {
+      "BatchSharedPictureIdsRequest": {
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "only_unscored": {
-            "type": "boolean",
-            "title": "Only Unscored"
-          },
-          "updated_ids": {
+          "picture_ids": {
             "items": {
               "type": "integer"
             },
             "type": "array",
-            "title": "Updated Ids",
-            "default": []
-          },
-          "updated_count": {
-            "type": "integer",
-            "title": "Updated Count"
-          },
-          "skipped_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Skipped Ids",
-            "default": []
-          },
-          "skipped_count": {
-            "type": "integer",
-            "title": "Skipped Count"
-          },
-          "missing_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Missing Ids",
-            "default": []
-          },
-          "missing_count": {
-            "type": "integer",
-            "title": "Missing Count"
-          },
-          "reset_triggered": {
-            "type": "boolean",
-            "title": "Reset Triggered"
+            "title": "Picture Ids"
           }
         },
-        "additionalProperties": true,
         "type": "object",
-        "required": [
-          "status",
-          "only_unscored",
-          "updated_count",
-          "skipped_count",
-          "missing_count",
-          "reset_triggered"
-        ],
-        "title": "ApplyScoresResponse"
+        "title": "BatchSharedPictureIdsRequest"
       },
       "Body_get_batch_character_membership_api_v1_characters_membership_post": {
         "properties": {
@@ -7280,6 +8484,20 @@
         },
         "type": "object",
         "title": "Body_import_pictures_api_v1_pictures_import_post"
+      },
+      "Body_post_me_watermark_api_v1_users_me_watermark_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_post_me_watermark_api_v1_users_me_watermark_post"
       },
       "Body_search_by_character_likeness_api_v1_characters_likeness_search_post": {
         "properties": {
@@ -7359,131 +8577,9 @@
         "type": "object",
         "title": "BulkFetchTagsRequest"
       },
-      "BulkPictureTagsResponse": {
+      "ChangePasswordRequest": {
         "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "tags": {
-            "items": {
-              "$ref": "#/components/schemas/TagItemResponse"
-            },
-            "type": "array",
-            "title": "Tags",
-            "default": []
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "title": "BulkPictureTagsResponse",
-        "description": "Tags for a single picture in a bulk-fetch response."
-      },
-      "CharacterDeleteResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "deleted_id": {
-            "type": "integer",
-            "title": "Deleted Id"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "deleted_id"
-        ],
-        "title": "CharacterDeleteResponse",
-        "description": "Result of deleting a character."
-      },
-      "CharacterFaceAssignmentResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "face_ids": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Face Ids"
-          },
-          "character_id": {
-            "type": "integer",
-            "title": "Character Id"
-          },
-          "already_assigned_ids": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Already Assigned Ids"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "character_id"
-        ],
-        "title": "CharacterFaceAssignmentResponse",
-        "description": "Result of assigning or unassigning faces for a character."
-      },
-      "CharacterLikenessResultResponse": {
-        "properties": {
-          "character_id": {
-            "type": "integer",
-            "title": "Character Id"
-          },
-          "likeness": {
-            "type": "number",
-            "title": "Likeness"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "character_id",
-          "likeness"
-        ],
-        "title": "CharacterLikenessResultResponse",
-        "description": "A single character likeness-search result."
-      },
-      "CharacterListItemResponse": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "name": {
+          "current_password": {
             "anyOf": [
               {
                 "type": "string"
@@ -7492,8 +8588,23 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Current Password"
           },
+          "new_password": {
+            "type": "string",
+            "minLength": 8,
+            "title": "New Password",
+            "description": "Password must be at least 8 characters long"
+          }
+        },
+        "type": "object",
+        "required": [
+          "new_password"
+        ],
+        "title": "ChangePasswordRequest"
+      },
+      "CreateTokenRequest": {
+        "properties": {
           "description": {
             "anyOf": [
               {
@@ -7505,7 +8616,12 @@
             ],
             "title": "Description"
           },
-          "extra_metadata": {
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": "ALL"
+          },
+          "resource_type": {
             "anyOf": [
               {
                 "type": "string"
@@ -7514,9 +8630,9 @@
                 "type": "null"
               }
             ],
-            "title": "Extra Metadata"
+            "title": "Resource Type"
           },
-          "reference_picture_set_id": {
+          "resource_id": {
             "anyOf": [
               {
                 "type": "integer"
@@ -7525,279 +8641,99 @@
                 "type": "null"
               }
             ],
-            "title": "Reference Picture Set Id"
+            "title": "Resource Id"
           },
-          "project_id": {
+          "expires_at": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "string",
+                "format": "date-time"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Project Id"
+            "title": "Expires At"
           },
-          "has_reference_faces": {
+          "include_attachments": {
             "type": "boolean",
-            "title": "Has Reference Faces",
+            "title": "Include Attachments",
             "default": false
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "title": "CharacterListItemResponse",
-        "description": "A character in the list endpoint, annotated with reference-face presence."
-      },
-      "CharacterMembershipResponse": {
-        "properties": {
-          "character_assignments": {
-            "additionalProperties": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "type": "object",
-            "title": "Character Assignments",
-            "default": {}
           },
-          "pictures_with_faces": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Pictures With Faces",
-            "default": []
+          "watermark": {
+            "type": "boolean",
+            "title": "Watermark",
+            "default": true
           }
         },
-        "additionalProperties": true,
         "type": "object",
-        "title": "CharacterMembershipResponse",
-        "description": "Batch character membership lookup result."
+        "title": "CreateTokenRequest"
       },
-      "CharacterMutationResponse": {
+      "FilesystemBrowseResponse": {
         "properties": {
-          "status": {
+          "path": {
             "type": "string",
-            "title": "Status"
+            "title": "Path"
           },
-          "character": {
+          "parent": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/CharacterResponse"
+                "type": "string"
               },
               {
                 "type": "null"
               }
-            ]
+            ],
+            "title": "Parent"
+          },
+          "image_count": {
+            "type": "integer",
+            "title": "Image Count"
+          },
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/FilesystemEntry"
+            },
+            "type": "array",
+            "title": "Entries"
           }
         },
-        "additionalProperties": true,
         "type": "object",
         "required": [
-          "status"
+          "path",
+          "parent",
+          "image_count",
+          "entries"
         ],
-        "title": "CharacterMutationResponse",
-        "description": "Result of creating or updating a character."
+        "title": "FilesystemBrowseResponse"
       },
-      "CharacterReferencePicturesResponse": {
+      "FilesystemEntry": {
         "properties": {
-          "reference_picture_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Reference Picture Ids",
-            "default": []
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "title": "CharacterReferencePicturesResponse",
-        "description": "Reference picture ids selected for a character."
-      },
-      "CharacterResponse": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
             "title": "Name"
           },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
+          "path": {
+            "type": "string",
+            "title": "Path"
           },
-          "extra_metadata": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Extra Metadata"
-          },
-          "reference_picture_set_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reference Picture Set Id"
-          },
-          "project_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Project Id"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "title": "CharacterResponse",
-        "description": "A single character record (scalar fields of the Character model)."
-      },
-      "CharacterSummaryResponse": {
-        "properties": {
-          "character_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Character Id"
+          "is_dir": {
+            "type": "boolean",
+            "title": "Is Dir"
           },
           "image_count": {
             "type": "integer",
             "title": "Image Count",
             "default": 0
-          },
-          "thumbnail_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Thumbnail Url"
           }
         },
-        "additionalProperties": true,
-        "type": "object",
-        "title": "CharacterSummaryResponse",
-        "description": "Category summary counts and thumbnail reference for a character/category."
-      },
-      "ExportStartResponse": {
-        "properties": {
-          "task_id": {
-            "type": "string",
-            "title": "Task Id"
-          }
-        },
-        "additionalProperties": true,
         "type": "object",
         "required": [
-          "task_id"
+          "name",
+          "path",
+          "is_dir"
         ],
-        "title": "ExportStartResponse"
-      },
-      "ExportStatusResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "processed": {
-            "type": "integer",
-            "title": "Processed"
-          },
-          "progress": {
-            "type": "number",
-            "title": "Progress"
-          },
-          "download_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Download Url"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "total",
-          "processed",
-          "progress"
-        ],
-        "title": "ExportStatusResponse"
-      },
-      "FaceLikenessMatchResponse": {
-        "properties": {
-          "picture_id": {
-            "type": "integer",
-            "title": "Picture Id"
-          },
-          "likeness": {
-            "type": "number",
-            "title": "Likeness"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "picture_id",
-          "likeness"
-        ],
-        "title": "FaceLikenessMatchResponse"
+        "title": "FilesystemEntry"
       },
       "GridPicture": {
         "properties": {
@@ -8039,43 +8975,13 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
-      "ImageLikenessMatchResponse": {
+      "ImportFolderCreateRequest": {
         "properties": {
-          "picture_id": {
-            "type": "integer",
-            "title": "Picture Id"
-          },
-          "likeness": {
-            "type": "number",
-            "title": "Likeness"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "picture_id",
-          "likeness"
-        ],
-        "title": "ImageLikenessMatchResponse"
-      },
-      "ImportResultEntry": {
-        "properties": {
-          "status": {
+          "folder": {
             "type": "string",
-            "title": "Status"
+            "title": "Folder"
           },
-          "picture_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Picture Id"
-          },
-          "file": {
+          "label": {
             "anyOf": [
               {
                 "type": "string"
@@ -8084,67 +8990,9 @@
                 "type": "null"
               }
             ],
-            "title": "File"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "title": "ImportResultEntry"
-      },
-      "ImportStartResponse": {
-        "properties": {
-          "task_id": {
-            "type": "string",
-            "title": "Task Id"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "task_id"
-        ],
-        "title": "ImportStartResponse"
-      },
-      "ImportStatusResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
+            "title": "Label"
           },
-          "stage": {
-            "type": "string",
-            "title": "Stage"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "processed": {
-            "type": "integer",
-            "title": "Processed"
-          },
-          "progress": {
-            "type": "number",
-            "title": "Progress"
-          },
-          "results": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/ImportResultEntry"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Results"
-          },
-          "error": {
+          "host_path": {
             "anyOf": [
               {
                 "type": "string"
@@ -8153,46 +9001,131 @@
                 "type": "null"
               }
             ],
-            "title": "Error"
+            "title": "Host Path"
+          },
+          "delete_after_import": {
+            "type": "boolean",
+            "title": "Delete After Import",
+            "default": false
           }
         },
-        "additionalProperties": true,
         "type": "object",
         "required": [
-          "status",
-          "stage",
-          "total",
-          "processed",
-          "progress"
+          "folder"
         ],
-        "title": "ImportStatusResponse"
+        "title": "ImportFolderCreateRequest"
       },
-      "ListPictureTagsResponse": {
+      "ImportFolderResponse": {
         "properties": {
           "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "folder": {
+            "type": "string",
+            "title": "Folder"
+          },
+          "host_path": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Id"
+            "title": "Host Path"
           },
-          "tags": {
-            "items": {
-              "$ref": "#/components/schemas/TagItemResponse"
-            },
-            "type": "array",
-            "title": "Tags",
-            "default": []
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "delete_after_import": {
+            "type": "boolean",
+            "title": "Delete After Import"
+          },
+          "last_checked": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Checked"
+          },
+          "picture_count": {
+            "type": "integer",
+            "title": "Picture Count",
+            "default": 0
           }
         },
-        "additionalProperties": true,
         "type": "object",
-        "title": "ListPictureTagsResponse",
-        "description": "Result of listing a single picture's tags."
+        "required": [
+          "id",
+          "folder",
+          "host_path",
+          "label",
+          "delete_after_import",
+          "last_checked"
+        ],
+        "title": "ImportFolderResponse"
+      },
+      "ImportFolderUpdateRequest": {
+        "properties": {
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "host_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Path"
+          },
+          "delete_after_import": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delete After Import"
+          }
+        },
+        "type": "object",
+        "title": "ImportFolderUpdateRequest"
+      },
+      "ImportFoldersListResponse": {
+        "properties": {
+          "folders": {
+            "items": {
+              "$ref": "#/components/schemas/ImportFolderResponse"
+            },
+            "type": "array",
+            "title": "Folders"
+          }
+        },
+        "type": "object",
+        "required": [
+          "folders"
+        ],
+        "title": "ImportFoldersListResponse"
       },
       "LoginRequest": {
         "properties": {
@@ -8238,21 +9171,6 @@
         "type": "object",
         "title": "LoginRequest"
       },
-      "MessageResponse": {
-        "properties": {
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "message"
-        ],
-        "title": "MessageResponse",
-        "description": "Generic ``{\"message\": ...}`` body (login / logout)."
-      },
       "PictureCountResponse": {
         "properties": {
           "count": {
@@ -8274,552 +9192,6 @@
         "example": {
           "count": 28259
         }
-      },
-      "PictureDeleteResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "message"
-        ],
-        "title": "PictureDeleteResponse"
-      },
-      "PictureFullMetadataResponse": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "format": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Format"
-          },
-          "score": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Score"
-          },
-          "tags": {
-            "anyOf": [
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tags"
-          },
-          "smartScore": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Smartscore"
-          },
-          "metadata": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Metadata"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "title": "PictureFullMetadataResponse",
-        "description": "Single picture's full metadata, tags, optional smart score, and any\nembedded file metadata. The picture model is large/dynamic so common\nfields are enumerated and ``extra=\"allow\"`` preserves the rest."
-      },
-      "PictureMetadataResponse": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "format": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Format"
-          },
-          "score": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Score"
-          },
-          "likeness_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Likeness Score"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "title": "PictureMetadataResponse",
-        "description": "Serialized picture metadata as returned by search/CRUD endpoints.\n\nThe full picture model is large and dynamic; common fields are enumerated\nhere for documentation and ``extra=\"allow\"`` preserves every other field\n(including the search-only ``likeness_score`` overlay)."
-      },
-      "PicturePatchResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "picture": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Picture"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "picture"
-        ],
-        "title": "PicturePatchResponse"
-      },
-      "PictureSetAddPictureResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "title": "PictureSetAddPictureResponse"
-      },
-      "PictureSetBulkAddResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "added": {
-            "type": "integer",
-            "title": "Added"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "added"
-        ],
-        "title": "PictureSetBulkAddResponse"
-      },
-      "PictureSetBulkReplaceResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "members": {
-            "type": "integer",
-            "title": "Members"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "members"
-        ],
-        "title": "PictureSetBulkReplaceResponse"
-      },
-      "PictureSetCreateResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "picture_set": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Picture Set"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "picture_set"
-        ],
-        "title": "PictureSetCreateResponse"
-      },
-      "PictureSetDeleteResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "deleted_id": {
-            "type": "integer",
-            "title": "Deleted Id"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "deleted_id"
-        ],
-        "title": "PictureSetDeleteResponse"
-      },
-      "PictureSetMembersResponse": {
-        "properties": {
-          "picture_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Picture Ids"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "picture_ids"
-        ],
-        "title": "PictureSetMembersResponse"
-      },
-      "PictureSetPicturesResponse": {
-        "properties": {
-          "pictures": {
-            "anyOf": [
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pictures"
-          },
-          "set": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PictureSetResponse"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "project_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Project Id"
-          },
-          "set_icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Set Icon"
-          },
-          "set_color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Set Color"
-          },
-          "picture_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Picture Count"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "title": "PictureSetPicturesResponse",
-        "description": "Set contents response.\n\nCovers both shapes returned by ``get_picture_set``: the ``info=true`` path\nreturns picture set metadata (id/name/.../picture_count), while the default\npath returns ``{\"pictures\": [...], \"set\": {...}}``. All fields are optional\nso neither shape drops data, and ``extra=\"allow\"`` keeps anything else."
-      },
-      "PictureSetRemovePictureResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "title": "PictureSetRemovePictureResponse"
-      },
-      "PictureSetResponse": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "project_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Project Id"
-          },
-          "set_icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Set Icon"
-          },
-          "set_color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Set Color"
-          },
-          "picture_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Picture Count"
-          },
-          "top_picture_ids": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Top Picture Ids"
-          },
-          "thumbnail_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Thumbnail Url"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "title": "PictureSetResponse",
-        "description": "Picture set metadata as returned by set listing and lookup endpoints."
-      },
-      "PictureSetUpdateResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "title": "PictureSetUpdateResponse"
-      },
-      "PictureTagsResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "tags": {
-            "items": {
-              "$ref": "#/components/schemas/TagItemResponse"
-            },
-            "type": "array",
-            "title": "Tags",
-            "default": []
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "title": "PictureTagsResponse",
-        "description": "Result of mutating a picture's tags (add/remove/clear)."
       },
       "ProjectAttachmentResponse": {
         "properties": {
@@ -8941,73 +9313,6 @@
           "id"
         ],
         "title": "ProjectDeleteResponse"
-      },
-      "ProjectMembershipResponse": {
-        "properties": {
-          "project_assignments": {
-            "additionalProperties": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
-            "type": "object",
-            "title": "Project Assignments",
-            "default": {}
-          },
-          "unassigned_picture_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Unassigned Picture Ids",
-            "default": []
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "title": "ProjectMembershipResponse"
-      },
-      "ProjectPictureSetResponse": {
-        "properties": {
-          "id": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "project_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Project Id"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "id",
-          "name"
-        ],
-        "title": "ProjectPictureSetResponse"
       },
       "ProjectResponse": {
         "properties": {
@@ -9159,132 +9464,13 @@
         ],
         "title": "ProjectUrlAttachmentRequest"
       },
-      "RegistrationStatusResponse": {
+      "ReferenceFolderCreateRequest": {
         "properties": {
-          "needs_registration": {
-            "type": "boolean",
-            "title": "Needs Registration"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "needs_registration"
-        ],
-        "title": "RegistrationStatusResponse",
-        "description": "Body of ``GET /login`` (registration check)."
-      },
-      "ScrapheapDeleteResponse": {
-        "properties": {
-          "status": {
+          "folder": {
             "type": "string",
-            "title": "Status"
+            "title": "Folder"
           },
-          "deleted_count": {
-            "type": "integer",
-            "title": "Deleted Count"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "deleted_count"
-        ],
-        "title": "ScrapheapDeleteResponse"
-      },
-      "ScrapheapRestoreResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "restored_count": {
-            "type": "integer",
-            "title": "Restored Count"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "restored_count"
-        ],
-        "title": "ScrapheapRestoreResponse"
-      },
-      "SessionStatusResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "title": "SessionStatusResponse",
-        "description": "Body of ``GET /check-session`` (returned as a JSONResponse)."
-      },
-      "SetProjectForPicturesResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
-          "project_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Project Id"
-          },
-          "mode": {
-            "type": "string",
-            "title": "Mode"
-          },
-          "updated_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Updated Ids",
-            "default": []
-          },
-          "updated_count": {
-            "type": "integer",
-            "title": "Updated Count"
-          },
-          "missing_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Missing Ids",
-            "default": []
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "status",
-          "mode",
-          "updated_count"
-        ],
-        "title": "SetProjectForPicturesResponse"
-      },
-      "SortMechanismResponse": {
-        "properties": {
-          "key": {
-            "type": "string",
-            "title": "Key"
-          },
-          "field": {
+          "label": {
             "anyOf": [
               {
                 "type": "string"
@@ -9293,9 +9479,9 @@
                 "type": "null"
               }
             ],
-            "title": "Field"
+            "title": "Label"
           },
-          "description": {
+          "host_path": {
             "anyOf": [
               {
                 "type": "string"
@@ -9304,53 +9490,26 @@
                 "type": "null"
               }
             ],
-            "title": "Description"
+            "title": "Host Path"
           }
         },
-        "additionalProperties": true,
         "type": "object",
         "required": [
-          "key"
+          "folder"
         ],
-        "title": "SortMechanismResponse"
+        "title": "ReferenceFolderCreateRequest"
       },
-      "StackOrderResponse": {
-        "properties": {
-          "stack_id": {
-            "type": "integer",
-            "title": "Stack Id"
-          },
-          "picture_ids": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Picture Ids"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "stack_id",
-          "picture_ids"
-        ],
-        "title": "StackOrderResponse",
-        "description": "Stack id with the resulting ordered picture ids."
-      },
-      "StackResponse": {
+      "ReferenceFolderResponse": {
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "integer",
             "title": "Id"
           },
-          "name": {
+          "folder": {
+            "type": "string",
+            "title": "Folder"
+          },
+          "host_path": {
             "anyOf": [
               {
                 "type": "string"
@@ -9359,58 +9518,52 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Host Path"
           },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
+          "label": {
+            "type": "string",
+            "title": "Label"
           },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
+          "allow_delete_file": {
+            "type": "boolean",
+            "title": "Allow Delete File"
           },
-          "picture_ids": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Picture Ids"
-          },
-          "stack_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Stack Id"
+          "sync_captions": {
+            "type": "boolean",
+            "title": "Sync Captions"
           },
           "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "last_scanned": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Scanned"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "folder",
+          "host_path",
+          "label",
+          "allow_delete_file",
+          "sync_captions",
+          "status",
+          "last_scanned"
+        ],
+        "title": "ReferenceFolderResponse"
+      },
+      "ReferenceFolderUpdateRequest": {
+        "properties": {
+          "label": {
             "anyOf": [
               {
                 "type": "string"
@@ -9419,13 +9572,100 @@
                 "type": "null"
               }
             ],
-            "title": "Status"
+            "title": "Label"
+          },
+          "allow_delete_file": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allow Delete File"
+          },
+          "sync_captions": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Captions"
+          },
+          "host_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Path"
           }
         },
-        "additionalProperties": true,
         "type": "object",
-        "title": "StackResponse",
-        "description": "Stack metadata plus its ordered picture ids.\n\nAlso covers the unstacked response from ``get_stack_for_picture``\n(``{\"stack_id\": None, \"picture_ids\": []}``) and the stack-deleted response\nfrom ``remove_stack_members`` (``{\"status\", \"stack_id\": None,\n\"picture_ids\"}``), so all fields are optional and ``extra=\"allow\"``."
+        "title": "ReferenceFolderUpdateRequest"
+      },
+      "ReferenceFoldersListResponse": {
+        "properties": {
+          "in_docker": {
+            "type": "boolean",
+            "title": "In Docker"
+          },
+          "has_pending": {
+            "type": "boolean",
+            "title": "Has Pending"
+          },
+          "image_root": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Root"
+          },
+          "folders": {
+            "items": {
+              "$ref": "#/components/schemas/ReferenceFolderResponse"
+            },
+            "type": "array",
+            "title": "Folders"
+          }
+        },
+        "type": "object",
+        "required": [
+          "in_docker",
+          "has_pending",
+          "image_root",
+          "folders"
+        ],
+        "title": "ReferenceFoldersListResponse"
+      },
+      "ResetTagsRequest": {
+        "properties": {
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          }
+        },
+        "type": "object",
+        "title": "ResetTagsRequest",
+        "description": "Request body for reset_tags and reset_description endpoints."
       },
       "StreamPicturesResponse": {
         "properties": {
@@ -9477,51 +9717,18 @@
           ]
         }
       },
-      "TagCountResponse": {
+      "UpdateTokenRequest": {
         "properties": {
-          "tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "count": {
-            "type": "integer",
-            "title": "Count"
+          "watermark": {
+            "type": "boolean",
+            "title": "Watermark"
           }
         },
-        "additionalProperties": true,
         "type": "object",
         "required": [
-          "tag",
-          "count"
+          "watermark"
         ],
-        "title": "TagCountResponse",
-        "description": "A unique tag value with its usage count."
-      },
-      "TagItemResponse": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "tag": {
-            "type": "string",
-            "title": "Tag"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "tag"
-        ],
-        "title": "TagItemResponse",
-        "description": "A single tag attached to a picture."
+        "title": "UpdateTokenRequest"
       },
       "ValidationError": {
         "properties": {
@@ -9562,85 +9769,45 @@
           "type"
         ],
         "title": "ValidationError"
-      },
-      "VersionResponse": {
-        "properties": {
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
-          "version": {
-            "type": "string",
-            "title": "Version"
-          },
-          "install_type": {
-            "type": "string",
-            "title": "Install Type"
-          },
-          "docker_variant": {
-            "type": "string",
-            "title": "Docker Variant"
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "message",
-          "version",
-          "install_type",
-          "docker_variant"
-        ],
-        "title": "VersionResponse",
-        "description": "Body of ``GET /version``."
-      }
-    },
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT",
-        "description": "Personal API token from Account Settings \u2192 API Tokens. Read-only tokens may also be passed as a `?token=` query parameter."
       }
     }
   },
   "tags": [
     {
-      "name": "pictures",
-      "description": "Browse, search, import, export and edit the pictures and videos in your library \u2014 the core of the API.\n\n**Listing.** `GET /pictures` returns matching rows. Page with `offset` + `limit`, order with\n`sort` (plus `descending`), and control how much data comes back per row with `fields`:\n\n- `fields=grid` \u2014 compact set tuned for thumbnail grids (stack leaders only)\n- `fields=id,score,width,height` \u2014 only the columns you name\n- *(omit `fields`)* \u2014 full metadata for every row\n\nMost filters (tags, characters, sets, score ranges, \u2026) are passed as additional query parameters.\n\n### Common workflow\n\n```bash\n# 1) Newest 50, compact projection\ncurl \"https://your-pixlstash-host/api/v1/pictures?sort=DATE&limit=50&fields=grid\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n\n# 2) Full metadata for one picture\ncurl \"https://your-pixlstash-host/api/v1/pictures/123/metadata\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n\n# 3) Download the original file\ncurl \"https://your-pixlstash-host/api/v1/pictures/123.jpg\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -o 123.jpg\n\n# 4) Set a manual 5-star score\ncurl -X PATCH \"https://your-pixlstash-host/api/v1/pictures/123\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"score\": 5}'\n```\n\n### Sort values (`sort=`)\n\n| Value | Orders by |\n| --- | --- |\n| `DATE` | Capture / file date |\n| `IMPORTED_AT` | Import time |\n| `SCORE` | Manual star rating |\n| `SMART_SCORE` | Model-predicted aesthetic score |\n| `IMAGE_SIZE` | Pixel dimensions |\n| `TEXT_CONTENT` | Relevance to a text `query` |\n| `CHARACTER_LIKENESS` | Likeness to a chosen character |\n\nOmit `sort` for natural (id) order; add `descending=false` to reverse.\n\n### Exporting (async)\n\nExports run as a background job \u2014 start it, poll status, then download the ZIP:\n\n```bash\ntask=$(curl -s \"https://your-pixlstash-host/api/v1/pictures/export?set_id=7&resolution=original\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" | jq -r .task_id)\n\ncurl \"https://your-pixlstash-host/api/v1/pictures/export/status?task_id=$task\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n\ncurl \"https://your-pixlstash-host/api/v1/pictures/export/download/$task\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -o export.zip\n```\n\n> **Trash:** `DELETE /pictures/{id}` moves a picture to the *scrapheap* (recoverable via\n> `POST /pictures/scrapheap/restore`); `DELETE /pictures/scrapheap` purges it for good.\n"
+      "name": "config",
+      "description": "User configuration, auth helpers, worker progress and server config utilities."
     },
     {
       "name": "characters",
-      "description": "Create characters, assign detected faces to them, and search by face likeness.\n\nA *character* groups faces across your library. Assign faces (by `face_ids`, or whole\n`picture_ids`) and PixlStash builds a likeness model used for search and scoring.\n\n### Common workflow\n\n```bash\n# Create a character\ncid=$(curl -s -X POST \"https://your-pixlstash-host/api/v1/characters\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"Ada\"}' | jq -r .id)\n\n# Assign faces from some pictures\ncurl -X POST \"https://your-pixlstash-host/api/v1/characters/$cid/faces\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"picture_ids\": [123, 124, 125]}'\n\n# Reference pictures + category summary\ncurl \"https://your-pixlstash-host/api/v1/characters/$cid/reference_pictures\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n```\n\nFind characters whose faces resemble an image with `POST /characters/likeness-search`, or look\none up by project with `GET /projects/{project_name}/characters/{character_name}`.\n"
+      "description": "Character CRUD, summaries, reference pictures and face assignment endpoints."
     },
     {
       "name": "picture_sets",
-      "description": "Curated, manually-orderable collections of pictures. Create a set, then add, replace or remove members.\n\n### Common workflow\n\n```bash\n# Create a set\nsid=$(curl -s -X POST \"https://your-pixlstash-host/api/v1/picture_sets\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"Best of 2026\"}' | jq -r .id)\n\n# Bulk-add pictures\ncurl -X POST \"https://your-pixlstash-host/api/v1/picture_sets/$sid/members\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"picture_ids\": [123, 124, 125]}'\n\n# List members\ncurl \"https://your-pixlstash-host/api/v1/picture_sets/$sid/members\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n```\n\n`POST .../members` adds, `PUT .../members` **replaces** the whole membership, and\n`DELETE .../members/{picture_id}` removes one. `POST /picture_sets/membership` checks set\nmembership for many pictures in a single call.\n"
+      "description": "Picture set CRUD and picture membership management."
     },
     {
       "name": "tags",
-      "description": "Read and edit the tags on pictures, and list every tag in the library.\n\n### Common workflow\n\n```bash\n# Every distinct tag\ncurl \"https://your-pixlstash-host/api/v1/tags\" -H \"Authorization: Bearer YOUR_TOKEN\"\n\n# Tags on one picture\ncurl \"https://your-pixlstash-host/api/v1/pictures/123/tags\" -H \"Authorization: Bearer YOUR_TOKEN\"\n\n# Add a tag\ncurl -X POST \"https://your-pixlstash-host/api/v1/pictures/123/tags\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"tag\": \"sunset\"}'\n\n# Tags for many pictures at once (max 200 ids)\ncurl -X POST \"https://your-pixlstash-host/api/v1/pictures/tags/bulk_fetch\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"picture_ids\": [123, 124, 125]}'\n```\n\n`DELETE /pictures/{id}/tags/{tag_id}` removes one tag; `DELETE /pictures/{id}/tags` clears them all.\n"
+      "description": "Tag management for pictures, faces"
     },
     {
       "name": "stacks",
-      "description": "Stacks group related shots (bursts, edits, variants) under one leader, with a manual order.\n\n### Common workflow\n\n```bash\n# Create a stack from some pictures\nstack=$(curl -s -X POST \"https://your-pixlstash-host/api/v1/stacks\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"picture_ids\": [123, 124, 125]}' | jq -r .id)\n\n# Add a member\ncurl -X POST \"https://your-pixlstash-host/api/v1/stacks/$stack/members\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"picture_ids\": [126]}'\n\n# Set the display order\ncurl -X PATCH \"https://your-pixlstash-host/api/v1/stacks/$stack/order\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"picture_ids\": [124, 123, 125, 126]}'\n```\n\nFind the stack a picture belongs to with `GET /pictures/{picture_id}/stack`, and move a single\nmember with `PATCH /stacks/{stack_id}/members/{picture_id}`.\n"
+      "description": "Stack creation, ordering and membership operations."
+    },
+    {
+      "name": "pictures",
+      "description": "Picture listing, metadata, thumbnails, import/export and media operations."
+    },
+    {
+      "name": "comfyui",
+      "description": "ComfyUI workflow management and image-to-image execution."
     },
     {
       "name": "projects",
-      "description": "Top-level workspaces that scope characters and picture sets and hold file/URL attachments.\nEndpoints accept a project **id or name**.\n\n### Common workflow\n\n```bash\n# Create a project\npid=$(curl -s -X POST \"https://your-pixlstash-host/api/v1/projects\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"Album cover\", \"description\": \"2026 shoot\"}' | jq -r .id)\n\n# Attach a reference file (multipart)\ncurl -X POST \"https://your-pixlstash-host/api/v1/projects/$pid/attachments\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -F \"file=@moodboard.pdf\"\n\n# ...or bookmark a URL\ncurl -X POST \"https://your-pixlstash-host/api/v1/projects/$pid/attachments/url\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -H \"Content-Type: application/json\" \\\n  -d '{\"url\": \"https://example.com/ref\", \"title\": \"Reference\"}'\n\n# Export the whole project as a ZIP\ncurl \"https://your-pixlstash-host/api/v1/projects/$pid/export\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\" -o project.zip\n```\n\n`GET /projects/{id_or_name}/summary` returns the picture count; the nested\n`/picture_sets` lists the sets scoped to the project.\n"
+      "description": "Project management, including character/set scoping and file attachments."
     },
     {
-      "name": "auth",
-      "description": "Session login for the web UI. **For API access, prefer a personal token** (see *Authentication*\nat the top) and send it as `Authorization: Bearer \u2026` on every request.\n\n- `POST /login` \u2014 authenticate a username/password and set a session cookie.\n- `GET /login` \u2014 report whether first-run registration is still needed.\n- `GET /check-session` \u2014 validate the current session or token.\n- `POST /logout` \u2014 end the session.\n"
-    },
-    {
-      "name": "server",
-      "description": "Server status. `GET /version` is public (no token) and returns the running version and install\ntype \u2014 handy as a health / compatibility check:\n\n```bash\ncurl \"https://your-pixlstash-host/version\"\n```\n"
-    }
-  ],
-  "servers": [
-    {
-      "url": "/",
-      "description": "This server"
+      "name": "taggers",
+      "description": "Tagger plugin registry, artifact downloads and deletion."
     }
   ]
 }

--- a/website/latest-version.json
+++ b/website/latest-version.json
@@ -1,1 +1,1 @@
-{"version": "1.4.1"}
+{"version": "1.4.2", "security": "High"}


### PR DESCRIPTION
Automated website update triggered by release **v1.4.2**.

Changes included:
- `website/api/v{major}.{minor}/` — versioned OpenAPI docs generated
  from the release tag's own backend code.
- `website/latest-version.json` — updated to this release (if it is
  strictly newer than the currently published version; skipped otherwise).
  The `[Security: ...]` tag was taken from the release tag's own `CHANGELOG.md`.