### PR TITLE
Fix likeness-seed race that flaked test_stack_query_respects_project_filter

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,10 +26,9 @@ from pixlstash.db_models.face import Face
 from pixlstash.db_models.picture_set import PictureSetMember
 import pixlstash.routes.pictures as pictures_routes
 from pixlstash.pixl_logging import get_logger
-from pixlstash.utils.likeness.likeness_parameter_utils import LikenessParameterUtils
 from pixlstash.tasks.task_type import TaskType
 from pixlstash.server import Server
-from tests.utils import upload_pictures_and_wait, wait_for_faces
+from tests.utils import seed_likeness_stable, upload_pictures_and_wait, wait_for_faces
 
 logger = get_logger(__name__)
 
@@ -1410,31 +1409,10 @@ def test_stack_query_respects_project_filter():
                 )
                 session.commit()
 
-            # Wait for LikenessParametersTask to finish before seeding edges.
-            # That task calls reset_likeness_for_pictures which wipes PictureLikeness rows.
-            _deadline = time.monotonic() + 30.0
-            while time.monotonic() < _deadline:
-                _pending = server.vault.db.run_immediate_read_task(
-                    LikenessParameterUtils.count_pending_parameters
-                )
-                if (
-                    _pending == 0
-                    and not server.vault._task_runner.has_active_task_of_type(
-                        "LikenessParametersTask"
-                    )
-                ):
-                    break
-                time.sleep(0.05)
-            assert (
-                _pending == 0
-                and not server.vault._task_runner.has_active_task_of_type(
-                    "LikenessParametersTask"
-                )
-            ), (
-                f"LikenessParametersTask did not complete within deadline ({_pending} pending)"
-            )
-
-            server.vault.db.run_task(seed_likeness)
+            # The background likeness pipeline both wipes pairs
+            # (reset_likeness_for_pictures) and writes its own real ones, so seed
+            # only once it is quiescent and on a wiped slate.
+            seed_likeness_stable(server, seed_likeness)
 
             stacks_a_resp = client.get(
                 "/pictures/likeness-groups",
@@ -1968,9 +1946,9 @@ def test_pictures_likeness_groups_supports_set_intersection_filter():
             assert set_b_id is not None
 
             # /pictures/likeness-groups groups are built from likeness edges, so seed a chain.
-            def seed_likeness_edges(session, a: int, b: int, c: int):
-                ab_a, ab_b = sorted((a, b))
-                bc_a, bc_b = sorted((b, c))
+            def seed_likeness_edges(session):
+                ab_a, ab_b = sorted((pic_a, pic_b))
+                bc_a, bc_b = sorted((pic_b, pic_c))
                 session.add(
                     PictureLikeness(
                         picture_id_a=ab_a,
@@ -1989,32 +1967,10 @@ def test_pictures_likeness_groups_supports_set_intersection_filter():
                 )
                 session.commit()
 
-            # Wait for LikenessParametersTask to finish before seeding edges.
-            # That task calls reset_likeness_for_pictures which deletes PictureLikeness
-            # rows, so any edges seeded before it completes will be wiped.
-            _deadline = time.monotonic() + 30.0
-            while time.monotonic() < _deadline:
-                _pending = server.vault.db.run_immediate_read_task(
-                    LikenessParameterUtils.count_pending_parameters
-                )
-                if (
-                    _pending == 0
-                    and not server.vault._task_runner.has_active_task_of_type(
-                        "LikenessParametersTask"
-                    )
-                ):
-                    break
-                time.sleep(0.05)
-            assert (
-                _pending == 0
-                and not server.vault._task_runner.has_active_task_of_type(
-                    "LikenessParametersTask"
-                )
-            ), (
-                f"LikenessParametersTask did not complete within deadline ({_pending} pending)"
-            )
-
-            server.vault.db.run_task(seed_likeness_edges, pic_a, pic_b, pic_c)
+            # The background likeness pipeline both wipes pairs
+            # (reset_likeness_for_pictures) and writes its own real ones, so seed
+            # only once it is quiescent and on a wiped slate.
+            seed_likeness_stable(server, seed_likeness_edges)
 
             assert (
                 client.post(f"/picture_sets/{set_a_id}/members/{pic_b}").status_code

--- a/tests/test_tag_health_api.py
+++ b/tests/test_tag_health_api.py
@@ -16,9 +16,8 @@ from datetime import datetime, timedelta
 from fastapi.testclient import TestClient
 from PIL import Image
 from sqlalchemy import event as sa_event
-from sqlalchemy import func
 from sqlalchemy import insert as sa_insert
-from sqlmodel import delete, select
+from sqlmodel import select
 
 from pixlstash.db_models import (
     Picture,
@@ -28,13 +27,12 @@ from pixlstash.db_models import (
     PictureStack,
     Tag,
 )
-from pixlstash.db_models.picture_likeness import PictureLikenessQueue
 from pixlstash.db_models.tag_prediction import TagPrediction
 from pixlstash.db_models.tag_suggestion import TagSuggestion
 from pixlstash.db_models.tagger_run import TaggerRun
 from pixlstash.server import Server
 from pixlstash.utils.quality.anomaly_penalty import DEFAULT_TAG_PRECISION
-from tests.utils import upload_pictures_and_wait
+from tests.utils import seed_likeness_stable, upload_pictures_and_wait
 
 API = "/api/v1"
 
@@ -155,86 +153,6 @@ def _rebuild_and_wait(client, timeout_s=30):
     raise AssertionError("tag_health rebuild did not finish in time")
 
 
-def _wait_likeness_settled(server, timeout_s=180):
-    """Block until the background likeness pipeline has fully processed every
-    uploaded picture, so a manually-seeded ``PictureLikeness`` fixture will not
-    be clobbered underneath the board's ``mismatch`` read.
-
-    ``timeout_s`` is generous (CPU embeddings + likeness recompute for the
-    uploaded fixtures can take well over 30s on a loaded CI runner); the poll
-    returns as soon as the pipeline is quiescent, so a large cap costs nothing
-    on a fast machine and only avoids a spurious timeout under contention.
-
-    Uploading real pictures runs two background stages that mutate the
-    ``picturelikeness`` table: the likeness-parameter pass calls
-    ``LikenessParameterUtils.reset_likeness_for_pictures`` (which DELETEs every
-    pair touching a picture and re-queues it), then ``LikenessTask`` recomputes
-    real pairs. Both race with the tag-health reads and would delete/replace a
-    seeded near-duplicate pair, making ``mismatch`` non-deterministic (the value
-    even flips across test order because the recomputed real likeness straddles
-    ``MISMATCH_LIKENESS_THRESHOLD`` and depends on image size). Once every
-    picture is fully processed (embedding + likeness_parameters + perceptual_hash
-    all set), the queue is drained, and the pair table is stable across two
-    polls, the pipeline is quiescent: a subsequent atomic reseed (see
-    ``_seed_stable``) then stays put because the finder has no further work
-    (queue empty + pairs present).
-    """
-
-    def _snapshot(session):
-        total = int(session.exec(select(func.count()).select_from(Picture)).one())
-        ready = int(
-            session.exec(
-                select(func.count())
-                .select_from(Picture)
-                .where(
-                    Picture.image_embedding.is_not(None),
-                    Picture.likeness_parameters.is_not(None),
-                    Picture.perceptual_hash.is_not(None),
-                )
-            ).one()
-        )
-        queued = int(
-            session.exec(select(func.count()).select_from(PictureLikenessQueue)).one()
-        )
-        pairs = int(
-            session.exec(select(func.count()).select_from(PictureLikeness)).one()
-        )
-        return total, ready, queued, pairs
-
-    start = time.time()
-    prev_pairs = None
-    while time.time() - start < timeout_s:
-        total, ready, queued, pairs = server.vault.db.run_immediate_read_task(_snapshot)
-        # Quiescent only when every picture is fully processed and the queue is
-        # empty; stable across two polls confirms the last recompute wrote.
-        if total > 0 and ready == total and queued == 0 and pairs == prev_pairs:
-            return
-        prev_pairs = pairs
-        time.sleep(0.25)
-    raise AssertionError("likeness pipeline did not settle in time")
-
-
-def _seed_stable(server, seed_fn):
-    """Wait for the likeness pipeline to quiesce, then seed with a clean
-    ``picturelikeness`` slate in one atomic transaction.
-
-    Deletes any pipeline-computed pairs and drains the queue *inside* the seed
-    transaction so no observer ever sees an empty-table/empty-queue state (which
-    would re-trigger ``LikenessUtils.seed_queue``). After commit the queue is
-    empty and the seeded pairs are present, so ``MissingLikenessFinder`` has no
-    further work and the fixture stays authoritative. Returns whatever
-    ``seed_fn`` returns.
-    """
-    _wait_likeness_settled(server)
-
-    def _wrapped(session):
-        session.exec(delete(PictureLikeness))
-        session.exec(delete(PictureLikenessQueue))
-        return seed_fn(session)
-
-    return server.vault.db.run_task(_wrapped)
-
-
 def test_tag_health_aggregates_on_fixture_vault():
     temp_dir, client, server = _setup()
     try:
@@ -330,8 +248,8 @@ def test_tag_health_aggregates_on_fixture_vault():
 
         # Seed with a stable likeness slate: the background likeness pipeline
         # would otherwise delete/recompute the seeded near-duplicate pair and
-        # make `mismatch` non-deterministic (see _seed_stable).
-        _seed_stable(server, seed)
+        # make `mismatch` non-deterministic (see seed_likeness_stable).
+        seed_likeness_stable(server, seed)
 
         body = _rebuild_and_wait(client)
         assert body["computed_at"] is not None
@@ -391,7 +309,7 @@ def test_tag_health_same_stack_mismatch_and_no_double_count():
             )
             session.commit()
 
-        _seed_stable(server, seed)
+        seed_likeness_stable(server, seed)
 
         body = _rebuild_and_wait(client)
         rows = {r["tag"]: r for r in body["rows"]}
@@ -512,7 +430,7 @@ def test_tag_health_scoped_mismatch_excludes_out_of_scope_pairs():
             session.commit()
             return ps.id
 
-        set_id = _seed_stable(server, seed)
+        set_id = seed_likeness_stable(server, seed)
 
         # Vault-wide: both disagreeing pairs count.
         body = _rebuild_and_wait(client)
@@ -1145,7 +1063,7 @@ def test_tag_health_default_tag_merges_folds_across_all_signals():
             )
             session.commit()
 
-        _seed_stable(server, seed)
+        seed_likeness_stable(server, seed)
 
         body = _rebuild_and_wait(client)
         rows = {r["tag"]: r for r in body["rows"]}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,11 @@
 import time
 
+from sqlalchemy import func
+from sqlmodel import delete, select
+
+from pixlstash.db_models.picture import Picture
+from pixlstash.db_models.picture_likeness import PictureLikeness, PictureLikenessQueue
+
 API_PREFIX = "/api/v1"
 
 _DEFAULT_TIMEOUT_S = 180
@@ -85,3 +91,87 @@ def wait_for_faces(client, picture_id, timeout_s=30, poll_interval=0.5):
     resp = client.get(f"{API_PREFIX}/pictures/{picture_id}/faces")
     assert resp.status_code == 200
     return resp.json().get("faces", [])
+
+
+def wait_likeness_settled(server, timeout_s=_DEFAULT_TIMEOUT_S):
+    """Block until the background likeness pipeline has fully processed every
+    uploaded picture, so a manually-seeded ``PictureLikeness`` fixture will not
+    be clobbered underneath the assertions that read it.
+
+    ``timeout_s`` is generous (CPU embeddings + likeness recompute for the
+    uploaded fixtures can take well over 30s on a loaded CI runner); the poll
+    returns as soon as the pipeline is quiescent, so a large cap costs nothing
+    on a fast machine and only avoids a spurious timeout under contention.
+
+    Uploading real pictures runs two background stages that mutate the
+    ``picturelikeness`` table: the likeness-parameter pass calls
+    ``LikenessParameterUtils.reset_likeness_for_pictures`` (which DELETEs every
+    pair touching a picture and re-queues it), then ``LikenessTask`` recomputes
+    real pairs. Both race with a seeded fixture. Waiting on the parameter stage
+    alone is not enough: ``count_pending_parameters`` reads 0 in the gaps
+    between per-picture embedding batches, and ``MissingLikenessFinder`` then
+    seeds the queue and writes real pairs for the pictures that *are* ready —
+    which collides with the fixture's own INSERT on the
+    ``(picture_id_a, picture_id_b)`` unique constraint.
+
+    Once every picture is fully processed (embedding + likeness_parameters +
+    perceptual_hash all set), the queue is drained, and the pair table is stable
+    across two polls, the pipeline is quiescent: a subsequent atomic reseed (see
+    ``seed_likeness_stable``) then stays put because the finder has no further
+    work (queue empty + pairs present).
+    """
+
+    def _snapshot(session):
+        total = int(session.exec(select(func.count()).select_from(Picture)).one())
+        ready = int(
+            session.exec(
+                select(func.count())
+                .select_from(Picture)
+                .where(
+                    Picture.image_embedding.is_not(None),
+                    Picture.likeness_parameters.is_not(None),
+                    Picture.perceptual_hash.is_not(None),
+                )
+            ).one()
+        )
+        queued = int(
+            session.exec(select(func.count()).select_from(PictureLikenessQueue)).one()
+        )
+        pairs = int(
+            session.exec(select(func.count()).select_from(PictureLikeness)).one()
+        )
+        return total, ready, queued, pairs
+
+    start = time.time()
+    prev_pairs = None
+    while time.time() - start < timeout_s:
+        total, ready, queued, pairs = server.vault.db.run_immediate_read_task(_snapshot)
+        # Quiescent only when every picture is fully processed and the queue is
+        # empty; stable across two polls confirms the last recompute wrote.
+        if total > 0 and ready == total and queued == 0 and pairs == prev_pairs:
+            return
+        prev_pairs = pairs
+        time.sleep(0.25)
+    raise AssertionError("likeness pipeline did not settle in time")
+
+
+def seed_likeness_stable(server, seed_fn):
+    """Wait for the likeness pipeline to quiesce, then seed with a clean
+    ``picturelikeness`` slate in one atomic transaction.
+
+    Deletes any pipeline-computed pairs and drains the queue *inside* the seed
+    transaction so no observer ever sees an empty-table/empty-queue state (which
+    would re-trigger ``LikenessUtils.seed_queue``). Wiping first also means the
+    fixture's own INSERTs cannot collide with a real pair the pipeline already
+    computed for the same picture ids. After commit the queue is empty and the
+    seeded pairs are present, so ``MissingLikenessFinder`` has no further work
+    and the fixture stays authoritative. Returns whatever ``seed_fn`` returns.
+    """
+    wait_likeness_settled(server)
+
+    def _wrapped(session):
+        session.exec(delete(PictureLikeness))
+        session.exec(delete(PictureLikenessQueue))
+        return seed_fn(session)
+
+    return server.vault.db.run_task(_wrapped)


### PR DESCRIPTION
## Problem

`tests/test_server.py::test_stack_query_respects_project_filter` fails intermittently in CI with:

```
sqlite3.IntegrityError: UNIQUE constraint failed: picturelikeness.picture_id_a, picturelikeness.picture_id_b
```

(seen on PR #595, a CSS-only branch, so it is a pre-existing flake rather than a regression from that change).

## Root cause

The test gated its `PictureLikeness` seeding on `count_pending_parameters == 0` plus no active `LikenessParametersTask`. That condition reads 0 in the gaps between per-picture embedding batches, while later uploads are still unembedded. `MissingLikenessFinder` then sees `candidates > 0, pairs == 0`, seeds the queue, and `LikenessTask` writes a real pair for the pictures that are ready. The test's own INSERT for the same pair then hits the unique constraint.

## Fix

`tests/test_tag_health_api.py` already had the hardened pattern for this race. It is promoted to `tests/utils.py` and reused:

- `wait_likeness_settled(server)` waits until every picture has `image_embedding`, `likeness_parameters` and `perceptual_hash`, the likeness queue is drained, and the pair count is stable across two polls.
- `seed_likeness_stable(server, seed_fn)` waits for that quiescence, then deletes `picturelikeness` and `picturelikenessqueue` inside the same transaction as the seed, so no observer sees an empty table (which would re-trigger `LikenessUtils.seed_queue`) and the fixture cannot collide with a pipeline-computed pair.

Both `test_server.py` seeding sites now use the helper, and `test_tag_health_api.py` imports it instead of keeping its own copy.

## Verification

- `ruff format` and `ruff check` clean on the three changed files.
- `pytest tests/test_tag_health_api.py tests/test_server.py --fast-captions --force-cpu` -> 51 passed (7m21s).

Test-only change: no production code, workflow or dependency changes.