### PR TITLE
Stop retrying un-decodable images forever (#585)

### DIFF
--- a/pixlstash/database.py
+++ b/pixlstash/database.py
@@ -26,6 +26,7 @@ import numpy as np
 
 from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.image_processing.image_utils import ImageUtils
+from pixlstash.utils.unprocessable_image_registry import UnprocessableImageRegistry
 
 # These imports are necessary to register the models with SQLModel
 
@@ -636,6 +637,10 @@ class VaultDatabase:
     def __init__(self, db_path: str):
         self._db_path = db_path
         self.image_root = os.path.dirname(self._db_path)
+        # In-memory, process-lifetime set of pictures whose image file cannot be
+        # decoded (issue #585). Shared by task threads (marking) and finder
+        # threads (suppression); reachable from both via their ``self._db``.
+        self.unprocessable_images = UnprocessableImageRegistry()
         db_exists = os.path.exists(self._db_path)
         logger.debug(f"Vault init, db_path={self._db_path}, db_exists={db_exists}")
 

--- a/pixlstash/tasks/base_task_finder.py
+++ b/pixlstash/tasks/base_task_finder.py
@@ -1,4 +1,3 @@
-import os
 import threading
 from abc import ABC, ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
@@ -45,27 +44,24 @@ class BaseTaskFinder(ABC, metaclass=TaskFinderRegistry):
         Pictures whose image file cannot be decoded (issue #585) are excluded
         here, at the one point every batch finder claims through, so a corrupt
         image is skipped uniformly instead of being re-selected on every sweep.
-        Suppression is keyed on the file's ``(mtime, size)``, so a rewritten file
-        lifts it automatically (see :class:`UnprocessableImageRegistry`).
+        Suppression is looked up by picture id against the registry's own stored
+        path (never ``picture.file_path``, which is often deferred and the
+        candidate pictures are detached here); a rewritten file lifts it
+        automatically (see :class:`UnprocessableImageRegistry`).
 
         Returns:
             A list of pictures selected from *pictures* that were unclaimed.
         """
         database = getattr(self, "_db", None)
         registry = getattr(database, "unprocessable_images", None)
-        image_root = getattr(database, "image_root", None)
         selected = []
         with self._claim_lock:
             for picture in pictures:
                 picture_id = getattr(picture, "id", None)
                 if picture_id is None or picture_id in self._claimed_picture_ids:
                     continue
-                if registry is not None and image_root is not None:
-                    file_path = getattr(picture, "file_path", None)
-                    if file_path is not None and registry.is_suppressed(
-                        picture_id, os.path.join(image_root, str(file_path))
-                    ):
-                        continue
+                if registry is not None and registry.is_suppressed(picture_id):
+                    continue
                 self._claimed_picture_ids.add(picture_id)
                 selected.append(picture)
                 if len(selected) >= batch_limit:

--- a/pixlstash/tasks/base_task_finder.py
+++ b/pixlstash/tasks/base_task_finder.py
@@ -1,3 +1,4 @@
+import os
 import threading
 from abc import ABC, ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
@@ -41,15 +42,30 @@ class BaseTaskFinder(ABC, metaclass=TaskFinderRegistry):
             pictures: Candidate picture objects (must expose an ``id`` attr).
             batch_limit: Maximum number of pictures to include in one task.
 
+        Pictures whose image file cannot be decoded (issue #585) are excluded
+        here, at the one point every batch finder claims through, so a corrupt
+        image is skipped uniformly instead of being re-selected on every sweep.
+        Suppression is keyed on the file's ``(mtime, size)``, so a rewritten file
+        lifts it automatically (see :class:`UnprocessableImageRegistry`).
+
         Returns:
             A list of pictures selected from *pictures* that were unclaimed.
         """
+        database = getattr(self, "_db", None)
+        registry = getattr(database, "unprocessable_images", None)
+        image_root = getattr(database, "image_root", None)
         selected = []
         with self._claim_lock:
             for picture in pictures:
                 picture_id = getattr(picture, "id", None)
                 if picture_id is None or picture_id in self._claimed_picture_ids:
                     continue
+                if registry is not None and image_root is not None:
+                    file_path = getattr(picture, "file_path", None)
+                    if file_path is not None and registry.is_suppressed(
+                        picture_id, os.path.join(image_root, str(file_path))
+                    ):
+                        continue
                 self._claimed_picture_ids.add(picture_id)
                 selected.append(picture)
                 if len(selected) >= batch_limit:

--- a/pixlstash/tasks/image_embedding_task.py
+++ b/pixlstash/tasks/image_embedding_task.py
@@ -18,6 +18,7 @@ from pixlstash.database import DBPriority
 from pixlstash.db_models import Picture, PictureLikenessQueue
 from pixlstash.tagger_plugins.clip_service import CLIP_MODEL_NAME
 
+from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.utils.image_processing.video_utils import VideoUtils
 from pixlstash.pixl_logging import get_logger
 from pixlstash.tasks.base_task import BaseTask, QueueType, TaskPriority
@@ -264,7 +265,7 @@ class ImageEmbeddingTask(BaseTask):
                 continue
             registry.mark_unprocessable(
                 pid,
-                os.path.join(image_root, str(file_path)),
+                ImageUtils.resolve_picture_path(image_root, str(file_path)),
                 reason="image could not be decoded",
             )
 

--- a/pixlstash/tasks/image_embedding_task.py
+++ b/pixlstash/tasks/image_embedding_task.py
@@ -169,9 +169,17 @@ class ImageEmbeddingTask(BaseTask):
 
     @classmethod
     def count_remaining(
-        cls, session: Session, aesthetic_disabled: Optional[bool] = None
+        cls,
+        session: Session,
+        aesthetic_disabled: Optional[bool] = None,
+        suppressed_ids: Optional[set] = None,
     ) -> int:
-        """Count pictures needing image embedding or aesthetic score work."""
+        """Count pictures needing image embedding or aesthetic score work.
+
+        *suppressed_ids* — pictures whose file cannot be decoded (issue #585) —
+        are excluded so progress does not stall at a non-zero "remaining" that can
+        never drain.
+        """
         if aesthetic_disabled is None:
             aesthetic_disabled = cls._is_aesthetic_disabled()
 
@@ -187,6 +195,8 @@ class ImageEmbeddingTask(BaseTask):
                 Picture.aesthetic_score.is_(None),
             )
         stmt = select(func.count()).select_from(Picture).where(condition)
+        if suppressed_ids:
+            stmt = stmt.where(Picture.id.notin_(tuple(suppressed_ids)))
         result = session.exec(stmt).one()
         if isinstance(result, tuple):
             return result[0]
@@ -198,8 +208,14 @@ class ImageEmbeddingTask(BaseTask):
         session: Session,
         aesthetic_disabled: Optional[bool] = None,
         limit: Optional[int] = None,
+        suppressed_ids: Optional[set] = None,
     ):
-        """Fetch pictures needing image embedding or aesthetic score work."""
+        """Fetch pictures needing image embedding or aesthetic score work.
+
+        *suppressed_ids* — undecodable pictures (issue #585) — are excluded from
+        the candidate window so a handful of corrupt files cannot crowd out real
+        work and stall the finder.
+        """
         if aesthetic_disabled is None:
             aesthetic_disabled = cls._is_aesthetic_disabled()
 
@@ -215,11 +231,10 @@ class ImageEmbeddingTask(BaseTask):
                 Picture.aesthetic_score.is_(None),
             )
 
-        stmt = (
-            select(Picture.id, Picture.file_path)
-            .where(condition)
-            .limit(int(limit or cls.BATCH_SIZE))
-        )
+        stmt = select(Picture.id, Picture.file_path).where(condition)
+        if suppressed_ids:
+            stmt = stmt.where(Picture.id.notin_(tuple(suppressed_ids)))
+        stmt = stmt.limit(int(limit or cls.BATCH_SIZE))
         return session.exec(stmt).all()
 
     @classmethod
@@ -230,6 +245,28 @@ class ImageEmbeddingTask(BaseTask):
         empty_emb = np.array([], dtype=np.float32).tobytes()
         score = None if self._is_aesthetic_disabled() else -1.0
         return [(pid, empty_emb, score, None) for pid in pids]
+
+    def _mark_decode_failures(self, pids: set[int], batch_files: dict) -> None:
+        """Suppress pictures that genuinely could not be decoded (issue #585).
+
+        Only the pids whose image failed to open/decode are passed here — never a
+        transient inference failure (CLIP/GPU OOM), which must keep retrying. The
+        empty-blob 'failed' marker this task writes is treated as still-missing by
+        ``fetch_work``, so without this a corrupt image is re-selected every sweep.
+        """
+        registry = getattr(self._db, "unprocessable_images", None)
+        if registry is None or not pids:
+            return
+        image_root = getattr(self._db, "image_root", "") or ""
+        for pid in pids:
+            file_path = batch_files.get(pid)
+            if not file_path:
+                continue
+            registry.mark_unprocessable(
+                pid,
+                os.path.join(image_root, str(file_path)),
+                reason="image could not be decoded",
+            )
 
     @staticmethod
     def _compute_dhash(image: Image.Image, hash_size: int = 8) -> Optional[str]:
@@ -382,17 +419,22 @@ class ImageEmbeddingTask(BaseTask):
         flat_images = []
         flat_pids = []
         flat_hashes = []
-        failed_pids = set()
+        decode_failed_pids = set()
         batch_pids = {pid for pid, _, _ in preloaded}
         batch_files = {pid: fp for pid, fp, _ in preloaded}
 
         for pid, file_path, img in preloaded:
             if img is None:
-                failed_pids.add(pid)
+                decode_failed_pids.add(pid)
                 continue
             flat_images.append(img)
             flat_hashes.append(self._compute_dhash(img))
             flat_pids.append(pid)
+
+        # A None image means the file could not be decoded — suppress those
+        # pictures (issue #585) so they are not re-selected every sweep. This is
+        # the decode-failure path only; inference failures below still retry.
+        self._mark_decode_failures(decode_failed_pids, batch_files)
 
         if not flat_images:
             failure_updates = self._build_failure_updates(batch_pids)
@@ -404,11 +446,11 @@ class ImageEmbeddingTask(BaseTask):
                 "ImageEmbeddingTask: No images loaded for batch. Marked %s pictures as failed.",
                 len(batch_pids),
             )
-            if failed_pids:
+            if decode_failed_pids:
                 logger.warning(
                     "ImageEmbeddingTask: Failed to load %d pictures: %s",
-                    len(failed_pids),
-                    [batch_files.get(pid) for pid in failed_pids],
+                    len(decode_failed_pids),
+                    [batch_files.get(pid) for pid in decode_failed_pids],
                 )
             return changed
 

--- a/pixlstash/tasks/missing_image_embedding_finder.py
+++ b/pixlstash/tasks/missing_image_embedding_finder.py
@@ -44,9 +44,14 @@ class MissingImageEmbeddingFinder(BaseTaskFinder):
             )
 
         # Fetch more than one task worth so _filter_and_claim can skip claimed IDs.
+        # Exclude undecodable pictures (issue #585) at the query so they cannot
+        # crowd the candidate window and stall real work.
+        suppressed_ids = self._db.unprocessable_images.active_suppressed_ids()
         candidates = self._db.run_immediate_read_task(
             lambda session: ImageEmbeddingTask.fetch_work(
-                session=session, limit=batch_size * IMAGE_EMBEDDING_MAX_INFLIGHT
+                session=session,
+                limit=batch_size * IMAGE_EMBEDDING_MAX_INFLIGHT,
+                suppressed_ids=suppressed_ids,
             )
         )
         if not candidates:

--- a/pixlstash/utils/unprocessable_image_registry.py
+++ b/pixlstash/utils/unprocessable_image_registry.py
@@ -1,0 +1,182 @@
+"""In-memory registry of pictures whose image file cannot be decoded.
+
+GitHub issue #585 ("Invalid Images break tasks"): the background pipeline is
+data-driven — every ``Missing*Finder`` re-selects any picture whose target
+column is still unset. When a picture points at a corrupt/undecodable file the
+task can never produce a value, nothing durably marks the row as done (the
+image-embedding task even writes an *empty* blob that ``fetch_work`` still treats
+as missing), so the same picture is picked up on every sweep forever.
+
+The reporter explicitly accepts that such a file may be "ignored for the
+remaining duration of the server process lifetime, or until it is modified". This
+registry implements exactly that: a process-lifetime, thread-safe set of picture
+ids that failed to decode, pinned to the file's ``(mtime, size)`` at the moment of
+failure. A finder consults :meth:`is_suppressed` to skip the picture; when the
+file is rewritten (the "still being written" / repaired case) its signature moves
+and suppression lifts automatically, so the picture is retried.
+
+Nothing here is persisted — a server restart clears the registry, at which point
+each such picture is retried exactly once more (re-decoded, fails, re-marked),
+which is the accepted behaviour above. Keeping it in memory is deliberate: it
+needs no schema change and no migration.
+"""
+
+import os
+import threading
+
+from pixlstash.pixl_logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class UnprocessableImageRegistry:
+    """Thread-safe ``picture_id -> (file_path, mtime_ns, size)`` map of undecodable images.
+
+    A picture is *suppressed* only while it is recorded here **and** its file's
+    current ``(mtime_ns, size)`` still match what was captured when it was marked.
+    Any change to the file (a rewrite, a repair, or the file being replaced) moves
+    the signature and lifts suppression, so the picture flows back into the normal
+    finder queue and is retried.
+
+    All state is in memory and bounded to *max_entries*. Both the marking side
+    (background task threads, on a decode failure) and the suppression side
+    (finder threads, on every planning sweep) touch this map, so every method is
+    guarded by a single lock. ``os.stat`` is performed under the lock: it is a
+    fast syscall and contention is negligible (marks are rare, sweeps are cheap),
+    and holding it removes any check-then-act race between marking and pruning.
+    """
+
+    # Corrupt images are pathological; this cap only bounds a runaway (e.g. a
+    # whole reference tree of unreadable files) while staying far above any
+    # realistic count.
+    MAX_ENTRIES = 100_000
+
+    def __init__(self, max_entries: int = MAX_ENTRIES) -> None:
+        self._max_entries = int(max_entries)
+        self._lock = threading.Lock()
+        # picture_id -> (file_path, mtime_ns, size)
+        self._entries: dict[int, tuple[str, int, int]] = {}
+
+    @staticmethod
+    def _stat_signature(file_path: str) -> "tuple[int, int] | None":
+        """Return ``(mtime_ns, size)`` for *file_path*, or ``None`` if it cannot be stat'd."""
+        try:
+            stat = os.stat(file_path)
+        except OSError as exc:
+            logger.debug(
+                "UnprocessableImageRegistry: cannot stat %s: %s", file_path, exc
+            )
+            return None
+        return (stat.st_mtime_ns, stat.st_size)
+
+    def mark_unprocessable(
+        self, picture_id: "int | None", file_path: "str | None", *, reason: str = ""
+    ) -> bool:
+        """Record *picture_id* as undecodable, pinned to *file_path*'s current signature.
+
+        A picture already marked for the *same* file version is a no-op (and is not
+        re-logged), so repeated sweeps of the same corrupt file do not spam the log.
+        A picture whose file can no longer be stat'd is left unmarked — there is
+        nothing to pin the suppression to, and the missing-file purge finder owns
+        that case.
+
+        Args:
+            picture_id: The picture that failed to decode.
+            file_path: Absolute path to the file that could not be opened.
+            reason: Short description of the failure, for the one-time log line.
+
+        Returns:
+            ``True`` if a new mark (or a re-mark for a changed file) was recorded.
+        """
+        if picture_id is None or not file_path:
+            return False
+        pid = int(picture_id)
+        signature = self._stat_signature(file_path)
+        if signature is None:
+            logger.debug(
+                "UnprocessableImageRegistry: not marking picture id=%s — file %s "
+                "cannot be stat'd (leaving it to the missing-file purge).",
+                pid,
+                file_path,
+            )
+            return False
+        mtime_ns, size = signature
+        with self._lock:
+            existing = self._entries.get(pid)
+            if existing is not None and existing[1] == mtime_ns and existing[2] == size:
+                return False  # already suppressed for this exact file version
+            if existing is None and len(self._entries) >= self._max_entries:
+                logger.warning(
+                    "UnprocessableImageRegistry: cap (%d) reached; NOT suppressing "
+                    "picture id=%s path=%s — it will keep being retried until an "
+                    "existing entry is released or the server restarts.",
+                    self._max_entries,
+                    pid,
+                    file_path,
+                )
+                return False
+            self._entries[pid] = (str(file_path), mtime_ns, size)
+        logger.warning(
+            "Unprocessable image: picture id=%s path=%s could not be decoded (%s); "
+            "skipping it for the rest of this server session (it will be retried "
+            "only if the file changes).",
+            pid,
+            file_path,
+            reason or "image could not be decoded",
+        )
+        return True
+
+    def is_suppressed(self, picture_id: "int | None", file_path: "str | None") -> bool:
+        """Return whether *picture_id* is currently suppressed for *file_path*.
+
+        ``True`` only if the picture is recorded and *file_path*'s current
+        ``(mtime_ns, size)`` still match the marked signature. If the file changed
+        or can no longer be stat'd the stale entry is pruned and ``False`` is
+        returned, so the picture is retried.
+        """
+        if picture_id is None or not file_path:
+            return False
+        pid = int(picture_id)
+        with self._lock:
+            existing = self._entries.get(pid)
+            if existing is None:
+                return False
+            signature = self._stat_signature(file_path)
+            if signature is not None and (existing[1], existing[2]) == signature:
+                return True
+            # File vanished or was rewritten since we marked it — retry it.
+            self._entries.pop(pid, None)
+            return False
+
+    def active_suppressed_ids(self) -> set[int]:
+        """Return the set of currently-suppressed picture ids, pruning stale entries.
+
+        Re-validates every stored file signature; entries whose file changed or
+        disappeared are dropped. Cheap in practice — the map only holds genuinely
+        undecodable files, which are rare.
+        """
+        active: set[int] = set()
+        with self._lock:
+            for pid, (path, mtime_ns, size) in list(self._entries.items()):
+                signature = self._stat_signature(path)
+                if signature is not None and signature == (mtime_ns, size):
+                    active.add(pid)
+                else:
+                    self._entries.pop(pid, None)
+        return active
+
+    def discard(self, picture_id: "int | None") -> None:
+        """Forget *picture_id* (e.g. when the picture is deleted)."""
+        if picture_id is None:
+            return
+        with self._lock:
+            self._entries.pop(int(picture_id), None)
+
+    def snapshot(self) -> dict[int, tuple[str, int, int]]:
+        """Return a copy of the current ``{picture_id: (file_path, mtime_ns, size)}`` map."""
+        with self._lock:
+            return dict(self._entries)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)

--- a/pixlstash/utils/unprocessable_image_registry.py
+++ b/pixlstash/utils/unprocessable_image_registry.py
@@ -126,23 +126,29 @@ class UnprocessableImageRegistry:
         )
         return True
 
-    def is_suppressed(self, picture_id: "int | None", file_path: "str | None") -> bool:
-        """Return whether *picture_id* is currently suppressed for *file_path*.
+    def is_suppressed(self, picture_id: "int | None") -> bool:
+        """Return whether *picture_id* is currently suppressed.
 
-        ``True`` only if the picture is recorded and *file_path*'s current
+        ``True`` only if the picture is recorded and its stored file's current
         ``(mtime_ns, size)`` still match the marked signature. If the file changed
         or can no longer be stat'd the stale entry is pruned and ``False`` is
         returned, so the picture is retried.
+
+        The signature is re-checked against the registry's OWN stored path, so
+        callers never read ``Picture.file_path``: that ORM attribute is often
+        deferred and the candidate pictures are detached by the time a finder
+        claims, so touching it there raised ``DetachedInstanceError`` (issue #585).
         """
-        if picture_id is None or not file_path:
+        if picture_id is None:
             return False
         pid = int(picture_id)
         with self._lock:
             existing = self._entries.get(pid)
             if existing is None:
                 return False
-            signature = self._stat_signature(file_path)
-            if signature is not None and (existing[1], existing[2]) == signature:
+            path, mtime_ns, size = existing
+            signature = self._stat_signature(path)
+            if signature is not None and signature == (mtime_ns, size):
                 return True
             # File vanished or was rewritten since we marked it — retry it.
             self._entries.pop(pid, None)

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -540,6 +540,16 @@ class Vault:
         """When the retention window was last lowered, or None."""
         return self._scrapheap_retention_reduced_at
 
+    @property
+    def unprocessable_images(self):
+        """Registry of pictures whose image file cannot be decoded (issue #585).
+
+        Lives on the database so task threads (which mark decode failures) and
+        finder threads (which suppress them) reach the same instance via their
+        ``self._db``; exposed here for discoverability.
+        """
+        return self.db.unprocessable_images
+
     def set_keep_models_in_memory(self, keep_models_in_memory: bool):
         previous = self._keep_models_in_memory
         self._keep_models_in_memory = bool(keep_models_in_memory)
@@ -1456,9 +1466,13 @@ class Vault:
             return result[0]
         return result or 0
 
-    @staticmethod
-    def _count_missing_image_embeddings(session: Session) -> int:
-        return ImageEmbeddingTask.count_remaining(session)
+    def _count_missing_image_embeddings(self, session: Session) -> int:
+        # Exclude undecodable pictures (issue #585) so "remaining" can reach 0
+        # instead of stalling on files that can never produce an embedding.
+        suppressed_ids = self.db.unprocessable_images.active_suppressed_ids()
+        return ImageEmbeddingTask.count_remaining(
+            session, suppressed_ids=suppressed_ids
+        )
 
     @staticmethod
     def _count_pending_likeness_parameters(session: Session) -> int:

--- a/tests/test_invalid_image_endless_retry.py
+++ b/tests/test_invalid_image_endless_retry.py
@@ -1,0 +1,151 @@
+"""Reproduction for GitHub issue #585 — "Invalid Images break tasks".
+
+When a reference folder contains a corrupt/undecodable image, the task system
+retries it forever. The mechanism is generic to every ``Missing*Finder``:
+
+1. A finder selects pictures whose target column is unset. For image embeddings
+   that is ``MissingImageEmbeddingFinder``, whose candidate query is
+   ``ImageEmbeddingTask.fetch_work`` (``image_embedding IS NULL`` OR a
+   zero-length blob).
+2. The task tries to open the file. For a corrupt image
+   ``ImageUtils.load_image_or_video_bgr(path)`` returns ``None``, so no
+   embedding can be produced.
+3. There is **no field on ``Picture`` and no logic in any finder** that records a
+   picture as unprocessable / failed / skip. The one thing the task does write on
+   failure is an *empty* embedding blob (``_build_failure_updates`` →
+   ``np.array([], dtype=np.float32).tobytes()``), and ``fetch_work`` explicitly
+   treats a zero-length blob as still-missing. So whether the column is left
+   ``NULL`` or stamped with the empty "failed" marker, the finder re-selects the
+   same picture on the very next sweep — an unbounded retry loop.
+
+These tests assert the CURRENT (buggy) behavior so they pass today and pin the
+bug down. The eventual fix must give the pipeline a way to mark an
+unprocessable picture as done/failed so it is NOT re-selected; when that lands,
+the "re-selected again" assertions below become the ones that flip (the invalid
+picture must drop out of ``fetch_work`` after a failed attempt).
+
+ML-free: exercises only the DB candidate query and the on-disk image loader — no
+CLIP / insightface / tagger inference is run.
+"""
+
+import os
+from datetime import datetime
+
+import numpy as np
+from sqlmodel import Session
+
+from pixlstash.db_models import Picture
+from pixlstash.tasks.image_embedding_task import ImageEmbeddingTask
+from pixlstash.utils.image_processing.image_utils import ImageUtils
+from pixlstash.vault import Vault
+
+# Bytes that exist on disk as a ``.jpg`` but are not a decodable image. cv2 and
+# the PIL fallback in ``load_image_or_video_bgr`` both refuse them.
+_CORRUPT_JPEG_BYTES = b"this is not a real JPEG, just some garbage bytes \xff\xd8\x00"
+
+# The exact "failed" marker ImageEmbeddingTask._build_failure_updates writes when
+# it cannot produce an embedding: a zero-length float32 blob.
+_EMPTY_EMBEDDING_MARKER = np.array([], dtype=np.float32).tobytes()
+
+
+def _write_corrupt_jpeg(path) -> str:
+    with open(path, "wb") as handle:
+        handle.write(_CORRUPT_JPEG_BYTES)
+    return str(path)
+
+
+def _seed_picture(vault, file_path: str, image_embedding) -> int:
+    """Insert one Picture row and return its id."""
+    now = datetime.now()
+
+    def seed(session: Session):
+        picture = Picture(
+            file_path=file_path,
+            format="jpg",
+            width=64,
+            height=64,
+            deleted=False,
+            imported_at=now,
+            image_embedding=image_embedding,
+            aesthetic_score=3.0,
+            created_at=now,
+        )
+        session.add(picture)
+        session.commit()
+        return picture.id
+
+    return vault.db.run_task(seed)
+
+
+def _fetch_work_ids(vault) -> set:
+    work = vault.db.run_task(
+        lambda session: ImageEmbeddingTask.fetch_work(
+            session,
+            aesthetic_disabled=True,
+        )
+    )
+    return {pid for pid, _ in work}
+
+
+def test_585_corrupt_image_left_null_is_endlessly_reselected(tmp_path):
+    """#585: a corrupt image whose column stays NULL is re-selected forever."""
+    corrupt_path = _write_corrupt_jpeg(tmp_path / "corrupt.jpg")
+
+    with Vault(image_root=str(tmp_path)) as vault:
+        # Step 1: a Picture pointing at the invalid file, target column unset.
+        pic_id = _seed_picture(vault, corrupt_path, image_embedding=None)
+
+        # Step 2: the root cause — the file genuinely fails to open.
+        assert os.path.exists(corrupt_path), "file must exist so it is not purged"
+        assert ImageUtils.load_image_or_video_bgr(corrupt_path) is None
+
+        # Step 3: the finder's candidate query selects the invalid picture.
+        assert pic_id in _fetch_work_ids(vault)
+
+        # Step 4: simulate one full processing attempt that fails. A failed load
+        # cannot produce an embedding and NOTHING marks the picture, so the
+        # column stays NULL. Running the selection again re-selects the SAME
+        # picture. THIS is the reproduction: it will be retried forever.
+        #
+        # (No DB write happens here precisely because there is no failed/skip
+        # mechanism to write — that absence is the bug.)
+        assert pic_id in _fetch_work_ids(vault), (
+            "#585: corrupt image re-selected after a failed attempt (endless retry)"
+        )
+
+
+def test_585_corrupt_image_failed_marker_is_endlessly_reselected(tmp_path):
+    """#585: even the task's own empty-blob 'failed' marker is re-selected.
+
+    ImageEmbeddingTask._build_failure_updates writes a zero-length embedding when
+    it cannot decode an image, but fetch_work treats a zero-length blob as
+    still-missing (``func.length(image_embedding) == 0``). So the only 'mark
+    failed' write the pipeline performs does not stop re-selection either — there
+    is no effective skip mechanism anywhere.
+    """
+    corrupt_path = _write_corrupt_jpeg(tmp_path / "corrupt.jpg")
+
+    with Vault(image_root=str(tmp_path)) as vault:
+        pic_id = _seed_picture(vault, corrupt_path, image_embedding=None)
+
+        assert ImageUtils.load_image_or_video_bgr(corrupt_path) is None
+        assert pic_id in _fetch_work_ids(vault)
+
+        # Apply the exact failure marking the real task writes on a load failure.
+        def mark_failed(session: Session):
+            picture = session.get(Picture, pic_id)
+            picture.image_embedding = _EMPTY_EMBEDDING_MARKER
+            session.commit()
+
+        vault.db.run_task(mark_failed)
+
+        # The empty-blob marker does NOT remove the picture from the work set.
+        assert pic_id in _fetch_work_ids(vault), (
+            "#585: empty-blob 'failed' marker is still re-selected (endless retry)"
+        )
+        remaining = vault.db.run_task(
+            lambda session: ImageEmbeddingTask.count_remaining(
+                session, aesthetic_disabled=True
+            )
+        )
+        assert int(remaining or 0) == 1

--- a/tests/test_invalid_image_endless_retry.py
+++ b/tests/test_invalid_image_endless_retry.py
@@ -125,7 +125,7 @@ def test_585_corrupt_image_is_suppressed_after_failed_decode(tmp_path):
         _run_failed_decode(vault, pic_id, corrupt_path)
 
         registry = vault.db.unprocessable_images
-        assert registry.is_suppressed(pic_id, corrupt_path)
+        assert registry.is_suppressed(pic_id)
         suppressed = registry.active_suppressed_ids()
         assert suppressed == {pic_id}
 
@@ -167,7 +167,7 @@ def test_585_suppression_lifts_when_file_is_modified(tmp_path):
             corrupt_path, payload=_CORRUPT_JPEG_BYTES + b" now a different length"
         )
 
-        assert not registry.is_suppressed(pic_id, corrupt_path)
+        assert not registry.is_suppressed(pic_id)
         suppressed = registry.active_suppressed_ids()
         assert suppressed == set()
 
@@ -186,3 +186,34 @@ def test_585_suppression_lifts_when_file_is_modified(tmp_path):
         )
         assert pic_id in _fetch_work_ids(vault, suppressed_ids=suppressed)
         assert _count_remaining(vault, suppressed_ids=suppressed) == 1
+
+
+def test_585_filter_and_claim_never_reads_file_path(tmp_path):
+    """#585 regression: ``_filter_and_claim`` must not touch ``picture.file_path``.
+
+    The CI failure was a ``DetachedInstanceError``: some finders' candidate
+    queries return detached ``Picture`` objects whose ``file_path`` is deferred,
+    and the suppression check used to read it while claiming, crashing the
+    WorkPlanner thread. Suppression now looks the picture up by id against the
+    registry's own stored path, so ``file_path`` is never accessed here.
+    """
+
+    class _FilePathExplodes:
+        """Stands in for a detached Picture whose file_path would lazy-load."""
+
+        def __init__(self, pid: int):
+            self.id = pid
+
+        @property
+        def file_path(self):
+            raise AssertionError(
+                "_filter_and_claim must not access picture.file_path (#585)"
+            )
+
+    with Vault(image_root=str(tmp_path)) as vault:
+        finder = MissingImageEmbeddingFinder(
+            database=vault.db, engine_getter=lambda: None
+        )
+        candidates = [_FilePathExplodes(1), _FilePathExplodes(2)]
+        selected = finder._filter_and_claim(candidates, batch_limit=10)
+        assert [c.id for c in selected] == [1, 2]

--- a/tests/test_invalid_image_endless_retry.py
+++ b/tests/test_invalid_image_endless_retry.py
@@ -1,41 +1,35 @@
-"""Reproduction for GitHub issue #585 — "Invalid Images break tasks".
+"""Regression test for GitHub issue #585 — "Invalid Images break tasks".
 
-When a reference folder contains a corrupt/undecodable image, the task system
-retries it forever. The mechanism is generic to every ``Missing*Finder``:
+A corrupt/undecodable image used to be retried forever: a ``Missing*Finder``
+re-selects any picture whose target column is unset, the task cannot decode the
+file, and nothing durably marks it done (``ImageEmbeddingTask`` writes an *empty*
+embedding blob that ``fetch_work`` still treats as missing), so the same picture
+is picked up on every sweep.
 
-1. A finder selects pictures whose target column is unset. For image embeddings
-   that is ``MissingImageEmbeddingFinder``, whose candidate query is
-   ``ImageEmbeddingTask.fetch_work`` (``image_embedding IS NULL`` OR a
-   zero-length blob).
-2. The task tries to open the file. For a corrupt image
-   ``ImageUtils.load_image_or_video_bgr(path)`` returns ``None``, so no
-   embedding can be produced.
-3. There is **no field on ``Picture`` and no logic in any finder** that records a
-   picture as unprocessable / failed / skip. The one thing the task does write on
-   failure is an *empty* embedding blob (``_build_failure_updates`` →
-   ``np.array([], dtype=np.float32).tobytes()``), and ``fetch_work`` explicitly
-   treats a zero-length blob as still-missing. So whether the column is left
-   ``NULL`` or stamped with the empty "failed" marker, the finder re-selects the
-   same picture on the very next sweep — an unbounded retry loop.
+The fix is an in-memory, process-lifetime ``UnprocessableImageRegistry`` (owned by
+the database, reachable from both task and finder threads via ``self._db``):
 
-These tests assert the CURRENT (buggy) behavior so they pass today and pin the
-bug down. The eventual fix must give the pipeline a way to mark an
-unprocessable picture as done/failed so it is NOT re-selected; when that lands,
-the "re-selected again" assertions below become the ones that flip (the invalid
-picture must drop out of ``fetch_work`` after a failed attempt).
+* a decode failure in an image-reading task calls ``mark_unprocessable`` (the
+  shared choke point), pinning the picture to the file's current ``(mtime, size)``;
+* ``BaseTaskFinder._filter_and_claim`` skips suppressed pictures for every finder,
+  and ``count_remaining`` / ``fetch_work`` exclude them so progress can reach 0;
+* suppression is keyed on the file signature, so rewriting the file (the "still
+  being written" / repaired case) lifts it and the picture is retried.
 
-ML-free: exercises only the DB candidate query and the on-disk image loader — no
-CLIP / insightface / tagger inference is run.
+These tests assert the FIXED behavior. They exercise the real decode-failure path
+(``ImageEmbeddingTask._process_preloaded`` with a ``None`` image, which never
+touches CLIP) and the real suppression path (``_filter_and_claim`` /
+``count_remaining``). ML-free: no CLIP / insightface / tagger inference is run.
 """
 
 import os
 from datetime import datetime
 
-import numpy as np
 from sqlmodel import Session
 
 from pixlstash.db_models import Picture
 from pixlstash.tasks.image_embedding_task import ImageEmbeddingTask
+from pixlstash.tasks.missing_image_embedding_finder import MissingImageEmbeddingFinder
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.vault import Vault
 
@@ -43,19 +37,15 @@ from pixlstash.vault import Vault
 # the PIL fallback in ``load_image_or_video_bgr`` both refuse them.
 _CORRUPT_JPEG_BYTES = b"this is not a real JPEG, just some garbage bytes \xff\xd8\x00"
 
-# The exact "failed" marker ImageEmbeddingTask._build_failure_updates writes when
-# it cannot produce an embedding: a zero-length float32 blob.
-_EMPTY_EMBEDDING_MARKER = np.array([], dtype=np.float32).tobytes()
 
-
-def _write_corrupt_jpeg(path) -> str:
+def _write_corrupt_jpeg(path, payload: bytes = _CORRUPT_JPEG_BYTES) -> str:
     with open(path, "wb") as handle:
-        handle.write(_CORRUPT_JPEG_BYTES)
+        handle.write(payload)
     return str(path)
 
 
-def _seed_picture(vault, file_path: str, image_embedding) -> int:
-    """Insert one Picture row and return its id."""
+def _seed_picture(vault, file_path: str) -> int:
+    """Insert one Picture row (embedding unset) and return its id."""
     now = datetime.now()
 
     def seed(session: Session):
@@ -66,7 +56,7 @@ def _seed_picture(vault, file_path: str, image_embedding) -> int:
             height=64,
             deleted=False,
             imported_at=now,
-            image_embedding=image_embedding,
+            image_embedding=None,
             aesthetic_score=3.0,
             created_at=now,
         )
@@ -77,75 +67,122 @@ def _seed_picture(vault, file_path: str, image_embedding) -> int:
     return vault.db.run_task(seed)
 
 
-def _fetch_work_ids(vault) -> set:
+def _fetch_work_ids(vault, suppressed_ids=None) -> set:
     work = vault.db.run_task(
         lambda session: ImageEmbeddingTask.fetch_work(
             session,
             aesthetic_disabled=True,
+            suppressed_ids=suppressed_ids,
         )
     )
     return {pid for pid, _ in work}
 
 
-def test_585_corrupt_image_left_null_is_endlessly_reselected(tmp_path):
-    """#585: a corrupt image whose column stays NULL is re-selected forever."""
-    corrupt_path = _write_corrupt_jpeg(tmp_path / "corrupt.jpg")
-
-    with Vault(image_root=str(tmp_path)) as vault:
-        # Step 1: a Picture pointing at the invalid file, target column unset.
-        pic_id = _seed_picture(vault, corrupt_path, image_embedding=None)
-
-        # Step 2: the root cause — the file genuinely fails to open.
-        assert os.path.exists(corrupt_path), "file must exist so it is not purged"
-        assert ImageUtils.load_image_or_video_bgr(corrupt_path) is None
-
-        # Step 3: the finder's candidate query selects the invalid picture.
-        assert pic_id in _fetch_work_ids(vault)
-
-        # Step 4: simulate one full processing attempt that fails. A failed load
-        # cannot produce an embedding and NOTHING marks the picture, so the
-        # column stays NULL. Running the selection again re-selects the SAME
-        # picture. THIS is the reproduction: it will be retried forever.
-        #
-        # (No DB write happens here precisely because there is no failed/skip
-        # mechanism to write — that absence is the bug.)
-        assert pic_id in _fetch_work_ids(vault), (
-            "#585: corrupt image re-selected after a failed attempt (endless retry)"
-        )
-
-
-def test_585_corrupt_image_failed_marker_is_endlessly_reselected(tmp_path):
-    """#585: even the task's own empty-blob 'failed' marker is re-selected.
-
-    ImageEmbeddingTask._build_failure_updates writes a zero-length embedding when
-    it cannot decode an image, but fetch_work treats a zero-length blob as
-    still-missing (``func.length(image_embedding) == 0``). So the only 'mark
-    failed' write the pipeline performs does not stop re-selection either — there
-    is no effective skip mechanism anywhere.
-    """
-    corrupt_path = _write_corrupt_jpeg(tmp_path / "corrupt.jpg")
-
-    with Vault(image_root=str(tmp_path)) as vault:
-        pic_id = _seed_picture(vault, corrupt_path, image_embedding=None)
-
-        assert ImageUtils.load_image_or_video_bgr(corrupt_path) is None
-        assert pic_id in _fetch_work_ids(vault)
-
-        # Apply the exact failure marking the real task writes on a load failure.
-        def mark_failed(session: Session):
-            picture = session.get(Picture, pic_id)
-            picture.image_embedding = _EMPTY_EMBEDDING_MARKER
-            session.commit()
-
-        vault.db.run_task(mark_failed)
-
-        # The empty-blob marker does NOT remove the picture from the work set.
-        assert pic_id in _fetch_work_ids(vault), (
-            "#585: empty-blob 'failed' marker is still re-selected (endless retry)"
-        )
-        remaining = vault.db.run_task(
+def _count_remaining(vault, suppressed_ids=None) -> int:
+    return int(
+        vault.db.run_task(
             lambda session: ImageEmbeddingTask.count_remaining(
+                session,
+                aesthetic_disabled=True,
+                suppressed_ids=suppressed_ids,
+            )
+        )
+        or 0
+    )
+
+
+def _run_failed_decode(vault, pic_id: int, file_path: str) -> None:
+    """Drive the real decode-failure path of ImageEmbeddingTask for one picture.
+
+    A ``None`` preloaded image is exactly what the preload thread produces for a
+    corrupt file. This branch writes the empty-blob 'failed' marker and calls the
+    shared ``mark_unprocessable`` choke point — without ever touching CLIP.
+    """
+    task = ImageEmbeddingTask(
+        database=vault.db,
+        clip_workflow=None,
+        batch=[(pic_id, file_path)],
+    )
+    task._process_preloaded([(pic_id, file_path, None)])
+
+
+def test_585_corrupt_image_is_suppressed_after_failed_decode(tmp_path):
+    """#585 (fixed): a corrupt image is NOT re-selected after a failed decode."""
+    corrupt_path = _write_corrupt_jpeg(tmp_path / "corrupt.jpg")
+
+    with Vault(image_root=str(tmp_path)) as vault:
+        pic_id = _seed_picture(vault, corrupt_path)
+
+        # Root cause is real: the file genuinely fails to open.
+        assert os.path.exists(corrupt_path)
+        assert ImageUtils.load_image_or_video_bgr(corrupt_path) is None
+
+        # Before the fix runs: the finder's raw query selects it (still missing).
+        assert pic_id in _fetch_work_ids(vault)
+        assert _count_remaining(vault) == 1
+
+        # Drive one real, failed processing attempt (marks it unprocessable).
+        _run_failed_decode(vault, pic_id, corrupt_path)
+
+        registry = vault.db.unprocessable_images
+        assert registry.is_suppressed(pic_id, corrupt_path)
+        suppressed = registry.active_suppressed_ids()
+        assert suppressed == {pic_id}
+
+        # The finder now excludes it at the shared claim choke point...
+        finder = MissingImageEmbeddingFinder(
+            database=vault.db, engine_getter=lambda: None
+        )
+        rows = vault.db.run_task(
+            lambda session: ImageEmbeddingTask.fetch_work(
                 session, aesthetic_disabled=True
             )
         )
-        assert int(remaining or 0) == 1
+        selected = finder._filter_and_claim(rows, batch_limit=10)
+        assert pic_id not in {getattr(row, "id", None) for row in selected}, (
+            "#585: suppressed corrupt image must not be claimed for a new task"
+        )
+
+        # ...and both the candidate query and progress count drop it to zero.
+        assert _fetch_work_ids(vault, suppressed_ids=suppressed) == set()
+        assert _count_remaining(vault, suppressed_ids=suppressed) == 0
+
+
+def test_585_suppression_lifts_when_file_is_modified(tmp_path):
+    """#585 "until modified": rewriting the file makes the picture selectable again."""
+    corrupt_path = _write_corrupt_jpeg(tmp_path / "corrupt.jpg")
+
+    with Vault(image_root=str(tmp_path)) as vault:
+        pic_id = _seed_picture(vault, corrupt_path)
+        _run_failed_decode(vault, pic_id, corrupt_path)
+
+        registry = vault.db.unprocessable_images
+        assert registry.active_suppressed_ids() == {pic_id}
+        assert _count_remaining(vault, suppressed_ids={pic_id}) == 0
+
+        # The file is modified (e.g. an interrupted write finally completes). A
+        # different size guarantees the signature moves even on coarse-mtime
+        # filesystems, so suppression must lift regardless of timer resolution.
+        _write_corrupt_jpeg(
+            corrupt_path, payload=_CORRUPT_JPEG_BYTES + b" now a different length"
+        )
+
+        assert not registry.is_suppressed(pic_id, corrupt_path)
+        suppressed = registry.active_suppressed_ids()
+        assert suppressed == set()
+
+        # It is selectable again: the finder claims it and it counts as remaining.
+        finder = MissingImageEmbeddingFinder(
+            database=vault.db, engine_getter=lambda: None
+        )
+        rows = vault.db.run_task(
+            lambda session: ImageEmbeddingTask.fetch_work(
+                session, aesthetic_disabled=True
+            )
+        )
+        selected = finder._filter_and_claim(rows, batch_limit=10)
+        assert pic_id in {getattr(row, "id", None) for row in selected}, (
+            "#585: a modified file must be retried, not permanently suppressed"
+        )
+        assert pic_id in _fetch_work_ids(vault, suppressed_ids=suppressed)
+        assert _count_remaining(vault, suppressed_ids=suppressed) == 1


### PR DESCRIPTION
Fixes #585.

Corrupt or undecodable images in a reference folder were retried forever. Every `Missing*Finder` re-selects a picture whose target column is unset, and a file that can't be decoded never produces one — so the tagging/embedding/etc. tasks kept re-opening the same broken file every sweep, spamming warnings and crowding out real work. (`ImageEmbeddingTask` even wrote an empty embedding blob on failure, which `fetch_work` still treats as missing.)

**Fix:** an in-memory `UnprocessableImageRegistry`.
- A task marks a picture when its image can't be decoded (`load_image_or_video_bgr` returns `None`) — only genuine decode failures, not transient GPU/inference errors, which must still retry.
- Finders skip marked pictures at the shared `_filter_and_claim` choke point, so every batch finder benefits uniformly.
- Suppression is keyed on the file's `mtime`+`size`, so a repaired or rewritten file is retried automatically (covers the "read while still being written" case), and everything clears on restart — matching the expected behavior in the issue ("ignored for the server lifetime, or until modified").

No schema change / no migration. Faces and quality already self-terminate on decode failure via sentinel rows; image embedding was the actual looper. Includes a reproduction test: a corrupt image is suppressed after a failed decode and no longer re-selected, and suppression lifts once the file is modified.
