### PR TITLE
Extract useViewStore from App.vue (Phase 3 step 1)

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -41,6 +41,7 @@ frontend/src/
 │   └── design-tokens.css        # Design-system tokens: spacing, radius, type ramp, elevation, motion, colour
 │
 ├── stores/                      # Pinia stores (cross-component shared state)
+│   ├── useViewStore.js          # route → view resolution: the app's ONE route watcher (see §4.5)
 │   ├── useSelectionStore.js
 │   ├── useFilterStore.js
 │   ├── useSortStore.js
@@ -142,7 +143,7 @@ frontend/src/
 | UI component library | Vuetify 3 |
 | State management | **Pinia** — 16 domain stores in `src/stores/`; `App.vue` owns only UI-shell state |
 | HTTP client | Axios (singleton `apiClient`) |
-| Routing | **Vue Router 4** (`createWebHistory`). `Root.vue` gates on `isAuthenticated`; all authenticated views (`/`, `/character/:id`, `/set/:id`, `/project/:id`, `/scrapheap`) render `App.vue` via `<RouterView>`. `App.vue` watches the route and syncs params to Pinia stores; nav handlers call `router.push()` to update the URL. **The route is the single source of truth for what the grid shows** — only explicit entry clicks push routes; sidebar tab/category switches never do (see Key Design Principles). |
+| Routing | **Vue Router 4** (`createWebHistory`). `Root.vue` gates on `isAuthenticated`; all authenticated views (`/`, `/character/:id`, `/set/:id`, `/project/:id`, `/scrapheap`) render `App.vue` via `<RouterView>`. `useViewStore` owns the app's single route watcher and syncs params to Pinia stores (§4.5); `App.vue`'s nav handlers call `router.push()` to update the URL. **The route is the single source of truth for what the grid shows** — only explicit entry clicks push routes; sidebar tab/category switches never do (see Key Design Principles). |
 | Build tool | Vite 5 |
 | Unit tests | Vitest (jsdom environment) — test files co-located as `*.test.js` in `utils/` |
 | End-to-end tests | Playwright (`frontend/e2e/`) — drives the real SPA against a backend booted on a throwaway copy of the `test-data/` fixture. See `frontend/e2e/README.md`. |
@@ -181,6 +182,7 @@ Authentication gate rendered before `App`. On mount:
 
 The application shell. Responsibilities:
 - Owns **layout-shell state** only: sidebar/stats visibility. All domain state has moved to Pinia stores; the pill ids live in `useWsStore`.
+- Owns **route pushing** (`pushAppRoute` / `pushRouteForCurrentSelection`) and calls `useViewStore().startRouteSync(route, { watch })` once. Reading the route back into stores is `useViewStore`'s job, not App.vue's (see §4.5).
 - Renders the three-panel layout: `SideBar` | `ImageGrid` (+ `Toolbar`) | `StatsSidebar`.
 - Manages the `PhotosImportDialog`.
 - Owns the **WebSocket lifecycle only** (connect / reconnect / close / `set_filters`); the picture-event decision table is delegated to `useGridRealtimeSync` (see §9).
@@ -200,6 +202,7 @@ All state consumed by more than one component lives in a Pinia store. The stores
 
 | Store | File | Key State |
 |-------|------|-----------|
+| `useViewStore` | `useViewStore.js` | The route's parsed reflection: `view` (the resolved view descriptor) and `activeFolderKey`. Owns the app's **single route watcher** and is the only writer of route-derived selection/project state. Never pushes a route. See §4.5. |
 | `useSelectionStore` | `useSelectionStore.js` | `selectedCharacter`, `selectedCharacterIds`, `selectedSet`, `selectedSetIds`, `selectedFolderFilter` |
 | `useFilterStore` | `useFilterStore.js` | `mediaTypeFilter`, `minScoreFilter`, `maxScoreFilter`, `tagFilter`, `tagRejectedFilter`, `faceBboxFilter`, `sharedOnlyFilter`, `unassignedOnlyFilter`, etc. |
 | `useSortStore` | `useSortStore.js` | `selectedSort`, `selectedDescending`, `sortOptions`, `similarityCharacterOptions`, `selectedSimilarityCharacter` |
@@ -246,6 +249,22 @@ Sub-components that manage independent data (e.g. `AccountSection`, `SmartScoreS
 - `ComfyUiRunner` retired its inline in-progress banner (progress now lives in the Tasks tab). It still renders an **inline banner for the failed state only**, so an error is never buried in a collapsed sidebar.
 
 All indicator animations honour `prefers-reduced-motion: reduce`.
+
+### 4.5 Route → view resolution (`useViewStore`)
+
+The route is the single source of truth for what the grid shows (§2). `useViewStore` is the one place that turns the URL into the selection/project state the grid renders, and the only writer of that state from the route.
+
+It is split in two so the URL contract is testable on its own:
+
+- **`parseRouteView(route)`** is pure. It resolves a route to a *view descriptor* (project scope, selected character/characters, selected set/sets, multi modes, difference base, category label, folder key), or `null` for a route the grid is not driven from. Every URL shape the router declares is unit-tested here (`useViewStore.test.js`), with no router, grid, or mounted App.
+- **`applyRoute(route)`** writes the descriptor into `useSelectionStore` / `useProjectStore`. Idempotent by construction: values that have not changed are not written, and the character guard compares stringified ids because the id space mixes numbers with the `ALL` / `UNASSIGNED` / `SCRAPHEAP` pseudo-ids.
+
+**`startRouteSync(route, { watch })` installs the app's one and only route watcher**, called once from `App.vue`. `watch` is injected (same pattern as `useReviewRoute`) so the watcher is created in App.vue's effect scope and dies with it, and so the store stays testable. Two rules keep the seam honest:
+
+- The store **never pushes a route**. Route *pushing* stays in `App.vue` (`pushAppRoute` / `pushRouteForCurrentSelection`), next to the nav handlers that own navigation decisions.
+- Folder routes (`ref-folder` / `import-folder`) deliberately do **not** clear `selectedFolderFilter`. The sidebar owns that payload and emits `select-folder` once the folder has loaded, so the route must not wipe what the sidebar just set.
+
+The Phase 0 pin specs `route-as-truth.spec.js` and `stateless-tabs.spec.js` characterise the user-visible half of this contract.
 
 ---
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -32,6 +32,12 @@ import { useReviewSessionsStore } from "./stores/useReviewSessionsStore";
 import { useSnapshotsStore } from "./stores/useSnapshotsStore";
 import { useTasksStore } from "./stores/useTasksStore";
 import { useLockedSetsStore } from "./stores/useLockedSetsStore";
+import {
+  ALL_PICTURES_ID,
+  SCRAPHEAP_PICTURES_ID,
+  UNASSIGNED_PICTURES_ID,
+  useViewStore,
+} from "./stores/useViewStore";
 import { useGridRealtimeSync } from "./composables/useGridRealtimeSync";
 
 import SideBar from "./components/panels/SideBar.vue";
@@ -52,9 +58,6 @@ import {
 } from "./utils/thumbnailSizes";
 
 const BACKEND_URL = API_BASE_URL;
-const ALL_PICTURES_ID = "ALL";
-const UNASSIGNED_PICTURES_ID = "UNASSIGNED";
-const SCRAPHEAP_PICTURES_ID = "SCRAPHEAP";
 
 // --- Stores ---
 const selectionStore = useSelectionStore();
@@ -71,6 +74,9 @@ const reviewSessionsStore = useReviewSessionsStore();
 const snapshotsStore = useSnapshotsStore();
 const tasksStore = useTasksStore();
 const lockedSetsStore = useLockedSetsStore();
+// Owns route → view resolution (the app's single route watcher). Route pushing
+// stays here in App.vue; see stores/useViewStore.js.
+const viewStore = useViewStore();
 
 // --- Router ---
 const route = useRoute();
@@ -158,12 +164,8 @@ let stopOpenSettings = null;
 // --- Computed ---
 // Maps the current route to a sidebar folder key ('rf-{id}' or 'if-{id}') so
 // the sidebar can highlight the correct folder on deep-link or back-navigation.
-const activeFolderKey = computed(() => {
-  const { name, params } = route;
-  if (name === "ref-folder" && params.id) return `rf-${params.id}`;
-  if (name === "import-folder" && params.id) return `if-${params.id}`;
-  return null;
-});
+// Parsed once, by useViewStore.
+const activeFolderKey = computed(() => viewStore.activeFolderKey);
 
 const activeCategoryLabel = computed(() => {
   if (selectionStore.selectedFolderFilter) {
@@ -989,226 +991,10 @@ function pushRouteForCurrentSelection() {
   });
 }
 
-/**
- * Apply the current route params/query to the Pinia stores.
- * Called on initial load (immediate) and on every route change so that
- * back/forward navigation and direct URL entry update the grid correctly.
- *
- * This function is intentionally idempotent — writing the same values to
- * reactive refs is a no-op in Vue's reactivity system, so it is safe to
- * call it on every route tick without triggering unnecessary re-renders.
- */
-// True array equality by numeric content — avoids spurious reactive updates
-// when applyRouteToStores writes the same IDs that handleSelect* already set.
-function _sameNumIds(a, b) {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (Number(a[i]) !== Number(b[i])) return false;
-  }
-  return true;
-}
-
-function applyRouteToStores() {
-  const { name, params, query } = route;
-
-  if (name === "all-pictures") {
-    selectionStore.selectedFolderFilter = null;
-    selectionStore.selectedSet = null;
-    if (selectionStore.selectedSetIds.length > 0)
-      selectionStore.selectedSetIds = [];
-    if (String(selectionStore.selectedCharacter) !== String(ALL_PICTURES_ID))
-      selectionStore.selectedCharacter = ALL_PICTURES_ID;
-    if (selectionStore.selectedCharacterIds.length > 0)
-      selectionStore.selectedCharacterIds = [];
-    selectionStore.lastSelectedCharacterLabel = "All Pictures";
-    projectStore.projectViewMode = "global";
-    projectStore.selectedProjectId = null;
-  } else if (name === "character") {
-    const charIdRaw = params.id || ALL_PICTURES_ID;
-    const charIdNum = Number(charIdRaw);
-    const charId = Number.isFinite(charIdNum) ? charIdNum : String(charIdRaw);
-    const idsRaw = query.ids;
-    const modeRaw = query.mode;
-    // No ?ids= query → fall back to the single route character (when it is a
-    // real character, id > 0), mirroring the set branch. Falling back to []
-    // here would clear selectedCharacterIds after a single select, so the
-    // next Ctrl/Cmd-click would see an empty multi-set and never accumulate
-    // (this is why multi-select worked for sets but not characters).
-    const ids = idsRaw
-      ? String(idsRaw)
-          .split(",")
-          .map(Number)
-          .filter((id) => Number.isFinite(id) && id > 0)
-      : Number.isFinite(charIdNum) && charIdNum > 0
-        ? [charIdNum]
-        : [];
-    selectionStore.selectedFolderFilter = null;
-    selectionStore.selectedSet = null;
-    if (selectionStore.selectedSetIds.length > 0)
-      selectionStore.selectedSetIds = [];
-    if (String(selectionStore.selectedCharacter) !== String(charId))
-      selectionStore.selectedCharacter = charId;
-    if (!_sameNumIds(selectionStore.selectedCharacterIds, ids))
-      selectionStore.selectedCharacterIds = ids;
-    if (ids.length > 1 && modeRaw) {
-      selectionStore.characterMultiMode = String(modeRaw);
-    }
-    if (charId === ALL_PICTURES_ID) {
-      selectionStore.lastSelectedCharacterLabel = "All Pictures";
-    } else if (charId === UNASSIGNED_PICTURES_ID) {
-      selectionStore.lastSelectedCharacterLabel = "Unassigned Pictures";
-    }
-    projectStore.projectViewMode = "global";
-    projectStore.selectedProjectId = null;
-  } else if (name === "scrapheap") {
-    selectionStore.selectedFolderFilter = null;
-    selectionStore.selectedSet = null;
-    if (selectionStore.selectedSetIds.length > 0)
-      selectionStore.selectedSetIds = [];
-    if (
-      String(selectionStore.selectedCharacter) !== String(SCRAPHEAP_PICTURES_ID)
-    )
-      selectionStore.selectedCharacter = SCRAPHEAP_PICTURES_ID;
-    if (selectionStore.selectedCharacterIds.length > 0)
-      selectionStore.selectedCharacterIds = [];
-    selectionStore.lastSelectedCharacterLabel = "Scrapheap";
-    projectStore.projectViewMode = "global";
-    projectStore.selectedProjectId = null;
-  } else if (name === "set") {
-    const primaryId = Number(params.id);
-    const idsRaw = query.ids;
-    const modeRaw = query.mode;
-    const baseRaw = query.base;
-    const ids = idsRaw
-      ? String(idsRaw)
-          .split(",")
-          .map(Number)
-          .filter((id) => Number.isFinite(id) && id > 0)
-      : Number.isFinite(primaryId) && primaryId > 0
-        ? [primaryId]
-        : [];
-    selectionStore.selectedFolderFilter = null;
-    selectionStore.selectedCharacter = null;
-    if (selectionStore.selectedCharacterIds.length > 0)
-      selectionStore.selectedCharacterIds = [];
-    const nextSet = ids[0] ?? null;
-    if (selectionStore.selectedSet !== nextSet)
-      selectionStore.selectedSet = nextSet;
-    if (!_sameNumIds(selectionStore.selectedSetIds, ids))
-      selectionStore.selectedSetIds = ids;
-    if (ids.length > 1 && modeRaw) {
-      selectionStore.setMultiMode = String(modeRaw);
-    }
-    if (ids.length > 1 && baseRaw) {
-      const baseId = Number(baseRaw);
-      if (Number.isFinite(baseId) && baseId > 0) {
-        selectionStore.setDifferenceBaseId = baseId;
-      }
-    }
-    projectStore.projectViewMode = "global";
-    projectStore.selectedProjectId = null;
-  } else if (name === "project") {
-    const projectId = Number(params.id);
-    projectStore.projectViewMode = "project";
-    projectStore.selectedProjectId =
-      Number.isFinite(projectId) && projectId > 0 ? projectId : null;
-    if (String(selectionStore.selectedCharacter) !== String(ALL_PICTURES_ID))
-      selectionStore.selectedCharacter = ALL_PICTURES_ID;
-    if (selectionStore.selectedCharacterIds.length > 0)
-      selectionStore.selectedCharacterIds = [];
-    selectionStore.selectedSet = null;
-    if (selectionStore.selectedSetIds.length > 0)
-      selectionStore.selectedSetIds = [];
-    selectionStore.selectedFolderFilter = null;
-    selectionStore.lastSelectedCharacterLabel = "All Pictures";
-  } else if (name === "project-character") {
-    const projectId = Number(params.projectId);
-    const charIdRaw = params.id || ALL_PICTURES_ID;
-    const charIdNum = Number(charIdRaw);
-    const charId = Number.isFinite(charIdNum) ? charIdNum : String(charIdRaw);
-    // Parse the multi-selection from the query (mirrors the global character
-    // branch); fall back to the single route character so a single select in
-    // project mode does not clear selectedCharacterIds — which previously made
-    // the next Ctrl/Cmd-click restart from empty (multi-select never worked in
-    // the project tab).
-    const idsRaw = query.ids;
-    const modeRaw = query.mode;
-    const ids = idsRaw
-      ? String(idsRaw)
-          .split(",")
-          .map(Number)
-          .filter((id) => Number.isFinite(id) && id > 0)
-      : Number.isFinite(charIdNum) && charIdNum > 0
-        ? [charIdNum]
-        : [];
-    projectStore.projectViewMode = "project";
-    projectStore.selectedProjectId =
-      Number.isFinite(projectId) && projectId > 0 ? projectId : null;
-    selectionStore.selectedFolderFilter = null;
-    selectionStore.selectedSet = null;
-    if (selectionStore.selectedSetIds.length > 0)
-      selectionStore.selectedSetIds = [];
-    if (String(selectionStore.selectedCharacter) !== String(charId))
-      selectionStore.selectedCharacter = charId;
-    if (!_sameNumIds(selectionStore.selectedCharacterIds, ids))
-      selectionStore.selectedCharacterIds = ids;
-    if (ids.length > 1 && modeRaw) {
-      selectionStore.characterMultiMode = String(modeRaw);
-    }
-  } else if (name === "project-set") {
-    const projectId = Number(params.projectId);
-    const setId = Number(params.id);
-    const idsRaw = query.ids;
-    const modeRaw = query.mode;
-    const baseRaw = query.base;
-    const ids = idsRaw
-      ? String(idsRaw)
-          .split(",")
-          .map(Number)
-          .filter((id) => Number.isFinite(id) && id > 0)
-      : Number.isFinite(setId) && setId > 0
-        ? [setId]
-        : [];
-    projectStore.projectViewMode = "project";
-    projectStore.selectedProjectId =
-      Number.isFinite(projectId) && projectId > 0 ? projectId : null;
-    selectionStore.selectedFolderFilter = null;
-    selectionStore.selectedCharacter = null;
-    if (selectionStore.selectedCharacterIds.length > 0)
-      selectionStore.selectedCharacterIds = [];
-    const nextSet = ids[0] ?? null;
-    if (selectionStore.selectedSet !== nextSet)
-      selectionStore.selectedSet = nextSet;
-    if (!_sameNumIds(selectionStore.selectedSetIds, ids))
-      selectionStore.selectedSetIds = ids;
-    if (ids.length > 1 && modeRaw) {
-      selectionStore.setMultiMode = String(modeRaw);
-    }
-    if (ids.length > 1 && baseRaw) {
-      const baseId = Number(baseRaw);
-      if (Number.isFinite(baseId) && baseId > 0) {
-        selectionStore.setDifferenceBaseId = baseId;
-      }
-    }
-    selectionStore.lastSelectedCharacterLabel = "All Pictures";
-  } else if (name === "ref-folder" || name === "import-folder") {
-    // Folder routes — clear all other selection state. The sidebar will emit
-    // select-folder with the full payload once it loads the folder data.
-    projectStore.projectViewMode = "global";
-    projectStore.selectedProjectId = null;
-    if (String(selectionStore.selectedCharacter) !== String(ALL_PICTURES_ID))
-      selectionStore.selectedCharacter = ALL_PICTURES_ID;
-    if (selectionStore.selectedCharacterIds.length > 0)
-      selectionStore.selectedCharacterIds = [];
-    selectionStore.selectedSet = null;
-    if (selectionStore.selectedSetIds.length > 0)
-      selectionStore.selectedSetIds = [];
-    selectionStore.lastSelectedCharacterLabel = "All Pictures";
-  }
-}
-
-// Sync route → stores on every navigation (and immediately on mount for deep-linking).
-watch(route, applyRouteToStores, { immediate: true, deep: true });
+// Route -> stores: install the app's single route watcher (immediately on
+// mount for deep-linking, then on every navigation). The parsing and the
+// writes live in useViewStore; App.vue keeps only the route PUSHING above.
+viewStore.startRouteSync(route, { watch });
 
 // Stateless sidebar tabs: switching the Global ↔ Project mode (or the
 // project picker) must not navigate or change the grid — the route is the
@@ -1224,9 +1010,9 @@ function handleUpdateSelectedProjectId(id) {
   projectStore.selectedProjectId = id;
 }
 
-// Explicit "view this project" entry click → navigate. applyRouteToStores
-// (watching the route) sets projectViewMode/selectedProjectId from the URL,
-// which scopes the grid to the project.
+// Explicit "view this project" entry click → navigate. useViewStore (watching
+// the route) sets projectViewMode/selectedProjectId from the URL, which scopes
+// the grid to the project.
 function handleViewProject(id) {
   if (id == null) return;
   pushAppRoute({ name: "project", params: { id: String(id) } });

--- a/frontend/src/stores/useViewStore.js
+++ b/frontend/src/stores/useViewStore.js
@@ -1,0 +1,288 @@
+// useViewStore.js — route → view resolution: the one place the app parses the
+// URL into the selection/project state the grid renders.
+//
+// The route stays the SINGLE SOURCE OF TRUTH for what the grid shows (see
+// frontend_architecture.md §2 "Key Design Principles" and the Phase 0 pin specs
+// `route-as-truth.spec.js` / `stateless-tabs.spec.js`). This store is merely the
+// route's parsed reflection: it never pushes a route and never decides
+// navigation. Route *pushing* stays in App.vue (`pushAppRoute` /
+// `pushRouteForCurrentSelection`), where the nav handlers live.
+//
+// The contract this file exists to hold:
+//
+//   * exactly ONE route watcher in the whole app, installed by
+//     `startRouteSync` and called once from App.vue. It is the only writer of
+//     route-derived selection/project state;
+//   * parsing is a pure function (`parseRouteView`), so every URL shape is
+//     unit-testable without a router, a grid, or a mounted App;
+//   * applying is idempotent. Writing a value a ref already holds is a no-op in
+//     Vue's reactivity, and the guards below additionally skip writes that
+//     differ only by number-vs-string, so a route tick that changes nothing
+//     re-renders nothing.
+
+import { computed, ref } from "vue";
+import { defineStore } from "pinia";
+
+import { useSelectionStore } from "./useSelectionStore";
+import { useProjectStore } from "./useProjectStore";
+
+export const ALL_PICTURES_ID = "ALL";
+export const UNASSIGNED_PICTURES_ID = "UNASSIGNED";
+export const SCRAPHEAP_PICTURES_ID = "SCRAPHEAP";
+
+/**
+ * Parse a `?ids=1,2,3` multi-selection list.
+ *
+ * With no `ids` query we fall back to the single route id (when it is a real
+ * entity id, > 0). Falling back to `[]` would clear the multi-set after a single
+ * select, so the next Ctrl/Cmd-click would start from empty and never
+ * accumulate, the original cause of "multi-select works for sets, not people".
+ *
+ * @param {string|string[]|undefined} idsRaw `route.query.ids`
+ * @param {number} fallbackId the route's own primary id (may be NaN)
+ * @returns {number[]}
+ */
+function parseIds(idsRaw, fallbackId) {
+  if (idsRaw) {
+    return String(idsRaw)
+      .split(",")
+      .map(Number)
+      .filter((id) => Number.isFinite(id) && id > 0);
+  }
+  return Number.isFinite(fallbackId) && fallbackId > 0 ? [fallbackId] : [];
+}
+
+// A multi mode (`?mode=union|intersection|difference`) only means something for
+// a multi-selection; a single-entity route must not rewrite the sticky mode.
+function parseMultiMode(ids, modeRaw) {
+  return ids.length > 1 && modeRaw ? String(modeRaw) : null;
+}
+
+// `?base=<setId>`: the subtrahend of a set difference. Same rule as the mode.
+function parseBaseId(ids, baseRaw) {
+  if (ids.length <= 1 || !baseRaw) return null;
+  const baseId = Number(baseRaw);
+  return Number.isFinite(baseId) && baseId > 0 ? baseId : null;
+}
+
+// Character ids are a mixed space: numeric character ids plus the pseudo-ids
+// "ALL" / "UNASSIGNED" / "SCRAPHEAP", which stay strings.
+function parseCharacterId(raw) {
+  const value = raw || ALL_PICTURES_ID;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : String(value);
+}
+
+function parseProjectId(raw) {
+  const projectId = Number(raw);
+  return Number.isFinite(projectId) && projectId > 0 ? projectId : null;
+}
+
+function characterLabelFor(charId) {
+  if (charId === ALL_PICTURES_ID) return "All Pictures";
+  if (charId === UNASSIGNED_PICTURES_ID) return "Unassigned Pictures";
+  return null;
+}
+
+/**
+ * The neutral view every route branch starts from: the global All-Pictures
+ * view. Branches below override only what their URL actually says.
+ *
+ * `null` fields mean "leave the store's current value alone" (sticky multi
+ * modes, the difference base, the category label); everything else is written
+ * on every route tick.
+ */
+function baseView(name) {
+  return {
+    name,
+    projectViewMode: "global",
+    selectedProjectId: null,
+    selectedCharacter: ALL_PICTURES_ID,
+    selectedCharacterIds: [],
+    characterMultiMode: null,
+    selectedSet: null,
+    selectedSetIds: [],
+    setMultiMode: null,
+    setDifferenceBaseId: null,
+    // Folder routes are the one exception: the sidebar owns the folder filter
+    // payload and emits `select-folder` once it has loaded the folder, so the
+    // route must not clear what the sidebar just set.
+    clearFolderFilter: true,
+    characterLabel: null,
+    folderKey: null,
+  };
+}
+
+/**
+ * Resolve a route to the view it denotes. Pure: no store access, no side
+ * effects. Returns `null` for a route this app does not drive the grid from.
+ *
+ * @param {{name: string, params: object, query: object}} route
+ * @returns {object|null}
+ */
+export function parseRouteView(route) {
+  const { name, params = {}, query = {} } = route || {};
+  const view = baseView(name);
+
+  if (name === "all-pictures") {
+    view.characterLabel = "All Pictures";
+    return view;
+  }
+
+  if (name === "scrapheap") {
+    view.selectedCharacter = SCRAPHEAP_PICTURES_ID;
+    view.characterLabel = "Scrapheap";
+    return view;
+  }
+
+  if (name === "character" || name === "project-character") {
+    const charId = parseCharacterId(params.id);
+    const ids = parseIds(query.ids, Number(params.id || ALL_PICTURES_ID));
+    view.selectedCharacter = charId;
+    view.selectedCharacterIds = ids;
+    view.characterMultiMode = parseMultiMode(ids, query.mode);
+    if (name === "project-character") {
+      view.projectViewMode = "project";
+      view.selectedProjectId = parseProjectId(params.projectId);
+    } else {
+      view.characterLabel = characterLabelFor(charId);
+    }
+    return view;
+  }
+
+  if (name === "set" || name === "project-set") {
+    const ids = parseIds(query.ids, Number(params.id));
+    view.selectedCharacter = null;
+    view.selectedSet = ids[0] ?? null;
+    view.selectedSetIds = ids;
+    view.setMultiMode = parseMultiMode(ids, query.mode);
+    view.setDifferenceBaseId = parseBaseId(ids, query.base);
+    if (name === "project-set") {
+      view.projectViewMode = "project";
+      view.selectedProjectId = parseProjectId(params.projectId);
+      view.characterLabel = "All Pictures";
+    }
+    return view;
+  }
+
+  if (name === "project") {
+    view.projectViewMode = "project";
+    view.selectedProjectId = parseProjectId(params.id);
+    view.characterLabel = "All Pictures";
+    return view;
+  }
+
+  if (name === "ref-folder" || name === "import-folder") {
+    view.clearFolderFilter = false;
+    view.characterLabel = "All Pictures";
+    if (params.id) {
+      view.folderKey =
+        name === "ref-folder" ? `rf-${params.id}` : `if-${params.id}`;
+    }
+    return view;
+  }
+
+  return null;
+}
+
+// True array equality by numeric content. Avoids spurious reactive updates
+// when the route applies the same ids a `handleSelect*` handler already set.
+function sameNumIds(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (Number(a[i]) !== Number(b[i])) return false;
+  }
+  return true;
+}
+
+/**
+ * Write a parsed view into the selection/project stores.
+ *
+ * Every write is guarded so re-applying the same route is inert. The character
+ * guard compares stringified values because the id space mixes numbers and the
+ * "ALL"/"UNASSIGNED"/"SCRAPHEAP" pseudo-ids, and `5 !== "5"` would otherwise
+ * churn the grid on every route tick.
+ */
+function applyView(view, selectionStore, projectStore) {
+  if (!view) return;
+
+  if (view.clearFolderFilter) selectionStore.selectedFolderFilter = null;
+
+  if (
+    String(selectionStore.selectedCharacter) !== String(view.selectedCharacter)
+  ) {
+    selectionStore.selectedCharacter = view.selectedCharacter;
+  }
+  if (
+    !sameNumIds(selectionStore.selectedCharacterIds, view.selectedCharacterIds)
+  ) {
+    selectionStore.selectedCharacterIds = view.selectedCharacterIds;
+  }
+  if (view.characterMultiMode) {
+    selectionStore.characterMultiMode = view.characterMultiMode;
+  }
+
+  if (selectionStore.selectedSet !== view.selectedSet) {
+    selectionStore.selectedSet = view.selectedSet;
+  }
+  if (!sameNumIds(selectionStore.selectedSetIds, view.selectedSetIds)) {
+    selectionStore.selectedSetIds = view.selectedSetIds;
+  }
+  if (view.setMultiMode) selectionStore.setMultiMode = view.setMultiMode;
+  if (view.setDifferenceBaseId != null) {
+    selectionStore.setDifferenceBaseId = view.setDifferenceBaseId;
+  }
+
+  if (view.characterLabel) {
+    selectionStore.lastSelectedCharacterLabel = view.characterLabel;
+  }
+
+  projectStore.projectViewMode = view.projectViewMode;
+  projectStore.selectedProjectId = view.selectedProjectId;
+}
+
+export const useViewStore = defineStore("view", () => {
+  const selectionStore = useSelectionStore();
+  const projectStore = useProjectStore();
+
+  // The last parsed route. `null` for a route the grid is not driven from.
+  const view = ref(null);
+
+  // Sidebar folder highlight key ('rf-{id}' / 'if-{id}') for the current route,
+  // so a deep link or a Back navigation lights the right folder row.
+  const activeFolderKey = computed(() => view.value?.folderKey ?? null);
+
+  let stopRouteWatch = null;
+
+  /**
+   * Parse `route` and apply it to the stores. Safe to call on every route tick.
+   * @param {object} route a (reactive) route location
+   */
+  function applyRoute(route) {
+    view.value = parseRouteView(route);
+    applyView(view.value, selectionStore, projectStore);
+  }
+
+  /**
+   * Install the app's one and only route watcher. Called once, from App.vue.
+   *
+   * `watch` is injected (same pattern as `useReviewRoute`) so this store stays
+   * unit-testable, and so the watcher is created in the CALLER's effect scope:
+   * it therefore dies with App.vue rather than outliving it on the store. A
+   * second call (App.vue remounting after a re-login) replaces the first.
+   *
+   * @param {object} route reactive route (useRoute())
+   * @param {{watch: Function}} vue injected `watch`
+   * @returns {Function} stop handle
+   */
+  function startRouteSync(route, { watch }) {
+    stopRouteWatch?.();
+    stopRouteWatch = watch(route, () => applyRoute(route), {
+      immediate: true,
+      deep: true,
+    });
+    return stopRouteWatch;
+  }
+
+  return { view, activeFolderKey, applyRoute, startRouteSync };
+});

--- a/frontend/src/stores/useViewStore.test.js
+++ b/frontend/src/stores/useViewStore.test.js
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { reactive, watch, nextTick } from "vue";
+
+import { parseRouteView, useViewStore } from "./useViewStore";
+import { useSelectionStore } from "./useSelectionStore";
+import { useProjectStore } from "./useProjectStore";
+
+// Route → view resolution is the Phase 3 seam that replaced App.vue's inline
+// `applyRouteToStores`. These tests pin the URL shapes the router declares
+// (router/index.js) plus the two behaviours that were bugs before: the ids
+// fallback that makes multi-select accumulate, and folder routes NOT clearing
+// the folder filter the sidebar owns.
+
+function routeOf(name, params = {}, query = {}) {
+  return { name, params, query };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe("parseRouteView", () => {
+  it("resolves the all-pictures route to the global all view", () => {
+    expect(parseRouteView(routeOf("all-pictures"))).toMatchObject({
+      projectViewMode: "global",
+      selectedProjectId: null,
+      selectedCharacter: "ALL",
+      selectedCharacterIds: [],
+      selectedSet: null,
+      selectedSetIds: [],
+      characterLabel: "All Pictures",
+      clearFolderFilter: true,
+    });
+  });
+
+  it("keeps the pseudo-ids as strings and numeric character ids as numbers", () => {
+    expect(parseRouteView(routeOf("character", { id: "7" }))).toMatchObject({
+      selectedCharacter: 7,
+      selectedCharacterIds: [7],
+      characterLabel: null,
+    });
+    expect(
+      parseRouteView(routeOf("character", { id: "UNASSIGNED" })),
+    ).toMatchObject({
+      selectedCharacter: "UNASSIGNED",
+      selectedCharacterIds: [],
+      characterLabel: "Unassigned Pictures",
+    });
+    expect(parseRouteView(routeOf("scrapheap"))).toMatchObject({
+      selectedCharacter: "SCRAPHEAP",
+      characterLabel: "Scrapheap",
+    });
+  });
+
+  it("falls back to the route's own id when there is no ?ids= query", () => {
+    // Regression: falling back to [] cleared the multi-set after a single
+    // select, so the next Ctrl/Cmd-click restarted from empty.
+    expect(
+      parseRouteView(routeOf("character", { id: "7" })).selectedCharacterIds,
+    ).toEqual([7]);
+    expect(parseRouteView(routeOf("set", { id: "3" })).selectedSetIds).toEqual([
+      3,
+    ]);
+  });
+
+  it("parses a multi-selection and its mode, dropping junk ids", () => {
+    const view = parseRouteView(
+      routeOf("character", { id: "7" }, { ids: "7,9,x,0,-2", mode: "union" }),
+    );
+    expect(view.selectedCharacterIds).toEqual([7, 9]);
+    expect(view.characterMultiMode).toBe("union");
+  });
+
+  it("ignores mode/base on a single-entity route so the sticky mode survives", () => {
+    const view = parseRouteView(
+      routeOf("set", { id: "3" }, { mode: "difference", base: "3" }),
+    );
+    expect(view.setMultiMode).toBeNull();
+    expect(view.setDifferenceBaseId).toBeNull();
+  });
+
+  it("parses a set difference base only when it is a real id", () => {
+    const q = { ids: "3,4", mode: "difference" };
+    expect(
+      parseRouteView(routeOf("set", { id: "3" }, { ...q, base: "4" }))
+        .setDifferenceBaseId,
+    ).toBe(4);
+    expect(
+      parseRouteView(routeOf("set", { id: "3" }, { ...q, base: "nope" }))
+        .setDifferenceBaseId,
+    ).toBeNull();
+  });
+
+  it("scopes the project routes and rejects an unusable project id", () => {
+    expect(parseRouteView(routeOf("project", { id: "12" }))).toMatchObject({
+      projectViewMode: "project",
+      selectedProjectId: 12,
+      selectedCharacter: "ALL",
+    });
+    expect(
+      parseRouteView(routeOf("project", { id: "nope" })).selectedProjectId,
+    ).toBeNull();
+    expect(
+      parseRouteView(
+        routeOf("project-character", { projectId: "12", id: "7" }),
+      ),
+    ).toMatchObject({
+      projectViewMode: "project",
+      selectedProjectId: 12,
+      selectedCharacter: 7,
+      // The project-character branch deliberately leaves the label alone.
+      characterLabel: null,
+    });
+    expect(
+      parseRouteView(routeOf("project-set", { projectId: "12", id: "3" })),
+    ).toMatchObject({
+      projectViewMode: "project",
+      selectedProjectId: 12,
+      selectedCharacter: null,
+      selectedSet: 3,
+      selectedSetIds: [3],
+    });
+  });
+
+  it("does not clear the folder filter on folder routes, and yields the key", () => {
+    // The sidebar owns the folder payload and emits select-folder once it has
+    // loaded the folder; the route must not wipe what it just set.
+    expect(parseRouteView(routeOf("ref-folder", { id: "5" }))).toMatchObject({
+      clearFolderFilter: false,
+      folderKey: "rf-5",
+      selectedCharacter: "ALL",
+      characterLabel: "All Pictures",
+    });
+    expect(
+      parseRouteView(routeOf("import-folder", { id: "5" })).folderKey,
+    ).toBe("if-5");
+  });
+
+  it("returns null for a route the grid is not driven from", () => {
+    expect(parseRouteView(routeOf("something-else"))).toBeNull();
+    expect(parseRouteView(undefined)).toBeNull();
+  });
+});
+
+describe("useViewStore.applyRoute", () => {
+  it("writes the parsed view into the selection and project stores", () => {
+    const viewStore = useViewStore();
+    const selection = useSelectionStore();
+    const project = useProjectStore();
+    selection.selectedFolderFilter = { label: "stale" };
+
+    viewStore.applyRoute(
+      routeOf(
+        "set",
+        { id: "3" },
+        { ids: "3,4", mode: "difference", base: "4" },
+      ),
+    );
+
+    expect(selection.selectedFolderFilter).toBeNull();
+    expect(selection.selectedCharacter).toBeNull();
+    expect(selection.selectedSet).toBe(3);
+    expect(selection.selectedSetIds).toEqual([3, 4]);
+    expect(selection.setMultiMode).toBe("difference");
+    expect(selection.setDifferenceBaseId).toBe(4);
+    expect(project.projectViewMode).toBe("global");
+  });
+
+  it("leaves the sidebar's folder filter alone on a folder route", () => {
+    const viewStore = useViewStore();
+    const selection = useSelectionStore();
+    const filter = { referenceFolderId: 5, label: "Refs" };
+    selection.selectedFolderFilter = filter;
+
+    viewStore.applyRoute(routeOf("ref-folder", { id: "5" }));
+
+    expect(selection.selectedFolderFilter).toStrictEqual(filter);
+    expect(viewStore.activeFolderKey).toBe("rf-5");
+  });
+
+  it("is idempotent: re-applying the same route rewrites nothing", () => {
+    const viewStore = useViewStore();
+    const selection = useSelectionStore();
+    const route = routeOf(
+      "character",
+      { id: "7" },
+      { ids: "7,9", mode: "union" },
+    );
+    viewStore.applyRoute(route);
+
+    const seen = [];
+    watch(
+      () => [selection.selectedCharacter, selection.selectedCharacterIds],
+      () => seen.push("changed"),
+      { deep: true },
+    );
+    viewStore.applyRoute(route);
+    viewStore.applyRoute(route);
+
+    expect(seen).toEqual([]);
+  });
+
+  it("does not churn when a numeric id arrives as a string", () => {
+    const viewStore = useViewStore();
+    const selection = useSelectionStore();
+    viewStore.applyRoute(routeOf("character", { id: "7" }));
+    selection.selectedCharacter = "7";
+
+    viewStore.applyRoute(routeOf("character", { id: "7" }));
+
+    expect(selection.selectedCharacter).toBe("7");
+  });
+
+  it("ignores an unknown route entirely", () => {
+    const viewStore = useViewStore();
+    const selection = useSelectionStore();
+    viewStore.applyRoute(routeOf("set", { id: "3" }));
+    viewStore.applyRoute(routeOf("something-else"));
+
+    expect(selection.selectedSetIds).toEqual([3]);
+    expect(viewStore.activeFolderKey).toBeNull();
+  });
+});
+
+describe("useViewStore.startRouteSync", () => {
+  it("applies immediately and on every navigation, and replaces a prior watcher", async () => {
+    const viewStore = useViewStore();
+    const selection = useSelectionStore();
+
+    const stop = vi.fn();
+    const fakeWatch = vi.fn(() => stop);
+    viewStore.startRouteSync(routeOf("character", { id: "7" }), {
+      watch: fakeWatch,
+    });
+    expect(fakeWatch).toHaveBeenCalledTimes(1);
+    expect(fakeWatch.mock.calls[0][2]).toEqual({ immediate: true, deep: true });
+
+    // A second install (App.vue remounting) stops the first watcher.
+    viewStore.startRouteSync(routeOf("character", { id: "7" }), {
+      watch: fakeWatch,
+    });
+    expect(stop).toHaveBeenCalledTimes(1);
+
+    // With the real `watch` and a reactive route (what vue-router hands us),
+    // the store applies on install and follows every navigation after it.
+    const live = reactive(routeOf("all-pictures"));
+    viewStore.startRouteSync(live, { watch });
+    expect(selection.selectedCharacter).toBe("ALL");
+    Object.assign(live, routeOf("set", { id: "3" }));
+    await nextTick();
+    expect(selection.selectedSetIds).toEqual([3]);
+  });
+});


### PR DESCRIPTION
Lane A of v1.9.0, first refactor PR. Moves route→view resolution out of App.vue into a new `useViewStore` (pure `parseRouteView` + guarded `applyRoute`), with the watcher installed from App.vue's effect scope via `startRouteSync`. App.vue drops 2665 → 2452 lines; production diff 559 lines.

- Route pushing stays in App.vue per plan step 4.
- Semantics preserved branch-for-branch, incl. the `?ids=` fallback and folder routes not clearing `selectedFolderFilter`.
- Unit suite 896 passed; e2e pins 11 passed; entities spec 3 passed; lint + build clean.

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U