### PR TITLE
Don't fail imports when the WD14 tagger can't download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,23 @@ jobs:
       - name: Cache HuggingFace models
         uses: actions/cache@v4
         with:
-          path: ~/.cache/huggingface
-          key: hf-models-${{ runner.os }}-${{ hashFiles('pixlstash/picture_tagger.py') }}
+          # Two distinct on-disk locations, both required:
+          #  * ~/.cache/huggingface — the HF hub cache used by CLIP/SBert/
+          #    Florence via from_pretrained_local_first.
+          #  * ~/.local/share/pixlstash/downloaded_models — platformdirs
+          #    user_data_dir, where the WD14 and PixlStash taggers land because
+          #    they call hf_hub_download(local_dir=...), which bypasses the hub
+          #    cache entirely. The old key cached only the hub dir and was thus
+          #    a no-op for the taggers that actually 429'd.
+          # A warm cache makes needs_download() (a pure file-existence check)
+          # return False, so download() — and its HEAD revalidation, the call
+          # that returns 429 — is never issued. Key off the tagger plugins so a
+          # model/revision bump busts the cache; restore-keys keeps it warm
+          # across unrelated commits.
+          path: |
+            ~/.cache/huggingface
+            ~/.local/share/pixlstash/downloaded_models
+          key: hf-models-${{ runner.os }}-${{ hashFiles('pixlstash/tagger_plugins/wd14.py', 'pixlstash/tagger_plugins/pixlstash_tagger.py', 'pixlstash/tagger_plugins/florence2.py') }}
           restore-keys: hf-models-${{ runner.os }}-
 
       - name: Verify wheel includes Alembic assets
@@ -250,8 +265,16 @@ jobs:
       - name: Cache HuggingFace models
         uses: actions/cache@v4
         with:
-          path: ~\.cache\huggingface
-          key: hf-models-${{ runner.os }}-${{ hashFiles('pixlstash/picture_tagger.py') }}
+          # See the Linux `build` job for the rationale. The taggers download
+          # via hf_hub_download(local_dir=...) into platformdirs' Windows
+          # user_data_dir — %LOCALAPPDATA%\pixlstash\pixlstash\downloaded_models
+          # (the doubled "pixlstash" is platformdirs' appauthor=appname default)
+          # — NOT ~\.cache\huggingface. Caching both is what makes a warm runner
+          # skip the HEAD revalidation that returns the 429.
+          path: |
+            ~\.cache\huggingface
+            ~\AppData\Local\pixlstash\pixlstash\downloaded_models
+          key: hf-models-${{ runner.os }}-${{ hashFiles('pixlstash/tagger_plugins/wd14.py', 'pixlstash/tagger_plugins/pixlstash_tagger.py', 'pixlstash/tagger_plugins/florence2.py') }}
           restore-keys: hf-models-${{ runner.os }}-
 
       # Windows only validates OS-sensitive behaviour (file/path/process

--- a/pixlstash/inference/engine.py
+++ b/pixlstash/inference/engine.py
@@ -493,7 +493,22 @@ class InferenceEngine:
             silent=True,
         )
         if wd14_service.needs_download():
-            wd14_service.download()
+            # Best-effort, mirroring the PixlStash tagger above: a transient
+            # model-download failure (e.g. a HuggingFace 429) must disable WD14
+            # tagging, not propagate out of engine creation and fail the
+            # caller. Tagging is async/best-effort, so a network blip here must
+            # never fail a user's import.
+            try:
+                wd14_service.download()
+            except Exception as exc:
+                logger.warning(
+                    "WD14 tagger download failed (%s), disabling.", exc
+                )
+        if wd14_service.needs_download():
+            logger.warning(
+                "WD14 tagger model not found in %s, disabling.", model_dir
+            )
+            wd14_enabled = False
 
         vram_budget = VramBudget(device)
         vram_budget.set_budget_gb(max_vram_gb)


### PR DESCRIPTION
A HuggingFace 429 on the WD14 model download was bubbling up and marking the whole import as failed, which is why the Windows tests kept flaking. Disable the tagger on download failure like we already do for the PixlStash tagger, and fix the CI cache to actually point at where the tagger models land so warm runners skip the network entirely.