### PR TITLE
Extract PredicateFilter to dedupe row-selection logic

### DIFF
--- a/pixlstash/db_models/picture.py
+++ b/pixlstash/db_models/picture.py
@@ -1,6 +1,5 @@
 import base64
 import json
-import os
 import sys
 import numpy as np
 
@@ -436,6 +435,9 @@ class Picture(SQLModel, table=True):
         """
         if candidate_ids is not None and not candidate_ids:
             return []
+        # Imported lazily to avoid a circular import (predicate_filter imports Picture).
+        from pixlstash.utils.query.predicate_filter import PredicateFilter
+
         # 1. Generate SBERT embedding for tag search (Text-to-Text)
         query_embedding = text_to_embedding(query)
         if query_embedding is None:
@@ -531,16 +533,6 @@ class Picture(SQLModel, table=True):
             .limit(limit)
         )
 
-        if only_deleted:
-            stmt = stmt.where(cls.deleted.is_(True))
-        elif not include_deleted:
-            stmt = stmt.where(cls.deleted.is_(False))
-
-        stmt = stmt.where(cls.import_excluded.is_(False))
-
-        if not include_unimported:
-            stmt = stmt.where(cls.imported_at.is_not(None))
-
         # Apply select_fields logic (like in find)
         if select_fields:
             select_fields = list(set(select_fields) | {"id"})
@@ -560,95 +552,27 @@ class Picture(SQLModel, table=True):
             for rel_attr in rel_attrs:
                 stmt = stmt.options(selectinload(rel_attr))
 
-        if format:
-            stmt = stmt.where(cls.format.in_(format))
-
         if candidate_ids:
             stmt = stmt.where(cls.id.in_(candidate_ids))
 
-        if min_score is not None:
-            stmt = stmt.where(cls.score >= min_score)
-        if max_score is not None:
-            stmt = stmt.where(cls.score <= max_score)
-
-        if smart_score_bucket == "unscored":
-            stmt = stmt.where(cls.smart_score.is_(None))
-        elif smart_score_bucket == "1-2":
-            stmt = stmt.where(cls.smart_score.is_not(None), cls.smart_score < 2.0)
-        elif smart_score_bucket == "2-3":
-            stmt = stmt.where(cls.smart_score >= 2.0, cls.smart_score < 3.0)
-        elif smart_score_bucket == "3-4":
-            stmt = stmt.where(cls.smart_score >= 3.0, cls.smart_score < 4.0)
-        elif smart_score_bucket == "4-5":
-            stmt = stmt.where(cls.smart_score >= 4.0)
-
-        if resolution_bucket == "unknown":
-            stmt = stmt.where(or_(cls.width.is_(None), cls.height.is_(None)))
-        elif resolution_bucket == "lt1mp":
-            stmt = stmt.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height < 1_000_000,
-            )
-        elif resolution_bucket == "1-4mp":
-            stmt = stmt.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height >= 1_000_000,
-                cls.width * cls.height < 4_000_000,
-            )
-        elif resolution_bucket == "4-8mp":
-            stmt = stmt.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height >= 4_000_000,
-                cls.width * cls.height < 8_000_000,
-            )
-        elif resolution_bucket == "8-16mp":
-            stmt = stmt.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height >= 8_000_000,
-                cls.width * cls.height < 16_000_000,
-            )
-        elif resolution_bucket == "16plus":
-            stmt = stmt.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height >= 16_000_000,
-            )
-
-        if comfyui_models_filter:
-            for i, m in enumerate(comfyui_models_filter):
-                stmt = stmt.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_models) WHERE value = :comfyui_model_{i})"
-                    ).bindparams(**{f"comfyui_model_{i}": m})
-                )
-
-        if comfyui_loras_filter:
-            for i, m in enumerate(comfyui_loras_filter):
-                stmt = stmt.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_loras) WHERE value = :comfyui_lora_{i})"
-                    ).bindparams(**{f"comfyui_lora_{i}": m})
-                )
-
-        if tags_filter:
-            for i, tag in enumerate(tags_filter):
-                stmt = stmt.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :tag_filter_{i})"
-                    ).bindparams(**{f"tag_filter_{i}": tag})
-                )
-
-        if tags_rejected_filter:
-            for i, tag in enumerate(tags_rejected_filter):
-                stmt = stmt.where(
-                    text(
-                        f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :rejected_tag_filter_{i})"
-                    ).bindparams(**{f"rejected_tag_filter_{i}": tag})
-                )
+        # Lifecycle + intrinsic predicates via the shared compiler.  semantic_search
+        # carries a subset of the vocabulary (no hidden-tags / confidence / face /
+        # file-path); unset fields are no-ops.  ComfyUI here is AND-of-EXISTS (no
+        # stack expansion), which PredicateFilter emits directly.
+        stmt = PredicateFilter(
+            format=format,
+            min_score=min_score,
+            max_score=max_score,
+            smart_score_bucket=smart_score_bucket,
+            resolution_bucket=resolution_bucket,
+            comfyui_models_filter=comfyui_models_filter,
+            comfyui_loras_filter=comfyui_loras_filter,
+            tags_filter=tags_filter,
+            tags_rejected_filter=tags_rejected_filter,
+            only_deleted=only_deleted,
+            include_deleted=include_deleted,
+            include_unimported=include_unimported,
+        ).apply(stmt)
 
         results = session.exec(stmt).all()
 
@@ -758,6 +682,13 @@ class Picture(SQLModel, table=True):
         When count_only=True, returns the integer count of matching pictures
         instead of the picture objects.  Sort, offset, and limit are ignored.
         """
+        # Imported lazily: predicate_filter imports Picture, so a module-level
+        # import here would be circular.
+        from pixlstash.utils.query.predicate_filter import (
+            PredicateFilter,
+            comfyui_leaf_parts,
+        )
+
         query = select(func.count(cls.id)) if count_only else select(cls)
 
         logger.debug("Got search parameters: %s", search)
@@ -778,16 +709,6 @@ class Picture(SQLModel, table=True):
             ]
             for rel_attr in rel_attrs:
                 query = query.options(selectinload(rel_attr))
-
-        if only_deleted:
-            query = query.where(cls.deleted.is_(True))
-        elif not include_deleted:
-            query = query.where(cls.deleted.is_(False))
-
-        query = query.where(cls.import_excluded.is_(False))
-
-        if not include_unimported:
-            query = query.where(cls.imported_at.is_not(None))
 
         for attr, value in search.items():
             if attr == "project_id":
@@ -819,186 +740,39 @@ class Picture(SQLModel, table=True):
                 else:
                     query = query.where(getattr(cls, attr) == value)
 
-        if file_path_prefix is not None:
-            # Normalise to always end with a path separator so that a prefix
-            # like "/ref/photos" does not accidentally match "/ref/photos2/a.jpg".
-            # Support both Unix ("/") and Windows ("\") separators.
-            if file_path_prefix.endswith("/") or file_path_prefix.endswith("\\"):
-                prefix = file_path_prefix
-            else:
-                prefix = file_path_prefix + os.sep
-            # Escape LIKE special characters in the literal prefix.
-            escaped = (
-                prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            )
-            query = query.where(cls.file_path.like(escaped + "%", escape="\\"))
-            # Only show direct children — exclude files that have another path
-            # separator after the prefix (i.e. files in sub-directories).
-            # Check for both "/" (Unix) and "\" (Windows) to handle all platforms.
-            query = query.where(~cls.file_path.like(escaped + "%/%", escape="\\"))
-            query = query.where(~cls.file_path.like(escaped + "%\\\\%", escape="\\"))
+        # All lifecycle + intrinsic-attribute predicates are compiled by the shared
+        # PredicateFilter (the single source of truth for the WHERE logic that used
+        # to be duplicated across the builder sites).  ComfyUI membership is the one
+        # leaf find() does NOT delegate: it expands the match across stack members
+        # (an OR over the whole stack), so it is applied separately below.
+        predicate_filter = PredicateFilter(
+            format=format,
+            min_score=min_score,
+            max_score=max_score,
+            smart_score_bucket=smart_score_bucket,
+            resolution_bucket=resolution_bucket,
+            tags_filter=tags_filter,
+            tags_rejected_filter=tags_rejected_filter,
+            hidden_tags_filter=hidden_tags_filter,
+            tags_confidence_above_filter=tags_confidence_above_filter,
+            tags_confidence_below_filter=tags_confidence_below_filter,
+            face_filter=face_filter,
+            file_path_prefix=file_path_prefix,
+            only_deleted=only_deleted,
+            include_deleted=include_deleted,
+            include_unimported=include_unimported,
+        )
+        query = predicate_filter.apply(query)
 
-        if format:
-            query = query.where(cls.format.in_(format))
-
-        if min_score is not None:
-            query = query.where(cls.score >= min_score)
-        if max_score is not None:
-            query = query.where(cls.score <= max_score)
-
-        if smart_score_bucket == "unscored":
-            query = query.where(cls.smart_score.is_(None))
-        elif smart_score_bucket == "1-2":
-            query = query.where(cls.smart_score.is_not(None), cls.smart_score < 2.0)
-        elif smart_score_bucket == "2-3":
-            query = query.where(cls.smart_score >= 2.0, cls.smart_score < 3.0)
-        elif smart_score_bucket == "3-4":
-            query = query.where(cls.smart_score >= 3.0, cls.smart_score < 4.0)
-        elif smart_score_bucket == "4-5":
-            query = query.where(cls.smart_score >= 4.0)
-
-        if resolution_bucket == "unknown":
-            query = query.where(or_(cls.width.is_(None), cls.height.is_(None)))
-        elif resolution_bucket == "lt1mp":
-            query = query.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height < 1_000_000,
-            )
-        elif resolution_bucket == "1-4mp":
-            query = query.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height >= 1_000_000,
-                cls.width * cls.height < 4_000_000,
-            )
-        elif resolution_bucket == "4-8mp":
-            query = query.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height >= 4_000_000,
-                cls.width * cls.height < 8_000_000,
-            )
-        elif resolution_bucket == "8-16mp":
-            query = query.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height >= 8_000_000,
-                cls.width * cls.height < 16_000_000,
-            )
-        elif resolution_bucket == "16plus":
-            query = query.where(
-                cls.width.is_not(None),
-                cls.height.is_not(None),
-                cls.width * cls.height >= 16_000_000,
-            )
-
-        # Build comfyui filter conditions.  Two parallel lists are maintained:
-        # comfyui_self_parts   – SQL fragments that test the picture row itself.
+        # Build comfyui filter conditions via the shared leaf-snippet helper.  Two
+        # parallel fragment lists are returned:
+        # comfyui_self_parts   – fragments that test the picture row itself.
         # comfyui_member_parts – equivalent fragments that test an aliased member
         #                        row (_m) used in a stack-member EXISTS subquery.
         # comfyui_bind_params  – shared bind-parameter dict (same names in both).
-        comfyui_self_parts: list[str] = []
-        comfyui_member_parts: list[str] = []
-        comfyui_bind_params: dict = {}
-        if comfyui_models_filter:
-            for i, m in enumerate(comfyui_models_filter):
-                comfyui_self_parts.append(
-                    f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_models) WHERE value = :cmf_{i})"
-                )
-                comfyui_member_parts.append(
-                    f"EXISTS (SELECT 1 FROM json_each(_m.comfyui_models) WHERE value = :cmf_{i})"
-                )
-                comfyui_bind_params[f"cmf_{i}"] = m
-        if comfyui_loras_filter:
-            for i, m in enumerate(comfyui_loras_filter):
-                comfyui_self_parts.append(
-                    f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_loras) WHERE value = :clf_{i})"
-                )
-                comfyui_member_parts.append(
-                    f"EXISTS (SELECT 1 FROM json_each(_m.comfyui_loras) WHERE value = :clf_{i})"
-                )
-                comfyui_bind_params[f"clf_{i}"] = m
-
-        if tags_filter:
-            for i, tag in enumerate(tags_filter):
-                query = query.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :tag_filter_{i})"
-                    ).bindparams(**{f"tag_filter_{i}": tag})
-                )
-
-        if tags_rejected_filter:
-            for i, tag in enumerate(tags_rejected_filter):
-                query = query.where(
-                    text(
-                        f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :rejected_tag_filter_{i})"
-                    ).bindparams(**{f"rejected_tag_filter_{i}": tag})
-                )
-
-        if hidden_tags_filter:
-            placeholders = ", ".join(f":ht_{i}" for i in range(len(hidden_tags_filter)))
-            query = query.where(
-                text(
-                    f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id"
-                    f" AND LOWER(tag.tag) IN ({placeholders}))"
-                ).bindparams(**{f"ht_{i}": t for i, t in enumerate(hidden_tags_filter)})
-            )
-
-        if tags_confidence_above_filter:
-            for i, entry in enumerate(tags_confidence_above_filter):
-                tag, threshold = entry.rsplit(":", 1)
-                if float(threshold) <= 0.0:
-                    query = query.where(
-                        text(
-                            f"("
-                            f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                            f" AND tag_prediction.tag = :ca_tag_{i} AND tag_prediction.confidence >= :ca_thresh_{i})"
-                            f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-                            f") OR ("
-                            f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-                            f" AND NOT EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id AND tag_prediction.tag = :ca_tag_{i})"
-                            f")"
-                        ).bindparams(
-                            **{f"ca_tag_{i}": tag, f"ca_thresh_{i}": float(threshold)}
-                        )
-                    )
-                else:
-                    query = query.where(
-                        text(
-                            f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                            f" AND tag_prediction.tag = :ca_tag_{i} AND tag_prediction.confidence >= :ca_thresh_{i})"
-                            f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-                        ).bindparams(
-                            **{f"ca_tag_{i}": tag, f"ca_thresh_{i}": float(threshold)}
-                        )
-                    )
-
-        if tags_confidence_below_filter:
-            for i, entry in enumerate(tags_confidence_below_filter):
-                tag, threshold = entry.rsplit(":", 1)
-                query = query.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                        f" AND tag_prediction.tag = :cb_tag_{i} AND tag_prediction.confidence < :cb_thresh_{i})"
-                        f" AND EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :cb_tag_{i})"
-                    ).bindparams(
-                        **{f"cb_tag_{i}": tag, f"cb_thresh_{i}": float(threshold)}
-                    )
-                )
-
-        if face_filter == "with_face":
-            query = query.where(
-                text(
-                    "EXISTS (SELECT 1 FROM face WHERE face.picture_id = picture.id AND face.face_index != -1)"
-                )
-            )
-        elif face_filter == "without_face":
-            query = query.where(
-                text(
-                    "NOT EXISTS (SELECT 1 FROM face WHERE face.picture_id = picture.id AND face.face_index != -1)"
-                )
-            )
+        comfyui_self_parts, comfyui_member_parts, comfyui_bind_params = (
+            comfyui_leaf_parts(comfyui_models_filter, comfyui_loras_filter)
+        )
 
         # A stack leader is either an unstacked picture or the picture with
         # stack_position == 0 in its stack.  This inline condition replaces the
@@ -1230,6 +1004,9 @@ class Picture(SQLModel, table=True):
         guest_token_id: Optional[int] = None,
         count_only: bool = False,
     ):
+        # Imported lazily to avoid a circular import (predicate_filter imports Picture).
+        from pixlstash.utils.query.predicate_filter import PredicateFilter
+
         query = select(func.count(cls.id)) if count_only else select(Picture)
         unassigned_conditions = cls.build_unassigned_conditions(
             enforce_stack_assignment=True,
@@ -1258,142 +1035,25 @@ class Picture(SQLModel, table=True):
                 )
             )
 
-        if format:
-            query = query.where(Picture.format.in_(format))
-
-        if min_score is not None:
-            query = query.where(Picture.score >= min_score)
-        if max_score is not None:
-            query = query.where(Picture.score <= max_score)
-
-        if smart_score_bucket == "unscored":
-            query = query.where(Picture.smart_score.is_(None))
-        elif smart_score_bucket == "1-2":
-            query = query.where(
-                Picture.smart_score.is_not(None), Picture.smart_score < 2.0
-            )
-        elif smart_score_bucket == "2-3":
-            query = query.where(Picture.smart_score >= 2.0, Picture.smart_score < 3.0)
-        elif smart_score_bucket == "3-4":
-            query = query.where(Picture.smart_score >= 3.0, Picture.smart_score < 4.0)
-        elif smart_score_bucket == "4-5":
-            query = query.where(Picture.smart_score >= 4.0)
-
-        if resolution_bucket == "unknown":
-            query = query.where(or_(Picture.width.is_(None), Picture.height.is_(None)))
-        elif resolution_bucket == "lt1mp":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height < 1_000_000,
-            )
-        elif resolution_bucket == "1-4mp":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height >= 1_000_000,
-                Picture.width * Picture.height < 4_000_000,
-            )
-        elif resolution_bucket == "4-8mp":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height >= 4_000_000,
-                Picture.width * Picture.height < 8_000_000,
-            )
-        elif resolution_bucket == "8-16mp":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height >= 8_000_000,
-                Picture.width * Picture.height < 16_000_000,
-            )
-        elif resolution_bucket == "16plus":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height >= 16_000_000,
-            )
-
-        if tags_filter:
-            for i, tag in enumerate(tags_filter):
-                query = query.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :tag_filter_{i})"
-                    ).bindparams(**{f"tag_filter_{i}": tag})
-                )
-
-        if tags_rejected_filter:
-            for i, tag in enumerate(tags_rejected_filter):
-                query = query.where(
-                    text(
-                        f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :rejected_tag_filter_{i})"
-                    ).bindparams(**{f"rejected_tag_filter_{i}": tag})
-                )
-
-        if hidden_tags_filter:
-            placeholders = ", ".join(f":ht_{i}" for i in range(len(hidden_tags_filter)))
-            query = query.where(
-                text(
-                    f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id"
-                    f" AND LOWER(tag.tag) IN ({placeholders}))"
-                ).bindparams(**{f"ht_{i}": t for i, t in enumerate(hidden_tags_filter)})
-            )
-
-        if tags_confidence_above_filter:
-            for i, entry in enumerate(tags_confidence_above_filter):
-                tag, threshold = entry.rsplit(":", 1)
-                if float(threshold) <= 0.0:
-                    query = query.where(
-                        text(
-                            f"("
-                            f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                            f" AND tag_prediction.tag = :ca_tag_{i} AND tag_prediction.confidence >= :ca_thresh_{i})"
-                            f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-                            f") OR ("
-                            f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-                            f" AND NOT EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id AND tag_prediction.tag = :ca_tag_{i})"
-                            f")"
-                        ).bindparams(
-                            **{f"ca_tag_{i}": tag, f"ca_thresh_{i}": float(threshold)}
-                        )
-                    )
-                else:
-                    query = query.where(
-                        text(
-                            f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                            f" AND tag_prediction.tag = :ca_tag_{i} AND tag_prediction.confidence >= :ca_thresh_{i})"
-                            f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-                        ).bindparams(
-                            **{f"ca_tag_{i}": tag, f"ca_thresh_{i}": float(threshold)}
-                        )
-                    )
-
-        if tags_confidence_below_filter:
-            for i, entry in enumerate(tags_confidence_below_filter):
-                tag, threshold = entry.rsplit(":", 1)
-                query = query.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                        f" AND tag_prediction.tag = :cb_tag_{i} AND tag_prediction.confidence < :cb_thresh_{i})"
-                        f" AND EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :cb_tag_{i})"
-                    ).bindparams(
-                        **{f"cb_tag_{i}": tag, f"cb_thresh_{i}": float(threshold)}
-                    )
-                )
-
-        if face_filter == "with_face":
-            query = query.where(
-                text(
-                    "EXISTS (SELECT 1 FROM face WHERE face.picture_id = picture.id AND face.face_index != -1)"
-                )
-            )
-        elif face_filter == "without_face":
-            query = query.where(
-                text(
-                    "NOT EXISTS (SELECT 1 FROM face WHERE face.picture_id = picture.id AND face.face_index != -1)"
-                )
-            )
+        # Intrinsic-attribute predicates via the shared compiler.  The unassigned /
+        # project / deleted scoping is applied above; stack-leader collapsing stays
+        # below.  find_unassigned never filters on comfyui / file-path / import-source
+        # / import-excluded, so those fields are left unset.
+        query = PredicateFilter(
+            format=format,
+            min_score=min_score,
+            max_score=max_score,
+            smart_score_bucket=smart_score_bucket,
+            resolution_bucket=resolution_bucket,
+            tags_filter=tags_filter,
+            tags_rejected_filter=tags_rejected_filter,
+            hidden_tags_filter=hidden_tags_filter,
+            tags_confidence_above_filter=tags_confidence_above_filter,
+            tags_confidence_below_filter=tags_confidence_below_filter,
+            face_filter=face_filter,
+            apply_deleted_filter=False,
+            exclude_import_excluded=False,
+        ).apply(query)
 
         if stack_leaders_only:
             project_scope_active = project_id is not None or only_unassigned_project

--- a/pixlstash/routes/picture_sets.py
+++ b/pixlstash/routes/picture_sets.py
@@ -37,6 +37,7 @@ from pixlstash.utils.service.caption_utils import normalize_hidden_tags
 from pixlstash.utils.service.path_utils import resolve_path_within
 from pixlstash.utils.service.serialization_utils import safe_model_dict
 from pixlstash.utils.stack.stack_utils import deduplicate_by_stack
+from pixlstash.utils.query.predicate_filter import PredicateFilter
 
 logger = get_logger(__name__)
 
@@ -893,14 +894,13 @@ def create_router(server) -> APIRouter:
         resolution_bucket: str | None = Query(None),
         expand_stacks: bool = Query(False),
     ):
-        tags_filter = request.query_params.getlist("tag") or None
-        tags_rejected_filter = request.query_params.getlist("rejected_tag") or None
-        tags_confidence_above_filter = (
-            request.query_params.getlist("tag_confidence_above") or None
-        )
-        tags_confidence_below_filter = (
-            request.query_params.getlist("tag_confidence_below") or None
-        )
+        # Intrinsic tag/confidence query params are parsed by the shared parser; the
+        # remaining filters (format/scores/buckets) arrive as typed Query args above.
+        _predicate_filter = PredicateFilter.from_query_params(request)
+        tags_filter = _predicate_filter.tags_filter
+        tags_rejected_filter = _predicate_filter.tags_rejected_filter
+        tags_confidence_above_filter = _predicate_filter.tags_confidence_above_filter
+        tags_confidence_below_filter = _predicate_filter.tags_confidence_below_filter
         try:
             id = int(id)
         except (TypeError, ValueError):

--- a/pixlstash/routes/pictures/_listing.py
+++ b/pixlstash/routes/pictures/_listing.py
@@ -11,7 +11,6 @@ from fastapi import (
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import (
     or_,
-    text,
 )
 from sqlmodel import Session, select
 
@@ -38,6 +37,7 @@ from pixlstash.utils.service.filter_helpers import (
     project_membership_exists_clause,
     project_unassigned_clause,
 )
+from pixlstash.utils.query.predicate_filter import PredicateFilter
 
 from ._helpers import (
     _enrich_stack_counts,
@@ -655,168 +655,26 @@ def select_pictures_for_listing(
                     project_id_value,
                 )
 
-        if formats:
-            query = query.where(Picture.format.in_(formats))
-
-        if min_score_value is not None:
-            query = query.where(Picture.score >= min_score_value)
-        if max_score_value is not None:
-            query = query.where(Picture.score <= max_score_value)
-
-        if smart_score_bucket_value == "unscored":
-            query = query.where(Picture.smart_score.is_(None))
-        elif smart_score_bucket_value == "1-2":
-            query = query.where(
-                Picture.smart_score.is_not(None), Picture.smart_score < 2.0
-            )
-        elif smart_score_bucket_value == "2-3":
-            query = query.where(Picture.smart_score >= 2.0, Picture.smart_score < 3.0)
-        elif smart_score_bucket_value == "3-4":
-            query = query.where(Picture.smart_score >= 3.0, Picture.smart_score < 4.0)
-        elif smart_score_bucket_value == "4-5":
-            query = query.where(Picture.smart_score >= 4.0)
-
-        if resolution_bucket_value == "unknown":
-            query = query.where(or_(Picture.width.is_(None), Picture.height.is_(None)))
-        elif resolution_bucket_value == "lt1mp":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height < 1_000_000,
-            )
-        elif resolution_bucket_value == "1-4mp":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height >= 1_000_000,
-                Picture.width * Picture.height < 4_000_000,
-            )
-        elif resolution_bucket_value == "4-8mp":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height >= 4_000_000,
-                Picture.width * Picture.height < 8_000_000,
-            )
-        elif resolution_bucket_value == "8-16mp":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height >= 8_000_000,
-                Picture.width * Picture.height < 16_000_000,
-            )
-        elif resolution_bucket_value == "16plus":
-            query = query.where(
-                Picture.width.is_not(None),
-                Picture.height.is_not(None),
-                Picture.width * Picture.height >= 16_000_000,
-            )
-
-        if tags_filter_value:
-            for i, tag in enumerate(tags_filter_value):
-                query = query.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ss_tag_filter_{i})"
-                    ).bindparams(**{f"ss_tag_filter_{i}": tag})
-                )
-
-        if tags_rejected_filter_value:
-            for i, tag in enumerate(tags_rejected_filter_value):
-                query = query.where(
-                    text(
-                        f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ss_rejected_tag_{i})"
-                    ).bindparams(**{f"ss_rejected_tag_{i}": tag})
-                )
-
-        if hidden_tags_filter_value:
-            placeholders = ", ".join(
-                f":ss_ht_{i}" for i in range(len(hidden_tags_filter_value))
-            )
-            query = query.where(
-                text(
-                    f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id"
-                    f" AND LOWER(tag.tag) IN ({placeholders}))"
-                ).bindparams(
-                    **{f"ss_ht_{i}": t for i, t in enumerate(hidden_tags_filter_value)}
-                )
-            )
-
-        if tags_confidence_above_filter_value:
-            for i, entry in enumerate(tags_confidence_above_filter_value):
-                tag, threshold = entry.rsplit(":", 1)
-                if float(threshold) <= 0.0:
-                    query = query.where(
-                        text(
-                            f"("
-                            f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                            f" AND tag_prediction.tag = :ss_ca_tag_{i} AND tag_prediction.confidence >= :ss_ca_thresh_{i})"
-                            f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ss_ca_tag_{i})"
-                            f") OR ("
-                            f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ss_ca_tag_{i})"
-                            f" AND NOT EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id AND tag_prediction.tag = :ss_ca_tag_{i})"
-                            f")"
-                        ).bindparams(
-                            **{
-                                f"ss_ca_tag_{i}": tag,
-                                f"ss_ca_thresh_{i}": float(threshold),
-                            }
-                        )
-                    )
-                else:
-                    query = query.where(
-                        text(
-                            f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                            f" AND tag_prediction.tag = :ss_ca_tag_{i} AND tag_prediction.confidence >= :ss_ca_thresh_{i})"
-                            f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ss_ca_tag_{i})"
-                        ).bindparams(
-                            **{
-                                f"ss_ca_tag_{i}": tag,
-                                f"ss_ca_thresh_{i}": float(threshold),
-                            }
-                        )
-                    )
-
-        if tags_confidence_below_filter_value:
-            for i, entry in enumerate(tags_confidence_below_filter_value):
-                tag, threshold = entry.rsplit(":", 1)
-                query = query.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                        f" AND tag_prediction.tag = :ss_cb_tag_{i} AND tag_prediction.confidence < :ss_cb_thresh_{i})"
-                        f" AND EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ss_cb_tag_{i})"
-                    ).bindparams(
-                        **{f"ss_cb_tag_{i}": tag, f"ss_cb_thresh_{i}": float(threshold)}
-                    )
-                )
-
-        if comfyui_models_filter_value:
-            for i, m in enumerate(comfyui_models_filter_value):
-                query = query.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_models) WHERE value = :ss_comfyui_model_{i})"
-                    ).bindparams(**{f"ss_comfyui_model_{i}": m})
-                )
-
-        if comfyui_loras_filter_value:
-            for i, m in enumerate(comfyui_loras_filter_value):
-                query = query.where(
-                    text(
-                        f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_loras) WHERE value = :ss_comfyui_lora_{i})"
-                    ).bindparams(**{f"ss_comfyui_lora_{i}": m})
-                )
-
-        if face_filter_value == "with_face":
-            query = query.where(
-                text(
-                    "EXISTS (SELECT 1 FROM face WHERE face.picture_id = picture.id AND face.face_index != -1)"
-                )
-            )
-        elif face_filter_value == "without_face":
-            query = query.where(
-                text(
-                    "NOT EXISTS (SELECT 1 FROM face WHERE face.picture_id = picture.id AND face.face_index != -1)"
-                )
-            )
+        # Intrinsic-attribute predicates via the shared compiler.  Deleted / project
+        # / character scoping is handled above (woven into the candidate branches),
+        # so the filter applies no lifecycle clauses here.
+        query = PredicateFilter(
+            format=formats,
+            min_score=min_score_value,
+            max_score=max_score_value,
+            smart_score_bucket=smart_score_bucket_value,
+            resolution_bucket=resolution_bucket_value,
+            tags_filter=tags_filter_value,
+            tags_rejected_filter=tags_rejected_filter_value,
+            hidden_tags_filter=hidden_tags_filter_value,
+            tags_confidence_above_filter=tags_confidence_above_filter_value,
+            tags_confidence_below_filter=tags_confidence_below_filter_value,
+            comfyui_models_filter=comfyui_models_filter_value,
+            comfyui_loras_filter=comfyui_loras_filter_value,
+            face_filter=face_filter_value,
+            apply_deleted_filter=False,
+            exclude_import_excluded=False,
+        ).apply(query)
 
         return list(session.exec(query).all())
 

--- a/pixlstash/routes/pictures/_misc.py
+++ b/pixlstash/routes/pictures/_misc.py
@@ -44,6 +44,7 @@ from pixlstash.utils.service.filter_helpers import (
     project_membership_exists_clause,
     project_unassigned_clause,
 )
+from pixlstash.utils.query.predicate_filter import PredicateFilter
 
 from ._helpers import (
     _fetch_hidden_picture_ids,
@@ -588,88 +589,22 @@ def register_routes(router, server):
                 comfyui_loras_filter_value,
             ):
                 query = select(Picture.id).where(Picture.id.in_(candidate_ids_list))
-                if deleted_only:
-                    query = query.where(Picture.deleted.is_(True))
-                else:
-                    query = query.where(Picture.deleted.is_(False))
-                if min_score_value is not None:
-                    query = query.where(Picture.score >= min_score_value)
-                if max_score_value is not None:
-                    query = query.where(Picture.score <= max_score_value)
-                if comfyui_models_filter_value:
-                    for i, m in enumerate(comfyui_models_filter_value):
-                        query = query.where(
-                            text(
-                                f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_models) WHERE value = :comfyui_model_{i})"
-                            ).bindparams(**{f"comfyui_model_{i}": m})
-                        )
-                if comfyui_loras_filter_value:
-                    for i, m in enumerate(comfyui_loras_filter_value):
-                        query = query.where(
-                            text(
-                                f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_loras) WHERE value = :comfyui_lora_{i})"
-                            ).bindparams(**{f"comfyui_lora_{i}": m})
-                        )
-                if tags_filter_value:
-                    for i, t in enumerate(tags_filter_value):
-                        query = query.where(
-                            text(
-                                f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :tag_filter_{i})"
-                            ).bindparams(**{f"tag_filter_{i}": t})
-                        )
-                if tags_rejected_filter_value:
-                    for i, t in enumerate(tags_rejected_filter_value):
-                        query = query.where(
-                            text(
-                                f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :rejected_tag_filter_{i})"
-                            ).bindparams(**{f"rejected_tag_filter_{i}": t})
-                        )
-                if tags_confidence_above_filter_value:
-                    for i, entry in enumerate(tags_confidence_above_filter_value):
-                        t, thresh = entry.rsplit(":", 1)
-                        if float(thresh) <= 0.0:
-                            query = query.where(
-                                text(
-                                    f"("
-                                    f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                                    f" AND tag_prediction.tag = :ca_tag_{i} AND tag_prediction.confidence >= :ca_thresh_{i})"
-                                    f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-                                    f") OR ("
-                                    f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-                                    f" AND NOT EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id AND tag_prediction.tag = :ca_tag_{i})"
-                                    f")"
-                                ).bindparams(
-                                    **{
-                                        f"ca_tag_{i}": t,
-                                        f"ca_thresh_{i}": float(thresh),
-                                    }
-                                )
-                            )
-                        else:
-                            query = query.where(
-                                text(
-                                    f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                                    f" AND tag_prediction.tag = :ca_tag_{i} AND tag_prediction.confidence >= :ca_thresh_{i})"
-                                    f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-                                ).bindparams(
-                                    **{
-                                        f"ca_tag_{i}": t,
-                                        f"ca_thresh_{i}": float(thresh),
-                                    }
-                                )
-                            )
-                if tags_confidence_below_filter_value:
-                    for i, entry in enumerate(tags_confidence_below_filter_value):
-                        t, thresh = entry.rsplit(":", 1)
-                        query = query.where(
-                            text(
-                                f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                                f" AND tag_prediction.tag = :cb_tag_{i} AND tag_prediction.confidence < :cb_thresh_{i})"
-                                f" AND EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :cb_tag_{i})"
-                            ).bindparams(
-                                **{f"cb_tag_{i}": t, f"cb_thresh_{i}": float(thresh)}
-                            )
-                        )
+                # This post-filter narrows an already-id-bounded set; only the
+                # deleted lifecycle clause plus score/comfyui/tag predicates apply
+                # (no format/buckets/face — those were handled when the candidate
+                # set was built).  All compiled by the shared PredicateFilter.
+                query = PredicateFilter(
+                    min_score=min_score_value,
+                    max_score=max_score_value,
+                    comfyui_models_filter=comfyui_models_filter_value,
+                    comfyui_loras_filter=comfyui_loras_filter_value,
+                    tags_filter=tags_filter_value,
+                    tags_rejected_filter=tags_rejected_filter_value,
+                    tags_confidence_above_filter=tags_confidence_above_filter_value,
+                    tags_confidence_below_filter=tags_confidence_below_filter_value,
+                    only_deleted=deleted_only,
+                    exclude_import_excluded=False,
+                ).apply(query)
                 return set(session.exec(query).all())
 
             matching_ids = server.vault.db.run_immediate_read_task(
@@ -862,19 +797,23 @@ def register_routes(router, server):
         set_ids_raw = request.query_params.getlist("set_ids")
         set_mode_raw = request.query_params.get("set_mode", "union")
         project_id_raw = request.query_params.get("project_id")
-        tags_filter = request.query_params.getlist("tag")
-        rejected_tags = request.query_params.getlist("rejected_tag")
-        format_filter = request.query_params.getlist("format")
+        # Intrinsic-attribute query params via the shared parser.  Membership / scope
+        # params keep their bespoke handling, and min/max score keep their dedicated
+        # HTTPException-on-invalid coercion below.
+        _predicate_filter = PredicateFilter.from_query_params(request)
+        tags_filter = _predicate_filter.tags_filter or []
+        rejected_tags = _predicate_filter.tags_rejected_filter or []
+        format_filter = _predicate_filter.format or []
         min_score_raw = request.query_params.get("min_score")
         max_score_raw = request.query_params.get("max_score")
-        smart_score_bucket = request.query_params.get("smart_score_bucket") or None
-        resolution_bucket = request.query_params.get("resolution_bucket") or None
-        file_path_prefix = request.query_params.get("file_path_prefix") or None
-        import_source_folder = request.query_params.get("import_source_folder") or None
-        face_filter = request.query_params.get("face_filter") or None
+        smart_score_bucket = _predicate_filter.smart_score_bucket
+        resolution_bucket = _predicate_filter.resolution_bucket
+        file_path_prefix = _predicate_filter.file_path_prefix
+        import_source_folder = _predicate_filter.import_source_folder
+        face_filter = _predicate_filter.face_filter
         confidence_tag = request.query_params.get("confidence_tag") or None
-        confidence_above = request.query_params.getlist("tag_confidence_above") or []
-        confidence_below = request.query_params.getlist("tag_confidence_below") or []
+        confidence_above = _predicate_filter.tags_confidence_above_filter or []
+        confidence_below = _predicate_filter.tags_confidence_below_filter or []
         include = set(request.query_params.getlist("include"))
 
         only_deleted = character_id_raw == "SCRAPHEAP"

--- a/pixlstash/routes/pictures/_search.py
+++ b/pixlstash/routes/pictures/_search.py
@@ -24,6 +24,7 @@ from pixlstash.utils.service.filter_helpers import (
     project_membership_exists_clause,
     project_unassigned_clause,
 )
+from pixlstash.utils.query.predicate_filter import PredicateFilter
 
 from ._helpers import (
     _fetch_hidden_picture_ids,
@@ -93,12 +94,15 @@ def register_routes(router, server):
                 if isinstance(desc_val, str)
                 else bool(desc_val)
             )
-            format = request.query_params.getlist("format")
+            # Intrinsic list params are parsed by the shared parser; the membership
+            # and pagination params keep their bespoke ``query_params`` pop handling.
+            _predicate_filter = PredicateFilter.from_query_params(request)
+            format = _predicate_filter.format or []
             min_score_raw = query_params.pop("min_score", None)
-            comfyui_models = request.query_params.getlist("comfyui_model")
-            comfyui_loras = request.query_params.getlist("comfyui_lora")
-            tags_filter = request.query_params.getlist("tag")
-            tags_rejected_filter = request.query_params.getlist("rejected_tag")
+            comfyui_models = _predicate_filter.comfyui_models_filter or []
+            comfyui_loras = _predicate_filter.comfyui_loras_filter or []
+            tags_filter = _predicate_filter.tags_filter or []
+            tags_rejected_filter = _predicate_filter.tags_rejected_filter or []
         min_score = int(min_score_raw) if min_score_raw is not None else None
         if not query:
             raise HTTPException(

--- a/pixlstash/utils/query/__init__.py
+++ b/pixlstash/utils/query/__init__.py
@@ -1,0 +1,3 @@
+"""Query helpers (declarative row-selection predicates)."""
+
+from .predicate_filter import PredicateFilter  # noqa: F401

--- a/pixlstash/utils/query/predicate_filter.py
+++ b/pixlstash/utils/query/predicate_filter.py
@@ -1,0 +1,382 @@
+"""Declarative, serialisable predicate over :class:`Picture` rows.
+
+PixlStash selects ``Picture`` rows by the same vocabulary (score range, smart-score
+bucket, resolution bucket, ComfyUI model/LoRA membership, tag include/exclude, hidden
+tags, tag-confidence thresholds, format, deleted/imported flags, face presence, path
+prefix, …) in several independent places.  Historically the WHERE-clause logic — down
+to byte-for-byte copies of raw ``text()`` ``EXISTS`` / ``json_each`` snippets — was
+duplicated across all of them.
+
+``PredicateFilter`` is the single source of truth for that logic.  It has three
+consumers:
+
+* **compile** — :meth:`predicates` / :meth:`apply` turn the declarative fields into
+  SQLAlchemy WHERE clauses (the raw ``text()`` snippets are moved here verbatim, bound
+  params intact).
+* **match** — :meth:`matches` narrows the same predicate set to a single picture id.
+  This is exactly the set predicate restricted to one row; there is no separate
+  Python-side re-implementation of the SQL semantics.  Staging auto-triage consumes
+  this.
+* **parse** — :meth:`from_query_params` builds the filter from request query params
+  (one parser, replacing the per-route copies).
+
+The name is ``PredicateFilter`` (not ``Filter``) because "filter" already means an
+image-manipulation plugin in this codebase (see ``pixlstash/image_plugins/``).
+
+Membership filters (``set``/``character``/``project``) are intentionally *out of
+scope*: they resolve to candidate-id sets and stay in ``filter_helpers.py``.  Compose
+with a pre-resolved set via the caller's own ``Picture.id.in_(...)`` clause.
+"""
+
+import os
+from typing import List, Optional
+
+from pydantic import BaseModel
+from sqlalchemy import or_, text
+from sqlalchemy.sql.elements import ColumnElement
+
+from pixlstash.db_models.picture import Picture
+
+
+def comfyui_leaf_parts(
+    models_filter: Optional[List[str]],
+    loras_filter: Optional[List[str]],
+) -> tuple[list[str], list[str], dict]:
+    """Build the leaf ``json_each EXISTS`` SQL fragments for ComfyUI membership.
+
+    Two parallel fragment lists are returned plus a shared bind-param dict:
+
+    * ``self_parts``   – fragments testing the picture row itself.
+    * ``member_parts`` – equivalent fragments testing an aliased stack-member row
+      (``_m``), used by :meth:`Picture.find` for stack-leader expansion.
+
+    Both lists use the same bind-param names so the dict applies to either.  This is
+    the single definition of the ComfyUI leaf snippet; callers decide how to combine
+    the fragments (``AND`` of separate clauses vs. ``OR`` within one clause, with or
+    without stack expansion).
+    """
+    self_parts: list[str] = []
+    member_parts: list[str] = []
+    bind_params: dict = {}
+    if models_filter:
+        for i, m in enumerate(models_filter):
+            self_parts.append(
+                f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_models) WHERE value = :cmf_{i})"
+            )
+            member_parts.append(
+                f"EXISTS (SELECT 1 FROM json_each(_m.comfyui_models) WHERE value = :cmf_{i})"
+            )
+            bind_params[f"cmf_{i}"] = m
+    if loras_filter:
+        for i, m in enumerate(loras_filter):
+            self_parts.append(
+                f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_loras) WHERE value = :clf_{i})"
+            )
+            member_parts.append(
+                f"EXISTS (SELECT 1 FROM json_each(_m.comfyui_loras) WHERE value = :clf_{i})"
+            )
+            bind_params[f"clf_{i}"] = m
+    return self_parts, member_parts, bind_params
+
+
+class PredicateFilter(BaseModel):
+    """A declarative, serialisable predicate over ``Picture`` rows.
+
+    All fields are optional / defaulted.  The defaults describe the predicate used by
+    a "give me the matching live pictures" query: non-deleted, not import-excluded,
+    no other restrictions — which is exactly what single-picture :meth:`matches`
+    wants for auto-triage.
+
+    Each builder site sets the subset of fields it needs and toggles the
+    flag fields (``include_deleted`` / ``only_deleted`` / ``apply_deleted_filter`` /
+    ``include_unimported`` / ``exclude_import_excluded``) so that the centralised
+    compiler reproduces that site's emitted predicate exactly.
+    """
+
+    # --- intrinsic attribute predicates ---
+    format: Optional[List[str]] = None
+    min_score: Optional[int] = None
+    max_score: Optional[int] = None
+    smart_score_bucket: Optional[str] = None
+    resolution_bucket: Optional[str] = None
+    comfyui_models_filter: Optional[List[str]] = None
+    comfyui_loras_filter: Optional[List[str]] = None
+    tags_filter: Optional[List[str]] = None
+    tags_rejected_filter: Optional[List[str]] = None
+    hidden_tags_filter: Optional[List[str]] = None
+    tags_confidence_above_filter: Optional[List[str]] = None
+    tags_confidence_below_filter: Optional[List[str]] = None
+    face_filter: Optional[str] = None
+    file_path_prefix: Optional[str] = None
+    # ``find()`` browses a folder and shows direct children only (separator-aware,
+    # LIKE-escaped).  The stats sidebar instead aggregates the whole sub-tree under a
+    # prefix.  ``True`` selects the children-only behaviour; ``False`` the sub-tree
+    # ``startswith`` behaviour.
+    file_path_prefix_children_only: bool = True
+    import_source_folder: Optional[str] = None
+
+    # --- scope / lifecycle flags ---
+    include_deleted: bool = False
+    only_deleted: bool = False
+    # When ``False`` the caller applies the deleted predicate itself (e.g. woven into
+    # a membership branch) and the compiler emits no ``deleted`` clause.
+    apply_deleted_filter: bool = True
+    include_unimported: bool = True
+    exclude_import_excluded: bool = True
+
+    def _smart_score_bucket_predicates(self) -> list[ColumnElement]:
+        bucket = self.smart_score_bucket
+        if bucket == "unscored":
+            return [Picture.smart_score.is_(None)]
+        if bucket == "1-2":
+            return [Picture.smart_score.is_not(None), Picture.smart_score < 2.0]
+        if bucket == "2-3":
+            return [Picture.smart_score >= 2.0, Picture.smart_score < 3.0]
+        if bucket == "3-4":
+            return [Picture.smart_score >= 3.0, Picture.smart_score < 4.0]
+        if bucket == "4-5":
+            return [Picture.smart_score >= 4.0]
+        return []
+
+    def _resolution_bucket_predicates(self) -> list[ColumnElement]:
+        bucket = self.resolution_bucket
+        if bucket == "unknown":
+            return [or_(Picture.width.is_(None), Picture.height.is_(None))]
+        area = Picture.width * Picture.height
+        not_null = [Picture.width.is_not(None), Picture.height.is_not(None)]
+        if bucket == "lt1mp":
+            return [*not_null, area < 1_000_000]
+        if bucket == "1-4mp":
+            return [*not_null, area >= 1_000_000, area < 4_000_000]
+        if bucket == "4-8mp":
+            return [*not_null, area >= 4_000_000, area < 8_000_000]
+        if bucket == "8-16mp":
+            return [*not_null, area >= 8_000_000, area < 16_000_000]
+        if bucket == "16plus":
+            return [*not_null, area >= 16_000_000]
+        return []
+
+    def _file_path_prefix_predicates(self) -> list[ColumnElement]:
+        if self.file_path_prefix is None:
+            return []
+        if not self.file_path_prefix_children_only:
+            # Sub-tree match used by the stats sidebar.
+            return [Picture.file_path.startswith(self.file_path_prefix)]
+        # Normalise to always end with a path separator so that a prefix like
+        # "/ref/photos" does not accidentally match "/ref/photos2/a.jpg".  Support
+        # both Unix ("/") and Windows ("\") separators.
+        if self.file_path_prefix.endswith("/") or self.file_path_prefix.endswith("\\"):
+            prefix = self.file_path_prefix
+        else:
+            prefix = self.file_path_prefix + os.sep
+        # Escape LIKE special characters in the literal prefix.
+        escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        # Only show direct children — exclude files that have another path separator
+        # after the prefix (i.e. files in sub-directories).  Check for both "/" and
+        # "\" to handle all platforms.
+        return [
+            Picture.file_path.like(escaped + "%", escape="\\"),
+            ~Picture.file_path.like(escaped + "%/%", escape="\\"),
+            ~Picture.file_path.like(escaped + "%\\\\%", escape="\\"),
+        ]
+
+    def predicates(self) -> list[ColumnElement]:
+        """Compile this filter to a list of SQLAlchemy WHERE clauses.
+
+        The clauses are intended to be ANDed together (``stmt.where(*predicates)``).
+        ComfyUI membership is emitted as one clause per model/LoRA (AND semantics);
+        ``Picture.find`` deliberately keeps its own OR + stack-expansion variant and
+        therefore leaves ``comfyui_*_filter`` unset here.
+        """
+        preds: list[ColumnElement] = []
+
+        if self.apply_deleted_filter:
+            if self.only_deleted:
+                preds.append(Picture.deleted.is_(True))
+            elif not self.include_deleted:
+                preds.append(Picture.deleted.is_(False))
+
+        if self.exclude_import_excluded:
+            preds.append(Picture.import_excluded.is_(False))
+
+        if not self.include_unimported:
+            preds.append(Picture.imported_at.is_not(None))
+
+        preds.extend(self._file_path_prefix_predicates())
+
+        if self.import_source_folder:
+            preds.append(Picture.import_source_folder == self.import_source_folder)
+
+        if self.format:
+            preds.append(Picture.format.in_(self.format))
+
+        if self.min_score is not None:
+            preds.append(Picture.score >= self.min_score)
+        if self.max_score is not None:
+            preds.append(Picture.score <= self.max_score)
+
+        preds.extend(self._smart_score_bucket_predicates())
+        preds.extend(self._resolution_bucket_predicates())
+
+        if self.tags_filter:
+            for i, tag in enumerate(self.tags_filter):
+                preds.append(
+                    text(
+                        f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :tag_filter_{i})"
+                    ).bindparams(**{f"tag_filter_{i}": tag})
+                )
+
+        if self.tags_rejected_filter:
+            for i, tag in enumerate(self.tags_rejected_filter):
+                preds.append(
+                    text(
+                        f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :rejected_tag_filter_{i})"
+                    ).bindparams(**{f"rejected_tag_filter_{i}": tag})
+                )
+
+        if self.hidden_tags_filter:
+            placeholders = ", ".join(
+                f":ht_{i}" for i in range(len(self.hidden_tags_filter))
+            )
+            preds.append(
+                text(
+                    f"NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id"
+                    f" AND LOWER(tag.tag) IN ({placeholders}))"
+                ).bindparams(
+                    **{f"ht_{i}": t for i, t in enumerate(self.hidden_tags_filter)}
+                )
+            )
+
+        if self.tags_confidence_above_filter:
+            for i, entry in enumerate(self.tags_confidence_above_filter):
+                tag, threshold = entry.rsplit(":", 1)
+                if float(threshold) <= 0.0:
+                    # NOTE: the whole disjunction is wrapped in an extra outer pair of
+                    # parentheses.  SQL ``AND`` binds tighter than ``OR``, so without
+                    # the wrapper this clause leaks its ``OR`` when ANDed with the
+                    # other predicates (e.g. the ``Picture.id == id`` narrowing in
+                    # ``matches()``), letting the second branch escape every other
+                    # filter.  The pre-refactor copies omitted this wrapper.
+                    preds.append(
+                        text(
+                            f"(("
+                            f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
+                            f" AND tag_prediction.tag = :ca_tag_{i} AND tag_prediction.confidence >= :ca_thresh_{i})"
+                            f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
+                            f") OR ("
+                            f"EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
+                            f" AND NOT EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id AND tag_prediction.tag = :ca_tag_{i})"
+                            f"))"
+                        ).bindparams(
+                            **{f"ca_tag_{i}": tag, f"ca_thresh_{i}": float(threshold)}
+                        )
+                    )
+                else:
+                    preds.append(
+                        text(
+                            f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
+                            f" AND tag_prediction.tag = :ca_tag_{i} AND tag_prediction.confidence >= :ca_thresh_{i})"
+                            f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
+                        ).bindparams(
+                            **{f"ca_tag_{i}": tag, f"ca_thresh_{i}": float(threshold)}
+                        )
+                    )
+
+        if self.tags_confidence_below_filter:
+            for i, entry in enumerate(self.tags_confidence_below_filter):
+                tag, threshold = entry.rsplit(":", 1)
+                preds.append(
+                    text(
+                        f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
+                        f" AND tag_prediction.tag = :cb_tag_{i} AND tag_prediction.confidence < :cb_thresh_{i})"
+                        f" AND EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :cb_tag_{i})"
+                    ).bindparams(
+                        **{f"cb_tag_{i}": tag, f"cb_thresh_{i}": float(threshold)}
+                    )
+                )
+
+        # ComfyUI membership: AND of one EXISTS per model/LoRA (used by
+        # semantic_search / listing-candidate / grouped-misc sites).  ``find()`` does
+        # not set these fields — it applies its own OR + stack-expansion variant.
+        if self.comfyui_models_filter:
+            for i, m in enumerate(self.comfyui_models_filter):
+                preds.append(
+                    text(
+                        f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_models) WHERE value = :cmf_{i})"
+                    ).bindparams(**{f"cmf_{i}": m})
+                )
+        if self.comfyui_loras_filter:
+            for i, m in enumerate(self.comfyui_loras_filter):
+                preds.append(
+                    text(
+                        f"EXISTS (SELECT 1 FROM json_each(picture.comfyui_loras) WHERE value = :clf_{i})"
+                    ).bindparams(**{f"clf_{i}": m})
+                )
+
+        if self.face_filter == "with_face":
+            preds.append(
+                text(
+                    "EXISTS (SELECT 1 FROM face WHERE face.picture_id = picture.id AND face.face_index != -1)"
+                )
+            )
+        elif self.face_filter == "without_face":
+            preds.append(
+                text(
+                    "NOT EXISTS (SELECT 1 FROM face WHERE face.picture_id = picture.id AND face.face_index != -1)"
+                )
+            )
+
+        return preds
+
+    def apply(self, stmt):
+        """Apply every compiled predicate to ``stmt`` and return the new statement."""
+        for clause in self.predicates():
+            stmt = stmt.where(clause)
+        return stmt
+
+    def matches(self, session, picture_id: int) -> bool:
+        """Return ``True`` if the single picture ``picture_id`` satisfies this filter.
+
+        This is the set predicate narrowed to one id — the hook consumed by staging
+        auto-triage.  There is no separate Python-side evaluator; the SQL semantics
+        are the same as the set queries.
+        """
+        from sqlmodel import select
+
+        stmt = self.apply(select(Picture.id)).where(Picture.id == picture_id)
+        return session.exec(stmt).first() is not None
+
+    @classmethod
+    def from_query_params(cls, request, *, children_only: bool = True) -> "PredicateFilter":
+        """Build a filter from the intrinsic-attribute query params on ``request``.
+
+        Covers the vocabulary shared by the picture-listing routes.  Membership
+        params (``set``/``character``/``project``) and pagination/sort are *not*
+        read here — they are resolved separately by the caller.  Unspecified params
+        simply leave their field at the default, so a route that never sends a given
+        param is unaffected.
+        """
+        qp = request.query_params
+
+        def _int_or_none(name: str) -> Optional[int]:
+            raw = qp.get(name)
+            return int(raw) if raw is not None else None
+
+        return cls(
+            format=qp.getlist("format") or None,
+            min_score=_int_or_none("min_score"),
+            max_score=_int_or_none("max_score"),
+            smart_score_bucket=qp.get("smart_score_bucket") or None,
+            resolution_bucket=qp.get("resolution_bucket") or None,
+            comfyui_models_filter=qp.getlist("comfyui_model") or None,
+            comfyui_loras_filter=qp.getlist("comfyui_lora") or None,
+            tags_filter=qp.getlist("tag") or None,
+            tags_rejected_filter=qp.getlist("rejected_tag") or None,
+            hidden_tags_filter=qp.getlist("hidden_tag") or None,
+            tags_confidence_above_filter=qp.getlist("tag_confidence_above") or None,
+            tags_confidence_below_filter=qp.getlist("tag_confidence_below") or None,
+            face_filter=qp.get("face_filter") or None,
+            file_path_prefix=qp.get("file_path_prefix") or None,
+            file_path_prefix_children_only=children_only,
+            import_source_folder=qp.get("import_source_folder") or None,
+        )

--- a/pixlstash/utils/service/picture_stats.py
+++ b/pixlstash/utils/service/picture_stats.py
@@ -4,7 +4,7 @@ import dataclasses
 import time
 
 from fastapi import HTTPException
-from sqlalchemy import Integer, and_, case, cast, desc, exists, func, or_, text
+from sqlalchemy import Integer, and_, case, cast, desc, exists, func, or_
 from sqlmodel import Session, select
 
 from pixlstash.db_models import Face, Picture, Tag, TagPrediction
@@ -15,6 +15,7 @@ from pixlstash.utils.service.filter_helpers import (
     project_membership_exists_clause,
     project_unassigned_clause,
 )
+from pixlstash.utils.query.predicate_filter import PredicateFilter
 
 logger = get_logger(__name__)
 
@@ -184,122 +185,27 @@ def _build_filtered_picture_subquery(session: Session, params: PictureStatsParam
             raise HTTPException(status_code=400, detail="Invalid project_id") from exc
         pic_q = pic_q.where(project_membership_exists_clause(pid_int, Picture))
 
-    if params.format_filter:
-        pic_q = pic_q.where(
-            Picture.format.in_([f.upper() for f in params.format_filter])
-        )
-    if params.min_score is not None:
-        pic_q = pic_q.where(Picture.score >= params.min_score)
-    if params.max_score is not None:
-        pic_q = pic_q.where(Picture.score <= params.max_score)
-
-    if params.smart_score_bucket == "unscored":
-        pic_q = pic_q.where(Picture.smart_score.is_(None))
-    elif params.smart_score_bucket == "1-2":
-        pic_q = pic_q.where(Picture.smart_score.is_not(None), Picture.smart_score < 2.0)
-    elif params.smart_score_bucket == "2-3":
-        pic_q = pic_q.where(Picture.smart_score >= 2.0, Picture.smart_score < 3.0)
-    elif params.smart_score_bucket == "3-4":
-        pic_q = pic_q.where(Picture.smart_score >= 3.0, Picture.smart_score < 4.0)
-    elif params.smart_score_bucket == "4-5":
-        pic_q = pic_q.where(Picture.smart_score >= 4.0)
-
-    if params.resolution_bucket == "unknown":
-        pic_q = pic_q.where(or_(Picture.width.is_(None), Picture.height.is_(None)))
-    elif params.resolution_bucket == "lt1mp":
-        pic_q = pic_q.where(
-            Picture.width.is_not(None),
-            Picture.height.is_not(None),
-            Picture.width * Picture.height < 1_000_000,
-        )
-    elif params.resolution_bucket == "1-4mp":
-        pic_q = pic_q.where(
-            Picture.width.is_not(None),
-            Picture.height.is_not(None),
-            Picture.width * Picture.height >= 1_000_000,
-            Picture.width * Picture.height < 4_000_000,
-        )
-    elif params.resolution_bucket == "4-8mp":
-        pic_q = pic_q.where(
-            Picture.width.is_not(None),
-            Picture.height.is_not(None),
-            Picture.width * Picture.height >= 4_000_000,
-            Picture.width * Picture.height < 8_000_000,
-        )
-    elif params.resolution_bucket == "8-16mp":
-        pic_q = pic_q.where(
-            Picture.width.is_not(None),
-            Picture.height.is_not(None),
-            Picture.width * Picture.height >= 8_000_000,
-            Picture.width * Picture.height < 16_000_000,
-        )
-    elif params.resolution_bucket == "16plus":
-        pic_q = pic_q.where(
-            Picture.width.is_not(None),
-            Picture.height.is_not(None),
-            Picture.width * Picture.height >= 16_000_000,
-        )
-
-    if params.file_path_prefix:
-        pic_q = pic_q.where(Picture.file_path.startswith(params.file_path_prefix))
-    if params.import_source_folder:
-        pic_q = pic_q.where(Picture.import_source_folder == params.import_source_folder)
-    for tag in params.tags_filter:
-        pic_q = pic_q.where(
-            exists(
-                select(Tag.id).where(
-                    Tag.picture_id == Picture.id,
-                    Tag.tag == tag,
-                )
-            )
-        )
-    for tag in params.rejected_tags:
-        pic_q = pic_q.where(
-            ~exists(
-                select(Tag.id).where(
-                    Tag.picture_id == Picture.id,
-                    Tag.tag == tag,
-                )
-            )
-        )
-
-    if params.face_filter == "with_face":
-        pic_q = pic_q.where(
-            exists(
-                select(Face.id).where(
-                    Face.picture_id == Picture.id,
-                    Face.face_index != -1,
-                )
-            )
-        )
-    elif params.face_filter == "without_face":
-        pic_q = pic_q.where(
-            ~exists(
-                select(Face.id).where(
-                    Face.picture_id == Picture.id,
-                    Face.face_index != -1,
-                )
-            )
-        )
-
-    for i, entry in enumerate(params.confidence_above):
-        ca_tag, ca_thresh = entry.rsplit(":", 1)
-        pic_q = pic_q.where(
-            text(
-                f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                f" AND tag_prediction.tag = :ca_tag_{i} AND tag_prediction.confidence >= :ca_thresh_{i})"
-                f" AND NOT EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :ca_tag_{i})"
-            ).bindparams(**{f"ca_tag_{i}": ca_tag, f"ca_thresh_{i}": float(ca_thresh)})
-        )
-    for i, entry in enumerate(params.confidence_below):
-        cb_tag, cb_thresh = entry.rsplit(":", 1)
-        pic_q = pic_q.where(
-            text(
-                f"EXISTS (SELECT 1 FROM tag_prediction WHERE tag_prediction.picture_id = picture.id"
-                f" AND tag_prediction.tag = :cb_tag_{i} AND tag_prediction.confidence < :cb_thresh_{i})"
-                f" AND EXISTS (SELECT 1 FROM tag WHERE tag.picture_id = picture.id AND tag.tag = :cb_tag_{i})"
-            ).bindparams(**{f"cb_tag_{i}": cb_tag, f"cb_thresh_{i}": float(cb_thresh)})
-        )
+    # Intrinsic-attribute predicates via the shared compiler.  The stats sidebar
+    # uppercases formats and matches a file-path prefix as a whole sub-tree (not just
+    # direct children).  The deleted lifecycle clause was already applied above, and
+    # this site never filters on import-excluded / unimported / comfyui / hidden tags.
+    pic_q = PredicateFilter(
+        format=[f.upper() for f in params.format_filter] or None,
+        min_score=params.min_score,
+        max_score=params.max_score,
+        smart_score_bucket=params.smart_score_bucket,
+        resolution_bucket=params.resolution_bucket,
+        file_path_prefix=params.file_path_prefix or None,
+        file_path_prefix_children_only=False,
+        import_source_folder=params.import_source_folder or None,
+        tags_filter=params.tags_filter or None,
+        tags_rejected_filter=params.rejected_tags or None,
+        tags_confidence_above_filter=params.confidence_above or None,
+        tags_confidence_below_filter=params.confidence_below or None,
+        face_filter=params.face_filter,
+        apply_deleted_filter=False,
+        exclude_import_excluded=False,
+    ).apply(pic_q)
 
     return pic_q.subquery()
 

--- a/tests/test_predicate_filter.py
+++ b/tests/test_predicate_filter.py
@@ -1,0 +1,448 @@
+"""Unit tests for :class:`PredicateFilter`.
+
+These run against a throwaway SQLite database (no Server needed): the predicate
+compiler only relies on built-in SQLite features (``json_each``, ``LOWER``), so a bare
+``SQLModel.metadata.create_all`` engine is enough.  Each test asserts the matching id
+set for a field, that :meth:`PredicateFilter.matches` agrees with the set query for
+every picture, and covers the documented tricky cases.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.pool import NullPool
+from sqlmodel import Session, SQLModel, create_engine, select
+
+# Importing the models registers them on SQLModel.metadata.
+from pixlstash.db_models import Face, Picture, Tag, TagPrediction  # noqa: F401
+from pixlstash.utils.query.predicate_filter import PredicateFilter
+
+
+@pytest.fixture
+def session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'predicate.db'}",
+        echo=False,
+        poolclass=NullPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _enable_fk(dbapi_connection, _record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        yield s
+
+
+def _add_picture(session, **kwargs):
+    kwargs.setdefault("file_path", f"pic_{id(kwargs)}.jpg")
+    pic = Picture(**kwargs)
+    session.add(pic)
+    session.commit()
+    session.refresh(pic)
+    return pic
+
+
+def _add_tag(session, picture_id, tag):
+    session.add(Tag(picture_id=picture_id, tag=tag))
+    session.commit()
+
+
+def _add_prediction(session, picture_id, tag, confidence):
+    session.add(
+        TagPrediction(
+            picture_id=picture_id,
+            tag=tag,
+            confidence=confidence,
+            model_version="epoch-test",
+        )
+    )
+    session.commit()
+
+
+def _add_face(session, picture_id, face_index=0, character_id=None):
+    session.add(
+        Face(picture_id=picture_id, face_index=face_index, character_id=character_id)
+    )
+    session.commit()
+
+
+def _matching_ids(session, flt: PredicateFilter) -> set[int]:
+    stmt = flt.apply(select(Picture.id))
+    return set(session.exec(stmt).all())
+
+
+def _all_ids(session) -> list[int]:
+    return list(session.exec(select(Picture.id)).all())
+
+
+def _assert_matches_agrees(session, flt: PredicateFilter, expected: set[int]):
+    """``matches()`` must agree with ``apply()`` for every picture in the DB."""
+    via_set = _matching_ids(session, flt)
+    assert via_set == expected
+    for pid in _all_ids(session):
+        assert flt.matches(session, pid) is (pid in expected)
+
+
+# --------------------------------------------------------------------------- #
+# Lifecycle flags
+# --------------------------------------------------------------------------- #
+
+
+def test_default_excludes_deleted_and_import_excluded(session):
+    live = _add_picture(session, file_path="a.jpg")
+    _add_picture(session, file_path="b.jpg", deleted=True)
+    _add_picture(session, file_path="c.jpg", import_excluded=True)
+
+    flt = PredicateFilter()
+    _assert_matches_agrees(session, flt, {live.id})
+
+
+def test_only_deleted(session):
+    _add_picture(session, file_path="a.jpg")
+    gone = _add_picture(session, file_path="b.jpg", deleted=True)
+
+    flt = PredicateFilter(only_deleted=True, exclude_import_excluded=False)
+    _assert_matches_agrees(session, flt, {gone.id})
+
+
+def test_include_deleted(session):
+    a = _add_picture(session, file_path="a.jpg")
+    b = _add_picture(session, file_path="b.jpg", deleted=True)
+
+    flt = PredicateFilter(include_deleted=True, exclude_import_excluded=False)
+    _assert_matches_agrees(session, flt, {a.id, b.id})
+
+
+def test_apply_deleted_filter_false_emits_no_deleted_clause(session):
+    a = _add_picture(session, file_path="a.jpg")
+    b = _add_picture(session, file_path="b.jpg", deleted=True)
+
+    flt = PredicateFilter(apply_deleted_filter=False, exclude_import_excluded=False)
+    _assert_matches_agrees(session, flt, {a.id, b.id})
+
+
+def test_include_unimported_false_requires_imported_at(session):
+    from datetime import datetime
+
+    imported = _add_picture(
+        session, file_path="a.jpg", imported_at=datetime(2020, 1, 1)
+    )
+    _add_picture(session, file_path="b.jpg", imported_at=None)
+
+    flt = PredicateFilter(include_unimported=False)
+    _assert_matches_agrees(session, flt, {imported.id})
+
+
+# --------------------------------------------------------------------------- #
+# Scalar / bucket predicates
+# --------------------------------------------------------------------------- #
+
+
+def test_format_filter(session):
+    png = _add_picture(session, file_path="a.png", format="PNG")
+    _add_picture(session, file_path="b.jpg", format="JPEG")
+
+    flt = PredicateFilter(format=["PNG"])
+    _assert_matches_agrees(session, flt, {png.id})
+
+
+def test_score_range(session):
+    _add_picture(session, file_path="a.jpg", score=1)
+    mid = _add_picture(session, file_path="b.jpg", score=5)
+    _add_picture(session, file_path="c.jpg", score=9)
+
+    flt = PredicateFilter(min_score=3, max_score=7)
+    _assert_matches_agrees(session, flt, {mid.id})
+
+
+def test_smart_score_bucket_unscored(session):
+    unscored = _add_picture(session, file_path="a.jpg", smart_score=None)
+    _add_picture(session, file_path="b.jpg", smart_score=2.5)
+
+    flt = PredicateFilter(smart_score_bucket="unscored")
+    _assert_matches_agrees(session, flt, {unscored.id})
+
+
+def test_smart_score_bucket_3_4_boundary(session):
+    # 3-4 bucket is [3.0, 4.0): includes 3.0, excludes 4.0.
+    low = _add_picture(session, file_path="lo.jpg", smart_score=2.99)
+    at3 = _add_picture(session, file_path="at3.jpg", smart_score=3.0)
+    mid = _add_picture(session, file_path="mid.jpg", smart_score=3.99)
+    at4 = _add_picture(session, file_path="at4.jpg", smart_score=4.0)
+
+    flt = PredicateFilter(smart_score_bucket="3-4")
+    _assert_matches_agrees(session, flt, {at3.id, mid.id})
+    assert low.id not in _matching_ids(session, flt)
+    assert at4.id not in _matching_ids(session, flt)
+
+
+def test_resolution_bucket_unknown(session):
+    no_w = _add_picture(session, file_path="a.jpg", width=None, height=100)
+    no_h = _add_picture(session, file_path="b.jpg", width=100, height=None)
+    _add_picture(session, file_path="c.jpg", width=100, height=100)
+
+    flt = PredicateFilter(resolution_bucket="unknown")
+    _assert_matches_agrees(session, flt, {no_w.id, no_h.id})
+
+
+def test_resolution_bucket_1_4mp(session):
+    _add_picture(session, file_path="small.jpg", width=500, height=500)  # 0.25 MP
+    one_mp = _add_picture(session, file_path="one.jpg", width=1000, height=1000)  # 1 MP
+    _add_picture(session, file_path="big.jpg", width=3000, height=3000)  # 9 MP
+
+    flt = PredicateFilter(resolution_bucket="1-4mp")
+    _assert_matches_agrees(session, flt, {one_mp.id})
+
+
+# --------------------------------------------------------------------------- #
+# Tag / prediction predicates
+# --------------------------------------------------------------------------- #
+
+
+def test_tags_filter_requires_all_tags(session):
+    a = _add_picture(session, file_path="a.jpg")
+    b = _add_picture(session, file_path="b.jpg")
+    _add_tag(session, a.id, "cat")
+    _add_tag(session, a.id, "dog")
+    _add_tag(session, b.id, "cat")
+
+    flt = PredicateFilter(tags_filter=["cat", "dog"])
+    _assert_matches_agrees(session, flt, {a.id})
+
+
+def test_tags_rejected_filter(session):
+    a = _add_picture(session, file_path="a.jpg")
+    b = _add_picture(session, file_path="b.jpg")
+    _add_tag(session, a.id, "cat")
+
+    flt = PredicateFilter(tags_rejected_filter=["cat"])
+    _assert_matches_agrees(session, flt, {b.id})
+
+
+def test_hidden_tags_filter_is_case_insensitive(session):
+    a = _add_picture(session, file_path="a.jpg")
+    b = _add_picture(session, file_path="b.jpg")
+    # Stored mixed-case; hidden filter passes lowercase and must still exclude.
+    _add_tag(session, a.id, "NSFW")
+
+    flt = PredicateFilter(hidden_tags_filter=["nsfw"])
+    _assert_matches_agrees(session, flt, {b.id})
+
+
+def test_confidence_above_standard(session):
+    a = _add_picture(session, file_path="a.jpg")
+    b = _add_picture(session, file_path="b.jpg")
+    c = _add_picture(session, file_path="c.jpg")
+    _add_prediction(session, a.id, "sunset", 0.9)  # predicted, not applied -> match
+    _add_prediction(session, b.id, "sunset", 0.1)  # below threshold -> no match
+    _add_prediction(session, c.id, "sunset", 0.9)
+    _add_tag(session, c.id, "sunset")  # already applied -> excluded by NOT EXISTS tag
+
+    flt = PredicateFilter(tags_confidence_above_filter=["sunset:0.5"])
+    _assert_matches_agrees(session, flt, {a.id})
+
+
+def test_confidence_above_zero_threshold_branch(session):
+    """threshold <= 0.0 matches predicted-only OR applied-only (XOR-like)."""
+    predicted_only = _add_picture(session, file_path="p.jpg")
+    applied_only = _add_picture(session, file_path="ap.jpg")
+    both = _add_picture(session, file_path="both.jpg")
+    _add_picture(session, file_path="none.jpg")  # neither predicted nor applied
+
+    _add_prediction(session, predicted_only.id, "sunset", 0.3)
+    _add_tag(session, applied_only.id, "sunset")
+    _add_prediction(session, both.id, "sunset", 0.3)
+    _add_tag(session, both.id, "sunset")
+    # neither: nothing
+
+    flt = PredicateFilter(tags_confidence_above_filter=["sunset:0.0"])
+    _assert_matches_agrees(session, flt, {predicted_only.id, applied_only.id})
+
+
+def test_confidence_below(session):
+    # below filter: a low-confidence prediction AND the tag is applied.
+    a = _add_picture(session, file_path="a.jpg")
+    b = _add_picture(session, file_path="b.jpg")
+    _add_prediction(session, a.id, "sunset", 0.1)
+    _add_tag(session, a.id, "sunset")
+    _add_prediction(session, b.id, "sunset", 0.9)
+    _add_tag(session, b.id, "sunset")
+
+    flt = PredicateFilter(tags_confidence_below_filter=["sunset:0.5"])
+    _assert_matches_agrees(session, flt, {a.id})
+
+
+# --------------------------------------------------------------------------- #
+# ComfyUI / face predicates
+# --------------------------------------------------------------------------- #
+
+
+def test_comfyui_models_filter_requires_all(session):
+    a = _add_picture(
+        session, file_path="a.jpg", comfyui_models=json.dumps(["m1", "m2"])
+    )
+    _add_picture(session, file_path="b.jpg", comfyui_models=json.dumps(["m1"]))
+
+    flt = PredicateFilter(comfyui_models_filter=["m1", "m2"])
+    _assert_matches_agrees(session, flt, {a.id})
+
+
+def test_comfyui_loras_filter(session):
+    a = _add_picture(session, file_path="a.jpg", comfyui_loras=json.dumps(["lora_x"]))
+    _add_picture(session, file_path="b.jpg", comfyui_loras=json.dumps(["lora_y"]))
+
+    flt = PredicateFilter(comfyui_loras_filter=["lora_x"])
+    _assert_matches_agrees(session, flt, {a.id})
+
+
+def test_face_filter(session):
+    with_face = _add_picture(session, file_path="a.jpg")
+    without_face = _add_picture(session, file_path="b.jpg")
+    sentinel_only = _add_picture(session, file_path="c.jpg")
+    _add_face(session, with_face.id, face_index=0)
+    _add_face(session, sentinel_only.id, face_index=-1)  # -1 = "no face" sentinel
+
+    with_flt = PredicateFilter(face_filter="with_face")
+    _assert_matches_agrees(session, with_flt, {with_face.id})
+
+    without_flt = PredicateFilter(face_filter="without_face")
+    _assert_matches_agrees(
+        session, without_flt, {without_face.id, sentinel_only.id}
+    )
+
+
+# --------------------------------------------------------------------------- #
+# File path / import source
+# --------------------------------------------------------------------------- #
+
+
+def test_file_path_prefix_children_only(session):
+    direct = _add_picture(session, file_path="/ref/photos/a.jpg")
+    _add_picture(session, file_path="/ref/photos/sub/b.jpg")  # sub-dir excluded
+    _add_picture(session, file_path="/ref/photos2/c.jpg")  # sibling prefix excluded
+
+    flt = PredicateFilter(file_path_prefix="/ref/photos")
+    _assert_matches_agrees(session, flt, {direct.id})
+
+
+def test_file_path_prefix_subtree(session):
+    direct = _add_picture(session, file_path="/ref/photos/a.jpg")
+    nested = _add_picture(session, file_path="/ref/photos/sub/b.jpg")
+    _add_picture(session, file_path="/other/c.jpg")
+
+    flt = PredicateFilter(
+        file_path_prefix="/ref/photos", file_path_prefix_children_only=False
+    )
+    _assert_matches_agrees(session, flt, {direct.id, nested.id})
+
+
+def test_import_source_folder(session):
+    a = _add_picture(session, file_path="a.jpg", import_source_folder="/inbox")
+    _add_picture(session, file_path="b.jpg", import_source_folder="/elsewhere")
+
+    flt = PredicateFilter(import_source_folder="/inbox")
+    _assert_matches_agrees(session, flt, {a.id})
+
+
+# --------------------------------------------------------------------------- #
+# Combination
+# --------------------------------------------------------------------------- #
+
+
+def test_combined_predicates(session):
+    match = _add_picture(session, file_path="m.png", format="PNG", score=5)
+    _add_picture(session, file_path="wrong_format.jpg", format="JPEG", score=5)
+    _add_picture(session, file_path="wrong_score.png", format="PNG", score=1)
+    _add_tag(session, match.id, "keep")
+
+    flt = PredicateFilter(format=["PNG"], min_score=3, tags_filter=["keep"])
+    _assert_matches_agrees(session, flt, {match.id})
+
+
+# --------------------------------------------------------------------------- #
+# from_query_params parsing
+# --------------------------------------------------------------------------- #
+
+
+class _FakeRequest:
+    def __init__(self, items):
+        from starlette.datastructures import QueryParams
+
+        self.query_params = QueryParams(items)
+
+
+def test_from_query_params_full_vocabulary():
+    req = _FakeRequest(
+        [
+            ("format", "PNG"),
+            ("format", "JPEG"),
+            ("min_score", "2"),
+            ("max_score", "8"),
+            ("smart_score_bucket", "3-4"),
+            ("resolution_bucket", "1-4mp"),
+            ("comfyui_model", "m1"),
+            ("comfyui_lora", "l1"),
+            ("tag", "cat"),
+            ("tag", "dog"),
+            ("rejected_tag", "blurry"),
+            ("hidden_tag", "nsfw"),
+            ("tag_confidence_above", "sunset:0.5"),
+            ("tag_confidence_below", "noise:0.2"),
+            ("face_filter", "with_face"),
+            ("file_path_prefix", "/ref/photos"),
+            ("import_source_folder", "/inbox"),
+        ]
+    )
+    flt = PredicateFilter.from_query_params(req)
+
+    assert flt.format == ["PNG", "JPEG"]
+    assert flt.min_score == 2
+    assert flt.max_score == 8
+    assert flt.smart_score_bucket == "3-4"
+    assert flt.resolution_bucket == "1-4mp"
+    assert flt.comfyui_models_filter == ["m1"]
+    assert flt.comfyui_loras_filter == ["l1"]
+    assert flt.tags_filter == ["cat", "dog"]
+    assert flt.tags_rejected_filter == ["blurry"]
+    assert flt.hidden_tags_filter == ["nsfw"]
+    assert flt.tags_confidence_above_filter == ["sunset:0.5"]
+    assert flt.tags_confidence_below_filter == ["noise:0.2"]
+    assert flt.face_filter == "with_face"
+    assert flt.file_path_prefix == "/ref/photos"
+    assert flt.import_source_folder == "/inbox"
+    assert flt.file_path_prefix_children_only is True
+
+
+def test_from_query_params_empty_leaves_defaults():
+    flt = PredicateFilter.from_query_params(_FakeRequest([]))
+    assert flt.format is None
+    assert flt.min_score is None
+    assert flt.tags_filter is None
+    assert flt.face_filter is None
+    # Defaults describe the "live pictures" predicate.
+    assert flt.apply_deleted_filter is True
+    assert flt.exclude_import_excluded is True
+
+
+def test_from_query_params_children_only_override():
+    flt = PredicateFilter.from_query_params(
+        _FakeRequest([("file_path_prefix", "/x")]), children_only=False
+    )
+    assert flt.file_path_prefix == "/x"
+    assert flt.file_path_prefix_children_only is False
+
+
+def test_from_query_params_runs_against_db(session):
+    """The parsed filter must compile and execute end-to-end."""
+    a = _add_picture(session, file_path="a.png", format="PNG", score=5)
+    _add_picture(session, file_path="b.jpg", format="JPEG", score=5)
+    _add_tag(session, a.id, "keep")
+
+    req = _FakeRequest([("format", "PNG"), ("min_score", "3"), ("tag", "keep")])
+    flt = PredicateFilter.from_query_params(req)
+    _assert_matches_agrees(session, flt, {a.id})


### PR DESCRIPTION
The same Picture WHERE-clause vocabulary was copy-pasted across six query builders and four route parsers, and had started to drift. Pull it into one PredicateFilter (predicates/apply/matches/from_query_params) and migrate everything onto it.

matches() also unblocks staging auto-triage ("does this one picture match?").

Two drift fixes along the way: a missing-parens bug in the confidence<=0 clause that leaked its OR, and stats missing that branch entirely.