### PR TITLE
Add e2e coverage for tags, ratings, sets and a few more features

### DIFF
--- a/docs/regular-tests.md
+++ b/docs/regular-tests.md
@@ -74,15 +74,60 @@ shrinks as automated coverage grows.
 |------|--------|--------|
 | expands and collapses stacks from the View menu | Expand-all / collapse-all stack controls in the View menu | ✅ |
 
+## Tags — `tags.spec.js` (plan §5)
+| Test | Covers | Status |
+|------|--------|--------|
+| adds and removes a tag in the overlay | Add a tag via the inline input; remove it via its ✕ button (chip appears/disappears with no reload) | ✅ |
+
+## Star rating — `rating.spec.js` (plan §6)
+| Test | Covers | Status |
+|------|--------|--------|
+| sets a rating that persists across a reload | Click the Nth star in the overlay; the score round-trips to the backend and survives a reload | ✅ |
+
+## Picture Sets / Projects / Characters — `entities.spec.js` (plan §7/§8/§9)
+| Test | Covers | Status |
+|------|--------|--------|
+| filters the grid to a picture set (§7) | Sidebar set row → `/set/:id`, row goes active, grid renders | ✅ |
+| filters the grid to a character (§9) | Sidebar character row → `/character/:id`, row goes active, grid renders | ✅ |
+| opens a project from the Projects tab (§8) | Projects tab → project row → `/project/:id` | ✅ |
+
+## Context menu — `context-menu.spec.js` (plan §3.5)
+| Test | Covers | Status |
+|------|--------|--------|
+| opens on right-click and lists picture actions | Right-click a card opens `.image-ctx-menu` exposing Tag / Reverse image search / Share image; Escape dismisses it | ✅ |
+
+## Statistics sidebar — `stats.spec.js`
+| Test | Covers | Status |
+|------|--------|--------|
+| toggles the stats sidebar open and closed | Toolbar chart-bar toggle shows/hides `.stats-sidebar-content` with its Tags/Pictures/Tasks tabs | ✅ |
+
+## Boolean set operations — `set-operations.spec.js`
+| Test | Covers | Status |
+|------|--------|--------|
+| combines multiple sets via the multi-select toolbar | Ctrl-click a second set reveals the combine toolbar with Union / Overlap / Difference / Unique (XOR); clearing dismisses it | ✅ |
+
+## Sharing — `sharing.spec.js`
+| Test | Covers | Status |
+|------|--------|--------|
+| creates a read-only share link for a picture | Context menu → Share image → Create Link mints a read-only URL shown for copying | ✅ |
+
+## Snapshots — `snapshots.spec.js`
+| Test | Covers | Status |
+|------|--------|--------|
+| lists restore points with a restore action (list-only) | Settings → Snapshots lists ≥1 restore point, each offering a Restore action (rollback itself is **not** clicked — it would rewrite the shared DB) | ✅ |
+
 ---
 
 ## Coverage gaps / testing debt (risk-based)
 
 Tracked so they aren't forgotten — weighted by blast radius:
 
-- **Snapshots & rollback (v1.5) — HIGHEST RISK, not yet automated.** The
-  round-trip (snapshot → mutate → rollback) and *selective metadata restore*
-  have no E2E coverage. Data-loss territory; should be the next spec.
+- **Snapshots rollback & selective restore (v1.5) — HIGH RISK, partially
+  automated.** `snapshots.spec.js` now asserts the restore-point list renders
+  with a Restore action, but the destructive round-trip (snapshot → mutate →
+  rollback) and *selective metadata restore* are still uncovered — clicking
+  Restore would rewrite the shared fixture DB, so it needs an isolated backend.
+  Data-loss territory; should be the next spec.
 - **Bulk operations at scale** — select-all/range and apply-to-many beyond a
   handful of pictures are only smoke-covered.
 - **Import of malformed / huge / unsupported files** — graceful handling

--- a/frontend/e2e/fixtures/test.js
+++ b/frontend/e2e/fixtures/test.js
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url'
 import { GridPage } from '../pages/GridPage.js'
 import { ImageOverlay } from '../pages/ImageOverlay.js'
 import { SettingsDialog } from '../pages/SettingsDialog.js'
+import { SideBar } from '../pages/SideBar.js'
+import { ShareDialog } from '../pages/ShareDialog.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const TOKEN_PATH = resolve(__dirname, '../.auth/token.json')
@@ -66,6 +68,12 @@ export const test = base.extend({
   },
   settings: async ({ page }, use) => {
     await use(new SettingsDialog(page))
+  },
+  sidebar: async ({ page }, use) => {
+    await use(new SideBar(page))
+  },
+  shareDialog: async ({ page }, use) => {
+    await use(new ShareDialog(page))
   },
 })
 

--- a/frontend/e2e/pages/GridPage.js
+++ b/frontend/e2e/pages/GridPage.js
@@ -34,6 +34,20 @@ export class GridPage {
     this.searchOverlay = page.locator('.search-overlay')
     this.searchInput = page.locator('.search-overlay input').first()
     this.searchHistoryChips = page.locator('.search-history-chip')
+    // Right-click context menu (§3.5) — ImageGridContextMenu.vue.
+    this.contextMenu = page.locator('.image-ctx-menu')
+    // Statistics sidebar — toggled from the toolbar. Its title flips with state
+    // ("Show"/"Hide stats sidebar"), so target the (single) chart-bar button by
+    // icon, which is stable across both states.
+    this.statsToggle = page.locator('.bar-btn:has(.mdi-chart-bar)').first()
+    this.statsSidebar = page.locator('.stats-sidebar')
+    this.statsContent = page.locator('.stats-sidebar-content')
+    this.statsTabs = page.locator('.stats-tab-btn')
+    // Boolean set-operation toolbar (appears when >1 set/character selected).
+    this.multiSelectToolbar = page.locator('.multi-select-toolbar')
+    this.multiSelectMode = page.locator('.multi-select-toolbar__mode')
+    this.multiSelectLabel = page.locator('.multi-select-toolbar__label')
+    this.multiSelectClear = page.locator('.multi-select-toolbar__clear')
   }
 
   async goto() {
@@ -76,5 +90,17 @@ export class GridPage {
 
   sortOption(label) {
     return this.page.locator('.gb-sort-grid-btn', { hasText: label }).first()
+  }
+
+  /** Right-click a card (first by default) to open the context menu. */
+  async openContextMenu(cardLocator) {
+    const target = cardLocator ?? this.cards.first()
+    await target.click({ button: 'right' })
+    await expect(this.contextMenu).toBeVisible()
+  }
+
+  /** A context-menu action item by its visible label. */
+  contextMenuItem(label) {
+    return this.contextMenu.locator('.ctx-item', { hasText: label }).first()
   }
 }

--- a/frontend/e2e/pages/ImageOverlay.js
+++ b/frontend/e2e/pages/ImageOverlay.js
@@ -20,8 +20,50 @@ export class ImageOverlay {
       name: 'Toggle face bounding boxes',
     })
     this.faceBboxes = page.locator('.face-bbox-overlay')
-    // Tags (used in later phases)
+    // Tags (§5) — chips, the "Add tag (T)" affordance, and the inline input.
     this.tags = page.locator('.overlay-tag')
+    this.addTagButton = page.locator('.section-meta-btn[title="Add tag (T)"]').first()
+    this.tagInput = page.locator('.tag-add-input')
+    // Star rating (§6) — the overlay topbar widget. Scoped to .image-overlay so
+    // it never matches the grid's .star-overlay--compact thumbnails. Filled
+    // stars carry an inline colour referencing --v-theme-accent; unfilled ones
+    // reference --v-theme-on-background, so filled stars are countable.
+    this.starWidget = page.locator('.image-overlay .star-overlay').first()
+    this.stars = this.starWidget.locator('.v-icon')
+  }
+
+  /** A tag chip located by its visible label. */
+  tag(label) {
+    return this.tags.filter({ hasText: label }).first()
+  }
+
+  /** Add a tag through the inline input (commits on Enter). */
+  async addTag(label) {
+    await this.addTagButton.click()
+    await expect(this.tagInput).toBeVisible()
+    await this.tagInput.fill(label)
+    await this.page.keyboard.press('Enter')
+  }
+
+  /** Remove a tag via the ✕ delete button on its chip. */
+  async removeTag(label) {
+    const chip = this.tag(label)
+    await chip.hover()
+    await chip.locator('.tag-delete-btn').click()
+  }
+
+  /** Click the Nth star (1-based) in the overlay rating widget. */
+  async setRating(n) {
+    await this.stars.nth(n - 1).click()
+  }
+
+  /** Count of filled stars, derived from the accent-coloured inline style. */
+  filledStarCount() {
+    return this.stars.evaluateAll(
+      (els) =>
+        els.filter((e) => (e.getAttribute('style') || '').includes('--v-theme-accent'))
+          .length,
+    )
   }
 
   /** Open the overlay by clicking a grid thumbnail (first by default). */

--- a/frontend/e2e/pages/SettingsDialog.js
+++ b/frontend/e2e/pages/SettingsDialog.js
@@ -4,7 +4,8 @@ import { expect } from '@playwright/test'
  * The user settings dialog (UserSettingsDialog.vue / AccountSection.vue).
  * Opened from the toolbar gear (mdi-cog-outline). Selectors verified in source:
  * .settings-dialog-card, .settings-logout-btn, the "Account Settings" v-tab,
- * the "Token description" field, the "Create Token" button, .settings-token-row.
+ * the "Token description" field, the "Create Token" button, .settings-token-row,
+ * the "Snapshots" v-tab, .snapshots-section and .snapshot-row.
  */
 export class SettingsDialog {
   constructor(page) {
@@ -16,6 +17,10 @@ export class SettingsDialog {
     this.tokenDescription = page.getByLabel('Token description')
     this.createTokenButton = page.getByRole('button', { name: 'Create Token' })
     this.tokenRows = page.locator('.settings-token-row')
+    // Snapshots tab (SnapshotsSection.vue).
+    this.snapshotsTab = page.getByRole('tab', { name: 'Snapshots' })
+    this.snapshotsSection = page.locator('.snapshots-section')
+    this.snapshotRows = page.locator('.snapshot-row')
   }
 
   async open() {
@@ -26,5 +31,10 @@ export class SettingsDialog {
   async openAccountTab() {
     await this.accountTab.click()
     await expect(this.tokenDescription).toBeVisible()
+  }
+
+  async openSnapshotsTab() {
+    await this.snapshotsTab.click()
+    await expect(this.snapshotsSection).toBeVisible()
   }
 }

--- a/frontend/e2e/pages/ShareDialog.js
+++ b/frontend/e2e/pages/ShareDialog.js
@@ -1,0 +1,23 @@
+import { expect } from '@playwright/test'
+
+/**
+ * The picture/entity share dialog (ShareDialog.vue), opened from the grid
+ * context menu's "Share image" action. Selectors verified in source:
+ * .share-dialog-card root, the "Create Link" button, .share-dialog-url (the
+ * generated read-only link), and a Close/Cancel button.
+ */
+export class ShareDialog {
+  constructor(page) {
+    this.page = page
+    this.card = page.locator('.share-dialog-card')
+    this.createButton = this.card.getByRole('button', { name: 'Create Link' })
+    this.url = page.locator('.share-dialog-url')
+    this.closeButton = this.card.getByRole('button', { name: /^(Close|Cancel)$/ })
+  }
+
+  /** Generate the share link and wait for the URL to appear. */
+  async createLink() {
+    await this.createButton.click()
+    await expect(this.url).toBeVisible()
+  }
+}

--- a/frontend/e2e/pages/SideBar.js
+++ b/frontend/e2e/pages/SideBar.js
@@ -1,0 +1,45 @@
+import { expect } from '@playwright/test'
+
+/**
+ * The left sidebar (SideBar.vue) — navigation that filters the grid by picture
+ * set (§7), project (§8), and character/person (§9). Thin wrapper around the
+ * stable selectors verified in source: .sidebar-set-item, the character rows in
+ * .sidebar-character-group, the "Projects" .sidebar-view-tab, and the project
+ * tree's .sidebar-project-tree-row. Per-row counts live in .sidebar-list-count.
+ */
+export class SideBar {
+  constructor(page) {
+    this.page = page
+    this.setItems = page.locator('.sidebar-set-item')
+    this.characterItems = page.locator('.sidebar-character-group .sidebar-list-item')
+    this.projectsTab = page.locator('.sidebar-view-tab', { hasText: 'Projects' }).first()
+    this.projectRows = page.locator('.sidebar-project-tree-row')
+  }
+
+  /** The count badge inside a set/character/project row. */
+  count(row) {
+    return row.locator('.sidebar-list-count').first()
+  }
+
+  /**
+   * The first row whose count badge is a positive number — picks a non-empty
+   * entity so a "grid filters to it" assertion has thumbnails to show. Falls
+   * back to the first row when no count is readable.
+   */
+  async firstNonEmpty(items) {
+    const n = await items.count()
+    for (let i = 0; i < n; i++) {
+      const row = items.nth(i)
+      const txt = (await this.count(row).innerText().catch(() => '')).trim()
+      const m = txt.match(/\d+/)
+      if (m && Number(m[0]) > 0) return row
+    }
+    return items.first()
+  }
+
+  /** Switch the sidebar to the Projects tree and wait for it to render. */
+  async openProjectsTab() {
+    await this.projectsTab.click()
+    await expect(this.projectRows.first()).toBeVisible()
+  }
+}

--- a/frontend/e2e/specs/context-menu.spec.js
+++ b/frontend/e2e/specs/context-menu.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '../fixtures/test.js'
+
+// Release plan §3.5 — the right-click context menu. Right-clicking a grid card
+// opens the menu and exposes the selection-scoped actions (Tag, Reverse image
+// search, Share image …). Read-only: we open the menu and dismiss it without
+// invoking any action.
+
+test.describe('context menu', () => {
+  test.beforeEach(async ({ grid }) => {
+    await grid.goto()
+  })
+
+  test('opens on right-click and lists picture actions (§3.5)', async ({ page, grid }) => {
+    await grid.openContextMenu()
+
+    await expect(grid.contextMenuItem('Tag')).toBeVisible()
+    await expect(grid.contextMenuItem('Reverse image search')).toBeVisible()
+    await expect(grid.contextMenuItem('Share image')).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(grid.contextMenu).toBeHidden()
+  })
+})

--- a/frontend/e2e/specs/entities.spec.js
+++ b/frontend/e2e/specs/entities.spec.js
@@ -1,0 +1,45 @@
+import { test, expect } from '../fixtures/test.js'
+
+// Release plan §7/§8/§9 — Picture Sets, Projects, and Characters. Clicking an
+// entity in the sidebar navigates to its route (/set, /project, /character) and
+// filters the grid to it. The grid virtualises, so we assert deterministic
+// signals (route change, the row's active state, thumbnails still render) rather
+// than exact thumbnail counts. Navigation only — no data is mutated.
+
+test.describe('entity navigation', () => {
+  test.beforeEach(async ({ grid }) => {
+    await grid.goto()
+  })
+
+  test('filters the grid to a picture set (§7)', async ({ page, grid, sidebar }) => {
+    await expect(sidebar.setItems.first()).toBeVisible()
+    const row = await sidebar.firstNonEmpty(sidebar.setItems)
+
+    await row.click()
+    await expect.poll(() => page.url()).toContain('/set/')
+    await expect(row).toHaveClass(/active/)
+    await expect(grid.thumbnails.first()).toBeVisible()
+  })
+
+  test('filters the grid to a character (§9)', async ({ page, grid, sidebar }) => {
+    await expect(sidebar.characterItems.first()).toBeVisible()
+    const row = await sidebar.firstNonEmpty(sidebar.characterItems)
+
+    await row.click()
+    await expect.poll(() => page.url()).toContain('/character/')
+    await expect(row).toHaveClass(/active/)
+    await expect(grid.thumbnails.first()).toBeVisible()
+  })
+
+  test('opens a project from the Projects tab (§8)', async ({ page, grid, sidebar }) => {
+    await sidebar.openProjectsTab()
+    const row = sidebar.projectRows.first()
+    await expect(row).toBeVisible()
+
+    await row.click()
+    await expect.poll(() => page.url()).toContain('/project/')
+    // A project view still renders the grid; some seeded projects may be empty,
+    // so we assert the grid container is present rather than a thumbnail count.
+    await expect(grid.grid).toBeVisible()
+  })
+})

--- a/frontend/e2e/specs/rating.spec.js
+++ b/frontend/e2e/specs/rating.spec.js
@@ -1,0 +1,25 @@
+import { test, expect } from '../fixtures/test.js'
+
+// Release plan §6 — Star rating. Set a rating in the ImageOverlay, confirm the
+// stars fill, then reload and reopen the same picture to prove the score round-
+// tripped to the backend and persisted. Setting the same rating again is
+// idempotent, so re-runs leave the shared fixture in a stable state.
+
+const RATING = 3
+
+test.describe('star rating', () => {
+  test('sets a rating that persists across a reload (§6)', async ({ page, grid, overlay }) => {
+    await grid.goto()
+    await overlay.openFromGrid()
+
+    await overlay.setRating(RATING)
+    await expect.poll(() => overlay.filledStarCount()).toBe(RATING)
+
+    // The open picture is encoded in the URL (?overlay=<id>), so a reload
+    // restores the overlay on the same picture. The rating must survive the
+    // round-trip to the backend.
+    await page.reload()
+    await expect(overlay.root).toBeVisible({ timeout: 15_000 })
+    await expect.poll(() => overlay.filledStarCount()).toBe(RATING)
+  })
+})

--- a/frontend/e2e/specs/set-operations.spec.js
+++ b/frontend/e2e/specs/set-operations.spec.js
@@ -1,0 +1,32 @@
+import { test, expect } from '../fixtures/test.js'
+
+// Boolean set operations — Ctrl/Cmd-clicking a second picture set enters
+// multi-select and reveals the combine toolbar with Union / Overlap /
+// Difference / Unique (XOR) modes. Navigation/preference state only; no data is
+// mutated.
+
+test.describe('boolean set operations', () => {
+  test('combines multiple sets via the multi-select toolbar', async ({ grid, sidebar }) => {
+    await grid.goto()
+    expect(await sidebar.setItems.count()).toBeGreaterThanOrEqual(2)
+
+    // First click selects a single set; Ctrl-click adds a second → multi-select.
+    await sidebar.setItems.nth(0).click()
+    await sidebar.setItems.nth(1).click({ modifiers: ['Control'] })
+
+    await expect(grid.multiSelectToolbar).toBeVisible()
+    await expect(grid.multiSelectLabel).toContainText(/sets selected/i)
+
+    const modes = await grid.multiSelectMode.locator('option').allInnerTexts()
+    for (const label of ['Union', 'Overlap', 'Difference', 'Unique (XOR)']) {
+      expect(modes).toContain(label)
+    }
+
+    // Switching the mode keeps the grid mounted (the combined view re-queries).
+    await grid.multiSelectMode.selectOption('intersection')
+    await expect(grid.grid).toBeVisible()
+
+    await grid.multiSelectClear.click()
+    await expect(grid.multiSelectToolbar).toBeHidden()
+  })
+})

--- a/frontend/e2e/specs/sharing.spec.js
+++ b/frontend/e2e/specs/sharing.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '../fixtures/test.js'
+
+// Picture sharing — the grid context menu's "Share image" action opens the
+// share dialog, and "Create Link" mints a read-only link that is shown for
+// copying. This adds a scoped READ token to the backend (an additive mutation
+// that does not affect other specs).
+
+test.describe('sharing', () => {
+  test('creates a read-only share link for a picture', async ({ grid, shareDialog }) => {
+    await grid.goto()
+    await grid.openContextMenu()
+    await grid.contextMenuItem('Share image').click()
+
+    await expect(shareDialog.card).toBeVisible()
+    await shareDialog.createLink()
+
+    // A real URL is produced (either a gallery ?token= link or a /share/ file link).
+    await expect(shareDialog.url).toContainText('http')
+
+    await shareDialog.closeButton.click()
+    await expect(shareDialog.card).toBeHidden()
+  })
+})

--- a/frontend/e2e/specs/snapshots.spec.js
+++ b/frontend/e2e/specs/snapshots.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from '../fixtures/test.js'
+
+// Snapshots — Settings → Snapshots lists the automatic metadata restore points
+// (the fixture ships several). We assert the list renders with at least one
+// restore point and that each row offers a Restore action, but we deliberately
+// never click Restore: a rollback would rewrite the shared fixture DB.
+
+test.describe('snapshots', () => {
+  test('lists restore points with a restore action (list-only)', async ({ grid, settings }) => {
+    await grid.goto()
+    await settings.open()
+    await settings.openSnapshotsTab()
+
+    expect(await settings.snapshotRows.count()).toBeGreaterThan(0)
+
+    const firstRow = settings.snapshotRows.first()
+    await expect(firstRow).toBeVisible()
+    await expect(firstRow.getByRole('button', { name: /Restore/ })).toBeVisible()
+  })
+})

--- a/frontend/e2e/specs/stats.spec.js
+++ b/frontend/e2e/specs/stats.spec.js
@@ -1,0 +1,25 @@
+import { test, expect } from '../fixtures/test.js'
+
+// Statistics sidebar (StatsSidebar.vue) — the toolbar toggle opens a panel with
+// Tags / Pictures / Tasks tabs summarising the library. Read-only: toggling the
+// panel changes only per-user UI state.
+
+test.describe('statistics sidebar', () => {
+  test('toggles the stats sidebar open and closed', async ({ grid }) => {
+    await grid.goto()
+    await expect(grid.statsToggle).toBeVisible()
+
+    // The sidebar's default open/closed state is a persisted preference, so
+    // normalise to open before asserting on its contents.
+    if ((await grid.statsContent.count()) === 0) await grid.statsToggle.click()
+    await expect(grid.statsContent).toBeVisible()
+    // It renders its tabbed sections (Tags / Pictures / Tasks).
+    expect(await grid.statsTabs.count()).toBeGreaterThanOrEqual(2)
+
+    // Toggling hides it, and toggling again brings it back.
+    await grid.statsToggle.click()
+    await expect(grid.statsContent).toBeHidden()
+    await grid.statsToggle.click()
+    await expect(grid.statsContent).toBeVisible()
+  })
+})

--- a/frontend/e2e/specs/tags.spec.js
+++ b/frontend/e2e/specs/tags.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from '../fixtures/test.js'
+
+// Release plan §5 — Tags. Add a tag through the ImageOverlay's inline input and
+// confirm the chip appears immediately, then remove it via its ✕ button and
+// confirm it disappears. The test adds and then removes its own unique tag, so
+// the shared fixture DB is left exactly as it was found.
+
+const TEMP_TAG = 'zz-e2e-temp-tag'
+
+test.describe('tags', () => {
+  test('adds and removes a tag in the overlay (§5)', async ({ grid, overlay }) => {
+    await grid.goto()
+    await overlay.openFromGrid()
+
+    await overlay.addTag(TEMP_TAG)
+    await expect(overlay.tag(TEMP_TAG)).toBeVisible()
+
+    await overlay.removeTag(TEMP_TAG)
+    await expect(overlay.tag(TEMP_TAG)).toBeHidden()
+  })
+})


### PR DESCRIPTION
Fills in the obvious gaps against the release test plan: tag add/remove, star ratings, set/project/character nav, context menu, stats sidebar, boolean set ops, sharing, and a read-only snapshots list.