### PR TITLE
Let users choose the GPU runtime install location (#472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [1.6.2] [Security:High]
+- Desktop app: choose where the GPU runtime (~2.5 GB) installs instead of always using the system drive. On Windows it now defaults to *inside the install folder you picked*; the first-run wizard and Settings → Compute let you change it, and changing it moves an already-installed runtime so the download isn't repeated.
 - Update several NPM packages (hasown, mime-types, form-data) for a [Security:High] alert
 - Support for batched combine mode for the face likeness gate node
 

--- a/docs/desktop-backend-migration.md
+++ b/docs/desktop-backend-migration.md
@@ -1,0 +1,230 @@
+# Desktop backend migration: bundled CPU runtime + on-demand GPU wheels
+
+## Context & goal
+Today the Electron app ships a thin shell and, on first run, downloads a full
+relocatable "compute backend" (standalone CPython + the `pixlstash` wheel + a
+hardware-matched torch) as a multi-GB `.tar.zst` we **build and host** per
+`(os, arch, accel)`, indexed by a catalog at `pixlstash.dev/backends/<version>.json`.
+
+We don't need to host anything. The only genuinely heavy, hardware-specific
+artifacts — `torch`/`torchvision` and `onnxruntime`/`onnxruntime-gpu` — already
+live on PyPI and `download.pytorch.org` with their own CDNs and hashes. So:
+
+- **Bundle a fully-working CPU (and, on macOS, Metal) runtime *inside the installer*** —
+  the app runs offline out of the box.
+- **Download only the GPU wheels on demand** (NVIDIA/CUDA, AMD/ROCm), straight from
+  PyTorch's index, into a user-writable overlay.
+- **Host nothing.** Delete the bundle-building matrix, the GitHub release assets,
+  the website catalog, and the catalog version/404 problem along with them.
+
+This is option **C** from the design discussion.
+
+## What ships vs. what's fetched (per platform)
+
+| Runner / platform | Bundled in the installer | Fetched on demand (from PyPI/PyTorch) |
+| --- | --- | --- |
+| Linux x64 | CPython + all deps + **CPU** torch + onnxruntime | NVIDIA → `torch+cu128`, `onnxruntime-gpu`; AMD → `torch+rocm` (ORT stays CPU — ROCm ORT isn't on PyPI) |
+| Windows x64 | CPython + all deps + **CPU** torch + onnxruntime | NVIDIA → `torch+cu128`, `onnxruntime-gpu` |
+| macOS arm64 | CPython + all deps + **Metal** torch (default PyPI macOS wheel) + onnxruntime | nothing — MPS is already in the bundled torch |
+
+Notes:
+- macOS arm64 is GPU-accelerated *in the bundled env* (default macOS torch includes MPS),
+  so Mac users never download anything.
+- Intel macOS (`x64`) isn't in the current matrix; out of scope (unchanged).
+- AI **model weights** (CLIP, etc.) keep auto-downloading to `userData` at runtime,
+  exactly as today — unchanged.
+
+## The one hard constraint: the shipped runtime is read-only
+You can't `pip install` into the bundled interpreter — the installed app is
+read-only/immutable on every target: AppImage is a read-only squashfs mount, a
+notarized macOS `.app` must not be modified, and Windows Program Files needs
+elevation. So GPU wheels must land in a **writable overlay under `userData/`**.
+
+**Mechanism (preferred): `pip install --target` + `PYTHONPATH` overlay.**
+```
+<bundled python> -m pip install --no-cache-dir \
+    --target <userData>/backends/<accel> \
+    torch==<bundled-ver> torchvision==<bundled-ver> --index-url <accel index> \
+    onnxruntime-gpu==<pinned>
+# launch: PYTHONPATH=<userData>/backends/<accel> prepended so the GPU torch
+# shadows the bundled CPU torch (PYTHONPATH precedes base site-packages).
+```
+`--target` is chosen over `python -m venv --system-site-packages` because it has
+**no hard-coded path to the base interpreter**, so it survives app updates/moves
+without re-downloading multi-GB torch. (venv is the fallback if `--target` shadowing
+proves fragile for torch/onnxruntime — to be validated during implementation.)
+
+**Version pinning:** the build writes `resources/runtime.json` recording the exact
+`torch`/`torchvision`/`onnxruntime` versions baked into the bundled env. The GPU
+installer pins to those same versions (just swapping the `+cpu` build for `+cu128`/
+`+rocm`), guaranteeing torch/torchvision ABI compatibility.
+
+## Overlay install location (issue #472)
+
+The GPU overlay is a multi-GB download, so *where* it lands matters. Originally it
+was hardcoded to `userData/backends/<accel>` — always on the system drive under
+AppData/`.config`, even when the user installed the app to another drive. Now the
+overlay root is configurable (`config.ts` `backendsRoot()`), with a per-platform
+default (`computeDefaultBackendsRoot`):
+
+- **Windows (packaged):** `<installDir>/backends` — i.e. *inside the folder the user
+  picked in the installer* (`dirname(process.resourcesPath)`). The NSIS install is
+  per-user (`perMachine:false`) and user-writable, so the heavy wheels follow the
+  install location and stay off C: when the user chose another drive. Because
+  `--target` installs carry no hard-coded base path, the overlay also survives app
+  moves.
+- **Linux / macOS:** `userData/backends`, unchanged — the AppImage is a read-only
+  squashfs mount and a notarized `.app` must not be modified, so there's no writable
+  install folder to use.
+
+Users can override the default anywhere: the first-run wizard shows an install-location
+picker when GPU is selected, and Settings → Compute → *Install location* changes it later.
+Changing it after an overlay is installed **moves** the existing overlay (rename, falling
+back to copy+delete across drives) so the multi-GB torch isn't re-downloaded — this also
+replaces the "move it manually + symlink" workaround users were doing. The chosen path is
+persisted to `userData/backends-location.json`; when it equals the computed default the
+override is cleared, so the default keeps tracking the install dir across updates.
+
+> Caveat: on Windows an in-place app update runs the NSIS uninstaller, which can remove
+> files under `<installDir>`. If that wipes an overlay the marker disappears and the user
+> re-installs it (no data loss — model weights and the library live elsewhere). Users who
+> want update-proof overlays can point the location at a folder outside the install dir.
+
+## Code changes
+
+### Electron app (`electron/src/`)
+- **`config.ts`** — drop `catalogBaseUrl`/`BackendCatalog`/`BackendEntry` catalog types.
+  Add path helpers: `bundledRuntimeDir()` (= `process.resourcesPath/python`, dev fallback),
+  `overlayDir(accel)` (= `backendsRoot()/<accel>`; the root is configurable — see
+  *Overlay install location* above), and an `accel → (torch index
+  URL, onnxruntime package)` map (mirrors `TORCH_INDEX`/`ONNX_PACKAGE` in the build script).
+  Keep `PIXLSTASH_BACKEND_*` env override, repurposed to override the pip index URL
+  (corporate mirrors/proxies).
+- **`HardwareDetector.ts`** — keep detection as-is. Replace `recommendBackend`/
+  `compatibleBackends` (which took a catalog) with `availableAccelerators(hw)` and a
+  flag for which need an on-demand install vs. are covered by the bundled env.
+- **`BackendManager.ts`** — replace catalog fetch / download / sha-verify / extract with:
+  - `activeRuntime()` → bundled env, or a GPU overlay if one is installed+selected.
+  - `installGpu(accel, onProgress)` → `pip install --target` the heavy wheels, parsing
+    pip stdout for progress (phase + current line/bytes; pip's own bar is TTY-only).
+  - `listInstalled()` / `setActive()` simplified to "which accel overlay is active".
+  - `remove(accel)` → `rm -rf` the overlay dir.
+- **`ServerProcess.ts`** — `interpreterPath()` resolves the bundled interpreter; when a
+  GPU overlay is active, launch the *bundled* python with `PYTHONPATH=<overlay>` injected.
+  `devInterpreter()` (repo `.venv`) unchanged.
+- **`main.ts`** — `boot()` no longer fetches a catalog. Detect hardware, then **launch the
+  bundled CPU/Metal env immediately** (instant, offline). If a GPU is present and no
+  overlay is installed, surface a non-blocking "Enable NVIDIA/AMD GPU acceleration"
+  action (in the existing Backends window) that runs `installGpu` with progress and
+  relaunches the server on the overlay.
+- **`preload.ts` / `renderer/`** — first-run UI changes from "choose & download a backend"
+  to "running on CPU — [Install GPU acceleration]" with a pip progress view.
+
+### `electron/package.json` (electron-builder config)
+- Add `extraResources` to copy the prebuilt runtime dir into the app:
+  `{ "from": "resources/python", "to": "python" }` (so it lands at `resourcesPath/python`).
+- Gitignore `electron/resources/python` (build output, produced per-platform in CI / locally).
+
+### Build scripts (`scripts/`)
+- **Repurpose `build_backend_bundle.py` → `build_desktop_runtime.py`**: keep
+  `fetch_standalone_python` + `populate_env` (accel = `cpu` on win/linux, `metal` on mac);
+  **drop** `archive_zst` / sha / `.meta.json`. Output the `python/` dir into
+  `electron/resources/`, plus `resources/runtime.json` with the pinned torch/onnx versions.
+- **Delete** `build_backend_catalog.py`.
+
+### CI (`.github/workflows/electron.yml`)
+- **Delete** the `build-backends` matrix job and the `publish-catalog` job.
+- **`build-electron`**: before `npm run dist`, run `build_desktop_runtime.py` on the native
+  runner (CPU on win/linux, Metal on mac) to populate `electron/resources/python`, then
+  electron-builder embeds it. Keep `build-wheel` (the wheel still publishes to PyPI via
+  `publish-pypi.yml`).
+- The semver/PEP-440 catalog-naming fix discussed earlier becomes **unnecessary** (no catalog).
+
+### Website
+- **Delete** `website/backends/` (catalog dir + README). No `pixlstash.dev/backends/*`
+  endpoint needed.
+
+## Desktop config: separate file, shared-able library
+The desktop app keeps its **own** `server-config.json` under Electron's `userData`
+and launches the backend with `--server-config <userData>/server-config.json`. It is
+never the same file as a standalone pip/Docker install's config, so the two can't
+overwrite each other's host/SSL/device settings. The backend stays config-agnostic;
+two ephemeral signals come from the launcher:
+- `PIXLSTASH_HOST`/`PIXLSTASH_PORT` — bind a free loopback port (existing).
+- `PIXLSTASH_DEFAULT_DEVICE` — the device the *active runtime* provides (CPU bundle vs
+  GPU overlay), so the config's `default_device` can't request a device this runtime
+  lacks. (The earlier shared-config + force-SSL-off approach is dropped.)
+
+Dev (`PIXLSTASH_DESKTOP_DEV=1`) keeps using the developer's default config/library.
+
+## First-run setup (UX)
+On first launch (no desktop config yet) the main window shows a **setup screen**
+(`renderer/setup.html`) before starting the backend:
+1. **Import** — if a standalone pip/Docker config is found (located via the backend's
+   own platformdirs, `setup:probe`), offer to copy its values as defaults — most
+   usefully the existing `image_root`, so an existing library is picked up automatically.
+2. **Library folder** — a folder picker (defaults to the imported `image_root`, else
+   `~/Pictures/PixlStash`).
+3. **CPU vs GPU** — shown only when a discrete GPU is detected; "GPU" routes through the
+   existing on-demand overlay install (`~2.5 GB`, progress UI). Mac = Metal (no choice),
+   no GPU = CPU (no choice).
+4. `setup:commit` writes the desktop config, installs/activates the chosen overlay, then
+   boots the backend and navigates the window into the library.
+
+Subsequent launches see the config exists → skip the wizard → straight into the library.
+
+## Phase 2: LAN exposure + SSL (decided, not yet built)
+The desktop window **always** talks plain HTTP over a private, ephemeral loopback port —
+that never changes, regardless of SSL. LAN exposure adds a *second* uvicorn listener for the
+same FastAPI app on the one event loop (`asyncio.gather` over two `uvicorn.Server`s), bound to
+`0.0.0.0` on the user's chosen (shareable) port, optionally with SSL using the self-signed
+cert we already generate in `_ensure_ssl_certificates`. Rationale (see design discussion):
+
+- SSL is meaningless on loopback, so the window stays on HTTP — **no Electron cert-trust
+  code**, and "the app opens" is decoupled from cert validity (an expired self-signed cert
+  can't break the window).
+- Single-port HTTPS + Electron cert pinning was considered and rejected for that coupling.
+- Self-signed ⇒ LAN clients (phones/browsers) see a cert warning — accepted; standard for
+  local-hosting users. Warning-free would need a trusted cert (mkcert local CA / real domain);
+  out of scope.
+- **Ports:** the loopback listener stays an **ephemeral free port** (hidden, conflict-proof,
+  as today); the LAN listener defaults to **9537** — the standard, shareable PixlStash port,
+  bound to `0.0.0.0`. A fixed port can collide (e.g. a pip/Docker PixlStash already on 9537),
+  so a bind failure on the LAN listener must surface as a clear "port in use" message and must
+  **not** take down the loopback window — the app still opens, only LAN sharing is unavailable.
+
+Backend change is swapping the blocking `uvicorn.run(...)` for the programmatic
+`Server`/`gather` form. Wizard gains a Network step (Local only / Local network → SSL
+sub-option). Also deferred: wiring automatic update checks.
+
+## Tradeoffs & risks (going in eyes-open)
+- **Installer size** grows to ~300–500 MB (CPython + deps + CPU/Metal torch). Acceptable for
+  a desktop AI app; comparable to peers.
+- **GPU install needs network + working pip** — corporate TLS-interception/proxies can break
+  it. Expose an index-URL/proxy override (env + setting). CPU/Metal works fully offline.
+- **Less hermetic** than extracting one prebuilt, sha-pinned tarball: we run pip on the user's
+  machine against PyTorch's index. Mitigate by pinning exact versions (from `runtime.json`);
+  pip still verifies index hashes over TLS.
+- **`--target` shadowing** for torch/onnxruntime must be validated (fallback: `venv
+  --system-site-packages`, accepting base-path-coupling and recreate-on-update).
+- **AMD ROCm**: torch from the rocm index, but `onnxruntime` stays CPU (no PyPI ROCm ORT) —
+  same limitation as today.
+
+## Verification
+- **Local CPU**: `build_desktop_runtime.py --accel cpu` → `npm start` → app opens into the
+  library with no network; server runs from the bundled env.
+- **Local GPU** (on an NVIDIA box): trigger `installGpu('cu128')` → confirm overlay created,
+  `torch.cuda.is_available()` true in the launched server, model inference uses the GPU.
+- **Offline**: disconnect network → CPU/Metal launch still works; GPU action fails gracefully
+  back to CPU.
+- **Packaged**: `npm run dist` on each OS → install → first run offline (CPU/Metal) → GPU
+  install online → relaunch on overlay.
+- **dev loop** (`npm run dev`, repo `.venv`) unchanged.
+
+## Rollout (phased)
+1. `build_desktop_runtime.py` + `extraResources` + `ServerProcess` launches the bundled env
+   (no GPU path yet). App works offline on CPU/Metal.
+2. `BackendManager.installGpu` (+ overlay launch) + Backends-window GPU action + progress UI.
+3. Delete `build_backend_catalog.py`, `website/backends/`, the `build-backends`/
+   `publish-catalog` CI jobs; trim `config.ts`/`HardwareDetector` catalog code.
+4. Docs: update `electron/README.md` and the backend section of the main `README.md`.

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, posix as pathPosix, resolve, win32 as pathWin32 } from 'node:path';
 
 /** Compute accelerators a PixlStash runtime can target. */
 export type Accel = 'cpu' | 'cu128' | 'rocm' | 'metal';
@@ -131,11 +131,99 @@ export function readRuntimeInfo(): RuntimeInfo | null {
 }
 
 /**
+ * Compute the per-platform *default* parent directory for GPU overlays. Pure (all
+ * inputs passed in) so the platform rule is unit-testable without electron.
+ *
+ * On Windows the packaged app installs to a user-writable, user-chosen location
+ * (electron-builder NSIS with perMachine:false + allowToChangeInstallationDirectory),
+ * so the heavy GPU wheels go *inside the install folder the user picked* rather
+ * than always landing on the system drive under AppData. `resourcesPath` is
+ * `<installDir>/resources`, so its parent is the install dir.
+ *
+ * Everywhere else the installed image is read-only (a Linux AppImage is a squashfs
+ * mount, a notarized macOS .app must not be modified) or we're running unpacked in
+ * dev — there is no writable "install folder" to use — so overlays stay under the
+ * app-data dir, as before. Users who want them elsewhere can still pick a custom
+ * location (see {@link backendsRoot}).
+ */
+export function computeDefaultBackendsRoot(
+  platform: NodeJS.Platform,
+  isPackaged: boolean,
+  resourcesPath: string,
+  userData: string,
+): string {
+  // Use the target platform's path semantics (so the win32 branch is correct —
+  // and unit-testable — even when this runs on a POSIX host in CI).
+  const p = platform === 'win32' ? pathWin32 : pathPosix;
+  if (platform === 'win32' && isPackaged) {
+    return p.join(p.dirname(resourcesPath), 'backends');
+  }
+  return p.join(userData, 'backends');
+}
+
+/** The per-platform default overlay location for this run (see {@link computeDefaultBackendsRoot}). */
+export function defaultBackendsRoot(): string {
+  return computeDefaultBackendsRoot(
+    process.platform,
+    app.isPackaged,
+    process.resourcesPath,
+    app.getPath('userData'),
+  );
+}
+
+/**
+ * Where a user-chosen overlay location is persisted. Kept under userData (which
+ * always survives app updates/moves) even when the overlays themselves live on a
+ * different drive, so the app can always find them again.
+ */
+export function backendsLocationPath(): string {
+  return join(app.getPath('userData'), 'backends-location.json');
+}
+
+/**
+ * Parent directory for GPU overlays: the user's chosen location if they set one,
+ * otherwise the per-platform {@link defaultBackendsRoot}. The default is computed
+ * (never stored), so when the user hasn't overridden it the overlays keep tracking
+ * the real install dir across updates/moves.
+ */
+export function backendsRoot(): string {
+  try {
+    const saved = JSON.parse(readFileSync(backendsLocationPath(), 'utf8'));
+    if (typeof saved?.dir === 'string' && saved.dir.trim()) return saved.dir;
+  } catch {
+    /* not set / unreadable → fall back to the computed default */
+  }
+  return defaultBackendsRoot();
+}
+
+/**
+ * Decide what to persist for a chosen overlay location: `null` (meaning "use the
+ * computed default") when the choice equals the default, else the resolved path.
+ * Pure so the custom-vs-default rule is unit-testable.
+ */
+export function normalizeBackendsRoot(chosen: string, def: string): string | null {
+  return resolve(chosen) === resolve(def) ? null : resolve(chosen);
+}
+
+/** Persist (`dir`) or clear (`null`/empty) the user's chosen overlay location. */
+export function setBackendsRoot(dir: string | null): void {
+  const path = backendsLocationPath();
+  if (dir === null || dir.trim() === '') {
+    rmSync(path, { force: true });
+    return;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify({ dir }, null, 2));
+}
+
+/**
  * Writable overlay holding on-demand GPU wheels, one directory per accelerator,
  * injected via PYTHONPATH so its torch/onnxruntime shadow the bundled CPU build.
+ * Lives under {@link backendsRoot} so the multi-GB download can follow the app's
+ * install location (Windows) or a folder the user picked.
  */
 export function overlayDir(accel: Accel): string {
-  return join(app.getPath('userData'), 'backends', accel);
+  return join(backendsRoot(), accel);
 }
 
 /** Marker written into an overlay once its install completed successfully. */

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -199,10 +199,24 @@ export function backendsRoot(): string {
 /**
  * Decide what to persist for a chosen overlay location: `null` (meaning "use the
  * computed default") when the choice equals the default, else the resolved path.
- * Pure so the custom-vs-default rule is unit-testable.
+ * Pure (platform passed in) so the custom-vs-default rule is unit-testable.
+ *
+ * Windows paths are case-insensitive, so a choice that differs from the default
+ * only by casing (e.g. a different drive-letter case) must still clear the
+ * override and keep tracking the install dir; POSIX filesystems are
+ * case-sensitive, so there the comparison is exact.
  */
-export function normalizeBackendsRoot(chosen: string, def: string): string | null {
-  return resolve(chosen) === resolve(def) ? null : resolve(chosen);
+export function normalizeBackendsRoot(
+  chosen: string,
+  def: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const resolved = resolve(chosen);
+  const same =
+    platform === 'win32'
+      ? resolved.toLowerCase() === resolve(def).toLowerCase()
+      : resolved === resolve(def);
+  return same ? null : resolved;
 }
 
 /** Persist (`dir`) or clear (`null`/empty) the user's chosen overlay location. */

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -540,7 +540,16 @@ async function moveDir(from: string, to: string): Promise<void> {
     await rename(from, to);
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code !== 'EXDEV') throw e;
-    await cp(from, to, { recursive: true });
+    // Cross-filesystem move: copy then delete the source. If the copy fails
+    // partway (e.g. the target drive fills up), clear the partial copy so we
+    // don't leave multiple GB of orphaned junk behind, then rethrow — the
+    // source is still intact for a retry.
+    try {
+      await cp(from, to, { recursive: true });
+    } catch (copyErr) {
+      await rm(to, { recursive: true, force: true });
+      throw copyErr;
+    }
     await rm(from, { recursive: true, force: true });
   }
 }
@@ -567,18 +576,29 @@ async function changeBackendsLocation(rawDir: string): Promise<void> {
     serverProcess?.stop();
     serverProcess = null;
   }
+  let moveError: unknown;
   try {
     for (const accel of await manager.listInstalled()) {
       await moveDir(join(oldRoot, accel), join(targetRoot, accel));
     }
     setBackendsRoot(normalizeBackendsRoot(targetRoot, defaultBackendsRoot()));
-  } finally {
-    // Whether the move succeeded or threw, relaunch the backend if we stopped it.
-    // On success it comes up on the new path; on failure backendsRoot() is still
-    // the old root (setBackendsRoot wasn't reached), so it uses the original
-    // overlay — the user gets the error without losing a running app.
-    if (active) await startAndLoad(active);
+  } catch (e) {
+    moveError = e;
   }
+  // Whether the move succeeded or threw, relaunch the backend if we stopped it.
+  // On success it comes up on the new path; on failure backendsRoot() is still
+  // the old root (setBackendsRoot wasn't reached), so it uses the original
+  // overlay — the user gets the error without losing a running app. A relaunch
+  // failure must not mask the original move error, so only surface it when the
+  // move itself succeeded.
+  if (active) {
+    try {
+      await startAndLoad(active);
+    } catch (relaunchErr) {
+      if (!moveError) throw relaunchErr;
+    }
+  }
+  if (moveError) throw moveError;
 }
 
 /** The pixlstash inference device for an accelerator (GPU overlays → cuda). */

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -11,6 +11,7 @@ import {
 } from 'electron';
 import { execFile } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { cp, mkdir, rename, rm } from 'node:fs/promises';
 import { createServer } from 'node:net';
 import { networkInterfaces } from 'node:os';
 import { dirname, join, resolve, sep } from 'node:path';
@@ -23,14 +24,18 @@ import {
   Accel,
   ACCEL_LABELS,
   RuntimeInfo,
+  backendsRoot,
   bundledInterpreter,
+  defaultBackendsRoot,
   defaultLibraryDir,
   isDevBackend,
+  normalizeBackendsRoot,
   overlayDir,
   parseForcedBackend,
   readRuntimeInfo,
   serverConfigPath,
   serverLogPath,
+  setBackendsRoot,
 } from './config';
 
 const execFileP = promisify(execFile);
@@ -521,6 +526,61 @@ function overlayFor(accel: Accel | null): string | null {
   return accel && accel !== bundledAccel() ? overlayDir(accel) : null;
 }
 
+/**
+ * Move a directory tree, falling back to copy-then-delete when `rename` can't
+ * cross filesystems (EXDEV) — the common case here, since the whole point is
+ * letting a user move the multi-GB overlay onto a *different* drive. A missing
+ * source is a no-op; a stale destination is cleared first so the move is clean.
+ */
+async function moveDir(from: string, to: string): Promise<void> {
+  if (!existsSync(from)) return;
+  await mkdir(dirname(to), { recursive: true });
+  await rm(to, { recursive: true, force: true });
+  try {
+    await rename(from, to);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'EXDEV') throw e;
+    await cp(from, to, { recursive: true });
+    await rm(from, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Change where GPU overlays are stored, moving any already-installed overlay to
+ * the new location so the multi-GB torch download isn't re-fetched (the `--target`
+ * install has no hard-coded base path, so it survives the move). When an overlay
+ * is *active* the live Python process holds its files open, so we stop the backend
+ * before moving and relaunch it on the new path afterwards; an inactive overlay
+ * (or none) needs no restart. The chosen location is persisted, except when it
+ * equals the per-platform default — then we clear the override so it keeps
+ * tracking the install dir across updates.
+ */
+async function changeBackendsLocation(rawDir: string): Promise<void> {
+  const newDir = (rawDir || '').trim();
+  if (!newDir) throw new Error('Please choose a folder.');
+  const oldRoot = backendsRoot();
+  const targetRoot = resolve(newDir);
+  if (targetRoot === resolve(oldRoot)) return; // unchanged
+
+  const active = await activeOverlayAccel();
+  if (active) {
+    serverProcess?.stop();
+    serverProcess = null;
+  }
+  try {
+    for (const accel of await manager.listInstalled()) {
+      await moveDir(join(oldRoot, accel), join(targetRoot, accel));
+    }
+    setBackendsRoot(normalizeBackendsRoot(targetRoot, defaultBackendsRoot()));
+  } finally {
+    // Whether the move succeeded or threw, relaunch the backend if we stopped it.
+    // On success it comes up on the new path; on failure backendsRoot() is still
+    // the old root (setBackendsRoot wasn't reached), so it uses the original
+    // overlay — the user gets the error without losing a running app.
+    if (active) await startAndLoad(active);
+  }
+}
+
 /** The pixlstash inference device for an accelerator (GPU overlays → cuda). */
 function deviceFor(accel: Accel | null): string | undefined {
   if (isDevBackend()) return undefined; // dev uses the developer's own env/config
@@ -679,6 +739,9 @@ function registerIpc(): void {
       defaults: {
         imageRoot: importedImageRoot || defaultLibraryDir(),
         useGpu: Boolean(gpu),
+        // Where the GPU runtime would install (only relevant when a GPU is
+        // offered). On Windows this is inside the chosen install folder.
+        installLocation: backendsRoot(),
       },
       gpu: gpu
         ? { available: true, accel: gpu, label: ACCEL_LABELS[gpu], name: hardware?.gpuName ?? null }
@@ -695,37 +758,48 @@ function registerIpc(): void {
     return res.canceled || !res.filePaths[0] ? null : res.filePaths[0];
   });
 
-  ipcMain.handle('setup:commit', async (_e, choices: { imageRoot: string; useGpu: boolean }) => {
-    if (!runtime) throw new Error('No bundled runtime available');
-    const imageRoot = (choices?.imageRoot || '').trim();
-    if (!imageRoot) throw new Error('Please choose a library folder.');
+  ipcMain.handle(
+    'setup:commit',
+    async (_e, choices: { imageRoot: string; useGpu: boolean; installLocation?: string }) => {
+      if (!runtime) throw new Error('No bundled runtime available');
+      const imageRoot = (choices?.imageRoot || '').trim();
+      if (!imageRoot) throw new Error('Please choose a library folder.');
 
-    // Write the desktop's own config. Loopback HTTP; the active runtime drives
-    // the device (default_device left as auto). The backend fills the rest of
-    // the defaults on first read.
-    mkdirSync(dirname(serverConfigPath()), { recursive: true });
-    writeFileSync(
-      serverConfigPath(),
-      JSON.stringify(
-        { host: '127.0.0.1', require_ssl: false, image_root: imageRoot, default_device: 'auto' },
-        null,
-        2,
-      ),
-    );
+      // Record where the GPU runtime should install (clearing the override when
+      // it matches the default, so it keeps tracking the install dir). Done
+      // before the overlay install below so the download lands in the right place.
+      const installLocation = (choices?.installLocation || '').trim();
+      if (installLocation) {
+        setBackendsRoot(normalizeBackendsRoot(installLocation, defaultBackendsRoot()));
+      }
 
-    // The GPU choice maps onto the existing on-demand wheel-overlay system.
-    const gpu = gpuUpgrade();
-    if (choices?.useGpu && gpu) {
-      await manager.installOverlay(gpu, runtime, (p) =>
-        mainWindow?.webContents.send('install:progress', p),
+      // Write the desktop's own config. Loopback HTTP; the active runtime drives
+      // the device (default_device left as auto). The backend fills the rest of
+      // the defaults on first read.
+      mkdirSync(dirname(serverConfigPath()), { recursive: true });
+      writeFileSync(
+        serverConfigPath(),
+        JSON.stringify(
+          { host: '127.0.0.1', require_ssl: false, image_root: imageRoot, default_device: 'auto' },
+          null,
+          2,
+        ),
       );
-      await manager.setActiveAccel(gpu);
-    } else {
-      await manager.setActiveAccel(null);
-    }
 
-    await startAndLoad(await activeOverlayAccel());
-  });
+      // The GPU choice maps onto the existing on-demand wheel-overlay system.
+      const gpu = gpuUpgrade();
+      if (choices?.useGpu && gpu) {
+        await manager.installOverlay(gpu, runtime, (p) =>
+          mainWindow?.webContents.send('install:progress', p),
+        );
+        await manager.setActiveAccel(gpu);
+      } else {
+        await manager.setActiveAccel(null);
+      }
+
+      await startAndLoad(await activeOverlayAccel());
+    },
+  );
 
   ipcMain.handle('desktop:openLibraryFolder', () => openLibraryFolder());
   ipcMain.handle('desktop:showLogs', () => showServerLogs());
@@ -758,6 +832,27 @@ function registerIpc(): void {
   ipcMain.handle('window:close', () => mainWindow?.close());
 
   ipcMain.handle('accel:list', async () => acceleratorState());
+
+  // Where on-demand GPU overlays are stored. Lets the user keep the multi-GB
+  // download off the system drive (the first-run wizard offers the same choice).
+  ipcMain.handle('backend:getLocation', () => ({
+    dir: backendsRoot(),
+    default: defaultBackendsRoot(),
+  }));
+
+  ipcMain.handle('backend:pickLocation', async (_e, current?: string) => {
+    const res = await dialog.showOpenDialog({
+      title: 'Choose where to install GPU acceleration',
+      defaultPath: current || backendsRoot(),
+      properties: ['openDirectory', 'createDirectory'],
+    });
+    return res.canceled || !res.filePaths[0] ? null : res.filePaths[0];
+  });
+
+  ipcMain.handle('backend:setLocation', async (_e, dir: string) => {
+    await changeBackendsLocation(dir);
+    return { dir: backendsRoot(), default: defaultBackendsRoot() };
+  });
 
   ipcMain.handle('accel:install', async (_e, accel: Accel) => {
     if (!runtime) throw new Error('No bundled runtime available');

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -14,6 +14,10 @@ contextBridge.exposeInMainWorld('pixlstashDesktop', {
   installAccelerator: (accel: string) => ipcRenderer.invoke('accel:install', accel),
   useAccelerator: (accel: string | null) => ipcRenderer.invoke('accel:use', accel),
   removeAccelerator: (accel: string) => ipcRenderer.invoke('accel:remove', accel),
+  // Where the on-demand GPU overlay is stored (keep the big download off C:).
+  getBackendLocation: () => ipcRenderer.invoke('backend:getLocation'),
+  pickBackendLocation: (current: string) => ipcRenderer.invoke('backend:pickLocation', current),
+  setBackendLocation: (dir: string) => ipcRenderer.invoke('backend:setLocation', dir),
   // Desktop conveniences re-homed from the (removed) native menu.
   openLibraryFolder: () => ipcRenderer.invoke('desktop:openLibraryFolder'),
   showLogs: () => ipcRenderer.invoke('desktop:showLogs'),

--- a/electron/src/renderer/setup.html
+++ b/electron/src/renderer/setup.html
@@ -37,6 +37,13 @@
       <div id="computePanel" class="panel hidden">
         <div class="hw">Compute</div>
         <div id="computeOptions"></div>
+        <div id="installLocation" class="install-location hidden">
+          <div class="field">
+            <input id="installPath" type="text" aria-label="GPU install location" readonly />
+            <button id="pickInstall" class="secondary" type="button">Change…</button>
+          </div>
+          <div class="sub">The GPU runtime (~2.5&nbsp;GB) is stored here.</div>
+        </div>
       </div>
 
       <div id="error" class="error hidden"></div>

--- a/electron/src/renderer/setup.js
+++ b/electron/src/renderer/setup.js
@@ -12,6 +12,9 @@ const els = {
   importedText: document.getElementById('importedText'),
   computePanel: document.getElementById('computePanel'),
   computeOptions: document.getElementById('computeOptions'),
+  installLocation: document.getElementById('installLocation'),
+  installPath: document.getElementById('installPath'),
+  pickInstall: document.getElementById('pickInstall'),
   start: document.getElementById('start'),
   error: document.getElementById('error'),
   progress: document.getElementById('progress'),
@@ -36,6 +39,13 @@ function showError(msg) {
 function selectedUseGpu() {
   const checked = els.computeOptions.querySelector('input[name="compute"]:checked');
   return checked ? checked.value === 'gpu' : false;
+}
+
+// The install-location picker only matters when a GPU runtime will be downloaded,
+// so reveal it exactly when GPU is the selected compute option.
+function updateInstallLocationVisibility() {
+  if (gpu.available && selectedUseGpu()) show(els.installLocation);
+  else hide(els.installLocation);
 }
 
 function renderCompute(defaultUseGpu) {
@@ -64,6 +74,7 @@ function renderCompute(defaultUseGpu) {
         .querySelectorAll('.choice')
         .forEach((c) => c.classList.remove('selected'));
       if (radio.checked) wrap.classList.add('selected');
+      updateInstallLocationVisibility();
     });
 
     const meta = document.createElement('div');
@@ -89,10 +100,12 @@ async function init() {
     els.importedText.textContent = `Imported your existing settings from ${p.importedFrom}.`;
     show(els.imported);
   }
+  els.installPath.value = p.defaults.installLocation || '';
   gpu = p.gpu || { available: false };
   if (gpu.available) {
     renderCompute(Boolean(p.defaults.useGpu));
     show(els.computePanel);
+    updateInstallLocationVisibility();
   }
 }
 
@@ -100,6 +113,12 @@ els.pick.addEventListener('click', async () => {
   if (busy) return;
   const dir = await api.pickLibraryFolder(els.folder.value);
   if (dir) els.folder.value = dir;
+});
+
+els.pickInstall.addEventListener('click', async () => {
+  if (busy) return;
+  const dir = await api.pickBackendLocation(els.installPath.value);
+  if (dir) els.installPath.value = dir;
 });
 
 els.start.addEventListener('click', async () => {
@@ -110,18 +129,21 @@ els.start.addEventListener('click', async () => {
     showError('Please choose a library folder.');
     return;
   }
+  const useGpu = gpu.available && selectedUseGpu();
   busy = true;
   els.start.disabled = true;
   els.pick.disabled = true;
+  els.pickInstall.disabled = true;
   els.start.textContent = 'Setting up…';
   try {
-    await api.commitSetup({ imageRoot, useGpu: gpu.available && selectedUseGpu() });
+    await api.commitSetup({ imageRoot, useGpu, installLocation: els.installPath.value.trim() });
     // Success → main process navigates this window to the library.
   } catch (e) {
     showError((e && e.message) || String(e));
     busy = false;
     els.start.disabled = false;
     els.pick.disabled = false;
+    els.pickInstall.disabled = false;
     els.start.textContent = 'Get started';
   }
 });

--- a/electron/src/renderer/styles.css
+++ b/electron/src/renderer/styles.css
@@ -373,6 +373,16 @@ button:disabled {
   white-space: nowrap;
 }
 
+/* GPU install-location picker, revealed under the compute options when GPU is
+   chosen. Reuses .field/.sub; just needs a little separation from the radios. */
+.install-location {
+  margin-top: 10px;
+}
+
+.install-location .sub {
+  margin-top: 6px;
+}
+
 .choice {
   display: flex;
   align-items: flex-start;

--- a/electron/test/backendsLocation.test.ts
+++ b/electron/test/backendsLocation.test.ts
@@ -57,4 +57,18 @@ describe('normalizeBackendsRoot — custom vs default persistence rule', () => {
   it('returns the resolved path when the choice differs from the default', () => {
     assert.equal(normalizeBackendsRoot('/mnt/big/backends', def), resolve('/mnt/big/backends'));
   });
+
+  it('on Windows, a choice differing only by case still clears the override', () => {
+    // Windows filesystems are case-insensitive, so /Data/Backends and
+    // /data/backends are the same folder — the override must be cleared so the
+    // default keeps tracking the install dir.
+    assert.equal(normalizeBackendsRoot('/Data/Backends', def, 'win32'), null);
+  });
+
+  it('on POSIX, a choice differing only by case is a genuinely different folder', () => {
+    assert.equal(
+      normalizeBackendsRoot('/Data/Backends', def, 'linux'),
+      resolve('/Data/Backends'),
+    );
+  });
 });

--- a/electron/test/backendsLocation.test.ts
+++ b/electron/test/backendsLocation.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { posix, resolve, sep, win32 } from 'node:path';
+import { computeDefaultBackendsRoot, normalizeBackendsRoot } from '../src/config';
+
+describe('computeDefaultBackendsRoot — where GPU overlays default to', () => {
+  it('Windows packaged installs next to the app (inside the chosen install folder)', () => {
+    // process.resourcesPath is <installDir>/resources, so the overlay sits in
+    // <installDir>/backends — following the location the user picked in the
+    // installer instead of always landing under AppData on the system drive.
+    const root = computeDefaultBackendsRoot(
+      'win32',
+      true,
+      'D:\\Apps\\PixlStash\\resources',
+      'C:\\Users\\me\\AppData\\Roaming\\pixlstash-desktop',
+    );
+    assert.equal(root, win32.join('D:\\Apps\\PixlStash', 'backends'));
+    // The system-drive AppData path must NOT be used as the default on Windows.
+    assert.ok(!root.includes('AppData'), 'Windows default must escape AppData');
+  });
+
+  it('Windows in dev (unpackaged) falls back to userData — no real install dir', () => {
+    const userData = 'C:\\Users\\me\\AppData\\Roaming\\pixlstash-desktop';
+    const root = computeDefaultBackendsRoot('win32', false, 'C:\\whatever\\resources', userData);
+    assert.equal(root, win32.join(userData, 'backends'));
+  });
+
+  it('Linux keeps overlays under userData (the AppImage image is read-only)', () => {
+    const userData = '/home/me/.config/pixlstash-desktop';
+    const root = computeDefaultBackendsRoot('linux', true, '/tmp/.mount_x/resources', userData);
+    assert.equal(root, posix.join(userData, 'backends'));
+  });
+
+  it('macOS keeps overlays under userData (the notarized .app must not be modified)', () => {
+    const userData = '/Users/me/Library/Application Support/pixlstash-desktop';
+    const root = computeDefaultBackendsRoot(
+      'darwin',
+      true,
+      '/Applications/PixlStash.app/Contents/Resources',
+      userData,
+    );
+    assert.equal(root, posix.join(userData, 'backends'));
+  });
+});
+
+describe('normalizeBackendsRoot — custom vs default persistence rule', () => {
+  const def = resolve('/data/backends');
+
+  it('returns null when the choice equals the default (so it keeps tracking the install dir)', () => {
+    assert.equal(normalizeBackendsRoot('/data/backends', def), null);
+  });
+
+  it('treats a trailing-separator path as the same as the default', () => {
+    assert.equal(normalizeBackendsRoot(`/data/backends${sep}`, def), null);
+  });
+
+  it('returns the resolved path when the choice differs from the default', () => {
+    assert.equal(normalizeBackendsRoot('/mnt/big/backends', def), resolve('/mnt/big/backends'));
+  });
+});

--- a/frontend/e2e/screenshots/desktopBridge.js
+++ b/frontend/e2e/screenshots/desktopBridge.js
@@ -55,6 +55,12 @@ function installDesktopBridge(overrides) {
     installAccelerator: val(undefined),
     useAccelerator: val(undefined),
     removeAccelerator: val(undefined),
+    getBackendLocation: val({
+      dir: 'C:\\Users\\You\\AppData\\Local\\Programs\\PixlStash\\backends',
+      default: 'C:\\Users\\You\\AppData\\Local\\Programs\\PixlStash\\backends',
+    }),
+    pickBackendLocation: val(null),
+    setBackendLocation: val(undefined),
     openLibraryFolder: noop,
     showLogs: noop,
   }

--- a/frontend/e2e/screenshots/wizard.spec.js
+++ b/frontend/e2e/screenshots/wizard.spec.js
@@ -39,11 +39,13 @@ function installSetupBridge(gpu) {
       defaults: {
         imageRoot: 'C:\\Users\\You\\Pictures\\PixlStash',
         useGpu: true,
+        installLocation: 'C:\\Users\\You\\AppData\\Local\\Programs\\PixlStash\\backends',
       },
       importedFrom: null,
       gpu,
     }),
     pickLibraryFolder: val(null),
+    pickBackendLocation: val(null),
     commitSetup: val(undefined),
     onProgress: () => () => {},
     windowMinimize: val(undefined),
@@ -79,9 +81,10 @@ test.describe('first-run setup wizard (compute choice)', () => {
   for (const scene of wizardScenes) {
     test(`wizard → ${scene.asset}`, async ({ page }) => {
       // Snug window framing the title bar + 560px panel. The wizard content is
-      // top-aligned and ~624px tall, so 680 leaves a small bottom margin without
-      // acres of empty space (the real window is taller, 1280×860).
-      await page.setViewportSize({ width: 820, height: 680 })
+      // top-aligned; with the GPU install-location picker shown it's ~690px tall,
+      // so 760 leaves a small bottom margin without acres of empty space (the real
+      // window is taller, 1280×860).
+      await page.setViewportSize({ width: 820, height: 760 })
       await page.addInitScript(installSetupBridge, scene.gpu)
       await page.goto(pathToFileURL(SETUP_HTML).href)
       // The compute panel only un-hides once probeSetup resolves a detected GPU.

--- a/frontend/src/components/settings/ComputeSection.vue
+++ b/frontend/src/components/settings/ComputeSection.vue
@@ -19,6 +19,10 @@ const error = ref("");
 const progress = ref(null); // { message, fraction } while installing
 let stopProgress = null;
 
+// Where on-demand GPU overlays are stored. Lets the user keep the multi-GB
+// download off the system drive; changing it relocates an installed overlay.
+const backendLocation = ref("");
+
 // External-server (remote access) settings. `server` mirrors the saved state
 // from the backend config; `serverDraft` is what the form edits until Apply.
 const server = ref(null); // { enabled, port, ssl, urls }
@@ -146,6 +150,30 @@ async function refresh() {
   }
 }
 
+async function refreshLocation() {
+  if (!desktop?.getBackendLocation) return;
+  try {
+    const res = await desktop.getBackendLocation();
+    backendLocation.value = res?.dir || "";
+  } catch (e) {
+    error.value = e?.message || String(e);
+  }
+}
+
+// Pick a new folder and move any installed overlay there. setBackendLocation
+// restarts the backend when an overlay is active, which reloads this page; when
+// none is active it just returns and we update the shown path.
+async function changeLocation() {
+  if (busy.value || !desktop?.pickBackendLocation) return;
+  const dir = await desktop.pickBackendLocation(backendLocation.value);
+  if (!dir) return;
+  await guarded(async () => {
+    progress.value = { message: "Moving GPU files to the new location…", fraction: -1 };
+    const res = await desktop.setBackendLocation(dir);
+    backendLocation.value = res?.dir || dir;
+  });
+}
+
 async function refreshDesktopPrefs() {
   if (!desktop?.getDesktopPrefs) return;
   try {
@@ -265,6 +293,7 @@ onMounted(() => {
     });
   }
   refresh();
+  refreshLocation();
   refreshServer();
   refreshDesktopPrefs();
   refreshAuthState();
@@ -280,6 +309,7 @@ watch(
   (isOpen) => {
     if (isOpen) {
       refresh();
+      refreshLocation();
       refreshServer();
       refreshDesktopPrefs();
       refreshAuthState();
@@ -518,6 +548,21 @@ watch(
         machine.
       </div>
 
+      <div v-if="state.items.length && backendLocation" class="compute-row">
+        <div class="compute-meta">
+          <div class="compute-label">Install location</div>
+          <div class="compute-sub compute-location-path">{{ backendLocation }}</div>
+        </div>
+        <v-btn
+          variant="text"
+          size="small"
+          :disabled="busy"
+          @click="changeLocation"
+        >
+          Change…
+        </v-btn>
+      </div>
+
       <div v-if="progress" class="compute-progress">
         <v-progress-linear
           :indeterminate="!(progress.fraction >= 0)"
@@ -624,6 +669,10 @@ watch(
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
+}
+
+.compute-location-path {
+  overflow-wrap: anywhere;
 }
 
 .compute-progress {


### PR DESCRIPTION
The on-demand GPU overlay (~2.5 GB torch + CUDA) was hardcoded to userData/backends/<accel> — always on the system drive under AppData/ .config, regardless of where the app itself was installed.

- Make the overlay root configurable (config.ts backendsRoot()).
- Default per-platform: Windows (packaged) installs inside the chosen install folder (dirname(resourcesPath)/backends), so it follows the installer location and stays off C: when another drive is picked. Linux/macOS stay under userData (AppImage/.app are read-only).
- First-run wizard and Settings → Compute expose an install-location picker. Changing it moves an already-installed overlay (rename, with a cross-drive copy+delete fallback) so the multi-GB download isn't repeated — replacing the manual move+symlink workaround.

Adds unit tests for the platform default and custom-vs-default rules.