### PR TITLE
Fix pre-existing bugs: PATCH tags 500 + silent hash-parse in derive_kind

### DIFF
--- a/pixlstash/routes/pictures/_crud.py
+++ b/pixlstash/routes/pictures/_crud.py
@@ -2005,7 +2005,11 @@ def register_routes(router, server):
         updated = False
         updated_fields = {}
         for key, value in params.items():
-            if not hasattr(pic, key):
+            # Validate the key against the mapped CLASS, not the instance:
+            # hasattr(pic, "tags") lazy-loads the tags relationship, which raises
+            # DetachedInstanceError (a 500) when pic is detached from its session.
+            # The class exposes the same mapped attributes without a DB access.
+            if not hasattr(type(pic), key):
                 logger.warning(
                     f"Picture does not have key '{key}' in PATCH request. Ignoring."
                 )

--- a/pixlstash/services/review_service.py
+++ b/pixlstash/services/review_service.py
@@ -568,8 +568,16 @@ def derive_kind(
         try:
             if hamming_distance(int(s_hash, 16), int(t_hash, 16)) <= max_twin_hamming:
                 return "pair"
-        except (ValueError, TypeError):
-            pass
+        except (ValueError, TypeError) as exc:
+            # A malformed/non-hex perceptual hash can't be compared; fall back to
+            # "binary" instead of silently swallowing it (no-silent-pass rule).
+            logger.debug(
+                "derive_kind: unparseable perceptual hash (suspect=%r, twin=%r): "
+                "%s; classifying pair as binary",
+                s_hash,
+                t_hash,
+                exc,
+            )
     return "binary"
 
 

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -378,6 +378,25 @@ def test_add_remove_tag_to_picture():
         gc.collect()
 
 
+def test_patch_picture_with_tags_key_does_not_500():
+    # Regression: PATCH /pictures/{id} carrying a `tags` key used to 500 for
+    # everyone — hasattr(pic, "tags") lazy-loaded the tags relationship on a
+    # session-detached Picture (DetachedInstanceError) before any handler ran.
+    temp_dir, client, server = _setup()
+    try:
+        pic_id = _upload_picture(client)
+
+        resp = client.patch(f"/pictures/{pic_id}", json={"tags": ["alpha", "beta"]})
+        assert resp.status_code == 200, resp.text
+
+        tags = client.get(f"/pictures/{pic_id}/tags").json().get("tags", [])
+        assert {t["tag"] for t in tags} == {"alpha", "beta"}
+    finally:
+        server.vault.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
 def test_get_all_tags_with_counts():
     temp_dir, client, server = _setup()
     try:


### PR DESCRIPTION
Two standalone pre-existing bug fixes on develop (surfaced during the picture-set-locking work), one commit each:

1. **PATCH /pictures/{id} 500 on a `tags` key** — `hasattr(pic, "tags")` lazy-loaded the tags relationship on a session-detached Picture (`DetachedInstanceError`) before any handler logic, so every PATCH carrying a tags key 500'd for everyone. Now validates the key against the mapped class. Regression test added (`test_patch_picture_with_tags_key_does_not_500`).
2. **Silent `except…pass` in `derive_kind`** — an unparseable perceptual hash silently downgraded a suspect/twin pair to `binary` with no trace; now logged at debug (no-silent-pass rule), behaviour unchanged.