### PR TITLE
Wait for watched files to settle before importing them

### DIFF
--- a/pixlstash/tasks/missing_watch_folder_import_finder.py
+++ b/pixlstash/tasks/missing_watch_folder_import_finder.py
@@ -25,9 +25,14 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
         folder (str): Absolute path to the directory to monitor recursively.
         delete_after_import (bool): When True, source files are deleted from
             the watch folder after a successful import. Defaults to False.
-        last_checked (float): Unix timestamp of the last scan. Updated
-            automatically after each scan; do not set this manually.
+        last_checked (float): Unix timestamp of the last scan. Reported for
+            operators only; candidacy is decided from per-path stat signatures,
+            not from this value. Updated automatically after each scan; do not
+            set this manually.
 
+    A file is only imported once its size and timestamps have stopped changing,
+    so a copy that is still in flight is never read half-written. See
+    ``_claim_if_settled``.
     """
 
     _supported_image_exts = {
@@ -44,16 +49,25 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
     def __init__(self, database):
         super().__init__()
         self._db = database
-        # Normalized paths seen in a previous scan cycle.  Any path not in this
-        # set is treated as newly discovered regardless of its mtime/ctime, which
-        # handles copy tools (e.g. shutil.copy2 on Windows) that preserve old
-        # timestamps on the destination file.
+        # Candidacy is decided from a per-path *stat signature* rather than from
+        # timestamps compared against ``last_checked``.  Timestamps are not a
+        # reliable "is this file new" signal in a watch folder: copy tools
+        # (e.g. shutil.copy2) preserve the source mtime on the destination, and
+        # on Windows ctime is the creation time and never moves at all.
         #
-        # This set is read/written by the finder on the WorkPlanner thread and
+        # ``_pending_stats`` holds the signature observed on the previous scan
+        # for paths that have not been handed to an import task yet.
+        # ``_dispatched_stats`` holds the signature a path had when it *was*
+        # handed over.  A path only becomes a candidate once its signature is
+        # identical on two consecutive scans, which is what keeps a file that is
+        # still being written out of the import (see ``_claim_if_settled``).
+        #
+        # Both dicts are read/written by the finder on the WorkPlanner thread and
         # also mutated by WatchFolderImportTask (via ``discard_seen_paths``) on
         # the TaskRunner thread when a candidate fails to import, so all access
         # is guarded by ``_seen_lock`` to avoid a concurrent-mutation race.
-        self._seen_file_paths: set[str] = set()
+        self._pending_stats: dict[str, tuple[int, float, float]] = {}
+        self._dispatched_stats: dict[str, tuple[int, float, float]] = {}
         self._seen_lock = threading.Lock()
 
     def finder_name(self) -> str:
@@ -85,41 +99,29 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
         candidate_files = []
         total_candidates = 0
         last_checked_updates = {}
+        observed_paths: set[str] = set()
 
         for entry in watch_folders:
             if entry.id is None:
                 continue
             folder = entry.folder
-            last_checked = float(entry.last_checked or 0)
             delete_after_import = bool(entry.delete_after_import)
 
             if not folder or not os.path.isdir(folder):
                 continue
 
-            latest_seen = last_checked
             for root, _, files in os.walk(folder):
                 for file_name in files:
                     file_path = os.path.join(root, file_name)
-                    normalized = os.path.normcase(os.path.abspath(file_path))
-                    try:
-                        mtime = os.path.getmtime(file_path)
-                        ctime = os.path.getctime(file_path)
-                    except OSError:
-                        continue
                     if not self._is_supported_file(file_path):
                         continue
-                    # Some copy workflows preserve mtime from the source file,
-                    # so rely on the newer of mtime/ctime when deciding whether
-                    # this file is new relative to last_checked.
-                    seen_ts = max(mtime, ctime)
-                    # A path not seen in any previous scan cycle is always a
-                    # candidate, even when both timestamps predate last_checked.
-                    # This handles shutil.copy2 on Windows, which copies ctime
-                    # from the source, making it equally old as mtime.
-                    with self._seen_lock:
-                        is_new_path = normalized not in self._seen_file_paths
-                        self._seen_file_paths.add(normalized)
-                    if seen_ts > last_checked or is_new_path:
+                    signature = self._stat_signature(file_path)
+                    if signature is None:
+                        continue
+                    normalized = os.path.normcase(os.path.abspath(file_path))
+                    observed_paths.add(normalized)
+
+                    if self._claim_if_settled(normalized, signature):
                         total_candidates += 1
                         candidate_files.append(
                             {
@@ -128,10 +130,10 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
                                 "import_source_folder": folder,
                             }
                         )
-                    if seen_ts > latest_seen:
-                        latest_seen = seen_ts
 
-            last_checked_updates[int(entry.id)] = max(latest_seen, now_ts)
+            last_checked_updates[int(entry.id)] = now_ts
+
+        self._forget_vanished_paths(observed_paths)
 
         if last_checked_updates and not candidate_files:
             self._persist_db_last_checked(last_checked_updates)
@@ -152,11 +154,10 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
         """Forget paths so a later scan re-discovers them as new.
 
         Called by :class:`WatchFolderImportTask` for candidate files that failed
-        to process (hash or import error). A file is normally added to
-        ``_seen_file_paths`` at discovery time; if it then fails to import and
-        also carries a copy-preserved old mtime (``seen_ts <= last_checked``),
-        it would never become a candidate again. Removing it here makes the
-        failure transient: the next scan sees the path as new and retries it.
+        to process (hash or import error). A file is recorded as dispatched when
+        it is handed to an import task; dropping that record here makes the
+        failure transient, because the next scans re-observe the path, wait for
+        it to settle again and retry it.
         """
         if not file_paths:
             return
@@ -166,7 +167,85 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
         if not normalized:
             return
         with self._seen_lock:
-            self._seen_file_paths.difference_update(normalized)
+            for path in normalized:
+                self._pending_stats.pop(path, None)
+                self._dispatched_stats.pop(path, None)
+
+    @staticmethod
+    def _stat_signature(file_path: str) -> tuple[int, float, float] | None:
+        """Return ``(size, mtime, ctime)`` for *file_path*, or None if unreadable.
+
+        A single ``os.stat`` call so all three values describe the same moment;
+        comparing this tuple across scans is what detects a file that is still
+        being written into the watch folder.
+        """
+        try:
+            stat_result = os.stat(file_path)
+        except OSError as exc:
+            logger.debug(
+                "MissingWatchFolderImportFinder: cannot stat %s, skipping this "
+                "scan: %s",
+                file_path,
+                exc,
+            )
+            return None
+        return (stat_result.st_size, stat_result.st_mtime, stat_result.st_ctime)
+
+    def _claim_if_settled(
+        self, normalized: str, signature: tuple[int, float, float]
+    ) -> bool:
+        """Claim *normalized* for import if it has stopped changing on disk.
+
+        Returns True when the path is ready to be handed to an import task,
+        recording it as dispatched so a later scan does not offer it again.
+
+        A path qualifies only once the same stat signature has been observed on
+        two consecutive scans. A file that is still being copied into the watch
+        folder changes size (and mtime) between scans, so it is held back until
+        the copy finishes. Without this, the importer hashes the bytes written so
+        far, stores a ``pixel_sha`` that does not describe the finished file, and
+        then imports the file a second time once it settles, because the settled
+        content hashes differently and the duplicate check misses it.
+
+        The cost is that a newly arrived file waits one extra planner cycle
+        before it is imported.
+
+        A file that changes after it was imported goes back through the same
+        wait, so an in-place overwrite is never read half-written either.
+        """
+        with self._seen_lock:
+            dispatched = self._dispatched_stats.get(normalized)
+            if dispatched is not None:
+                if dispatched == signature:
+                    return False
+                # Changed on disk since it was imported: re-settle before it is
+                # offered again.
+                del self._dispatched_stats[normalized]
+                self._pending_stats[normalized] = signature
+                return False
+
+            previous = self._pending_stats.get(normalized)
+            if previous != signature:
+                # First sighting, or still being written.
+                self._pending_stats[normalized] = signature
+                return False
+
+            del self._pending_stats[normalized]
+            self._dispatched_stats[normalized] = signature
+            return True
+
+    def _forget_vanished_paths(self, observed_paths: set[str]) -> None:
+        """Drop bookkeeping for paths that are no longer in any watch folder.
+
+        Keeps the tracking dicts bounded on a long-running server, which matters
+        most with ``delete_after_import`` where every imported file is removed
+        from the folder straight away.
+        """
+        with self._seen_lock:
+            for tracked in (self._pending_stats, self._dispatched_stats):
+                vanished = tracked.keys() - observed_paths
+                for path in vanished:
+                    del tracked[path]
 
     def _persist_db_last_checked(self, updates: dict[int, float]):
         def update(session: Session, values: dict[int, float]):

--- a/tests/test_watch_folder_worker.py
+++ b/tests/test_watch_folder_worker.py
@@ -349,3 +349,128 @@ def test_watch_folder_retries_after_transient_hash_failure(monkeypatch):
                     "Expected the watched file to be imported after a transient "
                     "hash failure (retry on a later scan)"
                 )
+
+
+def test_watch_folder_waits_for_a_file_to_finish_being_written():
+    """A file still being written must not be imported until it settles.
+
+    Regression test: the finder scans every 50ms, so it can see a file that is
+    still being copied into the watch folder. ``pixel_sha`` is a digest of the
+    raw file bytes, so hashing a half-written file yields a hash that does not
+    describe the finished file. The duplicate check therefore missed it and the
+    settled file was imported a *second* time, leaving one truncated picture
+    plus a duplicate. This reproduced as an intermittent CI failure in
+    ``test_watch_folder_imports_copied_files_with_old_mtime_after_initial_scan``
+    (3 pictures for 2 files).
+
+    Rather than racing the planner (which backs off to 10s when idle), the file
+    is left incomplete *before* the folder is registered, so the very first scan
+    is guaranteed to see it still growing. It is short by only its last few
+    bytes, which keeps it decodable — that is precisely the case the duplicate
+    check cannot catch, because a truncated file that fails to decode is already
+    handled as a transient failure and retried.
+    """
+    from pixlstash.db_models.import_folder import ImportFolder
+    from pixlstash.utils.image_processing.image_utils import ImageUtils
+    from sqlmodel import select
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        server_config_path = f"{temp_dir}/server-config.json"
+        source_dir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "pictures")
+        )
+        assert os.path.isdir(source_dir), "Pictures directory not found"
+        image_files = [
+            os.path.join(dirpath, f)
+            for dirpath, _, filenames in os.walk(source_dir)
+            for f in filenames
+            if f.lower().endswith((".png", ".jpg", ".jpeg", ".webp"))
+        ]
+        assert image_files, "No images found in pictures directory"
+
+        watch_dir = os.path.join(temp_dir, "watch")
+        os.makedirs(watch_dir, exist_ok=True)
+
+        src = image_files[0]
+        dst = os.path.join(watch_dir, os.path.basename(src))
+
+        with open(src, "rb") as source_handle:
+            payload = source_handle.read()
+        assert len(payload) > 4, "Need a non-trivial image for this test"
+
+        # The copy is "in flight": everything but the last few bytes is on disk.
+        with open(dst, "wb") as out:
+            out.write(payload[:-4])
+            out.flush()
+            os.fsync(out.fileno())
+
+        with Server(server_config_path) as server:
+            with TestClient(server.api) as client:
+                response = client.post(
+                    f"{API_PREFIX}/login",
+                    json={"username": "testuser", "password": "testpassword"},
+                )
+                assert response.status_code == 200
+
+                create_folder = client.post(
+                    f"{API_PREFIX}/import-folders",
+                    json={
+                        "folder": watch_dir,
+                        "delete_after_import": False,
+                    },
+                )
+                assert create_folder.status_code == 200
+
+                # ``last_checked`` only advances once a scan has completed, so
+                # this proves the finder has already looked at the partial file.
+                def read_folder(session):
+                    return session.exec(select(ImportFolder)).first()
+
+                scanned = False
+                start = time.monotonic()
+                while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
+                    folder_row = server.vault.db.run_task(read_folder)
+                    if folder_row is not None and (folder_row.last_checked or 0) > 0:
+                        scanned = True
+                        break
+                    time.sleep(0.1)
+                assert scanned, "Finder never completed a scan of the partial file"
+
+                # Finish the copy, then mimic a file manager restoring the source
+                # mtime (which bumps ctime and re-exposes the file to the finder).
+                with open(dst, "ab") as out:
+                    out.write(payload[-4:])
+                    out.flush()
+                    os.fsync(out.fileno())
+                old_ts = time.time() - (7 * 24 * 60 * 60)
+                os.utime(dst, (old_ts, old_ts))
+
+                start = time.monotonic()
+                pictures = []
+                while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
+                    pictures = server.vault.db.run_task(
+                        lambda session: Picture.find(session)
+                    )
+                    if len(pictures) >= 1:
+                        break
+                    time.sleep(0.25)
+
+                # Give a second, erroneous import a chance to land before
+                # asserting there is only one picture.
+                time.sleep(3.0)
+                pictures = server.vault.db.run_task(
+                    lambda session: Picture.find(session)
+                )
+
+                assert len(pictures) == 1, (
+                    "Expected exactly one picture for one watched file; a "
+                    f"half-written import would add a duplicate (got {len(pictures)})"
+                )
+                settled_sha = ImageUtils.calculate_hash_from_file_path(dst)
+                assert pictures[0].pixel_sha == settled_sha, (
+                    "Imported picture must carry the hash of the settled file, "
+                    "not of the bytes written so far"
+                )
+                assert pictures[0].size_bytes == os.path.getsize(dst), (
+                    "Imported picture must record the settled file size"
+                )


### PR DESCRIPTION
Fixes the intermittent `backend shard 2` failure seen on #620
(`test_watch_folder_imports_copied_files_with_old_mtime_after_initial_scan`,
3 pictures for 2 files). The flake is a real product bug, not a test artifact.

## Root cause

`MissingWatchFolderImportFinder` treated a file as importable the moment it
appeared in the folder. The WorkPlanner rescans every 50ms, so on a contended
runner a scan lands while a file is still being copied in.

`pixel_sha` is a SHA-256 over **raw file bytes** (sampled by size), with no
decode step, so a half-written file hashes to a perfectly valid but wrong
digest. The importer then:

1. hashes the partial bytes and imports a picture whose `pixel_sha` does not
   describe the finished file, then
2. imports the file a **second** time once it settles, because the settled
   content hashes differently and the `find_existing` duplicate check misses it.

Reproduced deterministically: one file in a watch folder produced two pictures,
`size_bytes=4004100` (partial) and `4004104` (settled).

This is user-facing, not just CI: copying a large file into a watch folder over
a slow disk or network share can leave a truncated import plus a duplicate.

## Change

Candidacy now comes from a per-path stat signature `(size, mtime, ctime)` that
must be identical on two consecutive scans before the file is handed to an
import task. A file being written changes size between scans and is held back.

This also replaces the `seen_ts > last_checked` timestamp comparison, which was
never a reliable "is this new" signal here: `shutil.copy2` preserves the source
mtime on the destination, and on Windows ctime is the creation time and never
moves. Both of those defeats already produced bugs in this finder. `last_checked`
is still recorded for operators but no longer drives candidacy.

A file modified after import goes back through the same wait, so an in-place
overwrite is never read half-written either. Tracking dicts are pruned of
vanished paths, which also bounds the old unbounded seen-set growth under
`delete_after_import`.

Cost: a newly arrived file waits one extra planner cycle before importing.

## Verification

- New `test_watch_folder_waits_for_a_file_to_finish_being_written` asserts one
  picture carrying the settled file's hash and size. It is deterministic in
  **both** directions: fails with `got 2` without the fix, passes with it.
  It registers the folder while the file is short by its last 4 bytes, so the
  first scan is guaranteed to see it growing, rather than racing the planner.
- `tests/test_watch_folder_worker.py` (5), `test_work_planner.py`,
  `test_full_pipeline.py`, `test_architecture_guardrails.py`,
  `test_docker_windows_host_paths.py`, `test_server_simple.py` — 60 passed.
- Watch-folder file run 4x concurrently to mimic CI shard contention: 20 passed.
- `ruff format` + `ruff check` clean.

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U