### PR TITLE
docs: refresh architecture/test/agent docs to match the code (audit fixes)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,7 +93,7 @@ Decompose by domain first, then fan out. **Independent** sub-tasks should run co
 ## Task System
 
 - The TaskRunner class manages asynchronous tasks, allowing for background processing of image quality calculations and other operations without blocking the main server thread.
-- Work is first found using the WorkPlanner which has multiple WorkFinders registered to find different types of work (e.g., quality calculation, metadata extraction).
+- Work is first found using the WorkPlanner (`pixlstash/work_planner.py`), whose `work_finders()` returns the registered finder instances that locate different types of work (e.g., quality calculation, metadata extraction). Each finder is a `Missing*Finder`/`*Finder` subclass of `BaseTaskFinder` in `pixlstash/tasks/`.
 - Once work is found a new Task for a batch of images is created and added to the TaskRunner's queue.
 - The TaskRunner continuously processes tasks from the queue, executing the associated work function, reporting progress and handling results.
 
@@ -111,7 +111,7 @@ Decompose by domain first, then fan out. **Independent** sub-tasks should run co
   - **Feature branch (schema still in flux):** it's fine to amend, squash, or merge migrations rather than stacking multiple migrations for the same change. Keep the migration history tidy before it lands.
   - **`main` branch:** strict patterns apply. A migration on `main` must never be modified; all subsequent schema changes go in new migration files. (Reason: anything on `main` may already have been deployed and run, so altering an existing migration would leave those databases divergent.)
 - Place schema upgrade steps in strictly increasing version order; never insert a migration out of sequence, so upgrades always apply in the correct order.
-- The Alembic revision identifier variables (`revision`, `down_revision`, `branch_labels`, `depends_on`) are read by Alembic at runtime via module import, not by explicit code references. Declare them as exported by including `__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]` after the `depends_on` line. This prevents false "unused variable" warnings from static analysers (including CodeQL) without needing `# noqa` comments. The script template (`migrations/script.py.mako`) already includes this line, so new migrations will have it automatically.
+- The Alembic revision identifier variables (`revision`, `down_revision`, `branch_labels`, `depends_on`) are read by Alembic at runtime via module import, not by explicit code references. Declare them as exported by including `__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]` after the `depends_on` line. This prevents false "unused variable" warnings from static analysers (including CodeQL) without needing `# noqa` comments. The script template (`pixlstash/migrations/script.py.mako`) already includes this line, so new migrations will have it automatically.
 - When a code change requires existing data to be regenerated (e.g. tags, embeddings, quality scores), trigger reprocessing by resetting the relevant column(s) to `NULL` in the Alembic migration script. The `Missing*Finder` classes in `pixlstash/tasks/` query for pictures with `NULL` values and will automatically pick up those rows for reprocessing when the server next runs. Alembic migrations should only contain schema changes and this kind of targeted `NULL`-reset; no application logic should be placed in migrations.
 - **All `op.add_column` calls must be conditional.** Always use `sa.inspect(op.get_bind())` to fetch existing columns and skip the `add_column` if the column already exists. The baseline migration (`0001_baseline`) uses `SQLModel.metadata.create_all()`, which creates tables with all current model columns; later migrations that blindly run `ALTER TABLE … ADD COLUMN` will therefore fail on a fresh database. The standard pattern is:
   ```python
@@ -124,7 +124,7 @@ Decompose by domain first, then fan out. **Independent** sub-tasks should run co
 ## Developer Workflows
 
 - **Install dependencies:** `pip install -e .`
-- **Run server:** `python -m pixlstash.server`
+- **Run server:** `python -m pixlstash.app`
 - **Run tests:** `python -m pytest -s -vvv --fast-captions --force-cpu`
 - **Check formatting:** `ruff check pixlstash`
 - **Build frontend:** `npm run build` (in `frontend/`)

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -62,6 +62,12 @@ pixlstash/
 │   ├── quality.py                    # Quality (sharpness, contrast, …)
 │   ├── tag.py                        # User-confirmed tags
 │   ├── tag_prediction.py             # Model-predicted tags + confidence
+│   ├── tag_health.py                 # Per-tag health board cache
+│   ├── tag_suggestion.py             # Suspected label fixes (review queue)
+│   ├── tagger_run.py                 # Tagger eval runs pushed from PixlTagger
+│   ├── review.py                     # Tag review sessions + item decisions
+│   ├── detection.py                  # Florence-2 object detections
+│   ├── snapshot.py                   # Vault snapshots (GFS retention)
 │   ├── picture_likeness.py           # Pairwise image similarity
 │   ├── picture_set.py                # Sets + membership
 │   ├── picture_stack.py              # Stacks (duplicates / variants)
@@ -127,6 +133,12 @@ pixlstash/
 │       └── plugin_template.py
 │
 ├── tagger_plugins/                   # TaggerPlugin subclasses + registry (WD14, PixlStash tagger, Florence-2, JoyCaption)
+│
+├── inference/                        # ML engine + model lifecycle
+│   ├── engine.py                     # InferenceEngine (captioning, detection, embeddings)
+│   ├── model_lifecycle.py            # Model load/unload management
+│   ├── vram_budget.py                # VRAM budgeting
+│   └── workflows/                    # tagging, description, text/clip/face embedding
 │
 ├── services/                         # Business-logic extracted from route handlers
 │   ├── config_service.py             # Hardware monitoring + import folder utilities
@@ -282,13 +294,13 @@ Key endpoints (see the auto-generated index below for the full set):
 | GET | `/pictures/search` | Keyword + semantic search |
 | GET | `/pictures/stats` | Aggregate stats |
 | POST | `/pictures/import` | Upload images → create Pictures |
-| GET | `/pictures/import/{task_id}/status` | Import progress |
+| GET | `/pictures/import/status?task_id=…` | Import progress |
 | GET | `/pictures/export` | Start async ZIP export |
-| GET | `/pictures/export/{task_id}/status` | Export progress |
-| GET | `/pictures/export/{task_id}/download` | Download finished ZIP |
-| GET | `/pictures/{id}/thumbnail` | Cached thumbnail |
+| GET | `/pictures/export/status?task_id=…` | Export progress |
+| GET | `/pictures/export/download/{task_id}` | Download finished ZIP |
+| GET | `/pictures/thumbnails/{id}.webp` | Cached thumbnail |
 | POST | `/pictures/thumbnails` | Batch thumbnails |
-| GET | `/pictures/{id}/{ext}` | Serve original (optionally watermarked) |
+| GET | `/pictures/{id}.{ext}` | Serve original (optionally watermarked) |
 | POST | `/pictures/{id}/plugin/{name}` | Run image plugin |
 | PATCH | `/pictures/project` | Bulk assign to project |
 | POST | `/pictures/scores` | Bulk apply user ratings |
@@ -551,10 +563,39 @@ UserToken: id, user_id, token_hash, scope (ALL|READ),
 GuestSession / GuestScore
 ```
 
+### Tag review & health
+
+```text
+TagHealth: id, tag (unique), est_wrong, est_missing,
+           est_wrong_adj, est_missing_adj, mismatch, verified_pct,
+           boundary_pct, overturn_rate, model_disputes, has_model,
+           last_reviewed_at, computed_at
+           → per-tag health board cache (rebuilt in the background)
+
+TagSuggestion: id, picture_id, tag, direction ("add"|"remove"),
+               source, score, reason, twin_picture_id, twin_sim,
+               review_id, neighbors (JSON), status, created_at,
+               reviewed_at, prior_review_id/status/reviewed_at
+               (suspected label fixes in the review queue)
+
+Review: id, tag, project_id, set_id, character_id, status
+        (OPEN|ARCHIVED|ABORTED), scanned, found, prev_reviewed,
+        created_at, refreshed_at, receipt_snapshot
+        (one review session = one tag + a frozen scope + one scan)
+
+TaggerRun: id, run (unique), model_version, verdict, recommend,
+           accepted, anomaly_macro_f1, report (JSON), created_at
+           (tagger eval runs pushed from PixlTagger)
+```
+
 ### Filesystem-linked
 
 ```text
 ReferenceFolder, ImportFolder, DeletedFileLog, Metadata
+
+Snapshot: id, kind, created_at, relative_path,
+          manifest_relative_path, byte_size, picture_count,
+          schema_version, label   (vault snapshots, GFS retention)
 ```
 
 **Vector storage**: image and text embeddings are stored as `BLOB` columns on `Picture` (no external vector DB). Face features are stored on `Face`.
@@ -576,6 +617,7 @@ ReferenceFolder, ImportFolder, DeletedFileLog, Metadata
 | Task | Queue | Finder | Purpose |
 |------|-------|--------|---------|
 | `FACE_EXTRACTION` | GPU | `MissingFaceExtractionFinder` | InsightFace detection + 512-d embedding |
+| `FACE_MODEL_REFRESH` | GPU | `MissingFaceModelRefreshFinder` | Re-embed `Face` rows in place when `insightface_model_pack` changes (selects faces whose `model_pack` differs from the configured pack, preserving `character_id`). `depends_on=[FACE_EXTRACTION]` so brand-new pictures are never starved by a pack-refresh sweep. Registered in `vault.py`. |
 | `QUALITY` | CPU | `MissingQualityFinder` | OpenCV quality metrics |
 | `TAGGER` | GPU | `MissingTagFinder` | All enabled tag plugins (union) |
 | `TAG_PREDICTION_BACKFILL` | GPU | `MissingTagPredictionFinder` | Recover `tag_prediction` rows for pictures with tags but no predictions (runs the PixlStash tagger for raw scores only; never re-tags). Gated on the PixlStash tagger being active; depends on `FACE_EXTRACTION` + `TAGGER` so live work runs first. |
@@ -592,7 +634,7 @@ ReferenceFolder, ImportFolder, DeletedFileLog, Metadata
 | `MISSING_FILE_PURGE` | CPU | `MissingFilePurgeFinder` | Remove records for vanished files |
 | `REFERENCE_FOLDER_SCAN` | CPU | `ReferenceFolderScanFinder` | Periodic reference-folder rescan |
 | `DETECTION` | GPU | _(none — user-triggered)_ | Florence-2 object detection / phrase grounding → `Detection` rows. Enqueued by `POST /pictures/detect` (the Segment action); HIGH priority, no WorkFinder. Reuses the captioning Florence-2 model via `InferenceEngine.detect_objects`. |
-| `PICTURE_SPLIT_ASSIGNMENT` | CPU | `PictureSplitAssignmentFinder` | Periodic existence check for pictures with no `PictureSplit` row; queues `picture_split_service.assign_splits` (idempotent — only unassigned pictures are targeted). Replaces the previously-uncalled `POST /picture_splits/assign` as the sole trigger, so freeze eligibility (`eval_candidate_n_pos`) moves without manual action. No `depends_on()` ordering on `IMAGE_EMBEDDING`/`LIKENESS` — deliberately soft (see the finder's module docstring): hard-blocking on those risks starving split assignment during active review, the exact bug this finder fixes. |
+| `GFS_SNAPSHOT` | CPU | `EnsureGfsSnapshotFinder` | Drives the Grandfather-Father-Son automatic snapshot schedule: at most one snapshot per check (every 5 minutes), of the highest tier that is due (`MONTHLY` / `WEEKLY` / `DAILY`). Retention prunes each tier independently (7 daily / 4 weekly / 12 monthly). Registered in `vault.py`. |
 | `TAG_HEALTH_AUTO_REBUILD` | CPU | `TagHealthAutoRebuildFinder` | Checks `tag_health_service.is_stale` at most every 5 minutes (`AUTO_REBUILD_CHECK_INTERVAL_S`); when stale and no rebuild is running, dispatches through the same idempotent `start_rebuild` path `POST /tag_health/rebuild` uses. Closes the loop so `GET /tag_health`'s `stale` flag (new pictures / `TaggerRun`s / reviewed `TagSuggestion`s since the cache's `computed_at`) self-heals without a manual click. |
 
 **Re-processing**: setting a work column to `NULL` (e.g. via an Alembic migration) makes the corresponding finder pick the row up on the next pass — this is how data regenerations are triggered.
@@ -673,12 +715,24 @@ Modules in [pixlstash/services/](../pixlstash/services/) contain business logic 
 
 | Module | Role |
 |--------|------|
-| [services/_filter_helpers.py](../pixlstash/services/_filter_helpers.py) | Shared SQL filter helpers (`normalize_set_mode`, `collect_set_filter_ids`, `project_membership_exists_clause`). Lives in `services/` to avoid a circular import between `routes/pictures/` and `services/picture_stats.py`; it is a utility module, not a service in the domain sense |
+| [utils/service/filter_helpers.py](../pixlstash/utils/service/filter_helpers.py) | Shared SQL filter helpers (`normalize_set_mode`, `collect_set_filter_ids`, `project_membership_exists_clause`). Lives under `utils/service/` (not `services/`); it is a stateless utility module, not a service in the domain sense |
+| [utils/service/picture_stats.py](../pixlstash/utils/service/picture_stats.py) | Aggregation queries for `GET /pictures/stats`; accepts a `PictureStatsParams` dataclass and returns the stats dict; used by `routes/pictures/_misc.py`. Lives under `utils/service/`, not `services/` |
 | [services/config_service.py](../pixlstash/services/config_service.py) | Hardware monitoring (CPU, RAM, GPU via `psutil` / `pynvml`) and import-folder path resolution; extracted from `routes/config.py` |
-| [services/picture_stats.py](../pixlstash/services/picture_stats.py) | Aggregation queries for `GET /pictures/stats`; accepts a `PictureStatsParams` dataclass and returns the stats dict; used by `routes/pictures/_misc.py` |
+| [services/picture_service.py](../pixlstash/services/picture_service.py) | DB-layer helpers for single-picture reads from route handlers; accept a `Database` (`vault.db`) and delegate session management to it |
+| [services/search_query_service.py](../pixlstash/services/search_query_service.py) | DB-layer helpers for face-search and likeness-search queries; same `Database`-delegating pattern as `picture_service.py` |
 | [services/plugin_service.py](../pixlstash/services/plugin_service.py) | Plugin listing and async orchestration for `POST /pictures/plugins/{name}`; emits `PLUGIN_PROGRESS` WebSocket events; used by `routes/pictures/_misc.py` |
 | [services/share_service.py](../pixlstash/services/share_service.py) | Validates picture share tokens (`UserToken`), resolves shared pictures, and returns the correct watermark bytes (custom or default) |
+| [services/stack_membership.py](../pixlstash/services/stack_membership.py) | Stack-atomic project & set membership helpers — keeps every member of a stack sharing the same project (`PictureProjectMember` / `Picture.project_id`) and set (`PictureSetMember`) membership |
+| [services/set_lock_service.py](../pixlstash/services/set_lock_service.py) | Single source of truth for picture-set lock enforcement: a `PictureSet` with `locked=True` is a hard whole-set freeze (set-level and member-level protections) |
+| [services/snapshot_service.py](../pixlstash/services/snapshot_service.py) | Snapshot creation (SQLite `VACUUM INTO` + JSON manifest + `Snapshot` row), listing, and GFS-style retention pruning (see §18) |
+| [services/restore_service.py](../pixlstash/services/restore_service.py) | Full-database and per-resource (picture / picture_set / project / character) restore from a snapshot; runs `alembic upgrade head` on the snapshot first (see §18) |
 | [services/tag_prediction_service.py](../pixlstash/services/tag_prediction_service.py) | Confirm, reject, delete, and reset tag predictions; encapsulates the `TagPrediction` → `Tag` promotion logic used by `routes/tag_predictions.py` |
+| [services/tagger_run_service.py](../pixlstash/services/tagger_run_service.py) | System-of-record DB side for tagger evaluation runs pushed from PixlTagger: upsert a posted report on the run name and list stored runs for the stats panel |
+| [services/tag_health_service.py](../pixlstash/services/tag_health_service.py) | Tag health board cache — computes one `TagHealth` row per tag from indexed SQL over `tag_prediction` / `tag` / `tag_suggestion` / `picture` plus stored `PictureLikeness` pairs; rebuilt in the background |
+| [services/tag_suggestion_service.py](../pixlstash/services/tag_suggestion_service.py) | Human half of the tag-suggestion review queue: list ranked suspects and apply (write through to `Tag`) or dismiss them |
+| [services/tag_scan_service.py](../pixlstash/services/tag_scan_service.py) | On-demand near-neighbour tag scan — finds one tag's suspects and appends them; reuses the shared `knn_disagreement_with_neighbors` kernel so CLI and UI can't drift |
+| [services/review_service.py](../pixlstash/services/review_service.py) | Service layer for review sessions (one tag + a frozen scope + one scan's results): create, scan-once, append-only refresh, archive/abort, and per-item decisions |
+| [services/impossible_tag_scan_service.py](../pixlstash/services/impossible_tag_scan_service.py) | On-demand impossible-tag scan — (re)builds the cleanup queue for person-tags that are impossible on a picture with no detectable face; sibling of `tag_scan_service.py` |
 | [services/impossible_tag_clear_service.py](../pixlstash/services/impossible_tag_clear_service.py) | Bulk-clear the filter-implied wrong tags for the human-reviewed "Impossible tags" grid selection (recording a human NEG per removed tag), plus the symmetric undo; used by the impossible-tags routes |
 
 ### 10.1 DB access rule for services (enforced in CI)
@@ -741,6 +795,20 @@ Selected milestones:
 | 0034 | Token scope columns |
 | 0038–0040 | Watermark fields, move `text_score` to `Picture` |
 | 0041–0044 | Guest scores, grid sort indexes |
+| 0045 | Tagger settings JSON column |
+| 0049 | Vault snapshots table |
+| 0053 | Face model pack tracking |
+| 0057 | Split caption sidecars |
+| 0058–0059 | Tag suggestions + tagger runs (PixlTagger eval history) |
+| 0061 | Florence-2 detections |
+| 0065 | Review sessions |
+| 0066–0067 | Tag health board (+ precision-adjusted estimates) |
+| 0068–0070 | Tag-review scoring subsystem: picture splits, eval slices, freeze eligibility *(removed by 0071)* |
+| 0071 | Remove the tag-review accuracy/scoring subsystem (drops `picture_split`, `tag_eval_slice*`, `eval_*` TagHealth columns) |
+| 0072 | Review receipt snapshot + suggestion prior-decision fields |
+| 0073 | Picture-set lock (`PictureSet.locked`) |
+
+Current head: `0073_add_pictureset_locked`.
 
 ---
 
@@ -1315,7 +1383,7 @@ sequenceDiagram
 
 ---
 
-*Last updated: 2026-05-26. Update this document whenever architectural patterns, module boundaries, or integration contracts change.*
+*Last updated: 2026-07-19. Update this document whenever architectural patterns, module boundaries, or integration contracts change.*
 
 ### Known drift / cleanup notes
 

--- a/docs/design/drift-audit-2026-06.md
+++ b/docs/design/drift-audit-2026-06.md
@@ -1,5 +1,23 @@
 # Visual drift audit — June 2026
 
+> **SUPERSEDED — mostly resolved on `develop` (as of 2026-07).** This document is
+> kept as a historical record of the June 2026 scan. Do **not** read it as the
+> current bug list. Since it was written, most of the fix order below has landed on
+> `develop`:
+> - **Step 1 (PressStart2P):** done. Zero live references remain in `frontend/src`
+>   (retired in favour of Tiny5).
+> - **Step 2 (adopt `design-tokens.css`):** done. It is imported globally via
+>   `frontend/src/main.js`.
+> - **Step 3 (hardcoded hex):** largely done. The audited count of 38 distinct hex
+>   values is down to ~9 in the scanned scope.
+> - Steps 4–7 (shadows, radius, spacing, type) are in progress; treat the specifics
+>   below as historical, not a live tally.
+>
+> **Still literally true:** one `9999px` radius lingers in
+> `frontend/src/components/views/ImageGrid.vue` (the pill-typo from the radius table
+> below); it should snap to `--radius-pill`. (Note: the other `-9999px` values in the
+> codebase are off-screen drag-ghost offsets, not radii, and are fine.)
+
 Why this exists: the sleekness slipped after v1.6.0. This is the evidence, measured
 not eyeballed, plus the order to fix it in. Numbers are from a scan of
 `frontend/src/components` + `App.css` + `style.css`.

--- a/docs/design/visual-language.md
+++ b/docs/design/visual-language.md
@@ -143,7 +143,7 @@ below.
 |---|---|
 | Page / grid canvas | `background` / `onBackground` |
 | Raised control surface (card, input, menu) | `surface` / `onSurface` |
-| Sidebar, toolbar, panels | `sidebar` / `toolbar` / `panel` (+ their `-text`) |
+| Sidebar, toolbar, panels | `sidebar` / `toolbar` / `panel` (text pair: `sidebar-text` / `toolbar-text`, but `onPanel` for panel) |
 | Brand accent, key state | `accent` / `onAccent` |
 | Primary action button | `primary` / `onPrimary` |
 | Secondary / tertiary action | `secondary` / `tertiary` |

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -37,7 +37,8 @@ frontend/src/
 │   └── unknown-person.png       # Fallback avatar for unrecognised faces
 │
 ├── styles/
-│   └── context-menu.css         # Shared CSS for native-style context menus
+│   ├── context-menu.css         # Shared CSS for native-style context menus
+│   └── design-tokens.css        # Design-system tokens: spacing, radius, type ramp, elevation, motion, colour
 │
 ├── stores/                      # Pinia stores (cross-component shared state)
 │   ├── useSelectionStore.js
@@ -51,6 +52,9 @@ frontend/src/
 │   ├── useSidebarStore.js
 │   ├── useSearchStore.js
 │   ├── useSnapshotsStore.js
+│   ├── useGenStackPrefsStore.js # remembered "stack generated/filtered output with source" prefs
+│   ├── useLockedSetsStore.js    # which pictures are frozen by a locked picture set
+│   ├── useReviewSessionsStore.js # tag-review sessions, health board, and sticker gamification
 │   ├── useEntityNamesStore.js   # id→name maps for the ImageGrid breadcrumb
 │   └── useTasksStore.js         # active background work (workers + ComfyUI runs); app-wide activity light
 │
@@ -61,15 +65,18 @@ frontend/src/
 │   ├── useStackOrdering.js      # Stack expand/collapse, reorder, visual mapping in ImageGrid
 │   ├── useGridFetch.js          # Grid image fetch state + all fetch/query-param functions
 │   ├── useGridKeyboardNav.js    # Keyboard navigation and keyboard-driven actions for ImageGrid
+│   ├── useGridRealtimeSync.js   # WebSocket picture-event decision table for ImageGrid (see §9)
 │   ├── useBreadcrumb.js         # Current-view breadcrumb trail from route + id→name maps; shared by in-grid nav and TitleBar
 │   └── useVersionCheck.js       # "New version available" check (pixlstash.dev poll); single owner gated by `enabled`
 │
 ├── utils/
 │   ├── apiClient.js             # Axios instance, auth state, session/token helpers
 │   ├── clipboard.js             # Cross-browser clipboard write helper
+│   ├── descriptions.js          # Pure helpers for picture-description formatting/normalisation
 │   ├── dockerHelpers.js         # Pure helpers for Docker volume/mount path building
 │   ├── media.js                 # File extension lists, file-type predicates, drop-target helpers
 │   ├── setAppearance.js         # Picture-set icon/colour palette constants (kept in sync with backend)
+│   ├── snapshots.js             # Snapshot kind→chip-colour and relative-date helpers (shared by snapshot UIs)
 │   ├── stack.js                 # Pure stack-ordering and leader-selection utilities
 │   ├── tags.js                  # Tag normalisation, deduplication, penalty scoring
 │   └── utils.js                 # Date formatting, score toggle, stack colours, ComfyUI error parsing
@@ -80,12 +87,24 @@ frontend/src/
 └── components/
     ├── TitleBar.vue             # Desktop-only custom window title bar (Electron): wordmark, breadcrumb, window controls, update alert
     ├── WordmarkLogo.vue         # "PixlStash" brand wordmark in the Tiny5 pixel font (two-tone via --wordmark-accent)
-    ├── views/       # Full-page / full-screen UI surfaces (ImageGrid, ImageOverlay, LoginScreen, SearchOverlay, overlay panels)
-    ├── panels/      # Large structural panels that form the app shell (SideBar, Toolbar, SelectionBar, SelectionMenu, StatsSidebar, …)
+    ├── views/       # Full-page / full-screen UI surfaces: ImageGrid, ImageOverlay + extracted OverlayTagsPanel/OverlayDescriptionPanel/OverlayMetadataPanel/OverlayFilmstrip, ReviewSessionsOverlay, LoginScreen
+    ├── panels/      # Large structural panels that form the app shell: SideBar, Toolbar + extracted TbTagPanel/TbComfyPanel/TbExportPanel/TbImportPanel/GbFilterPanel, SelectionBar, SelectionMenu, StatsSidebar, ProjectFiles, …
+    ├── reviews/     # Tag-review surfaces (see below)
+    │   ├── ReviewSessionView.vue      # One open review session: header, rail, and card queue
+    │   ├── ReviewRail.vue             # Rail of open review sessions
+    │   ├── ReviewBinaryCard.vue       # Single-tag accept/dismiss decision card
+    │   ├── ReviewPairCard.vue         # Twin/near-duplicate pair decision card
+    │   ├── ReviewDecisionBar.vue      # Accept/dismiss/fix/undo action bar
+    │   ├── ReviewCelebration.vue      # Session-complete celebration
+    │   ├── ReviewArchivedReceipt.vue  # Archived-session summary receipt
+    │   ├── ReviewSticker.vue          # Die-cut sticker award (vocabulary from setAppearance.js)
+    │   ├── NewReviewDialog.vue        # "Start a review" tag + scope picker
+    │   ├── TagHealthBoard.vue         # Landing tag-health board
+    │   └── tagHealthBoardLogic.js     # Pure board estimate/threshold helpers (+ *.test.js)
     ├── editors/     # Entity create / edit / delete dialogs
-    ├── settings/    # Settings dialog and its section sub-components (Appearance, Behaviour, SmartScore, Workflows, Account, Snapshots, Compute)
+    ├── settings/    # UserSettingsDialog, its section sub-components (Appearance, Behaviour, SmartScore, Workflows, Account, Snapshots, Compute), and the Settings* layout primitives (SettingsRow, SettingsSection, SettingsChip/ChipGrid, SettingsFieldBlock, SettingsSliderRow, SettingsTwoCol, SettingsInfoCard, SettingsAddTagRow)
     ├── io/          # Import / export / external-service connection
-    └── widgets/     # Reusable primitives used across multiple domains
+    └── widgets/     # Reusable primitives, including the App* design-system layer (AppButton/AppDialog/AppInput/AppSelect/AppStepper/AppTextarea + FieldLabel)
 ```
 
 ---
@@ -96,7 +115,7 @@ frontend/src/
 |---------|--------|
 | Framework | Vue 3 (Composition API, `<script setup>`) |
 | UI component library | Vuetify 3 |
-| State management | **Pinia** — 10 domain stores in `src/stores/`; `App.vue` owns only UI-shell state |
+| State management | **Pinia** — 16 domain stores in `src/stores/`; `App.vue` owns only UI-shell state |
 | HTTP client | Axios (singleton `apiClient`) |
 | Routing | **Vue Router 4** (`createWebHistory`). `Root.vue` gates on `isAuthenticated`; all authenticated views (`/`, `/character/:id`, `/set/:id`, `/project/:id`, `/scrapheap`) render `App.vue` via `<RouterView>`. `App.vue` watches the route and syncs params to Pinia stores; nav handlers call `router.push()` to update the URL. **The route is the single source of truth for what the grid shows** — only explicit entry clicks push routes; sidebar tab/category switches never do (see Key Design Principles). |
 | Build tool | Vite 5 |
@@ -107,7 +126,7 @@ frontend/src/
 ### Key Design Principles
 
 - **Pinia for cross-component state.** All state shared across more than one component lives in a Pinia store in `src/stores/`. `App.vue` owns only layout-shell state (sidebar/stats visibility, pending import counts) that is not consumed anywhere else.
-- **Sidebar tabs are stateless; the route is the single source of truth for the grid view.** Switching a sidebar tab/category (People / Sets / Projects / Folders, and the Global ↔ Project mode) is a *pure sidebar-display* operation: it only changes which list of entries the sidebar renders. It must **not** call `router.push()`, must **not** emit any `select-*` / navigation event, and must **not** write to the filter / selection / sort / grid stores. The grid keeps showing whatever the current route resolves to. Only an explicit **entry click** (a specific character / set / project) navigates, via `router.push()`. This decoupling is what lets a user stay on a global view, switch to the Projects tab purely to reveal its entries as **drop targets**, and drag the current selection onto a project or one of its characters without losing the view they found the pictures in. See [§5 → SideBar.vue](#sidebarvue--150-lines).
+- **Sidebar tabs are stateless; the route is the single source of truth for the grid view.** Switching a sidebar tab/category (People / Sets / Projects / Folders, and the Global ↔ Project mode) is a *pure sidebar-display* operation: it only changes which list of entries the sidebar renders. It must **not** call `router.push()`, must **not** emit any `select-*` / navigation event, and must **not** write to the filter / selection / sort / grid stores. The grid keeps showing whatever the current route resolves to. Only an explicit **entry click** (a specific character / set / project) navigates, via `router.push()`. This decoupling is what lets a user stay on a global view, switch to the Projects tab purely to reveal its entries as **drop targets**, and drag the current selection onto a project or one of its characters without losing the view they found the pictures in. See [§5 → SideBar.vue](#sidebarvue--9-320-lines).
 - **Composables for reusable logic.** Complex logic extracted from mega-components lives in `src/composables/` as `useX()` functions. Composables accept dependencies as parameters and are independently unit-testable.
 - **Flat component structure.** All components sit directly in `src/components/` with sub-directories by domain (`views/`, `panels/`, `editors/`, `settings/`, `io/`, `widgets/`). Shared presentational sub-components (e.g. `StarRatingOverlay`, `ProgressOverlay`) live in `widgets/`.
 - **Utilities are pure functions.** Every file in `src/utils/` exports only plain functions and constants; none hold reactive state themselves (except `apiClient.js`, which holds `isAuthenticated`, `sessionContext`, and `isReadOnly`).
@@ -166,6 +185,10 @@ All state consumed by more than one component lives in a Pinia store. The stores
 | `useProjectStore` | `useProjectStore.js` | `projectViewMode` *(sidebar-display only — see below)*, `selectedProjectId`, `characterProjectIds`, `setProjectIds` |
 | `useSidebarStore` | `useSidebarStore.js` | `sidebarDocked` (width pref), `sidebarPinned` (visibility pref), `statsOpen`, `sidebarForcedHidden`, `statsForcedHidden`, `characterMultiMode`, `setMultiMode`, `setDifferenceBaseId`; computeds `effectivePinned`, `effectiveDocked`, `sidebarVisible`, `sidebarOverlay` model the pin / dock / auto-hide behaviour (mobile `*ForcedHidden` overrides win). All localStorage access is try/caught. |
 | `useSearchStore` | `useSearchStore.js` | `searchQuery`, `searchInput`, `searchHistory`, `isSearchActive`, `searchOverlayVisible` |
+| `useSnapshotsStore` | `useSnapshotsStore.js` | `snapshots`, `loading`, `activeJob`, `error`, `dailySnapshotsEnabled`; drives the shared `RestoreConfirmDialog` hoisted in `App.vue` (`restoreDialogOpen`, `restoreDialogSnapshotId`, `restoreDialogResources`). Owns snapshot list load / create / restore and the snapshot WebSocket event handlers (called from `App.vue`). |
+| `useReviewSessionsStore` | `useReviewSessionsStore.js` | Tag-review state: the tag-health board, the rail of open review sessions (each = one tag + frozen scope + one scan's results), and the per-session binary/pair card queues. Per-item decisions write through `/tag_suggestions`; session bookkeeping talks to `/reviews`, the board to `/tag_health`. Also owns the opt-in gamification — variable-ratio sticker awards with monotonic XP / level / streak counters; the sticker vocabulary is imported from `setAppearance.js` so sets and stickers never drift. |
+| `useLockedSetsStore` | `useLockedSetsStore.js` | Which pictures are frozen by a locked picture set. Fed by `GET /picture_sets/locked-members`; refreshed on app start and on the same sidebar-refresh / `pictures_changed` ws triggers the sidebar uses. Single source of the lock-tooltip copy reused by the grid badge, overlay chip, and context-menu gating. |
+| `useGenStackPrefsStore` | `useGenStackPrefsStore.js` | Remembered client prefs for whether newly generated / filtered images stack with their source: `stackI2IOutputs` (ComfyUI image-to-image) and `stackFilterOutputs` (plugin "Filters" runs), both default ON and persisted to `localStorage`. |
 | `useEntityNamesStore` | `useEntityNamesStore.js` | `characterNames`, `setNames`, `projectNames`, `refFolderLabels`, `importFolderLabels` (id→name maps). One-directional id→name only (names aren't unique). `SideBar` publishes via `merge*` setters after each fetch; `ImageGrid`'s breadcrumb consumes them to label the route's IDs. |
 | `useTasksStore` | `useTasksStore.js` | `workerSnapshots`, `series` (per-worker throughput history), `systemUsage` (CPU/RAM/VRAM), `comfyuiRuns` (frontend-driven run progress keyed by run id); computeds `activeEntries` (backend workers + ComfyUI runs, merged), `hasActiveTasks`, `activeCount`. The **single poller** of `GET /workers/progress` (adaptive cadence — see §4.4) and the single source of truth for the app-wide "is the app working" indicators. |
 
@@ -205,10 +228,10 @@ All indicator animations honour `prefers-reduced-motion: reduce`.
 
 ### Layout and Shell
 
-#### `Root.vue` (66 lines)
+#### `Root.vue` (59 lines)
 Auth gate. Renders `LoginScreen` or `App` based on `isAuthenticated`. Handles `?token=` share links on mount.
 
-#### `App.vue` (~1 700 lines)
+#### `App.vue` (~2 580 lines)
 Application shell. Owns all global state. Renders `SideBar` + `ImageGrid` + `StatsSidebar`. Manages WebSocket, keyboard shortcuts, window drag/drop, paste, config loading, export, update checks.
 
 #### `TitleBar.vue` (~400 lines)
@@ -221,7 +244,7 @@ Presentational "PixlStash" brand wordmark in the Tiny5 pixel font (replaced the 
 
 ### Large Stateful Components
 
-#### `ImageGrid.vue` (~8 670 lines)
+#### `ImageGrid.vue` (~7 360 lines)
 The core image display engine. Responsibilities:
 - Virtualised grid scroll with dynamic thumbnail sizes (via `useVirtualScroll`).
 - Fetches images from `GET /pictures` with all filter params as query args.
@@ -234,7 +257,7 @@ The core image display engine. Responsibilities:
 - Emits: `open-overlay`, `refresh-sidebar`, `clear-search`, `reset-to-all`, `search-all`, `update:selected-sort`, `update:stack-stats`, `import-started`, `import-ended`, `clear-multi-selection`, `update:character-multi-mode`, `update:set-multi-mode`, `update:set-difference-base-id`, `update:embed-watermark`, `update:visible-range-label`, `load-pending-imports`
 - Key props: `thumbnailSize`, `columns`, `selectedCharacter`, `selectedSet`, `searchQuery`, `selectedSort`, `wsTagUpdate`, `wsPluginProgress`, `gridVersion`, `wsUpdateKey`, `publicUrl`, `embedWatermark`, + all filter props.
 
-#### `SideBar.vue` (~8 150 lines)
+#### `SideBar.vue` (~9 320 lines)
 Left navigation panel. Responsibilities:
 - Tabs: People, Sets, Projects, Folders.
 - Character list with face thumbnails, drag-drop assignment, inline create/edit.
@@ -273,7 +296,7 @@ The tab/category switch is **stateless** (see Key Design Principles). Concretely
   the view and breaks the drag-to-assign flow. Keep navigation in entry-click
   handlers only.
 
-#### `ImageOverlay.vue` (~6 590 lines)
+#### `ImageOverlay.vue` (~4 880 lines)
 Full-screen image lightbox. Responsibilities:
 - **Frozen navigation backbone (overlay-open deferral, see §9.1).** prev/next and the filmstrip read membership from a snapshot of `allImages` (`frozenAllImages`, captured on open and cleared on close) via the `overlayImages` computed, not from the live `allImages` prop. This keeps left/right working for the overlay's whole lifetime even after the current picture stops matching the active filter (e.g. the user removes the tag the view is filtered on) or a background refetch reshuffles the grid. The currently displayed card stays fresh independently: it lives in `image.value` and is updated by local edits / `fetchOverlayMetadata`, not by the snapshot. Stack expansion still loads fresh members from `/stacks/{id}/pictures`; only the sequence/membership is frozen.
 - Image display with pan/zoom (fit / 1.5× / 2×).
@@ -290,8 +313,15 @@ Full-screen image lightbox. Responsibilities:
 - Key props: `open`, `initialImageId`, `allImages`, `tagUpdate`, `hiddenTags`, `applyTagFilter`, `availablePlugins`, `comfyuiProgress`, `guestScore`
 - Emits: `close`, `apply-score`, `set-guest-score`, `add-tag`, `remove-tag`, `update-description`, `overlay-change`, `added-to-set`, `set-project`, `comfyui-run`, `run-plugin`
 
-#### `Toolbar.vue` (`panels/`, ~3 300 lines)
-Top/grid toolbar. Imports state directly from Pinia stores (`useGridStore`, `useSortStore`, `useFilterStore`, `useSearchStore`, `useExportStore`, `useSidebarStore`) — no `inject` or prop drilling. The selection action UI that used to live here was extracted into `SelectionBar.vue` + `SelectionMenu.vue` (see below); `Toolbar` no longer holds any selection state.
+#### Overlay side-panels (`views/`)
+The overlay's right-hand panels, extracted from `ImageOverlay.vue` so each owns its own markup and state:
+- `OverlayTagsPanel.vue` (~1 230 lines) — tag list, add/remove, autocomplete, AI-prediction accept/reject.
+- `OverlayDescriptionPanel.vue` (~450 lines) — inline description editing (uses `utils/descriptions.js`) and copy.
+- `OverlayMetadataPanel.vue` (~705 lines) — metadata, score, dates, file info, penalised-tag indicator.
+- `OverlayFilmstrip.vue` (~330 lines) — the frozen-navigation filmstrip strip (reads `overlayImages`, see §9.1).
+
+#### `Toolbar.vue` (`panels/`, ~1 410 lines)
+Top/grid toolbar. Imports state directly from Pinia stores (`useGridStore`, `useSortStore`, `useFilterStore`, `useSearchStore`, `useExportStore`, `useSidebarStore`) — no `inject` or prop drilling. The selection action UI that used to live here was extracted into `SelectionBar.vue` + `SelectionMenu.vue` (see below); the tag / ComfyUI / export / import / global-filter menu bodies were extracted into the `Tb*Panel` / `GbFilterPanel` sub-panels (see below). `Toolbar` no longer holds any selection state.
 
 Responsibilities:
 - Grid bar: sort selector, filter chips (tags, score, media type, resolution), column slider, stack controls, view mode toggles.
@@ -299,6 +329,14 @@ Responsibilities:
 - Export menu: type (full/face), caption mode, resolution, tag format, character name inclusion, bounding-box sidecar (`exportBboxMode`: none / COCO JSON → `bbox_mode` query param).
 - Props: `selectedCount`, `selectedCharacter`, `selectedSort`, `allPicturesId`, `unassignedPicturesId`, `backendUrl`, `comfyuiConfigured`.
 - Key emits: `comfyui-run-grid`, `expand-all-stacks`, `collapse-all-stacks`, `confirm-export-zip`, `open-import`, `open-settings`.
+
+#### Toolbar menu panels (`panels/`)
+The individual toolbar menu bodies, extracted from `Toolbar.vue` so each dropdown owns its own markup and state:
+- `TbTagPanel.vue` (~1 480 lines) — the tag filter / tag-management menu body.
+- `TbComfyPanel.vue` (~230 lines) — the ComfyUI-run menu body.
+- `TbExportPanel.vue` (~215 lines) — the export options menu body (type, caption, resolution, tag format, bbox sidecar).
+- `TbImportPanel.vue` (~370 lines) — the import-source menu body.
+- `GbFilterPanel.vue` (~1 240 lines) — the global-filter panel (score / media-type / resolution / tag filter controls) shared by the grid bar.
 
 #### `SelectionBar.vue` (`panels/`)
 Floating selection action bar shown above the grid when images are selected (the leftover from the Toolbar split). Driven by props from `ImageGrid`; it renders the per-selection plugin/ComfyUI run menus, the tag/caption controls, and the `SelectionMenu` dropdown. Uses the `@container selbar` query against the grid-content wrapper, so its layout responds to the available grid width.
@@ -326,8 +364,8 @@ Right-side statistics panel. Responsibilities:
 
 ### Settings Dialog and Sub-sections
 
-#### `UserSettingsDialog.vue` (~2 580 lines)
-Multi-tab settings dialog. Each tab now delegates to its own section component (the Behaviour, Workflows and Snapshots tabs were extracted from inline markup). Tabs:
+#### `UserSettingsDialog.vue` (~320 lines)
+Thin multi-tab settings shell. It now owns only the tab chrome and routing — every tab's content was extracted into its own section component, so the dialog itself holds no inline tab markup. Tabs:
 - **Appearance** → `<AppearanceSection>`
 - **Behaviour** → `<BehaviourSection>` (`!isReadOnly`)
 - **Smart Score** → `<SmartScoreSection>` (`!isReadOnly`)
@@ -361,6 +399,9 @@ Account management tab. Props: `open: Boolean`. Emits: `update:public-url`.
 - On `open` change: resets form, fetches auth info, tokens, public URL, watermark preview.
 - Manages: password change, API token CRUD (create/list/delete/copy), share-link builder, public URL config, watermark upload/clear.
 - Owns: `tokenDialogOpen` and `tokenDeleteDialogOpen` dialogs (rendered inside this component using Vuetify's overlay teleport system).
+
+#### Settings layout primitives (`settings/`)
+Small presentational building blocks shared by the section components above, so every tab lays out with one consistent grammar: `SettingsSection`, `SettingsRow`, `SettingsTwoCol`, `SettingsFieldBlock`, `SettingsSliderRow`, `SettingsInfoCard`, `SettingsChip` / `SettingsChipGrid`, and `SettingsAddTagRow`. Presentational only — state lives in the section components.
 
 ---
 
@@ -397,6 +438,9 @@ Actual file upload engine. Props: `backendUrl`, `selectedCharacterId`, `allPictu
 ---
 
 ### Shared / Primitive Components
+
+#### App* design-system layer (`widgets/`)
+The house-styled form/control primitives that wrap Vuetify with the PixlStash tokens (`styles/design-tokens.css`), so new UI composes from one consistent kit instead of raw Vuetify: `AppButton.vue` (~140 lines), `AppDialog.vue` (~165 lines), `AppInput.vue` (~95 lines), `AppSelect.vue` (~95 lines), `AppStepper.vue` (~125 lines), `AppTextarea.vue` (~60 lines), plus `FieldLabel.vue` (~15 lines) for consistent field labelling. Presentational; each takes `v-model` / props and emits the matching update events.
 
 #### `AddToEntityControl.vue` (966 lines)
 Reusable control for assigning images to/from characters and sets. Props: `type` (`'character'`|`'set'`), `imageIds`, `selectedCharacter`, `selectedSet`. Emits: `added`, `removed`, `selected`. Used in `Toolbar`, `ImageOverlay`, `ImageGridContextMenu`.
@@ -450,6 +494,45 @@ Empty-state illustration and caption for the scrapheap (deleted-images holding a
 
 #### `LoginScreen.vue` (209 lines)
 Login/registration form. On mount calls `checkLoginStatus()` to detect first-run (no users exist → show registration form). Calls `login()` from `apiClient.js`.
+
+---
+
+### Tag Review
+
+Tag review is modelled as first-class **review sessions** (one tag + a frozen scope + one scan's results), backed by `useReviewSessionsStore` (§4). State lives in the store; these components are the surface.
+
+#### `ReviewSessionsOverlay.vue` (`views/`, ~580 lines)
+Full-screen entry point for tag review. Hosts the tag-health board (landing view) and the open-session rail, and switches between them.
+
+#### `ReviewSessionView.vue` (`reviews/`, ~700 lines)
+One open review session: header, progress, and the queue of decision cards. Drives accept/dismiss/fix through the store, which writes to `/tag_suggestions`.
+
+#### `ReviewRail.vue` (`reviews/`, ~740 lines)
+Rail of open review sessions — each entry is one tag's in-progress review; select to resume, archive to close.
+
+#### `ReviewBinaryCard.vue` (`reviews/`, ~685 lines)
+Single-tag accept/dismiss decision card for one picture.
+
+#### `ReviewPairCard.vue` (`reviews/`, ~320 lines)
+Twin / near-duplicate pair card: compares a picture against a reference to fix-twin / swap.
+
+#### `ReviewDecisionBar.vue` (`reviews/`, ~275 lines)
+The accept / dismiss / fix / undo action bar shared by the decision cards.
+
+#### `ReviewCelebration.vue` (`reviews/`, ~355 lines)
+Session-complete celebration screen.
+
+#### `ReviewArchivedReceipt.vue` (`reviews/`, ~135 lines)
+Summary receipt shown for an archived session (what was decided).
+
+#### `ReviewSticker.vue` (`reviews/`, ~85 lines)
+Die-cut sticker award. The sticker vocabulary is imported from the Picture Set palette (`utils/setAppearance.js`) so sets and stickers never drift.
+
+#### `NewReviewDialog.vue` (`reviews/`, ~730 lines)
+"Start a review" dialog: pick a tag and freeze the scope for a new session.
+
+#### `TagHealthBoard.vue` (`reviews/`, ~935 lines)
+Landing tag-health board — precision-adjusted estimates and thresholds per tag, the jumping-off point for starting a review. Pure estimate/threshold math lives in `tagHealthBoardLogic.js` (~90 lines).
 
 ---
 

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -186,7 +186,7 @@ The backend's [EventType](../pixlstash/event_types.py) enum names are **not** se
 
 | Field | Type | Description |
 |---|---|---|
-| `type` | string | Wire type: `picture_imported` \| `pictures_changed` \| `tags_changed` \| `descriptions_changed` \| `characters_changed` \| `plugin_progress`. |
+| `type` | string | Wire type. Picture/mutation events: `picture_imported` \| `pictures_changed` \| `tags_changed` \| `descriptions_changed` \| `characters_changed` \| `plugin_progress`. Snapshot/restore events (carry snapshot/restore info rather than `picture_ids`): `snapshot_created` \| `snapshot_deleted` \| `restore_started` \| `restore_completed` \| `restore_failed`. |
 | `event` | string | Backend `EventType.name`; diagnostic only, not part of the behavioural contract. |
 | `source` | `"ui"` \| `"external"` | Coarse origin class. `"ui"` = an attributable owner action through the SPA; `"external"` = work that originated outside the UI (watch/reference folders, external API writes, background ML finishers, externally-run ComfyUI). Defaults to `"external"`. |
 | `origin_client_id` | `string` \| `null` | The `X-Client-Id` of the originating tab, or `null` for background/external work. **The primary signal** — a tab recognises the echo of its own change by matching this against its own id. |
@@ -202,7 +202,10 @@ Per-type payload specifics (all carry the envelope fields above):
 | `picture_imported` | New picture entered the vault (ComfyUI, watch folder, API) | — | Slick in-place insert for the initiating tab, targeted insert for a foreign owner tab, or the **"New pictures"** pill for external imports (§8.2). |
 | `characters_changed` | Character created/updated/deleted or face reassigned | — | Refresh sidebar (character list) |
 | `tags_changed` | Tags or tag predictions changed | `picture_ids: number[]` | Bump `wsTagUpdate` so affected grid cards re-render |
+| `descriptions_changed` | Picture descriptions/captions changed | `picture_ids: number[]` | Refresh affected descriptions |
 | `plugin_progress` | Image plugin run progress | `plugin`, `progress`, `total`, `picture_id` | Update `wsPluginProgress` for the plugin progress UI |
+| `snapshot_created` / `snapshot_deleted` | Vault snapshot created or deleted | snapshot info (id, kind, …) | Refresh the snapshots panel |
+| `restore_started` / `restore_completed` / `restore_failed` | Vault restore lifecycle | restore info | Drive the restore progress/result UI |
 
 > **`source` migration:** the import emit's legacy value `"user"` is migrated to `"ui"`. During the transition the frontend (`normaliseSource`) accepts **both** — the real signal is the `origin_client_id` match, so accepting the legacy value just over-notifies (safe). Drop the legacy acceptance once both ends have shipped.
 
@@ -256,9 +259,9 @@ Browser-native `<img>` tags **cannot** use the axios interceptor, so the integra
 
 | URL | Purpose |
 |-----|---------|
-| `GET /api/v1/pictures/{id}/thumbnail` | Cached WebP thumbnail. Backend uses an async lock + LRU memory cache + on-disk `.pixlstash/` cache. |
+| `GET /api/v1/pictures/thumbnails/{id}.webp` | Cached WebP thumbnail. Backend uses an async lock + LRU memory cache + on-disk `.pixlstash/` cache. |
 | `POST /api/v1/pictures/thumbnails` | Batch thumbnail metadata (JSON). |
-| `GET /api/v1/pictures/{id}/{ext}` | Original file (optionally watermarked). |
+| `GET /api/v1/pictures/{id}.{ext}` | Original file (optionally watermarked). |
 
 ### Watermarking
 
@@ -271,7 +274,7 @@ The decision to watermark is made server-side per request based on `User.embed_w
 - **Endpoint**: `POST /api/v1/pictures/import` (multipart/form-data).
 - **Content**: image files or `.zip` archives (extracted server-side).
 - **Deduplication**: server computes `pixel_sha` (SHA-256 of decoded pixels) and skips duplicates.
-- **Async**: the response includes a `task_id`. The frontend polls `GET /api/v1/pictures/import/{task_id}/status` for completion percentage.
+- **Async**: the response includes a `task_id`. The frontend polls `GET /api/v1/pictures/import/status?task_id=…` for completion percentage.
 - **Real-time**: as pictures are persisted, the backend also broadcasts `picture_imported` over the WebSocket carrying the uniform envelope (§8). The SPA distinguishes its **own** upload (drives a progress dialog) from a **foreign owner tab** (slick insert) and from **external** imports (the "New pictures" pill) via `source`/`origin_client_id`.
 
 **Contract**: the SPA sets `isUploadInProgress` for the duration of its own upload so that incoming `picture_imported` events don't double-count.
@@ -282,7 +285,7 @@ The decision to watermark is made server-side per request based on `User.embed_w
 
 Two complementary mechanisms; most workflows use both:
 
-1. **Task-id polling** — for client-initiated operations with a clear end state (import, export, bulk score apply, plugin run on many pictures): the endpoint returns `{task_id}`; the SPA polls `…/{task_id}/status` until completion, then fetches the result (e.g. download the ZIP).
+1. **Task-id polling** — for client-initiated operations with a clear end state (import, export, bulk score apply, plugin run on many pictures): the endpoint returns `{task_id}`; the SPA polls `…/status?task_id=…` until completion, then fetches the result (e.g. download the ZIP via `/pictures/export/download/{task_id}`).
 2. **WebSocket events** — for backend-initiated state changes (watch folder ingest, background quality/tag/embedding work, plugin progress): the SPA refreshes affected views from events without polling.
 
 **Rule of thumb**:
@@ -295,7 +298,7 @@ Two complementary mechanisms; most workflows use both:
 The **Segment** action runs Florence-2 object detection over the selected pictures and stores labelled boxes per picture (see [backend_architecture.md §6/§7](backend_architecture.md)). It follows the WebSocket-event branch of the rule above — it is a backend task, not a downloadable result.
 
 - **Enqueue**: `POST /api/v1/pictures/detect` with body `{ "picture_ids": [int, …], "prompt": "optional phrase" }`. An empty/omitted `prompt` runs dense object detection; a non-empty phrase runs open-vocabulary grounding for that phrase. Scoped tokens have `picture_ids` filtered to their grant (deny-by-default; all-out-of-scope → 403). Returns `{ "status": "queued", "task_id", "picture_ids", "prompt" }`. Progress surfaces in the existing task-manager UI.
-- **Completion**: the task fires a `changed_pictures` event (`{picture_ids, change_kind:"updated"}`) over the WebSocket; the SPA refreshes affected views.
+- **Completion**: the task fires a `pictures_changed` event (`{picture_ids, change_kind:"updated"}`) over the WebSocket; the SPA refreshes affected views.
 - **Read**: `GET /api/v1/pictures/{id}/detections` returns a **bare JSON array** (object-scope enforced before any read):
   ```json
   [ { "id": 1, "picture_id": 42, "frame_index": 0, "detection_index": 0,
@@ -360,7 +363,7 @@ Backend rule: errors must use FastAPI's `HTTPException(status_code, detail=...)`
 
 ### Dev workflow
 
-- Backend: `python -m pixlstash.server` (default port `9537`).
+- Backend: `python -m pixlstash.app` (default port `9537`).
 - Frontend: `npm run dev` inside [frontend/](../frontend/) (Vite at `:5173`, HMR enabled).
 - CORS regex automatically permits `localhost:5173`.
 - Cookies cross ports only if both sides agree on credentials (`withCredentials: true` + `allow_credentials=True`).
@@ -368,7 +371,7 @@ Backend rule: errors must use FastAPI's `HTTPException(status_code, detail=...)`
 ### Production workflow
 
 - `npm run build` → `pixlstash/frontend/dist/`.
-- Run `python -m pixlstash.server`; the SPA is served from the same origin as the API. No proxy needed.
+- Run `python -m pixlstash.app`; the SPA is served from the same origin as the API. No proxy needed.
 
 **Pitfall**: forgetting to run `npm run build` before packaging leaves users with the JSON status fallback at `/`.
 
@@ -447,7 +450,7 @@ sequenceDiagram
     API-->>AX: { task_id }
     AX-->>SPA: task_id
     loop until done
-        SPA->>AX: GET /pictures/import/{task_id}/status
+        SPA->>AX: GET /pictures/import/status?task_id=…
         AX-->>SPA: { progress }
     end
 
@@ -460,7 +463,7 @@ sequenceDiagram
     end
 
     U->>SPA: open a picture
-    SPA->>SPA: build <img src=/api/v1/pictures/{id}/{ext}>
+    SPA->>SPA: build <img src=/api/v1/pictures/{id}.{ext}>
     Note over SPA,API: Browser sends cookie automatically;<br/>share token appended via appendShareToken()
     API-->>SPA: image bytes (watermarked if applicable)
 ```
@@ -520,4 +523,4 @@ flowchart TB
 
 ---
 
-*Last updated: 2026-05-20. Update this document whenever any integration contract (URL prefix, event names, auth mode, build output path, CORS policy, share-token mechanism, settings field names) changes.*
+*Last updated: 2026-07-19. Update this document whenever any integration contract (URL prefix, event names, auth mode, build output path, CORS policy, share-token mechanism, settings field names) changes.*

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -32,7 +32,7 @@ the other two test layers:
 | Frontend units | Vitest | pure utils / pure logic |
 | **End-to-end** | **Playwright** | **the built SPA + a live backend, one origin** |
 
-There are **16 specs** today, all green locally. Each spec maps to a section of
+There are **21 specs** today, all green locally. Each spec maps to a section of
 [`docs/release-test-plan.md`](release-test-plan.md), so the manual release
 checklist shrinks as e2e coverage grows.
 
@@ -43,15 +43,24 @@ checklist shrinks as e2e coverage grows.
 | Smoke | [`grid.spec.js`](../frontend/e2e/specs/grid.spec.js) | Reference spec: render, overlay open/close, search toggle |
 | §1 Authentication | [`auth.spec.js`](../frontend/e2e/specs/auth.spec.js) | Session persists across reload, logged-out redirect, token generation, logout |
 | §3 Grid & browsing | [`grid-browse.spec.js`](../frontend/e2e/specs/grid-browse.spec.js) | Render, sort + direction flip, column reflow, search → history → reset |
+| §3.5 Context menu | [`context-menu.spec.js`](../frontend/e2e/specs/context-menu.spec.js) | Right-click a card opens the context menu listing Tag / Reverse image search / Share image; Escape dismisses |
 | §4 Picture detail | [`overlay.spec.js`](../frontend/e2e/specs/overlay.spec.js) | Overlay open/close, arrow-key next/prev, Escape close |
+| §4 Picture-set locking | [`set-locking.spec.js`](../frontend/e2e/specs/set-locking.spec.js) | Lock a set → grid lock badge + Tag action disabled; unlock restores tagging |
+| §5 Tags | [`tags.spec.js`](../frontend/e2e/specs/tags.spec.js) | Add a tag via the inline input, remove it via its ✕ chip |
+| §6 Star rating | [`rating.spec.js`](../frontend/e2e/specs/rating.spec.js) | Set a star rating in the overlay; it round-trips and survives a reload |
+| §7/§8/§9 Sets / Projects / Characters | [`entities.spec.js`](../frontend/e2e/specs/entities.spec.js) | Sidebar set/character rows filter the grid; Projects tab opens a project |
 | §10 Faces | [`faces.spec.js`](../frontend/e2e/specs/faces.spec.js) | Face crops in the side panel + bounding-box overlay toggle |
 | §11 Stacks | [`stacks.spec.js`](../frontend/e2e/specs/stacks.spec.js) | Expand-all / collapse-all from the View menu |
-| §20 Review Sessions | [`review-board.spec.js`](../frontend/e2e/specs/review-board.spec.js) | Tag-health board: open, render columns, filter, sort, anomalies toggle, Start-review row (drives the real `tag_health` cache) |
-| §20 Review Sessions | [`review-session.spec.js`](../frontend/e2e/specs/review-session.spec.js) | Session loop: create → binary Yes/No mapping, tally + backend receipt, focus advance, Undo, Skip, keyboard, archive. **`fixme`-guarded — blocked by the session card render crash (BUG-RS-1); see docs/regular-tests.md §Review Sessions** |
+| Statistics sidebar | [`stats.spec.js`](../frontend/e2e/specs/stats.spec.js) | Toolbar toggle shows/hides the stats sidebar with its Tags/Pictures/Tasks tabs |
+| Boolean set operations | [`set-operations.spec.js`](../frontend/e2e/specs/set-operations.spec.js) | Multi-select sets reveals Union / Overlap / Difference / Unique; clearing dismisses |
+| Sharing | [`sharing.spec.js`](../frontend/e2e/specs/sharing.spec.js) | Context menu → Share image → Create Link mints a read-only URL |
+| Snapshots | [`snapshots.spec.js`](../frontend/e2e/specs/snapshots.spec.js) | Settings → Snapshots lists ≥1 restore point with a Restore action (list-only) |
+| §19 Grid live-update | [`grid-own-change-no-pill.spec.js`](../frontend/e2e/specs/grid-own-change-no-pill.spec.js), [`grid-external-change-pill.spec.js`](../frontend/e2e/specs/grid-external-change-pill.spec.js), [`grid-injection.spec.js`](../frontend/e2e/specs/grid-injection.spec.js), [`grid-overlay-deferral.spec.js`](../frontend/e2e/specs/grid-overlay-deferral.spec.js) | WebSocket refresh: own change raises no pill, external raises the right pill, injection origin-suppression, flood coalescing, overlay deferral |
+| §20 Review Sessions | [`review-board.spec.js`](../frontend/e2e/specs/review-board.spec.js) | Tag-health board (9 cases): open, render columns, rebuild control, Why column, filter, sort, anomalies toggle, Start-review row (drives the real `tag_health` cache) |
+| §20 Review Sessions | [`review-session.spec.js`](../frontend/e2e/specs/review-session.spec.js) | Session loop (7 cases): create, binary Yes/No mapping + tally + backend receipt, and Escape-close run green (**BUG-RS-1 render crash resolved**); four further cases — Undo, Skip, keyboard, queue completion/archive — stay `test.fixme`'d for reasons unrelated to BUG-RS-1 (see docs/regular-tests.md §Review Sessions) |
 
-Still manual (candidates for future specs): §5 Tags, §6 Star rating / quality
-score, §7 Picture sets, §8 Projects, §9 Characters, §14 Tag predictions,
-§15 Export.
+Still manual (candidates for future specs): §14 Tag predictions, §15 Export,
+and the Selection ▾ ↔ context-menu parity comparison (#403).
 
 ## 3. Architecture
 

--- a/docs/regular-tests.md
+++ b/docs/regular-tests.md
@@ -44,18 +44,20 @@ shrinks as automated coverage grows.
 | reflows the grid when the column count changes | Column slider changes `grid-template-columns` track count (§3.1) | ✅ |
 | search filters, records history, then resets | Search narrows results, term enters history, clearing restores all (§3.3) | ✅ |
 
-## Selection ▾ / Context Menu Parity — `menu-parity.spec.js` (plan §3.5)
+## Selection ▾ / Context Menu Parity — manual (plan §3.5)
 | Test | Covers | Status |
 |------|--------|--------|
-| both menus list the same items for a set of pictures | Selection ▾ dropdown (`.selection-menu-panel`) and right-click context menu (`.image-ctx-menu`) expose identical selection-scoped actions for the same multi-picture selection | ❌ |
+| both menus list the same items for a set of pictures | Selection ▾ dropdown (`.selection-menu-panel`) and right-click context menu (`.image-ctx-menu`) expose identical selection-scoped actions for the same multi-picture selection | 📝 |
 
-> ❌ **Known failure — [#403](https://github.com/Pikselkroken/pixlstash/issues/403).**
-> The context menu has actions the Selection ▾ menu lacks: **Restore from
+> 📝 **Not automated — no parity spec exists.** The right-click context menu is
+> automated on its own (see the `context-menu.spec.js` section below); the
+> Selection ▾ ↔ context-menu *parity comparison* is manual only.
+> **Known gap — [#403](https://github.com/Pikselkroken/pixlstash/issues/403):**
+> the context menu has actions the Selection ▾ menu lacks — **Restore from
 > snapshot** and **Reverse image search** (plus, for a single selection,
-> **Share image** / **Find similar faces**). The spec is intentionally red to
-> keep this parity gap visible; it goes green once the menus are reconciled.
-> (Toolbar.vue documents the Selection menu as "mirrors the right-click context
-> menu exactly", so the source intent is parity.)
+> **Share image** / **Find similar faces**). Keep this ❌ manually until the
+> menus are reconciled. (Toolbar.vue documents the Selection menu as "mirrors the
+> right-click context menu exactly", so the source intent is parity.)
 
 ## Picture Detail (ImageOverlay) — `overlay.spec.js` (plan §4)
 | Test | Covers | Status |
@@ -106,6 +108,11 @@ shrinks as automated coverage grows.
 |------|--------|--------|
 | combines multiple sets via the multi-select toolbar | Ctrl-click a second set reveals the combine toolbar with Union / Overlap / Difference / Unique (XOR); clearing dismisses it | ✅ |
 
+## Picture-set locking — `set-locking.spec.js` (plan §4)
+| Test | Covers | Status |
+|------|--------|--------|
+| lock freezes tagging and unlock restores it (§4) | Lock a non-empty set from the sidebar → grid lock badge + set-row lock icon appear and the context-menu Tag action is disabled; unlock → badge/icon clear and Tag is enabled again (`afterEach` unlocks any leaked lock) | ✅ |
+
 ## Sharing — `sharing.spec.js`
 | Test | Covers | Status |
 |------|--------|--------|
@@ -151,32 +158,36 @@ mutations) is unit-covered in `src/stores/useReviewSessionsStore.test.js`.
 | Test | Covers | Status |
 |------|--------|--------|
 | opens from the toolbar and renders the ranked board | Toolbar `Review and fix tags` → `.rs-overlay`; board title + the redesigned columns (Tag / Est. fixes / Est. wrong / Est. missing / Mismatch / Why it ranks here); ≥1 tag row | ✅ |
+| the persistent rebuild control is visible in the header (Spec B) | The board header always exposes its rebuild control | ✅ |
+| the Why column is never blank for a row with a ranking signal | A row with a ranking signal always shows a "Why it ranks here" explanation | ✅ |
 | the filter input narrows the visible rows | `/`-focusable filter narrows rows to matches and restores on clear | ✅ |
 | a no-match filter shows the empty state | `.rs-board-empty` "No tags match…" | ✅ |
 | the anomalies-only toggle flips its pressed state | `aria-pressed` toggles false↔true | ✅ |
 | a sortable header toggles the active sort | Clicking "Est. wrong" header goes active; rows still render | ✅ |
 | the sort dropdown re-orders without emptying the board | Sort by tag / missing keeps rows | ✅ |
 | a row with a mismatch signal shows Start review | A mismatch-flagged tag ("shirt") exposes the "Start review" action | ✅ |
-| creating a review opens a session with a scan receipt and progress | Dialog → "Scan & create" → session view, receipt ("Scanned N · N suspects"), rail done/found, Undo disabled at start | ⛔ BUG-RS-1 |
-| binary Yes/No map to keep/remove; tally + backend receipt track it | remove-dir No=remove / Yes=keep; tally + `GET /reviews/{id}` receipt agree; focus advances to the re-keyed card; Undo enabled after a decision | ⛔ BUG-RS-1 |
-| Undo reverses the last decision and decrements the tally | Undo (net counter) decrements the tally and re-disables when the stack empties; backend receipt returns to 0 | ⛔ BUG-RS-1 |
-| Skip removes the card with no decision and is reported separately | Skip → `.rs-tally-skipped` + rail "N skipped"; receipt removed/added/kept unchanged, skipped++ | ⛔ BUG-RS-1 |
-| keyboard Y / N / S / U drive decisions and focus stays on the card | Keyboard parity with the buttons; focus stays on `.rs-card` | ⛔ BUG-RS-1 |
-| working through the queue reaches completion and archives to a receipt | Decide all → completion state → Archive → `.rs-archived` receipt; backend status ARCHIVED | ⛔ BUG-RS-1 |
+| creating a review opens a session with a scan receipt and progress | Dialog → "Scan & create" → session view, receipt ("Scanned N · N suspects"), rail done/found, Undo disabled at start | ✅ |
+| binary Yes/No map to keep/remove; tally + backend receipt track it | remove-dir No=remove / Yes=keep; tally + `GET /reviews/{id}` receipt agree; focus advances to the re-keyed card; Undo enabled after a decision | ✅ |
+| Escape closes the review first (back to tag health); a second Escape closes the overlay | In a session, Escape returns to the tag-health board; a second Escape dismisses the overlay | ✅ |
+| Undo reverses the last decision and decrements the tally | Undo (net counter) decrements the tally and re-disables when the stack empties; backend receipt returns to 0 | 📝 fixme |
+| Skip removes the card with no decision and is reported separately | Skip → `.rs-tally-skipped` + rail "N skipped"; receipt removed/added/kept unchanged, skipped++ | 📝 fixme |
+| keyboard Y / N / S / U drive decisions and focus stays on the card | Keyboard parity with the buttons; focus stays on `.rs-card` | 📝 fixme |
+| working through the queue reaches completion and archives to a receipt | Decide all → completion state → Archive → `.rs-archived` receipt; backend status ARCHIVED | 📝 fixme |
 
-**⛔ BUG-RS-1 (blocker):** the session card never renders in a real browser.
-The moment the suggestions queue loads, `ReviewSessionView` crashes with
-`TypeError: Cannot read properties of undefined (reading 'el')` in Vue's
-`patchBlockChildren`, and the session stays stuck on "Loading…". Reproduced in
-the production (minified), unminified, and dev builds. The six session-loop
-tests were **run and all failed** at the stuck card; they are committed guarded
-with `test.describe.fixme` (skipped, not failing) so CI stays green, and encode
-the intended behaviour — remove the `.fixme` once the crash is fixed and they
-run as-is. Not caught by the 61 API tests or 189 unit tests because **no review
-component has a mount/update test** (only the store is unit-tested). Suspected
-cause: the `<template v-if>/<template v-else>` conditional fragments sharing a
-block parent with dynamic siblings in `ReviewBinaryCard` (banner text, lines
-13–20) and/or `ReviewDecisionBar` (toolbar, lines 6/33). Fix is dev-lane work.
+**✅ BUG-RS-1 — RESOLVED.** The session card used to never render in a real
+browser: the moment the suggestions queue loaded, `ReviewSessionView` crashed
+with `TypeError: Cannot read properties of undefined (reading 'el')` in Vue's
+`patchBlockChildren` and stayed stuck on "Loading…". Root cause was a `:key`
+collision between the card's `v-else` branch and the compiler's numeric auto-key
+for the sibling "Loading" `v-if` (only surfacing in production block patching);
+fixed by namespacing the key (`card-${current.id}`) in `ReviewSessionView.vue`.
+The three active specs above (create, binary decide, Escape-close) are the
+authoritative regression guard and run green against the production build. The
+four rows marked **📝 fixme** stay `test.fixme`'d for reasons **unrelated to
+BUG-RS-1** — each encodes a behaviour that does not yet match the implementation
+(single-suspect queue emptying, Skip tally, keyboard focus, queue completion/
+archive) and needs QA+dev reconciliation; see the per-test `FIXME (not BUG-RS-1)`
+notes in the spec. Un-`fixme` each as its behaviour is settled.
 
 ---
 
@@ -194,13 +205,17 @@ Tracked so they aren't forgotten — weighted by blast radius:
   handful of pictures are only smoke-covered.
 - **Import of malformed / huge / unsupported files** — graceful handling
   (no crash, nothing silently dropped) is manual-only.
-- **Selection/context menu *actions* execute correctly** — `menu-parity.spec.js`
-  only compares the *item lists*; it does not click through each action. Once
-  #403 is fixed, consider asserting representative actions actually fire.
-- **Review Sessions — session loop blocked + manual-only signals (plan §20).**
-  The board is automated (`review-board.spec.js`). The whole session loop is
-  **blocked by BUG-RS-1** (card render crash); its specs are written and
-  `fixme`-guarded, ready to run once fixed. Separately, several board/creation
+- **Selection ▾ ↔ context-menu parity is not automated.** `context-menu.spec.js`
+  opens the right-click menu and lists its actions, but no spec compares the two
+  menus' *item lists*, and none clicks through each action. Tracked as the #403
+  parity gap (see the "Selection ▾ / Context Menu Parity" section above). Once
+  #403 is fixed, consider a parity spec plus asserting representative actions fire.
+- **Review Sessions — partial loop automation + manual-only signals (plan §20).**
+  The board is automated (`review-board.spec.js`, 9 cases). The session loop is
+  **partly automated**: create, binary decide, and Escape-close run green
+  (BUG-RS-1 is resolved); four further cases (Undo, Skip, keyboard, queue
+  completion/archive) stay `test.fixme`'d for reasons unrelated to BUG-RS-1 and
+  are tracked separately. Separately, several board/creation
   paths are **not exercisable against the committed fixture** and stay manual
   (see release-test-plan §20): `est_wrong`/`est_missing` columns and
   auto-resolvable/bulk-accept (the fixture's predictions never disagree with

--- a/docs/release-test-plan.md
+++ b/docs/release-test-plan.md
@@ -225,7 +225,9 @@ Covers the lazy ML library loading change introduced in 1.2.
 - [ ] Click the stack badge again — the stack collapses back to the leader thumbnail
 
 ### 3.5 Selection ▾ / Context Menu Parity
-Automated by `frontend/e2e/specs/menu-parity.spec.js` (see `docs/regular-tests.md`).
+The right-click context menu is automated by `frontend/e2e/specs/context-menu.spec.js`
+(opens on right-click and lists the picture actions, §3.5; see `docs/regular-tests.md`).
+The Selection ▾ parity assertion below is manual.
 - [ ] Select 2+ pictures (Ctrl-click) → open the **Selection ▾** dropdown (or press **S**) and note the action items
 - [ ] Right-click one of the **selected** pictures and note the context-menu action items
 - [ ] Both menus list the **same** selection-scoped actions
@@ -448,18 +450,21 @@ runs with `disable_background_workers: true`, so it cannot exercise this path).
 New in this release: a tag-health board, first-class review sessions in a rail,
 and binary/pair decision cards (replaces the old "Review tags" overlay). Spec:
 `docs/reviews/2026-07-review-sessions-redesign-draft.md` (Rulings + Decisions,
-2026-07-15). The board is automated (`review-board.spec.js`, 7 cases). The
-session loop is automated but **currently `fixme`-guarded** behind the blocker
-below.
+2026-07-15). The board is automated (`review-board.spec.js`, 9 cases). The
+session loop is automated: three cases (create, binary decide, Escape-close) are
+active and green; four further cases are `fixme`-guarded pending QA+dev
+behaviour reconciliation (see §20.9).
 
-> 🚫 **RELEASE BLOCKER — BUG-RS-1 (session card never renders).** Opening any
-> review shows the session header + rail correctly, then the card area is stuck
-> on **"Loading…"** forever. The browser throws
+> ✅ **BUG-RS-1 (session card never renders) — RESOLVED.** The card used to be
+> stuck on **"Loading…"** forever, with the browser throwing
 > `TypeError: Cannot read properties of undefined (reading 'el')` in Vue's
-> `patchBlockChildren` the instant the suggestions queue loads. Reproduced in the
-> production, unminified, and dev builds against the committed fixture vault. The
-> **entire session loop (§20.3–§20.8) is unusable** until this is fixed. Do not
-> ship the session loop with this open. The board (§20.1) is unaffected.
+> `patchBlockChildren` the instant the suggestions queue loaded (a `:key`
+> collision between the card's `v-else` branch and the compiler's numeric
+> auto-key for the sibling "Loading" `v-if`, only surfacing in production block
+> patching). Fixed by namespacing the key (`card-${current.id}`) in
+> `ReviewSessionView.vue`. The session loop renders and the core decision flow
+> works; the authoritative regression guard is the create + binary-decide specs
+> in `review-session.spec.js`.
 
 ### 20.1 Tag-health board — AUTOMATED (`review-board.spec.js`)
 
@@ -480,7 +485,7 @@ on a **real vault** (or a seeded fixture):
 - [ ] **Model-disputes** banner ("The current model disputes N of your earlier calls") when a human label contradicts a confident current-model prediction
 - [ ] **Build-progress bar** shows while the cache (re)builds on a large vault (on the small fixture the rebuild is synchronous and the bar does not visibly fill)
 
-### 20.3 Create a review — BLOCKED past the dialog by BUG-RS-1
+### 20.3 Create a review — AUTOMATED (`review-session.spec.js`, create case)
 
 - [ ] **New review** → pick a tag (open tags greyed / jump to their session) → optional scope (project/set/character) → **Scan & create**
 - [ ] The session cover-sheet receipt reads "Scanned N pictures · N suspects · N handled earlier"
@@ -488,7 +493,7 @@ on a **real vault** (or a seeded fixture):
 - [ ] "Include previously reviewed" toggle (default off) re-parents earlier-handled suspects into the new review
 - [ ] Auto-resolve line ("N obvious suspects — Auto-resolve") appears when neighbour vote + tagger agree ≥90% (needs aligned predictions; 0 on the current fixture)
 
-### 20.4 Session loop — binary — BLOCKED by BUG-RS-1
+### 20.4 Session loop — binary — AUTOMATED (`review-session.spec.js`, binary-decide + Escape-close cases)
 
 - [ ] One image, one question; **Yes / No / Skip / Undo** with `Y / N / S / U` keys
 - [ ] Direction mapping: **probably-wrong** card → No removes the tag, Yes keeps it; **probably-missing** card → Yes adds the tag, No leaves it untagged
@@ -496,22 +501,22 @@ on a **real vault** (or a seeded fixture):
 - [ ] Undo is disabled when the stack is empty, enabled after a decision; XP/streak **decrement** on undo (net counters); celebrations never fire on undo
 - [ ] Neighbour strip shows "N of M similar images have '<tag>'" with per-thumb tag/no-tag badges
 
-### 20.5 Session loop — pair cards — BLOCKED by BUG-RS-1
+### 20.5 Session loop — pair cards — MANUAL (no active spec yet)
 
 - [ ] For same-stack or dhash-near pairs a pair card appears with **Both / Neither / Left only / Right only** (`B / N / L / R`); Right-only performs the swap
 - [ ] LEFT pane = tagged side, RIGHT pane = untagged side
 
-### 20.6 Skip / refresh / staleness — BLOCKED by BUG-RS-1
+### 20.6 Skip / refresh / staleness — MANUAL (Skip case `fixme`'d, not BUG-RS-1)
 
 - [ ] Skip removes the item with **no** decision written (nothing to tags/ledger); rail shows "N skipped"; completion offers "Reopen N skipped"
 - [ ] After a vault change, the staleness hint ("Vault changed since scan → Refresh") appears; **Refresh appends** newly-found suspects with a **NEW — from refresh** badge and never resurrects decided cards
 
-### 20.7 Abort / archive — BLOCKED by BUG-RS-1
+### 20.7 Abort / archive — MANUAL (queue-completion case `fixme`'d, not BUG-RS-1)
 
 - [ ] Abort with decisions made shows a dialog: **Keep N changes** (decisions stand) / **Undo N changes** (review-scoped bulk-reopen) / Cancel
 - [ ] Working through the queue reaches an explicit completion state; **Archive** produces a receipt ("N reviewed — N removed, N added, N kept, N skipped")
 
-### 20.8 Manual tag / evidence region / gamification — BLOCKED by BUG-RS-1
+### 20.8 Manual tag / evidence region / gamification — MANUAL
 
 - [ ] Manual-tag escape hatch: bottom-left **Apply tags** button on the card + `T` shortcut opens the tag panel
 - [ ] Evidence region: `H` toggles the Grad-CAM heatmap + boxes on cards that have a region; preference persists
@@ -520,7 +525,13 @@ on a **real vault** (or a seeded fixture):
 ### 20.9 Acceptance criteria (release gate)
 
 - [ ] Board (§20.1) passes automated + manual
-- [ ] **BUG-RS-1 fixed**, the six `review-session.spec.js` cases un-`fixme`'d and green
+- [x] **BUG-RS-1 fixed** — the three authoritative `review-session.spec.js`
+      regression cases (create, binary decide, Escape-close) are un-`fixme`'d and
+      green against the production build. The remaining four cases in the spec
+      stay `fixme`'d for reasons **unrelated to BUG-RS-1** (single-suspect queue
+      emptying, Skip tally, keyboard focus, queue-completion/archive — see the
+      per-test `FIXME (not BUG-RS-1)` notes) and are tracked separately, not as a
+      release gate on the render fix
 - [ ] Binary + pair decision mapping verified against the backend receipt (accept/dismiss/swap/skip written correctly; skip writes nothing)
 - [ ] One-open-per-tag (409), abort keep-vs-undo, and archive receipt verified
 - [ ] Regressions in the old review overlay's replacement confirmed (no orphaned `TagSuggestion` rows; existing per-item accept/dismiss/reopen still work)

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -4,8 +4,9 @@
 
    This is the SHIPPED copy of the design tokens. The SPEC and the reasoning live
    in `docs/design/design-tokens.css` + `docs/design/visual-language.md`; this file
-   must stay byte-for-byte in sync with the values there. The lead designer owns
-   both. Do not edit values here without updating the doc (and vice versa).
+   must keep the token values in sync with the values there (the comments are
+   deliberately condensed here, so the two files are not byte-identical). The lead
+   designer owns both. Do not edit values here without updating the doc (and vice versa).
 
    COLOR is not here — it lives in the Vuetify themes in `main.js`
    (`pixlStashLight` / `pixlStashDark`), consumed as `rgb(var(--v-theme-*))`.


### PR DESCRIPTION
Doc-only refresh fixing the drift found in a develop-branch documentation audit. No source-code changes (one comment-only tweak in `design-tokens.css`; zero token values changed). Four domain-grouped commits:

1. **Backend/API + agent docs** — CLAUDE.md broken run-server command (`pixlstash.server`→`pixlstash.app`) + migration-template path; backend_architecture.md deletes the removed PictureSplit/eval subsystem, adds the review/tag-health services/models/finders, fixes moved helper paths, extends migration milestones to 0073; integration_architecture.md corrects three wrong URL contracts (thumbnail, original-file separator, import/export status), the `pictures_changed` wire type, and the snapshot/restore events.
2. **Frontend architecture** — recounted stale line counts, added the `components/reviews/` domain, store count 10→16, catalogued the App*/Overlay*/Tb*/Settings* layers + tokens/composables.
3. **Design docs** — superseded-banner on the June drift-audit, softened the byte-for-byte token overclaim, fixed the `panel`/`onPanel` gloss.
4. **Test docs** — removed the resolved BUG-RS-1 release-blocker language, fixed the gate premise + spec counts (16→21, board 7→9), dropped the nonexistent `menu-parity.spec.js`, added `set-locking.spec.js`. Closes the F7 stale-release-test-plan item.

The CI-checked machine-generated route index was not touched (`render_backend_architecture.py --check` passes).