### PR TITLE
chore: release v1.5.1 website update

### DIFF
--- a/website/api/v1.5/openapi.json
+++ b/website/api/v1.5/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PixlStash API",
     "description": "<a href=\"https://pixlstash.dev\" target=\"_blank\" rel=\"noopener\">\n  <img\n    src=\"scalar-assets/logo.png\"\n    alt=\"PixlStash\"\n    width=\"120\"\n    style=\"float: right; margin: 0 0 16px 24px\"\n  />\n</a>\n\n# Simplify your image workflow\n\n**PixlStash is a self-hosted, open-source image library for creators.** It imports your\npictures and videos, auto-tags and captions them with local AI models, recognises\ncharacters and faces, scores image quality, runs natural-language semantic search and\ndrives ComfyUI workflows \u2014 all on your own hardware, with no cloud and no lock-in.\n\n**Integrate with scripts, pipelines and external tools** \u2014 fetch images, metadata, tags and\nmore. This REST API exposes everything the app can do \u2014 **pictures, tags, stacks, sets,\ncharacters and projects** \u2014 so you can script imports, build integrations and automate your pipeline.\n\n### \u2192 Learn more and download at **[pixlstash.dev](https://pixlstash.dev)**\n\n<div style=\"clear: both\"></div>\n\n---\n\n## What can you do with this?\n\nDrive any tool or pipeline you can script. For a worked example, see the\n[**PixlStash LM Studio plugin**](https://github.com/pikselkroken/pixlstash-lmstudio) \u2014\nit uses this API to let a locally-running LLM illustrate its chat replies with\nmatching pictures from your PixlStash library.\n\n## Quick start\n\nCreate an API token (steps below), then fetch your first 50 pictures \u2014 replace\n`your-pixlstash-host` with your server's address:\n\n```bash\ncurl \"https://your-pixlstash-host/api/v1/pictures?limit=50\" \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n```\n\n## Authentication\n\nEvery request authenticates with a personal **API token**, sent as a Bearer header:\n\n```http\nAuthorization: Bearer YOUR_TOKEN\n```\n\nTokens have one of two access types:\n\n| Access type | Can do | Notes |\n| --- | --- | --- |\n| **Full access** | Read **and** write \u2014 everything your account can do | Never put a full-access token in a URL |\n| **Read-only** | `GET` requests only | May also be passed as a `?token=\u2026` query parameter (handy for share links) |\n\n## Creating a token\n\n**1. Open Settings** \u2014 click the gear icon in the top toolbar.\n\n![Open Settings from the top toolbar](scalar-assets/WhereIsUserSettings.jpg)\n\n**2. Open the *Account Settings* tab.**\n\n![The Account Settings tab](scalar-assets/ScreenshotsUserSettings.jpg)\n\n**3. Create the token** \u2014 in the **API Tokens** section, type a description, choose an\naccess type (*Full access* or *Read-only*), optionally tick *Apply watermark*, then click\n**Create Token**.\n\n![The API Tokens section in Account Settings](scalar-assets/ScreenshotTokens.jpg)\n\n**4. Copy it now** \u2014 the token is shown **only once**. Copy it and store it somewhere safe;\nyou won't be able to see it again.\n\n![Copy the newly created token](scalar-assets/ScreenshotToken.jpg)\n\n## Using the token\n\nThe API is served under `/api/v1`. Send your token in the `Authorization` header on every\nrequest, replacing `your-pixlstash-host` with the address of your PixlStash server. To\nconfirm a token is valid:\n\n```bash\ncurl https://your-pixlstash-host/api/v1/check-session \\\n  -H \"Authorization: Bearer YOUR_TOKEN\"\n```\n\nA **read-only** token may instead be passed in the query string for quick read requests\n(never do this with a full-access token):\n\n```bash\ncurl \"https://your-pixlstash-host/api/v1/pictures?limit=50&token=YOUR_READ_TOKEN\"\n```\n\nBrowse the endpoints below for full request and response details.\n",
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "paths": {
     "/api/v1/pictures": {
@@ -609,10 +609,10 @@
                   "$ref": "#/components/schemas/VersionResponse"
                 },
                 "example": {
-                  "message": "string",
-                  "version": "string",
-                  "install_type": "string",
-                  "docker_variant": "string"
+                  "message": "PixlStash REST API",
+                  "version": "1.5.0",
+                  "install_type": "docker",
+                  "docker_variant": "gpu"
                 }
               }
             }
@@ -10973,19 +10973,38 @@
         "properties": {
           "message": {
             "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "description": "Human-readable identifier for the API. Constant string.",
+            "examples": [
+              "PixlStash REST API"
+            ]
           },
           "version": {
             "type": "string",
-            "title": "Version"
+            "title": "Version",
+            "description": "Running PixlStash version, read from the installed package metadata (the `version` in `pyproject.toml`).",
+            "examples": [
+              "1.5.0"
+            ]
           },
           "install_type": {
             "type": "string",
-            "title": "Install Type"
+            "title": "Install Type",
+            "description": "How this server was installed, for active-install telemetry. Always exactly one of: `docker` (the reliable signal \u2014 set via the `PIXLSTASH_IN_DOCKER=1` env flag or the presence of `/.dockerenv`), `pip` (the default for a plain Python/pip install), or `other` (the uncertain fallback \u2014 e.g. an installer such as the Windows Inno Setup build that declares `PIXLSTASH_INSTALL_TYPE=other`). Clients should treat any unrecognised value as `other`.",
+            "examples": [
+              "docker",
+              "pip",
+              "other"
+            ]
           },
           "docker_variant": {
             "type": "string",
-            "title": "Docker Variant"
+            "title": "Docker Variant",
+            "description": "Which Docker image variant is running, reported from the `PIXLSTASH_DOCKER_VARIANT` env var. Only meaningful when `install_type` is `docker`; defaults to `gpu` otherwise.",
+            "examples": [
+              "gpu",
+              "cpu"
+            ]
           }
         },
         "additionalProperties": true,
@@ -10997,7 +11016,7 @@
           "docker_variant"
         ],
         "title": "VersionResponse",
-        "description": "Body of ``GET /version``."
+        "description": "Body of ``GET /version``.\n\nPublic, unauthenticated endpoint used by the SPA for version display and by\nthe daily active-install telemetry ping. ``extra=\"allow\"`` keeps the\nresponse forward-compatible: new diagnostic fields can be added without\nbreaking older clients that ignore unknown keys."
       }
     },
     "securitySchemes": {

--- a/website/latest-version.json
+++ b/website/latest-version.json
@@ -1,1 +1,1 @@
-{"version": "1.5.0", "security": "High"}
+{"version": "1.5.1", "security": "High"}

--- a/website/latest-version/docker.json
+++ b/website/latest-version/docker.json
@@ -1,1 +1,1 @@
-{"version": "1.5.0", "security": "High"}
+{"version": "1.5.1", "security": "High"}

--- a/website/latest-version/other.json
+++ b/website/latest-version/other.json
@@ -1,1 +1,1 @@
-{"version": "1.5.0", "security": "High"}
+{"version": "1.5.1", "security": "High"}

--- a/website/latest-version/pip.json
+++ b/website/latest-version/pip.json
@@ -1,1 +1,1 @@
-{"version": "1.5.0", "security": "High"}
+{"version": "1.5.1", "security": "High"}


### PR DESCRIPTION
Automated website update triggered by release **v1.5.1**.

Changes included:
- `website/api/v{major}.{minor}/` — versioned OpenAPI docs (Scalar UI)
  generated from the release tag's own backend code. The generator
  also heals any older version pages still on ReDoc and drops the
  legacy top-level `openapi.json`.
- `website/latest-version.json` — updated to this release (if it is
  strictly newer than the currently published version; skipped otherwise).
  The `[Security: ...]` tag was taken from the release tag's own `CHANGELOG.md`.
- `website/latest-version/{docker,pip,other}.json` — per-install-type
  manifests carrying the **identical** payload as the legacy file. These
  back the PATH-encoded version-check URLs so Cloudflare zone analytics can
  bucket active installs by type (docker vs pip vs other). Updated/skipped
  in lock-step with the legacy `latest-version.json` above.