### PR TITLE
Restore dark-surface status hues to a legible foreground set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed: Smart Score only counts defects that are actually in a picture's tag list, so pictures the tagger flagged behind the scenes but never tagged are no longer pushed down the grid. Affected scores are recalculated once in the background when you upgrade.
 - Unloading a model frees the VRAM it was holding, and the budget readout reflects it.
 - Refreshed Appearance pane and a unified amber palette across the app and the website, with dark mode fixes on the website and install pages.
+- Fixed: Status labels and buttons in the review rail, lightbox and notices are readable again on dark backgrounds. The refreshed palette had left several of them too dark to make out.
 - Symmetrical sidebars, a stats panel that docks at every width, and full-width pair review in the review overlay.
 - Fix watch folders importing the same picture twice when it was picked up while the file was still being copied in.
 - Every API route now goes through one deny-by-default authorization gate that enforces object access from a declared policy, and routes that declare nothing are refused instead of served [Security:Moderate]

--- a/docs/design/design-system-handoff.md
+++ b/docs/design/design-system-handoff.md
@@ -9,6 +9,13 @@ Sources of truth (in-repo): tokens `docs/design/design-tokens.css`, spec
 `docs/design/visual-language.md`, color `frontend/src/main.js`. This page mirrors them
 as of `v1.8.0-foundations` (2026-07). If they diverge later, the repo wins.
 
+> **Partially stale (2026-07-26).** `6e14c32c` deepened the four status hues and this
+> page was not updated with it, so the `<status>` / `on-<status>` rows and the contrast
+> figures quoted for them still describe the pre-`6e14c32c` palette. The
+> `dark-surface-<status>` rows *have* been corrected. For current status values read
+> `frontend/src/main.js`, or run `npm run audit:contrast` in `frontend/` for the
+> measured table.
+
 ---
 
 ## 1. The idea in three words
@@ -155,10 +162,10 @@ go white; dark: chrome is a raised dark surface, elevation reads by lightness).
 | `warning` / `on-warning` | `#b8861f` / `#23211d` | `#db7900` / `#1b1b1b` | warning |
 | `info` / `on-info` | `#1a6ec4` / `#ffffff` | `#2196F3` / `#1b1b1b` | info |
 | `dark-surface` / `on-dark-surface` | `#242628` / `#f2e5da` | `#181b20` / `#f2e5da` | deliberately-dark chrome (lightbox) |
-| `dark-surface-success` | `#4caf50` | `#4caf50` | status hue **inside** a `dark-surface` |
-| `dark-surface-error` | `#f44336` | `#f44336` | " |
-| `dark-surface-warning` | `#db7900` | `#db7900` | " |
-| `dark-surface-info` | `#2196F3` | `#2196F3` | " |
+| `dark-surface-success` | `#5d9c6c` | `#5d9c6c` | status hue **inside** a `dark-surface` (foreground, so lighter than the fill hue) |
+| `dark-surface-error` | `#c9786f` | `#c9786f` | " |
+| `dark-surface-warning` | `#e8912f` | `#e8912f` | " |
+| `dark-surface-info` | `#6b92b0` | `#6b92b0` | " |
 | `dark-surface-primary` | `#8EA604` | `#8EA604` | `primary` as a foreground **inside** a `dark-surface` |
 | `sidebar-hover` / `on-sidebar-hover` | `#9e6727` / `#ffffff` | `#b85c0c` / `#ffffff` | sidebar row hover (= the accent value) |
 | `focus` | `#7c4dff` | `#7c4dff` | (legacy; focus rings use `--focus-ring`) |

--- a/docs/design/notice-surface.md
+++ b/docs/design/notice-surface.md
@@ -358,11 +358,29 @@ theme's *canvas*, which is the opposite lightness. So there is now a fourth fami
 identical in both themes and equal to the dark-tuned hues:
 
 ```js
-'dark-surface-error':   '#f44336',   // 4.12:1 on #242628, 4.69:1 on #181b20
-'dark-surface-warning': '#db7900',   // 4.88 / 5.55
-'dark-surface-success': '#4caf50',   // 5.46 / 6.21
-'dark-surface-info':    '#2196F3',   // 4.86 / 5.53
+'dark-surface-error':   '#c9786f',   // 4.63:1 on #242628, 5.26:1 on #181b20
+'dark-surface-warning': '#e8912f',   // 6.16 / 7.01
+'dark-surface-success': '#5d9c6c',   // 4.65 / 5.29
+'dark-surface-info':    '#6b92b0',   // 4.60 / 5.23
 ```
+
+**This family is a FOREGROUND family, and that is the whole point.** Updated
+2026-07-26, after the values above were briefly replaced by the deep fill hues.
+`6e14c32c` deepened the four status hues — correct for the fill tier, where a deep
+hue is what lets a warm near-white label clear 4.5:1 — and the same four values were
+applied here in the same pass. That inverted the family's purpose: these are not
+fills that carry a label, they are the label. On `#242628` they fell to `error`
+**2.51**, `info` **2.48**, `success` **2.97**, against the 4.5:1 those 11px semibold
+`ReviewRail` buttons need. The current values are the same four hues lifted toward
+white until they read as text, so the palette stays one family with two lightness
+poles: deep for fills, light for foregrounds on dark chrome.
+
+The earlier values (`#f44336` / `#db7900` / `#4caf50` / `#2196F3`) were not restored:
+`#f44336` measured 4.12:1 here, already under the floor, and saturated Material
+primaries now sit beside the deepened fills.
+
+Arithmetic for every pair in both themes is enforced by
+`frontend/src/utils/contrastAudit.test.js`; `npm run audit:contrast` prints the table.
 
 The eleven `success` declarations moved onto it, as did the notice host's `--on-dark`
 variant (§2.5) and the two `ImageOverlay` chips above. **Not** migrated: the ~40

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
+    "audit:contrast": "node src/utils/contrastAudit.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -67,15 +67,18 @@ const pixlStashLight = {
     "dark-surface": "#242628",
     "on-dark-surface": "#f2e5da",
     // Status hues FOR the deliberately-dark surfaces. A `dark-surface` stays
-    // dark in both themes, so the theme's own status hues — tuned for that
-    // theme's canvas — are the wrong values inside it: the deepened light
-    // `success` reads 2.96:1 there. These four are identical in both themes
-    // (they are the dark-tuned hues) and measure 4.12:1 – 5.46:1 plain on
-    // `#242628`, 3.49:1 – 4.23:1 on their own 16% tint.
-    "dark-surface-error": "#b0392b  ",
+    // dark in both themes, so the theme's own status hues are the wrong values
+    // inside it — and in the specific direction that matters: the fill hues are
+    // tuned to CARRY a light label, not to BE one. This family is their light
+    // counterpart, the same four hues lifted until they read as 11px semibold
+    // text (`ReviewRail`'s Abort/Clear). Identical in both themes. Measured
+    // 4.60:1 – 6.16:1 plain on `#242628`, 5.23:1 – 7.01:1 on `#181b20`.
+    // Deep fill hues here would fail: `error` #b0392b reads 2.51:1, `info`
+    // #2f6690 2.48:1, `success` #2a7d3e 2.97:1.
+    "dark-surface-error": "#c9786f",
     "dark-surface-warning": "#e8912f",
-    "dark-surface-success": "#2a7d3e",
-    "dark-surface-info": "#2f6690",
+    "dark-surface-success": "#5d9c6c",
+    "dark-surface-info": "#6b92b0",
     // The fifth member of the family, same rationale: `primary` as a FOREGROUND
     // on a dark card. This is the dark theme's outgoing bright olive — a good
     // foreground on a dark card and a bad fill under a white label, so it moves
@@ -113,8 +116,8 @@ const pixlStashLight = {
     // Status hues + their authored foregrounds. The foreground is whichever of
     // the warm near-white / warm near-black clears 4.5:1 on the SOLID fill; it
     // is not a house style, it is the only value that passes. Measured:
-    error: "#b0392b",
-    "on-error": "#f7f1ea", //   4.86:1
+    error: "#b54538",
+    "on-error": "#f7f1ea", //   4.83:1 (same value in both themes)
     info: "#1a6ec4",
     "on-info": "#ffffff", //    5.16:1
     success: "#2e7d32",
@@ -144,13 +147,13 @@ const pixlStashDark = {
     "cancel-button-text": "#f2e5da",
     "dark-surface": "#181b20",
     "on-dark-surface": "#f2e5da",
-    // Same four values as the light theme by design — see the note there. In
-    // this theme they coincide with the theme's own status hues, so pointing a
-    // dark-surface consumer at them is a no-op here and a fix in light mode.
-    "dark-surface-error": "#b0392b",
+    // Same four values as the light theme by design — see the note there. They
+    // are deliberately LIGHTER than this theme's own status hues: those are
+    // fills, these are foregrounds, and a `dark-surface` needs the latter.
+    "dark-surface-error": "#c9786f",
     "dark-surface-warning": "#e8912f",
-    "dark-surface-success": "#2a7d3e",
-    "dark-surface-info": "#2f6690",
+    "dark-surface-success": "#5d9c6c",
+    "dark-surface-info": "#6b92b0",
     // Identical in both themes, like the four above. Keeps the retired bright
     // olive in service as a dark-card foreground (6.25:1 on #181b20).
     "dark-surface-primary": "#8EA604",
@@ -177,18 +180,20 @@ const pixlStashDark = {
     overlay: "#00000066",
     focus: "#7c4dff",
     hover: "#ffffff14",
-    // Status hues stay BRIGHT in dark mode: their dominant use is as a
-    // foreground on a dark surface, where deepening them would hurt. A bright
-    // fill takes a dark foreground, so all four pair with the same warm
-    // near-black the theme already uses for `on-accent`. Measured:
-    error: "#b0392b",
-    "on-error": "#f7f1ea", //   4.68:1
-    info: "#2f6690",
-    "on-info": "#1b1b1b", //    5.51:1
+    // Status hues are DEEP in both themes (unified Camp B palette), so three of
+    // the four carry the warm near-white label like every other fill tier here.
+    // `warning` is the exception: it is bright enough that the label has to flip
+    // to the warm near-black instead. Foreground-on-dark-chrome is a different
+    // job with its own family — see `dark-surface-<status>` above; do not reach
+    // for these values there. Measured on the SOLID fill:
+    error: "#b54538",
+    "on-error": "#f7f1ea", //   4.83:1
+    info: "#3b6f97",
+    "on-info": "#f7f1ea", //    4.79:1
     success: "#2a7d3e",
-    "on-success": "#1b1b1b", // 6.20:1
+    "on-success": "#f7f1ea", // 4.57:1
     warning: "#e8912f",
-    "on-warning": "#1b1b1b", // 5.53:1
+    "on-warning": "#1b1b1b", // 6.99:1
     scrim: "#000000",
     shadow: "#2a2f36",
     panel: "#313337",

--- a/frontend/src/utils/contrastAudit.js
+++ b/frontend/src/utils/contrastAudit.js
@@ -1,0 +1,253 @@
+/**
+ * Contrast audit for the status-colour token families in `src/main.js`.
+ *
+ * Why this exists: on 2026-07-26 the dark-mode status hues were deepened in one
+ * pass. That was right for the FILL tier and wrong for `dark-surface-<status>`,
+ * which is a FOREGROUND family — it styles 11px semibold labels on chrome that
+ * stays dark in both themes. Three of the four dropped to 2.48:1 – 2.97:1 and
+ * nothing caught it, because a token pair is only measured if some test happens
+ * to render it. The Playwright suite covers the notice card and nothing else.
+ *
+ * So the hues are parsed straight out of `main.js` rather than duplicated here:
+ * a value that changes there is re-measured here on the next run, and cannot
+ * drift out of sync the way the hand-written `// 5.51:1` comments did.
+ *
+ * Run it:      npm run audit:contrast
+ * Enforced by: src/utils/contrastAudit.test.js
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const MAIN_JS = resolve(HERE, '../main.js')
+
+const LEVELS = ['error', 'warning', 'success', 'info']
+
+/** Surfaces a status hue is rendered against, per theme. */
+const THEME_SURFACE = { light: '#ffffff', dark: '#23282f' }
+
+/**
+ * The deliberately-dark surfaces. These stay dark in BOTH themes, which is the
+ * whole reason `dark-surface-<status>` is a separate family.
+ */
+const DARK_CHROME = { light: '#242628', dark: '#181b20' }
+
+/** Tint alphas the notice host composites a status hue at (NoticeHost.vue). */
+const TINT_ON_THEME_SURFACE = 0.08
+const TINT_ON_DARK_CHROME = 0.14
+
+/**
+ * WCAG floors. 4.5 is the normal-text floor: `dark-surface-<status>` styles
+ * `--text-2xs` (11px) semibold labels in ReviewRail.vue, which is not large
+ * text. 2.5 is the notice rail's authored floor — it is decorative
+ * reinforcement (the glyph carries the variant) but must still read as a mark.
+ */
+const FLOOR_TEXT = 4.5
+const FLOOR_RAIL = 2.5
+
+/** `#rrggbb` → `{r,g,b}`. Tolerates stray whitespace in the source value. */
+export function parseHex(value) {
+  const h = String(value).trim().replace(/^#/, '')
+  if (!/^[0-9a-f]{6}$/i.test(h)) {
+    throw new Error(`Not a 6-digit hex colour: ${JSON.stringify(value)}`)
+  }
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  }
+}
+
+/** WCAG 2.x relative luminance. Matches `frontend/e2e/pages/NoticeHost.js`. */
+function luminance(c) {
+  const ch = [c.r, c.g, c.b].map((v) => {
+    const s = v / 255
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  })
+  return 0.2126 * ch[0] + 0.7152 * ch[1] + 0.0722 * ch[2]
+}
+
+/** Accept either `#rrggbb` or an already-parsed `{r,g,b}`. */
+function toRgb(value) {
+  return typeof value === 'string' ? parseHex(value) : value
+}
+
+/** WCAG contrast ratio between two opaque colours, either order. */
+export function contrastRatio(a, b) {
+  const la = luminance(toRgb(a))
+  const lb = luminance(toRgb(b))
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+}
+
+/**
+ * Composite a translucent hue over an opaque background.
+ *
+ * Channels stay FRACTIONAL. The e2e helper does the same, and rounding to 8-bit
+ * here would shift a ratio by ~0.002 — enough for this audit and the Playwright
+ * assertion to disagree about a pair sitting on its floor. Use `toHex` when a
+ * composited colour needs to be displayed.
+ */
+export function composite(fg, bg, alpha) {
+  const f = toRgb(fg)
+  const b = toRgb(bg)
+  const mix = (x, y) => x * alpha + y * (1 - alpha)
+  return { r: mix(f.r, b.r), g: mix(f.g, b.g), b: mix(f.b, b.b) }
+}
+
+/** `{r,g,b}` → `#rrggbb`, rounding to 8-bit only at the point of display. */
+export function toHex(c) {
+  return (
+    '#' +
+    [c.r, c.g, c.b]
+      .map((v) => Math.round(v).toString(16).padStart(2, '0'))
+      .join('')
+  )
+}
+
+/**
+ * Pull the two `colors: { … }` blocks out of `main.js`.
+ *
+ * A regex rather than an import because `main.js` boots the whole app (Vue,
+ * Vuetify, the router) the moment it is evaluated. The block is a flat map of
+ * string literals, so there is nothing here a parser would do better.
+ */
+export function readThemeColors(source = readFileSync(MAIN_JS, 'utf8')) {
+  const themes = {}
+  for (const [name, marker] of [
+    ['light', 'pixlStashLight'],
+    ['dark', 'pixlStashDark'],
+  ]) {
+    const start = source.indexOf(`const ${marker} = {`)
+    if (start === -1) throw new Error(`Could not find "const ${marker}" in main.js`)
+    const open = source.indexOf('colors: {', start)
+    if (open === -1) throw new Error(`Could not find the colors block for ${marker}`)
+    const close = source.indexOf('\n  },', open)
+    if (close === -1) throw new Error(`Unterminated colors block for ${marker}`)
+
+    const block = source.slice(open, close)
+    const colors = {}
+    // `key: "#hex"` or `"quoted-key": "#hex"`, ignoring trailing comments.
+    for (const m of block.matchAll(/^\s*"?([\w-]+)"?:\s*"([^"]+)"/gm)) {
+      colors[m[1]] = m[2]
+    }
+    if (Object.keys(colors).length === 0) {
+      throw new Error(`Parsed no colours for ${marker} — has main.js changed shape?`)
+    }
+    themes[name] = colors
+  }
+  return themes
+}
+
+/**
+ * Measure every status pair in both themes.
+ *
+ * @returns {Array<{group,name,fg,bg,ratio,floor,pass}>} one row per pair.
+ */
+export function auditContrast(themes = readThemeColors()) {
+  const rows = []
+  const add = (group, name, fg, bg, floor) => {
+    const ratio = contrastRatio(fg, bg)
+    rows.push({
+      group,
+      name,
+      fg: typeof fg === 'string' ? fg : toHex(fg),
+      bg: typeof bg === 'string' ? bg : toHex(bg),
+      ratio,
+      floor,
+      pass: ratio >= floor,
+    })
+  }
+
+  for (const theme of ['light', 'dark']) {
+    const c = themes[theme]
+    const surface = THEME_SURFACE[theme]
+    const chrome = DARK_CHROME[theme]
+
+    const need = (key) => {
+      const v = c[key]
+      if (!v) throw new Error(`${theme} theme is missing "${key}"`)
+      return v
+    }
+
+    // The authored label on its solid fill. This is the pair the stale
+    // `// 5.51:1` comments described, and the one nothing was checking.
+    for (const level of LEVELS) {
+      add(
+        `${theme} · fill label`,
+        `on-${level} on ${level}`,
+        need(`on-${level}`),
+        need(level),
+        FLOOR_TEXT,
+      )
+    }
+
+    // The notice rail: the hue against the card it tints. Mirrors
+    // NoticeHost.vue's `--notice-status` over `--notice-tint`.
+    for (const level of LEVELS) {
+      const fill = need(level)
+      add(
+        `${theme} · notice rail`,
+        `${level} rail`,
+        fill,
+        composite(fill, surface, TINT_ON_THEME_SURFACE),
+        FLOOR_RAIL,
+      )
+    }
+
+    // The foreground family, on the chrome that stays dark in this theme.
+    for (const level of LEVELS) {
+      const onDark = need(`dark-surface-${level}`)
+      add(
+        `${theme} · on dark chrome (${chrome})`,
+        `dark-surface-${level} text`,
+        onDark,
+        chrome,
+        FLOOR_TEXT,
+      )
+      add(
+        `${theme} · on dark chrome (${chrome})`,
+        `dark-surface-${level} rail`,
+        onDark,
+        composite(onDark, chrome, TINT_ON_DARK_CHROME),
+        FLOOR_RAIL,
+      )
+    }
+  }
+  return rows
+}
+
+/** Pretty-print the audit. Returns the process exit code. */
+export function reportContrast(rows = auditContrast(), log = console.log) {
+  let lastGroup = null
+  let failures = 0
+
+  for (const row of rows) {
+    if (row.group !== lastGroup) {
+      log(`\n  ${row.group}`)
+      log(`  ${'-'.repeat(64)}`)
+      lastGroup = row.group
+    }
+    if (!row.pass) failures += 1
+    const verdict = row.pass ? 'ok  ' : 'FAIL'
+    log(
+      `  ${verdict}  ${row.name.padEnd(30)} ` +
+        `${row.fg} on ${row.bg}  ` +
+        `${row.ratio.toFixed(2).padStart(5)} / ${row.floor.toFixed(1)}`,
+    )
+  }
+
+  log('')
+  if (failures === 0) {
+    log(`  All ${rows.length} pairs clear their floors.\n`)
+    return 0
+  }
+  log(`  ${failures} of ${rows.length} pairs are below their floor.\n`)
+  return 1
+}
+
+// CLI entry point: `npm run audit:contrast`.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = reportContrast()
+}

--- a/frontend/src/utils/contrastAudit.test.js
+++ b/frontend/src/utils/contrastAudit.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  auditContrast,
+  composite,
+  contrastRatio,
+  parseHex,
+  readThemeColors,
+  toHex,
+} from './contrastAudit.js'
+
+// Regression gate for the 2026-07-26 palette incident: deepening the status
+// hues in one pass broke `dark-surface-<status>`, which is a FOREGROUND family
+// (11px semibold labels in ReviewRail.vue on chrome that stays dark in both
+// themes). Three of four fell to 2.48:1 – 2.97:1 and shipped to develop,
+// because the only contrast coverage in the repo was the Playwright notice-card
+// spec — it renders the rail and nothing else.
+//
+// These assert the arithmetic on every pair, so a token edit that breaks a pair
+// no test happens to render still fails here.
+
+describe('contrast audit helpers', () => {
+  it('parses hex with and without a leading # and stray whitespace', () => {
+    expect(parseHex('#b54538')).toEqual({ r: 181, g: 69, b: 56 })
+    expect(parseHex('b54538')).toEqual({ r: 181, g: 69, b: 56 })
+    // A trailing-space typo shipped in main.js once ("#b0392b  "); Vuetify's
+    // parseHex silently rewrote the spaces to an FF alpha rather than erroring.
+    expect(parseHex('#b0392b  ')).toEqual({ r: 176, g: 57, b: 43 })
+  })
+
+  it('rejects anything that is not a 6-digit hex', () => {
+    expect(() => parseHex('#fff')).toThrow(/6-digit hex/)
+    expect(() => parseHex('rebeccapurple')).toThrow(/6-digit hex/)
+  })
+
+  it('computes the WCAG reference ratios', () => {
+    // The two anchors of the scale: identical colours are 1:1, black on white
+    // is 21:1.
+    expect(contrastRatio('#ffffff', '#ffffff')).toBeCloseTo(1, 5)
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 5)
+    // Order must not matter.
+    expect(contrastRatio('#b54538', '#ffffff')).toBeCloseTo(
+      contrastRatio('#ffffff', '#b54538'),
+      10,
+    )
+  })
+
+  it('matches the ratio Playwright measured for the failing rail', () => {
+    // frontend/e2e/specs/notice-surface.spec.js reported exactly this for
+    // dark/info before the fix. Same formula, so the audit and the e2e suite
+    // can never disagree about a value.
+    const bg = composite('#2f6690', '#23282f', 0.08)
+    expect(contrastRatio('#2f6690', bg)).toBeCloseTo(2.2762013, 5)
+  })
+
+  it('composites a translucent hue over its background', () => {
+    expect(toHex(composite('#ffffff', '#000000', 0))).toBe('#000000')
+    expect(toHex(composite('#ffffff', '#000000', 1))).toBe('#ffffff')
+    expect(toHex(composite('#ffffff', '#000000', 0.5))).toBe('#808080')
+  })
+
+  it('keeps composited channels fractional', () => {
+    // Rounding here would desync the audit from the Playwright assertion by
+    // ~0.002, which is enough to matter for a pair sitting on its floor.
+    expect(composite('#ffffff', '#000000', 0.5)).toEqual({
+      r: 127.5,
+      g: 127.5,
+      b: 127.5,
+    })
+  })
+})
+
+describe('main.js status tokens', () => {
+  const themes = readThemeColors()
+
+  it('defines both themes with all four status families', () => {
+    for (const theme of ['light', 'dark']) {
+      for (const level of ['error', 'warning', 'success', 'info']) {
+        expect(themes[theme][level], `${theme}.${level}`).toMatch(/^#[0-9a-f]{6}$/i)
+        expect(themes[theme][`on-${level}`], `${theme}.on-${level}`).toMatch(
+          /^#[0-9a-f]{6}$/i,
+        )
+        expect(
+          themes[theme][`dark-surface-${level}`],
+          `${theme}.dark-surface-${level}`,
+        ).toMatch(/^#[0-9a-f]{6}$/i)
+      }
+    }
+  })
+
+  it('keeps dark-surface-<status> identical across the two themes', () => {
+    // A dark-surface stays dark in both themes, so its status hues have no
+    // reason to differ. Divergence here means someone edited one theme only.
+    for (const level of ['error', 'warning', 'success', 'info']) {
+      expect(
+        themes.dark[`dark-surface-${level}`],
+        `dark-surface-${level} differs between themes`,
+      ).toBe(themes.light[`dark-surface-${level}`])
+    }
+  })
+
+  it('clears every contrast floor', () => {
+    const failures = auditContrast(themes)
+      .filter((row) => !row.pass)
+      .map(
+        (row) =>
+          `${row.group} — ${row.name}: ${row.fg} on ${row.bg} is ` +
+          `${row.ratio.toFixed(2)}:1, floor ${row.floor}:1`,
+      )
+    expect(failures).toEqual([])
+  })
+
+  it('measures every pair it claims to', () => {
+    // 2 themes x 4 levels x (fill label + notice rail + dark-chrome text +
+    // dark-chrome rail) = 32. Guards against a loop silently skipping a family.
+    expect(auditContrast(themes)).toHaveLength(32)
+  })
+})


### PR DESCRIPTION
Unblocks CI on `develop`, and fixes three further regressions from the same commit that no test was watching.

## What broke

`6e14c32c` (*Tweak UI colors*) deepened the four status hues. That is right for the **fill** tier, where a deep hue is what lets a warm near-white label clear 4.5:1. The same four values were applied to `dark-surface-<status>` in the same pass, and that family is the opposite job: it styles 11px semibold labels on chrome that stays dark in **both** themes (`ReviewRail.vue`'s Abort/Clear, the lightbox chips). Deepening it removed the one property it exists for.

| | ratio | floor | caught by CI |
|---|---|---|---|
| `dark-surface-info` as text on `#242628` | 2.48 | 4.5 | no |
| `dark-surface-error` as text on `#242628` | 2.51 | 4.5 | no |
| `dark-surface-success` as text on `#242628` | 2.97 | 4.5 | no |
| dark `on-info` (`#1b1b1b` on `#2f6690`) | 2.81 | 4.5 | no |
| dark `on-success` (`#1b1b1b` on `#2a7d3e`) | 3.36 | 4.5 | no |
| dark `info` notice rail | 2.28 | 2.5 | **yes** |
| dark `error` notice rail | 2.34 | 2.5 | next, once info passed |

The audit added here flags **12** failing pairs against current `develop`. CI saw one.

## What changed

- **`dark-surface-<status>` → the same hues at foreground lightness** (`#c9786f` / `#e8912f` / `#5d9c6c` / `#6b92b0`). Not the pre-`6e14c32c` Material brights: `#f44336` measured 4.12:1 here, already under the floor, and saturated primaries would now sit beside the deepened fills. Keeping one hue family with two lightness poles matches what `tokens/colors.css` already says about the palette being unified.
- **dark `on-info` / `on-success` → `#f7f1ea`.** Not a new decision: the design system's `tokens/colors.css` already declares `--info-on` and `--success-on` as `--ps-on-fill`, under a header stating every status fill is "deep enough to carry a warm near-white label at >=4.5:1". `main.js` simply never followed. `on-error` was already flipped in `6e14c32c`; these two were missed.
- **dark `info` `#2f6690`→`#3b6f97`, `error` `#b0392b`→`#b54538`** to clear the rail floor. `error` is changed in both themes so the two stay unified (light rail 4.84, label 4.83, both fine).
- Fixed `"dark-surface-error": "#b0392b  "` (trailing whitespace). Vuetify's `parseHex` was rewriting the spaces to an `FF` alpha, so it worked by accident.
- Corrected the ratio comments in `main.js`, which still quoted figures from the pre-`6e14c32c` hues.

## New coverage

`npm run audit:contrast` prints the measured table; `contrastAudit.test.js` asserts all 32 pairs. Hues are parsed out of `main.js` rather than duplicated, so the audit cannot drift the way the hand-written `// 5.51:1` comments did. Compositing stays in floating point to match `e2e/pages/NoticeHost.js` exactly, verified against the `2.2762013` Playwright reported.

The root cause was structural: a token pair is only measured if some test happens to render it, and the Playwright spec renders the notice card and nothing else. This closes that.

## Verification

- `npx playwright test` — 78 passed, 4 skipped. The failing `notice-surface.spec.js:430` (dark) now passes.
- `npx vitest run` — 839 passed, 57 files.
- `npx eslint` clean on all changed files.
- `npm run audit:contrast` — all 32 pairs clear.

## Notes

- A `Status on Dark Surfaces` card was added to the **PixlStash Design System** project in Claude Design. The family had no card, which is why nothing flagged the muting.
- `design-system-handoff.md`'s `<status>` / `on-<status>` rows were already stale before this branch (they still show `#cf3b30` / `#f44336`, i.e. pre-`6e14c32c`). I corrected the `dark-surface-*` rows this change owns and added a staleness note rather than half-rewriting the rest.