### PR TITLE
Add experimental AMD GPU (ROCm) support

### DIFF
--- a/.github/ISSUE_TEMPLATE/amd_gpu_test_report.md
+++ b/.github/ISSUE_TEMPLATE/amd_gpu_test_report.md
@@ -1,0 +1,38 @@
+---
+name: AMD GPU (ROCm) test report
+about: Report whether experimental AMD GPU acceleration works on your card
+title: '[ROCm] '
+labels: 'experimental, amd-rocm'
+assignees: ''
+
+---
+
+Thanks for testing! AMD GPU (ROCm) support is **experimental and unverified** — we
+don't own an AMD card, so your report is how we find out if it works. Crash reports
+are just as useful as success stories.
+
+**Your hardware**
+- GPU model (e.g. Radeon RX 7900 XTX):
+- ROCm version (`rocminfo | grep -i version` or your package manager):
+- Linux distro + version:
+- Kernel version (`uname -r`):
+- PixlStash version:
+
+**What happened?**
+- [ ] GPU was detected and offered as an upgrade
+- [ ] Backend installed successfully
+- [ ] App started on the GPU
+- [ ] App fell back to CPU
+- [ ] It crashed / failed to start
+
+**Throughput (if it ran on the GPU)**
+Compared against CPU on the same machine if you can. Useful numbers:
+- Image embeddings (CLIP) per minute:
+- Captions (Florence-2) per minute:
+- Anything else you measured:
+
+**Logs**
+Paste any startup-check output or errors here. Even a clean failure is helpful.
+
+**Notes**
+Anything else worth mentioning.

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -22,7 +22,7 @@ export interface RuntimeInfo {
 export const ACCEL_LABELS: Record<Accel, string> = {
   cpu: 'CPU',
   cu128: 'NVIDIA GPU (CUDA 12.8)',
-  rocm: 'AMD GPU (ROCm)',
+  rocm: 'AMD GPU (ROCm, experimental)',
   metal: 'Apple Silicon (Metal)',
 };
 
@@ -33,7 +33,11 @@ export const ACCEL_LABELS: Record<Accel, string> = {
 export const TORCH_INDEX: Record<Accel, string | null> = {
   cpu: 'https://download.pytorch.org/whl/cpu',
   cu128: 'https://download.pytorch.org/whl/cu128',
-  rocm: 'https://download.pytorch.org/whl/rocm6.2',
+  // ROCm is experimental and Linux-only. rocm7.1 is the index that publishes the
+  // same torch version line as the bundled CPU build; older rocmX.Y indexes lag
+  // several torch releases behind. Keep this in step with the bundled torch when
+  // it moves (the install-time fallback in BackendManager handles minor drift).
+  rocm: 'https://download.pytorch.org/whl/rocm7.1',
   metal: null,
 };
 

--- a/pixlstash/startup_checks.py
+++ b/pixlstash/startup_checks.py
@@ -285,6 +285,18 @@ class StartupChecks:
         is_auto_mode = device_value == "auto"
         is_explicit_gpu = device_value == "cuda"
 
+        # PyTorch's ROCm build drives the AMD GPU through the CUDA API (torch.cuda.*
+        # works, HIP masquerades as CUDA), so the checks below run unchanged; only
+        # torch.version.hip distinguishes it. ROCm is experimental and unverified,
+        # and we ship the CPU ONNX Runtime alongside it, so the ONNX models run on
+        # CPU by design while torch uses the GPU.
+        is_rocm = (
+            torch is not None
+            and getattr(getattr(torch, "version", None), "hip", None) is not None
+        )
+        accel_name = "ROCm" if is_rocm else "CUDA"
+        accel_note = " (experimental, unverified)" if is_rocm else ""
+
         if device_value == "cpu":
             outcome.notes.append(
                 "default_device is set to cpu in config; using CPU inference."
@@ -302,13 +314,21 @@ class StartupChecks:
             )
             return
 
-        if not torch.cuda.is_available():
+        try:
+            gpu_available = torch.cuda.is_available()
+        except Exception as exc:
+            # A broken ROCm/CUDA install (unsupported gfx arch, missing driver) can
+            # raise here rather than returning False; treat any error as "no GPU"
+            # and fall back to CPU cleanly instead of crashing startup.
+            gpu_available = False
+            outcome.notes.append(f"GPU availability probe failed ({exc}).")
+        if not gpu_available:
             self._handle_gpu_check_failure(
                 outcome,
                 is_auto_mode,
                 is_explicit_gpu,
-                "CUDA is unavailable; forcing CPU inference.",
-                "CUDA is unavailable while default_device is set to cuda.",
+                f"{accel_name} is unavailable; forcing CPU inference.",
+                f"{accel_name} is unavailable while default_device is set to cuda.",
             )
             return
 
@@ -317,7 +337,17 @@ class StartupChecks:
             providers = ort.get_available_providers() if ort is not None else []
         except Exception:
             providers = []
-        if "CUDAExecutionProvider" not in providers:
+        if is_rocm:
+            # The ROCm/MIGraphX ONNX Runtime build isn't on PyPI, so we bundle the
+            # CPU ORT on ROCm; the InsightFace face-extraction and optional WD14
+            # ONNX models run on CPU by design while PyTorch (HIP) uses the GPU for
+            # embeddings, captioning and the other torch workloads. This is expected
+            # on ROCm, so it's a note rather than a warning.
+            outcome.notes.append(
+                "AMD GPU (ROCm) is experimental and unverified. PyTorch will use the "
+                "GPU; the ONNX face-extraction and WD14 tagger models run on CPU."
+            )
+        elif "CUDAExecutionProvider" not in providers:
             provider_list = ", ".join(providers) if providers else "none"
             onnx_package = self._detect_onnxruntime_package()
             gpu_arch_note = self._detect_gpu_arch_note()
@@ -387,7 +417,8 @@ class StartupChecks:
             return
 
         outcome.notes.append(
-            f"GPU check passed ({free_mb:.0f} MB free VRAM); using CUDA inference."
+            f"GPU check passed ({free_mb:.0f} MB free VRAM); "
+            f"using {accel_name}{accel_note} inference."
         )
 
     def _force_cpu_with_warning(

--- a/tests/test_rocm_device_check.py
+++ b/tests/test_rocm_device_check.py
@@ -1,0 +1,92 @@
+"""ROCm-awareness of StartupChecks._check_device_and_vram.
+
+We own no AMD hardware, so these tests simulate a PyTorch ROCm build (HIP exposed
+through the torch.cuda API, torch.version.hip set) to verify the device check:
+labels ROCm as experimental, frames ONNX-on-CPU as expected rather than an error,
+and falls back to CPU cleanly when the GPU probe fails.
+"""
+
+import logging
+import types
+
+import pytest
+
+import pixlstash.startup_checks as sc
+from pixlstash.startup_checks import StartupCheckOutcome, StartupChecks
+
+
+def _make_torch(*, hip, available, mem=(8_000 * 1024**2, 16_000 * 1024**2)):
+    """Build a fake torch module. hip=None => CUDA build; a string => ROCm build."""
+    version = types.SimpleNamespace(hip=hip, cuda=None if hip else "12.8")
+
+    def is_available():
+        if isinstance(available, Exception):
+            raise available
+        return available
+
+    cuda = types.SimpleNamespace(
+        is_available=is_available,
+        mem_get_info=lambda: mem,
+        get_device_capability=lambda i=0: (9, 0),
+        get_device_name=lambda i=0: "Fake GPU",
+    )
+    return types.SimpleNamespace(version=version, cuda=cuda)
+
+
+def _make_ort(providers):
+    return types.SimpleNamespace(get_available_providers=lambda: list(providers))
+
+
+def _checks(device="cuda"):
+    cfg = {"default_device": device}
+    return StartupChecks(cfg, "/tmp/server_config.json", logging.getLogger("test"))
+
+
+@pytest.fixture
+def patch_runtime(monkeypatch):
+    def apply(torch_mod, ort_mod):
+        monkeypatch.setattr(sc, "torch", torch_mod)
+        monkeypatch.setattr(sc, "ort", ort_mod)
+
+    return apply
+
+
+def test_rocm_passes_and_labels_experimental(patch_runtime):
+    # ROCm build: torch reports the GPU available; only CPU ONNX Runtime present.
+    patch_runtime(_make_torch(hip="6.4.43482", available=True), _make_ort(["CPUExecutionProvider"]))
+    outcome = StartupCheckOutcome()
+    _checks("cuda")._check_device_and_vram(outcome)
+
+    assert not outcome.forced_cpu
+    assert not outcome.hard_failures
+    notes = " ".join(outcome.notes)
+    assert "ROCm (experimental, unverified) inference" in notes
+    assert "ONNX face-extraction and WD14 tagger models run on CPU" in notes
+    # ONNX-on-CPU is expected on ROCm: it must NOT be reported as a CUDA warning.
+    assert not any("CUDAExecutionProvider unavailable" in w for w in outcome.warnings)
+
+
+def test_rocm_probe_failure_falls_back_to_cpu(patch_runtime):
+    # A broken ROCm install raises from is_available(); must fall back, not crash.
+    boom = RuntimeError("HIP error: no ROCm-capable device is detected")
+    patch_runtime(_make_torch(hip="6.4.43482", available=boom), _make_ort(["CPUExecutionProvider"]))
+    outcome = StartupCheckOutcome()
+    _checks("auto")._check_device_and_vram(outcome)  # auto => graceful CPU fallback
+
+    assert outcome.forced_cpu
+    assert not outcome.hard_failures
+    assert any("ROCm is unavailable" in w for w in outcome.warnings)
+
+
+def test_cuda_path_unchanged(patch_runtime):
+    # Regression: a real CUDA build (no hip) still reports CUDA, not ROCm.
+    patch_runtime(
+        _make_torch(hip=None, available=True),
+        _make_ort(["CUDAExecutionProvider", "CPUExecutionProvider"]),
+    )
+    outcome = StartupCheckOutcome()
+    _checks("cuda")._check_device_and_vram(outcome)
+
+    notes = " ".join(outcome.notes)
+    assert "using CUDA inference" in notes
+    assert "experimental" not in notes


### PR DESCRIPTION
* torch ML runs on the GPU via PyTorch's HIP backend;
* ONNX face extraction and both the PixlStash and the WD14 taggers still use CPU
* Make the startup check ROCm-aware and label it experimental
* fall back to CPU on broken ROCm setups