### PR TITLE
Widen watch-folder import waits for concurrent CI

### DIFF
--- a/tests/test_watch_folder_worker.py
+++ b/tests/test_watch_folder_worker.py
@@ -10,6 +10,14 @@ from pixlstash.db_models.picture import Picture
 
 API_PREFIX = "/api/v1"
 
+# Upper bound for "the watcher eventually imports the file" polls below. These
+# loops break as soon as the expected pictures appear, so a generous bound costs
+# a passing run nothing and only bounds the failing case. It has to be generous:
+# CI runs the backend gate as 8 concurrent shards (plus 4 Windows), so a runner
+# is far more contended than when these waits were written against a single
+# sequential job, and a scan cycle can take much longer in wall-clock terms.
+_IMPORT_WAIT_SECONDS = 60
+
 
 def test_watch_folder():
     """Test watching a folder for changes."""
@@ -52,7 +60,7 @@ def test_watch_folder():
                 start = time.monotonic()
                 pictures = []
                 expected_count = len(image_files)
-                while time.monotonic() - start < 20:
+                while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
                     pictures = server.vault.db.run_task(
                         lambda session: Picture.find(session)
                     )
@@ -130,7 +138,7 @@ def test_watch_folder_delete_after_import():
                 expected_count = len(image_files)
                 start = time.monotonic()
                 pictures = []
-                while time.monotonic() - start < 20:
+                while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
                     pictures = server.vault.db.run_task(
                         lambda session: Picture.find(session)
                     )
@@ -207,7 +215,7 @@ def test_watch_folder_imports_copied_files_with_old_mtime_after_initial_scan():
 
                 # Wait for initial import to complete.
                 start = time.monotonic()
-                while time.monotonic() - start < 20:
+                while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
                     pictures = server.vault.db.run_task(
                         lambda session: Picture.find(session)
                     )
@@ -228,7 +236,7 @@ def test_watch_folder_imports_copied_files_with_old_mtime_after_initial_scan():
 
                 # The second file should still be discovered and imported.
                 start = time.monotonic()
-                while time.monotonic() - start < 20:
+                while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
                     pictures = server.vault.db.run_task(
                         lambda session: Picture.find(session)
                     )
@@ -326,7 +334,7 @@ def test_watch_folder_retries_after_transient_hash_failure(monkeypatch):
                 # on a later scan after the finder re-discovers it.
                 start = time.monotonic()
                 pictures = []
-                while time.monotonic() - start < 30:
+                while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
                     pictures = server.vault.db.run_task(
                         lambda session: Picture.find(session)
                     )


### PR DESCRIPTION
Fixes the flaky `backend shard 5` failure seen on #599:

```
FAILED tests/test_watch_folder_worker.py::test_watch_folder_imports_copied_files_with_old_mtime_after_initial_scan
AssertionError: Expected second copied file to be imported even with old mtime
```

## Root cause

The test polls for the watch-folder worker to import a file, bounded at 20 seconds:

```python
start = time.monotonic()
while time.monotonic() - start < 20:
    ...
    time.sleep(0.25)
```

That bound was chosen when the backend gate was a **single sequential job**. Since #590 the gate runs as **8 concurrent Linux shards plus 4 Windows shards**, so a runner is far more contended and a scan cycle can take much longer in wall-clock terms. The 20s budget lapses and the assertion fires.

This is a test-timing issue, not a product bug:
- The test passes **3/3 locally** (~2.8s each), and shard 5 passes locally in full.
- 12 of 13 shards were green on the same CI run.
- The failing file is untouched by #599 (whose diff is one unrelated test file).

## The change

Replaces the five hardcoded poll budgets (4x `20`, 1x `30`) with a single named constant:

```python
_IMPORT_WAIT_SECONDS = 60
```

All five loops are the same "eventually imported" shape and were equally exposed, so fixing only the one that happened to fail would have left four flaky siblings.

**This does not weaken any assertion.** The bound is an upper limit and every loop `break`s as soon as the expected state appears, so a passing run is unaffected — only the failing case waits longer before reporting. Confirmed by runtime: the file still completes in **17.87s**, the same as before.

## Verification

`pytest tests/test_watch_folder_worker.py` -> **4 passed** in 17.87s. `ruff format` leaves it unchanged; `ruff check` passes.

## Follow-up worth considering

If this recurs even at 60s, the next step is to check whether the worker genuinely stalls under load rather than widening further. Also note `fix/watch-folder-duplicate-import` (`4b3ca490`) touches this subsystem and is not yet on `develop`.