### PR TITLE
Operation log with metadata undo/redo (DAM 1.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,7 @@ jobs:
           tests/test_metadata_hash.py
           tests/test_migrations.py
           tests/test_openapi_response_schemas.py
+          tests/test_operation_log.py
           tests/test_picture_mutation_scope.py
           tests/test_picture_plugins.py
           tests/test_picture_set_locking.py

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -31,6 +31,7 @@
 18. [Snapshots & Restore](#18-snapshots--restore)
 19. [Mermaid Diagrams](#19-mermaid-diagrams)
 20. [Architectural Patterns](#20-architectural-patterns)
+21. [Operation Log](#21-operation-log--undoredo-and-the-audit-trail-dam-12)
 
 ---
 
@@ -412,6 +413,13 @@ Public guest scoring and shared-link endpoints.
 | GET    | /api/v1/login                                                                 | auth            | Check Registration                                         |
 | POST   | /api/v1/login                                                                 | auth            | Login                                                      |
 | POST   | /api/v1/logout                                                                | auth            | Logout                                                     |
+| GET    | /api/v1/operations                                                            | operations      | List recorded operations (newest first)                    |
+| POST   | /api/v1/operations/batches/{batch_id}/undo                                    | operations      | Undo one whole bulk action by its batch id                 |
+| POST   | /api/v1/operations/redo                                                       | operations      | Re-apply the most recently undone operation                |
+| POST   | /api/v1/operations/undo                                                       | operations      | Undo the newest reversible operation                       |
+| GET    | /api/v1/operations/undo-state                                                 | operations      | What undo and redo would do next                           |
+| GET    | /api/v1/operations/{operation_id}                                             | operations      | Get one operation including its before/after state         |
+| POST   | /api/v1/operations/{operation_id}/undo                                        | operations      | Undo one specific operation (and its batch)                |
 | GET    | /api/v1/picture_sets                                                          | picture_sets    | List picture sets                                          |
 | POST   | /api/v1/picture_sets                                                          | picture_sets    | Create picture set                                         |
 | GET    | /api/v1/picture_sets/locked-members                                           | picture_sets    | List locked sets and their frozen pictures                 |
@@ -628,6 +636,19 @@ TaggerRun: id, run (unique), model_version, verdict, recommend,
            (tagger eval runs pushed from PixlTagger)
 ```
 
+### Operation log (append-only)
+
+```text
+Operation: id, batch_id, created_at, actor, op_type, target_type,
+           target_ids (JSON list[int]), target_count,
+           before_state (JSON {picture_id: {facet: value}}),
+           after_state (same shape), source, origin_client_id,
+           undoable, status (applied|undone|superseded), undone_at,
+           summary
+           (one recorded change; undo restores before_state, redo
+            restores after_state — see §21)
+```
+
 ### Filesystem-linked
 
 ```text
@@ -776,6 +797,7 @@ Modules in [pixlstash/services/](../pixlstash/services/) contain business logic 
 | [services/tag_scan_service.py](../pixlstash/services/tag_scan_service.py) | On-demand near-neighbour tag scan — finds one tag's suspects and appends them; reuses the shared `knn_disagreement_with_neighbors` kernel so CLI and UI can't drift |
 | [services/review_service.py](../pixlstash/services/review_service.py) | Service layer for review sessions (one tag + a frozen scope + one scan's results): create, scan-once, append-only refresh, archive/abort, and per-item decisions |
 | [services/impossible_tag_scan_service.py](../pixlstash/services/impossible_tag_scan_service.py) | On-demand impossible-tag scan — (re)builds the cleanup queue for person-tags that are impossible on a picture with no detectable face; sibling of `tag_scan_service.py` |
+| [services/operation_log_service.py](../pixlstash/services/operation_log_service.py) | The operation log (§21): snapshots the reversible metadata facets of the affected pictures before and after a mutation, records the diff as one append-only `Operation` row (with a batch id when it is part of a bulk action), and applies a recorded state back for undo/redo. `run_recorded_metadata_task` is the wrapper mutation sites call instead of `vault.db.run_task`, so capture, mutation and recording share one queued task |
 | [services/impossible_tag_clear_service.py](../pixlstash/services/impossible_tag_clear_service.py) | Bulk-clear the filter-implied wrong tags for the human-reviewed "Impossible tags" grid selection (recording a human NEG per removed tag), plus the symmetric undo; used by the impossible-tags routes |
 
 ### 10.1 DB access rule for services (enforced in CI)
@@ -859,7 +881,11 @@ Selected milestones:
 
 | 0084 | Library-wide `smart_score` NULL-reset after rebalancing the positive weights |
 
-Current head: `0084_recompute_smart_score_rebalanced_weights`.
+| 0085 | `smart_score` NULL-reset after restoring the built-in anchors |
+
+| 0086 | Append-only `operation` table — the operation log / undo-redo substrate (§21), carrying `batch_id` from day one |
+
+Current head: `0086_add_operation_log`.
 
 ---
 
@@ -1475,7 +1501,46 @@ sequenceDiagram
 
 ---
 
-*Last updated: 2026-07-19. Update this document whenever architectural patterns, module boundaries, or integration contracts change.*
+## 21. Operation Log — undo/redo and the audit trail (DAM 1.2)
+
+The `operation` table ([db_models/operation.py](../pixlstash/db_models/operation.py)) is the **append-only** record of every user-visible change. It is the undo/redo stack today and the audit log / Studio activity feed later — one mechanism, three features (DAM roadmap §1.2 / §4.3), which is why it is built once and additively.
+
+### The design: record state, not inverses
+
+Instead of teaching each mutating endpoint how to invert itself, the log snapshots the **metadata state of the affected pictures before and after** the mutation and keeps only the facets that changed. Undo writes the recorded `before` back; redo writes `after` back. Consequences worth knowing:
+
+- The applier is uniform, so a new mutating endpoint becomes undoable by wrapping its DB task — there is no inverse to write and none to get wrong.
+- The stored payload is exactly the `{before, after}` shape the roadmap specifies for the audit log, so the feed needs no second representation.
+- Restoring is idempotent: applying a state twice is a no-op, so a retried undo cannot corrupt anything.
+
+**Reversible facets** (the DAM 1.2 metadata scope, `FACETS` in [services/operation_log_service.py](../pixlstash/services/operation_log_service.py)): tags, description/caption, score (rating), picture-set membership, project membership (`PictureProjectMember` + the `Picture.project_id` FK), per-face character assignment + `pending_character_id`, and stacking (`stack_id` / `stack_position`, with the stack's name so a dissolved stack can be recreated on undo). A file-mutating operation may be *recorded* with `undoable=False` for audit, but it is not reversible until copy-on-write versions land (v2.1).
+
+### Recording a change
+
+Metadata mutation sites call `operation_log_service.run_recorded_metadata_task(vault, work_fn, *args, op_type=…, picture_ids=…, **request_context(request))` **instead of** `vault.db.run_task(work_fn, *args)`. That wrapper runs capture → mutation → capture → record inside **one** queued DB task, so the `Operation` row and the change it describes commit against the same serialised writer; a separate before-read on the caller's thread would leave a window for another write to land between the snapshot and the mutation and be silently attributed to this operation. Pass `expand_stacks=True` when the mutation is stack-atomic, or undo would restore the clicked picture and leave its stack siblings behind. Pass `resolve_picture_ids=` — a `(session) -> ids` callable run on the mutation's own session just before the write — when the handler's targets are not knowable from the request alone (a request addressed by *face* id; a replace-all that evicts members it was never told about); without it the operation records a half-change undo could not fully reverse. A mutation that changed nothing records nothing.
+
+### `batch_id` — one bulk action, one Undo
+
+`batch_id` groups several rows into one user-visible action. Undoing any member reverts the whole batch (newest first), so a partially-undone bulk action cannot exist, and `POST /operations/batches/{batch_id}/undo` is the single-call revert behind a bulk report ("Collapsed 2,700 groups — Undo"). The column is present from the first migration deliberately: retrofitting a grouping key onto a log that already holds rows is exactly the pain the additive-only rule exists to prevent.
+
+### Append-only, and what "status" means
+
+Recorded content (`op_type` / `target_ids` / `before_state` / `after_state` / `actor` / `source` / `created_at`) is written once and never rewritten. The only mutable columns are the lifecycle markers `status` (`applied` → `undone` → `superseded`) and `undone_at`, which *append* the fact that an operation was reverted rather than erasing it. Recording a new operation supersedes the redo stack (classic linear undo history) by advancing those markers — no row is deleted. `tests/test_operation_log.py::test_log_is_append_only_across_undo_and_redo` pins this.
+
+### Origin discipline (§15) applies on both sides
+
+`source` / `origin_client_id` are read from the **request**, in the handler, on the request's own task (`operation_log_service.request_context`), then passed explicitly downstream and carried in the WS event `data` dict when undo announces itself. The service never reads `origin_client_id_var` — it runs on the DB worker thread where that contextvar is dead, the same hazard `test_source_origin_read_from_data_only` pins for the broadcaster. Both directions are tested: `tests/test_operation_log.py::test_service_module_never_reads_the_origin_contextvar` (an AST check, so a future edit cannot reintroduce the read) and `tests/test_ws_broadcaster.py::test_operation_log_undo_emits_origin_in_data_not_from_the_contextvar` (the producer side of the envelope contract).
+
+### Locked sets are not bypassed
+
+A locked picture set is a hard freeze on its members' label data. `apply_state_in_session` — the single sink every restore goes through — calls `enforce_pictures_not_locked` over the whole recorded state before dispatching, so undo/redo cannot become the one write path around the freeze; a frozen target yields `423` and the operation stays `applied`.
+
+### Endpoints and authorization
+
+`GET /operations`, `GET /operations/undo-state`, `GET /operations/{operation_id}`, `POST /operations/undo`, `POST /operations/redo`, `POST /operations/{operation_id}/undo`, `POST /operations/batches/{batch_id}/undo` — all declared **`OWNER_ONLY`** in `ROUTE_POLICIES` (§16.1). The log enumerates every change to the whole library and undo writes metadata back onto arbitrary pictures across the vault, so no resource-scoped grant can bound either. The handlers carry **no** authorization code; the gate is the sole enforcement.
+
+---
+
+*Last updated: 2026-07-28. Update this document whenever architectural patterns, module boundaries, or integration contracts change.*
 
 ### Known drift / cleanup notes
-

--- a/docs/reviews/authz-coverage-matrix.md
+++ b/docs/reviews/authz-coverage-matrix.md
@@ -2,6 +2,7 @@
 
 - **Branch:** `backend-refactoring`
 - **Scope:** Phase 1 **Step 2 only** of the centralised-authz refactor (backend refactor plan §3.5). This PR **declares** the access policy of every mounted HTTP route in `pixlstash/authz/registry.py::ROUTE_POLICIES`. It does **not** enforce anything (`AUTHZ_GATE_ENFORCING = False`), remove any inline check, or change any handler. It is the regenerated coverage matrix the adversarial security review consumes.
+- **Arithmetic completeness (updated 2026-07-28):** **224 declared**, covering the **223** routes mounted in the default configuration plus **1 conditionally-mounted** route. The v1.9 delta is **+7 `owner_only`** rows for the DAM 1.2 operation log (`operations.py`, table below), taking `owner_only` 83 → **90**. No existing declaration changed. Original Step-2 text follows.
 - **Arithmetic completeness:** **217 declared**, covering the **216** routes mounted in the default configuration plus **1 conditionally-mounted** route (was 207 at the Step-2 back-fill; +6 from the async streaming-staging import (#459), +2 from the v1.8.0 scrapheap-retention config pair GET/PATCH `/server-config/scrapheap-retention` (both `owner_only`), +1 GET `/server-config/scrapheap-retention/impact` (`owner_only`), +1 POST `/api/v1/test-hooks/ws-event` (`loopback_owner_only`)). Gate `enforce_startup` (both report-only and, as a dry check, `enforcing=True`) resolves the app with **0 undeclared, 0 dead declarations, 0 authoring problems** (every `PUBLIC`/`LOCAL_OWNER_ONLY` has a justification; every `*_SCOPED` `id_param` is a real template param). The audit allowlist in `tests/test_architecture_guardrails.py` has burned to **zero** (`_CURRENT_ROUTE_ALLOWLIST = frozenset()`); the registry is now the sole coverage matrix. Guardrail suite: **17 passed**.
 - **WebSockets:** the 2 WS routes (`/ws/comfyui`, `/api/v1/ws/updates`) are **out of the HTTP registry by design** — their chokepoint is `authenticate_websocket` (plan §6). They remain acknowledged in `tests/test_architecture_guardrails.py::test_websocket_routes_are_acknowledged`, and `registry.py` carries the `# WS routes: see authn/websocket.py` sentinel.
 
@@ -349,6 +350,30 @@ Rationale column is empty where it equals the policy-meaning table above (e.g. `
 | POST | `/api/v1/reviews/{review_id}/archive` | owner_only |  | Owner-only review surface; write |
 | POST | `/api/v1/reviews/{review_id}/refresh` | owner_only |  | Owner-only review surface; write |
 | GET | `/api/v1/reviews/{review_id}/suggestions` | owner_only |  | Owner-only review read (inline rejects scoped tokens) |
+
+### operations.py (added 2026-07-28 — DAM 1.2 operation log)
+
+Vault-wide change history plus the undo/redo stack. `owner_only` throughout: the
+log enumerates every change to the **whole library** (a resource-scoped share
+token must not read it), and undo/redo write metadata back onto arbitrary
+pictures across the vault, which no resource-scoped grant can bound. Every write
+here is a POST outside `READ_SAFE_POST_PATHS`, so a READ (⇒ scoped) token is
+already middleware-blocked; the reads are the rows `owner_only` actually
+tightens. **No inline authz check exists in these handlers** — the gate is the
+sole enforcement (pinned by
+`tests/test_operation_log.py::test_operations_routes_have_no_inline_authz_check`),
+and the declarations themselves are pinned by
+`tests/test_operation_log.py::test_every_operations_route_is_declared_owner_only`.
+
+| Method | Effective path | Policy | id_param / body_ids | Rationale (current enforcement) |
+|---|---|---|---|---|
+| GET | `/api/v1/operations` | owner_only |  | Vault-wide change history; owner-only read |
+| GET | `/api/v1/operations/undo-state` | owner_only |  | Vault-wide undo/redo availability; owner-only read |
+| GET | `/api/v1/operations/{operation_id}` | owner_only |  | One operation incl. the recorded before/after metadata of its targets (arbitrary vault pictures); owner-only read |
+| POST | `/api/v1/operations/undo` | owner_only |  | Reverts metadata across the vault; owner-only write |
+| POST | `/api/v1/operations/redo` | owner_only |  | Re-applies metadata across the vault; owner-only write |
+| POST | `/api/v1/operations/{operation_id}/undo` | owner_only |  | Reverts metadata across the vault; owner-only write |
+| POST | `/api/v1/operations/batches/{batch_id}/undo` | owner_only |  | Reverts a whole bulk action across the vault; owner-only write |
 
 ### tag_health.py
 

--- a/pixlstash/authz/registry.py
+++ b/pixlstash/authz/registry.py
@@ -721,6 +721,38 @@ ROUTE_POLICIES: dict[tuple[str, str], RoutePolicy] = {
     ("GET", "/api/v1/reviews/{review_id}/suggestions"): RoutePolicy(
         _OWNER, justification="Owner-only review read (inline rejects scoped tokens)"
     ),
+    # ── operations.py (the append-only operation log: history + undo/redo) ──
+    # Vault-wide change history and the undo/redo stack. OWNER_ONLY across the
+    # board: the log enumerates every change to the whole library (a scoped
+    # share token must not read it), and undo/redo write metadata back onto
+    # arbitrary pictures across the vault, which no scoped grant can bound. The
+    # handlers carry NO authz code — the gate is the only enforcement (§16.1).
+    ("GET", "/api/v1/operations"): RoutePolicy(
+        _OWNER, justification="Vault-wide change history; owner-only read"
+    ),
+    ("GET", "/api/v1/operations/undo-state"): RoutePolicy(
+        _OWNER, justification="Vault-wide undo/redo availability; owner-only read"
+    ),
+    ("GET", "/api/v1/operations/{operation_id}"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "One operation incl. the recorded before/after metadata of its "
+            "targets (arbitrary vault pictures); owner-only read"
+        ),
+    ),
+    ("POST", "/api/v1/operations/undo"): RoutePolicy(
+        _OWNER, justification="Reverts metadata across the vault; owner-only write"
+    ),
+    ("POST", "/api/v1/operations/redo"): RoutePolicy(
+        _OWNER, justification="Re-applies metadata across the vault; owner-only write"
+    ),
+    ("POST", "/api/v1/operations/{operation_id}/undo"): RoutePolicy(
+        _OWNER, justification="Reverts metadata across the vault; owner-only write"
+    ),
+    ("POST", "/api/v1/operations/batches/{batch_id}/undo"): RoutePolicy(
+        _OWNER,
+        justification="Reverts a whole bulk action across the vault; owner-only write",
+    ),
     # ── tag_health.py (bespoke "reject resource-scoped" gate; owner-only) ────
     # Same unscoped-READ nuance as reviews (see NEEDS REVIEW above).
     ("GET", "/api/v1/tag_health"): RoutePolicy(

--- a/pixlstash/db_models/__init__.py
+++ b/pixlstash/db_models/__init__.py
@@ -2,6 +2,14 @@ from .character import Character  # noqa: F401
 from .deleted_file_log import DeletedFileLog  # noqa: F401
 from .detection import Detection  # noqa: F401
 from .face import Face  # noqa: F401
+from .operation import (  # noqa: F401
+    Operation,
+    STATUS_APPLIED,
+    STATUS_SUPERSEDED,
+    STATUS_UNDONE,
+    TARGET_PICTURE,
+    VALID_STATUSES,
+)
 from .picture import Picture, SortMechanism  # noqa: F401
 from .picture_project import PictureProjectMember  # noqa: F401
 from .picture_set import PictureSet, PictureSetMember  # noqa: F401

--- a/pixlstash/db_models/operation.py
+++ b/pixlstash/db_models/operation.py
@@ -1,0 +1,110 @@
+"""The append-only operation log — DAM 1.2's undo/redo substrate and audit log.
+
+One :class:`Operation` row records one user-visible change: what changed, on
+which targets, the *before* and *after* metadata state of those targets, who did
+it, and where it came from (the WebSocket envelope's ``source`` /
+``origin_client_id`` discipline, §15). Undo restores ``before_state``; redo
+re-applies ``after_state``.
+
+**Append-only.** Recorded content (``op_type`` / ``target_ids`` /
+``before_state`` / ``after_state`` / ``actor`` / ``source`` / ``created_at``) is
+written once and never rewritten — that is what makes this table usable as the
+audit log and, later, the Studio activity feed (DAM roadmap §4.3). The only
+mutable columns are the lifecycle markers ``status`` / ``undone_at``, which
+*append* the fact that the operation was later reverted rather than erasing it.
+
+**Batch id from day one.** ``batch_id`` groups several rows into one
+user-visible action, so a bulk job (the v1.9 near-duplicate sweep, a future
+dehydration pass) is undone as a single unit through one endpoint. It is present
+in the schema from the first migration deliberately: retrofitting a grouping key
+onto a log that already has rows is exactly the migration pain the additive-only
+rule exists to avoid.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlmodel import Field, SQLModel
+
+# Lifecycle of a recorded operation. ``APPLIED`` is live; ``UNDONE`` sits on the
+# redo stack; ``SUPERSEDED`` is an undone operation whose redo was invalidated by
+# a newer operation (the classic linear undo history). Only the marker moves —
+# the recorded content never changes.
+STATUS_APPLIED = "applied"
+STATUS_UNDONE = "undone"
+STATUS_SUPERSEDED = "superseded"
+VALID_STATUSES = (STATUS_APPLIED, STATUS_UNDONE, STATUS_SUPERSEDED)
+
+# The only target type today. Declared as a column (not assumed) because the
+# audit log will later record set-, project- and model-shelf-level operations.
+TARGET_PICTURE = "picture"
+
+
+class Operation(SQLModel, table=True):
+    """One recorded, potentially reversible change to library metadata.
+
+    Attributes:
+        id: Surrogate key; also the log's total order (monotonic per DB).
+        batch_id: Opaque group id shared by every operation of one bulk action.
+            ``None`` for a plain single-shot operation. Undoing any member of a
+            batch undoes the whole batch.
+        created_at: UTC timestamp the operation was recorded.
+        actor: Who performed it — the user id as a string, or a service name for
+            a background actor. ``None`` when unauthenticated context is absent.
+        op_type: Dotted verb naming the change, e.g. ``"pictures.tags"``. Free
+            text on purpose: the undo applier is driven by the recorded state,
+            not by the verb, so a new op type needs no applier change.
+        target_type: Kind of object the ids in ``target_ids`` refer to
+            (:data:`TARGET_PICTURE` today).
+        target_ids: JSON list of affected object ids.
+        target_count: ``len(target_ids)``, denormalised so the activity feed can
+            aggregate without parsing every payload.
+        before_state: JSON ``{"<target_id>": {facet: value}}`` holding ONLY the
+            facets this operation changed, as they were *before* it ran.
+        after_state: The same shape, as the facets are *after* it ran.
+        source: WS-envelope source (``"ui"`` / ``"external"``), carried
+            explicitly from the request — never read from a contextvar.
+        origin_client_id: WS-envelope per-tab origin, same discipline.
+        undoable: ``True`` only for the metadata scope DAM 1.2 defines. A
+            file-mutating operation is *recorded* (audit) but not reversible
+            until copy-on-write versions exist, and is stored with ``False``.
+        status: One of :data:`VALID_STATUSES`.
+        undone_at: UTC timestamp of the undo, when it happened.
+        summary: Short human sentence for the activity feed / undo toast.
+    """
+
+    __tablename__ = "operation"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+
+    batch_id: Optional[str] = Field(default=None, index=True)
+
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    actor: Optional[str] = Field(default=None, index=True)
+
+    op_type: str = Field(index=True)
+    target_type: str = Field(default=TARGET_PICTURE)
+    target_ids: str = Field(sa_column=sa.Column(sa.Text(), nullable=False))
+    target_count: int = Field(default=0)
+
+    before_state: Optional[str] = Field(
+        default=None, sa_column=sa.Column(sa.Text(), nullable=True)
+    )
+    after_state: Optional[str] = Field(
+        default=None, sa_column=sa.Column(sa.Text(), nullable=True)
+    )
+
+    source: str = Field(default="external")
+    origin_client_id: Optional[str] = Field(default=None)
+
+    undoable: bool = Field(default=False, index=True)
+    status: str = Field(default=STATUS_APPLIED, index=True)
+    undone_at: Optional[datetime] = Field(default=None)
+
+    summary: Optional[str] = Field(default=None)
+
+    __table_args__ = (
+        # The undo/redo stacks are "newest row in this status, newest first".
+        sa.Index("ix_operation_status_id", "status", "id"),
+    )

--- a/pixlstash/migrations/versions/0086_add_operation_log.py
+++ b/pixlstash/migrations/versions/0086_add_operation_log.py
@@ -1,0 +1,108 @@
+"""Add the append-only operation log (DAM 1.2: undo/redo + the future audit log).
+
+Creates the ``operation`` table. One row records one user-visible change: its
+verb, the target ids, the *before* and *after* metadata state of those targets,
+the actor, and the WebSocket-envelope origin (``source`` / ``origin_client_id``)
+the change arrived with. Undo writes ``before_state`` back; redo writes
+``after_state`` back.
+
+``batch_id`` is present from this first migration on purpose. A bulk action (the
+v1.9 near-duplicate sweep, any later batch job) must be one undoable unit, and
+retrofitting a grouping key onto a log that already holds rows is exactly the
+migration pain the additive-only rule exists to avoid.
+
+Additive only: no existing table, column or constraint is touched, and no data
+is reset. Table creation is conditional on the table being absent, because the
+0001 baseline runs ``SQLModel.metadata.create_all()`` and therefore already
+creates it on a fresh database.
+
+Revision ID: 0086_add_operation_log
+Revises: 0085_recompute_smart_score_restored_builtin_anchors
+Create Date: 2026-07-28 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0086_add_operation_log"
+down_revision: Union[str, None] = "0085_recompute_smart_score_restored_builtin_anchors"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+_INDEXES = (
+    ("ix_operation_batch_id", ["batch_id"]),
+    ("ix_operation_created_at", ["created_at"]),
+    ("ix_operation_actor", ["actor"]),
+    ("ix_operation_op_type", ["op_type"]),
+    ("ix_operation_undoable", ["undoable"]),
+    ("ix_operation_status", ["status"]),
+    # The undo/redo stacks are "newest row in this status".
+    ("ix_operation_status_id", ["status", "id"]),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "operation" not in inspector.get_table_names():
+        op.create_table(
+            "operation",
+            sa.Column("id", sa.Integer(), nullable=False),
+            # Groups the rows of one bulk action so it is undone as a unit.
+            sa.Column("batch_id", sa.String(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("actor", sa.String(), nullable=True),
+            sa.Column("op_type", sa.String(), nullable=False),
+            sa.Column(
+                "target_type",
+                sa.String(),
+                nullable=False,
+                server_default="picture",
+            ),
+            # JSON list[int] of affected object ids.
+            sa.Column("target_ids", sa.Text(), nullable=False),
+            sa.Column("target_count", sa.Integer(), nullable=False, server_default="0"),
+            # JSON {"<target_id>": {facet: value}} — only the changed facets.
+            sa.Column("before_state", sa.Text(), nullable=True),
+            sa.Column("after_state", sa.Text(), nullable=True),
+            # WS-envelope provenance, carried explicitly from the request.
+            sa.Column("source", sa.String(), nullable=False, server_default="external"),
+            sa.Column("origin_client_id", sa.String(), nullable=True),
+            # False for changes recorded for audit only (file-mutating ops until
+            # copy-on-write versions exist).
+            sa.Column("undoable", sa.Boolean(), nullable=False, server_default="0"),
+            sa.Column("status", sa.String(), nullable=False, server_default="applied"),
+            sa.Column("undone_at", sa.DateTime(), nullable=True),
+            sa.Column("summary", sa.String(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    # Re-inspect: the Inspector above cached the pre-create_table reflection.
+    existing_indexes = {
+        ix["name"] for ix in sa.inspect(op.get_bind()).get_indexes("operation")
+    }
+    for index_name, columns in _INDEXES:
+        if index_name not in existing_indexes:
+            op.create_index(index_name, "operation", columns)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "operation" not in inspector.get_table_names():
+        return
+
+    existing_indexes = {ix["name"] for ix in inspector.get_indexes("operation")}
+    for index_name, _columns in _INDEXES:
+        if index_name in existing_indexes:
+            op.drop_index(index_name, table_name="operation")
+    op.drop_table("operation")

--- a/pixlstash/routes/characters_faces.py
+++ b/pixlstash/routes/characters_faces.py
@@ -18,7 +18,6 @@ from fastapi import APIRouter, Body, HTTPException, Request
 from pydantic import BaseModel, ConfigDict
 from sqlmodel import Session, select
 
-from pixlstash.database import DBPriority
 from pixlstash.db_models import (
     Character,
     Face,
@@ -30,6 +29,7 @@ from pixlstash.picture_scoring import (
     compute_character_likeness_for_faces,
     select_reference_faces_for_character,
 )
+from pixlstash.services import operation_log_service
 from pixlstash.services.stack_membership import expand_picture_ids_to_stacks
 from pixlstash.utils.service.filter_helpers import fetch_scope_allowed_picture_ids
 
@@ -95,6 +95,31 @@ def _enforce_face_mutation_scope(
             status_code=403,
             detail="Token is not authorised to access these pictures",
         )
+
+
+def _picture_ids_for_faces(face_ids):
+    """Resolver for the operation log: the pictures behind a face-id request.
+
+    Character assignment can be addressed either by picture id or by face id.
+    The face-id form does not name its pictures, so the operation log would
+    snapshot nothing and record a half-change. This returns a
+    ``(session) -> picture ids`` callable the recorder runs on the mutation's own
+    session just before the write, or ``None`` when the request already named its
+    pictures.
+    """
+    if not face_ids:
+        return None
+
+    def _resolve(session: Session):
+        return [
+            picture_id
+            for picture_id in session.exec(
+                select(Face.picture_id).where(Face.id.in_(list(face_ids)))
+            ).all()
+            if picture_id is not None
+        ]
+
+    return _resolve
 
 
 def create_router(server) -> APIRouter:
@@ -243,12 +268,25 @@ def create_router(server) -> APIRouter:
             existing_face_ids = [face.id for face in existing_faces]
             return faces_payload, existing_face_ids
 
-        faces, existing_face_ids = server.vault.db.run_task(
-            assign_faces,
-            face_ids,
-            picture_ids,
-            character_id,
-            priority=DBPriority.IMMEDIATE,
+        # Assignment is stack-atomic (the work function expands the request to
+        # whole stacks), so the snapshot expands too. A request addressed by face
+        # id does not name its pictures, so resolve them on the mutation's own
+        # session before the write — otherwise the operation would record a
+        # half-change that undo could not reverse.
+        (faces, existing_face_ids), _operation = (
+            operation_log_service.run_recorded_metadata_task(
+                server.vault,
+                assign_faces,
+                face_ids,
+                picture_ids,
+                character_id,
+                op_type="characters.assign",
+                picture_ids=picture_ids,
+                resolve_picture_ids=_picture_ids_for_faces(face_ids),
+                expand_stacks=True,
+                summary="Assigned pictures to a character",
+                **operation_log_service.request_context(request),
+            )
         )
         if not faces and len(existing_face_ids) > 0:
             # All requested faces are already assigned to this character — the
@@ -339,12 +377,20 @@ def create_router(server) -> APIRouter:
             session.refresh(face)
             return faces
 
-        server.vault.db.run_task(
+        # Unlike the assign above, this handler does not expand to stacks, so the
+        # snapshot covers exactly the requested pictures — plus the pictures of a
+        # face-id-addressed request, resolved on the mutation's own session.
+        operation_log_service.run_recorded_metadata_task(
+            server.vault,
             remove_faces_from_character,
             character_id,
             face_ids,
             picture_ids,
-            priority=DBPriority.IMMEDIATE,
+            op_type="characters.unassign",
+            picture_ids=picture_ids,
+            resolve_picture_ids=_picture_ids_for_faces(face_ids),
+            summary="Unassigned pictures from a character",
+            **operation_log_service.request_context(request),
         )
 
         server.vault.db.run_task(Picture.clear_field, picture_ids, "text_embedding")

--- a/pixlstash/routes/operations.py
+++ b/pixlstash/routes/operations.py
@@ -1,0 +1,240 @@
+"""HTTP routes for the operation log — history, undo and redo (DAM 1.2).
+
+The log is append-only and vault-wide: it is the undo/redo stack today and the
+audit log / activity feed later (DAM roadmap §4.3). Every route here is declared
+``OWNER_ONLY`` in ``pixlstash/authz/registry.py`` — a resource-scoped share token
+must never enumerate the owner's whole change history, and must never revert a
+change. There is deliberately **no** authorization code in these handlers; the
+authz gate owns it (``docs/backend_architecture.md`` §16.1).
+
+Origin discipline (§15): each mutating route reads ``X-Client-Id`` off the
+request via ``request.state.origin_client_id`` and hands it to the service
+**explicitly**, which carries it in the WebSocket event ``data`` dict. Nothing
+downstream reads the contextvar — it is dead on the DB worker thread and on the
+broadcaster's loop.
+
+See :mod:`pixlstash.services.operation_log_service` for the semantics.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict
+
+from pixlstash.db_models.operation import VALID_STATUSES
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services import operation_log_service
+from pixlstash.services.operation_log_service import OperationLogError
+
+logger = get_logger(__name__)
+
+
+class OperationResponse(BaseModel):
+    """One recorded operation as the API returns it."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int
+    batch_id: Optional[str] = None
+    created_at: Optional[str] = None
+    actor: Optional[str] = None
+    op_type: str
+    target_type: str
+    target_ids: list[int] = []
+    target_count: int = 0
+    source: str = "external"
+    origin_client_id: Optional[str] = None
+    undoable: bool = False
+    status: str
+    undone_at: Optional[str] = None
+    summary: Optional[str] = None
+
+
+class UndoStateResponse(BaseModel):
+    """What the Ctrl+Z / Ctrl+Shift+Z affordances should offer right now."""
+
+    can_undo: bool
+    can_redo: bool
+    next_undo: Optional[OperationResponse] = None
+    next_redo: Optional[OperationResponse] = None
+
+
+class UndoResultResponse(BaseModel):
+    """Which operations were reverted (or replayed) and what they touched."""
+
+    model_config = ConfigDict(extra="allow")
+
+    operations: list[OperationResponse] = []
+    picture_ids: list[int] = []
+    picture_count: int = 0
+
+
+class UndoRequest(BaseModel):
+    """Optional body for ``POST /operations/undo``."""
+
+    # Undo this specific operation instead of the newest reversible one. Its
+    # whole batch goes with it — a bulk action is one undoable unit.
+    operation_id: Optional[int] = None
+
+
+def create_router(server) -> APIRouter:
+    router = APIRouter()
+
+    def _origin(request: Request) -> Optional[str]:
+        # Read at request time, on the request's own task, and passed explicitly
+        # from here on (§15 threading caveat).
+        return getattr(request.state, "origin_client_id", None)
+
+    @router.get(
+        "/operations",
+        summary="List recorded operations (newest first)",
+        description=(
+            "Returns the append-only operation log, newest first: what changed, "
+            "how many targets it touched, who did it, where it came from and "
+            "whether it is still reversible. Filter with ``status`` "
+            "(applied | undone | superseded), ``batch_id`` (all operations of "
+            "one bulk action) or ``op_type``. The before/after payloads are "
+            "omitted here — fetch a single operation to see them."
+        ),
+        response_model=list[OperationResponse],
+    )
+    def list_operations(
+        request: Request,
+        limit: int = 50,
+        status: Optional[str] = None,
+        batch_id: Optional[str] = None,
+        op_type: Optional[str] = None,
+    ):
+        if status and status not in VALID_STATUSES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"status must be one of: {', '.join(VALID_STATUSES)}",
+            )
+        if limit < 1:
+            raise HTTPException(status_code=400, detail="limit must be >= 1")
+        return operation_log_service.list_operations(
+            server.vault,
+            limit=limit,
+            status=status,
+            batch_id=batch_id,
+            op_type=op_type,
+        )
+
+    # Registered before /operations/{operation_id} so the literal path is not
+    # swallowed by the id template.
+    @router.get(
+        "/operations/undo-state",
+        summary="What undo and redo would do next",
+        description=(
+            "Returns ``can_undo`` / ``can_redo`` plus the operation each would "
+            "act on, so the UI can label and enable its undo affordances "
+            "without fetching the whole log."
+        ),
+        response_model=UndoStateResponse,
+    )
+    def get_undo_state(request: Request):
+        return operation_log_service.undo_state(server.vault)
+
+    @router.get(
+        "/operations/{operation_id}",
+        summary="Get one operation including its before/after state",
+        description=(
+            "Returns a single operation with the full recorded ``before`` and "
+            "``after`` metadata state of its targets — the payload undo and redo "
+            "write back."
+        ),
+        response_model=OperationResponse,
+    )
+    def get_operation(request: Request, operation_id: int):
+        operation = operation_log_service.get_operation(server.vault, operation_id)
+        if operation is None:
+            raise HTTPException(status_code=404, detail="Operation not found")
+        return operation
+
+    @router.post(
+        "/operations/undo",
+        summary="Undo the newest reversible operation",
+        description=(
+            "Restores the recorded *before* state of the newest still-applied, "
+            "reversible operation — or of ``operation_id`` when the body names "
+            "one. If the operation belongs to a batch (one bulk action), the "
+            "**whole batch** is reverted, so a partially-undone bulk action "
+            "cannot exist. 409 when there is nothing to undo or the named "
+            "operation is not reversible; 423 when a locked picture set freezes "
+            "one of the targets."
+        ),
+        response_model=UndoResultResponse,
+    )
+    def undo_operation(request: Request, payload: UndoRequest | None = None):
+        try:
+            return operation_log_service.undo(
+                server.vault,
+                operation_id=(payload.operation_id if payload else None),
+                origin_client_id=_origin(request),
+            )
+        except OperationLogError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+
+    # Registered before /operations/{operation_id}/undo: "batches" would
+    # otherwise be matched against the int id template and 422.
+    @router.post(
+        "/operations/batches/{batch_id}/undo",
+        summary="Undo one whole bulk action by its batch id",
+        description=(
+            "The single-call revert behind a bulk action's report ('Collapsed "
+            "2,700 groups — Undo'). Reverts every still-applied, reversible "
+            "operation carrying this ``batch_id``, newest first. 409 when the "
+            "batch has nothing left to undo."
+        ),
+        response_model=UndoResultResponse,
+    )
+    def undo_batch(request: Request, batch_id: str):
+        try:
+            return operation_log_service.undo_batch(
+                server.vault,
+                batch_id,
+                origin_client_id=_origin(request),
+            )
+        except OperationLogError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+
+    @router.post(
+        "/operations/{operation_id}/undo",
+        summary="Undo one specific operation (and its batch)",
+        description=(
+            "Same semantics as ``POST /operations/undo`` with a body, addressed "
+            "by path instead. Undoing any member of a batch reverts the whole "
+            "batch."
+        ),
+        response_model=UndoResultResponse,
+    )
+    def undo_specific_operation(request: Request, operation_id: int):
+        try:
+            return operation_log_service.undo(
+                server.vault,
+                operation_id=operation_id,
+                origin_client_id=_origin(request),
+            )
+        except OperationLogError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+
+    @router.post(
+        "/operations/redo",
+        summary="Re-apply the most recently undone operation",
+        description=(
+            "Restores the recorded *after* state of the most recently undone "
+            "operation (and its whole batch). Recording any new operation "
+            "invalidates the redo stack, so redo only ever replays onto the "
+            "history it was undone from. 409 when there is nothing to redo."
+        ),
+        response_model=UndoResultResponse,
+    )
+    def redo_operation(request: Request):
+        try:
+            return operation_log_service.redo(
+                server.vault, origin_client_id=_origin(request)
+            )
+        except OperationLogError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+
+    return router

--- a/pixlstash/routes/picture_sets.py
+++ b/pixlstash/routes/picture_sets.py
@@ -24,6 +24,7 @@ from pixlstash.db_models import (
     Tag,
 )
 from pixlstash.event_types import EventType
+from pixlstash.services import operation_log_service
 from pixlstash.services.project_membership_service import (
     reconcile_entity_project_change,
 )
@@ -1498,12 +1499,19 @@ def create_router(server) -> APIRouter:
             session.commit()
             return added_any
 
-        success = server.vault.db.run_task(
+        # Set membership is stack-atomic, so the snapshot expands to the whole
+        # stack — otherwise undo would leave the stack siblings in the set.
+        success, _operation = operation_log_service.run_recorded_metadata_task(
+            server.vault,
             add_member,
             id,
             picture_id,
             reference_character_id=reference_character_id,
-            priority=DBPriority.IMMEDIATE,
+            op_type="picture_sets.members.add",
+            picture_ids=[picture_id],
+            expand_stacks=True,
+            summary="Added a picture to a set",
+            **operation_log_service.request_context(request),
         )
         if success:
             try:
@@ -1569,12 +1577,19 @@ def create_router(server) -> APIRouter:
             session.commit()
             return True
 
-        success = server.vault.db.run_task(
+        # Stack-atomic like the add above: the removal takes the whole stack out,
+        # so the snapshot has to cover the whole stack too.
+        success, _operation = operation_log_service.run_recorded_metadata_task(
+            server.vault,
             remove_member,
             id,
             picture_id,
             reference_character_id=reference_character_id,
-            priority=DBPriority.IMMEDIATE,
+            op_type="picture_sets.members.remove",
+            picture_ids=[picture_id],
+            expand_stacks=True,
+            summary="Removed a picture from a set",
+            **operation_log_service.request_context(request),
         )
         if success:
             if reference_character_id is not None:
@@ -1653,8 +1668,16 @@ def create_router(server) -> APIRouter:
             session.commit()
             return added
 
-        added = server.vault.db.run_task(
-            bulk_add, id, picture_ids, priority=DBPriority.IMMEDIATE
+        added, _operation = operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            bulk_add,
+            id,
+            picture_ids,
+            op_type="picture_sets.members.add",
+            picture_ids=picture_ids,
+            expand_stacks=True,
+            summary=f"Added {len(picture_ids)} picture(s) to a set",
+            **operation_log_service.request_context(request),
         )
         if added is None:
             raise HTTPException(status_code=404, detail="Picture set not found")
@@ -1737,8 +1760,25 @@ def create_router(server) -> APIRouter:
             session.commit()
             return added
 
-        added = server.vault.db.run_task(
-            bulk_replace, id, picture_ids, priority=DBPriority.IMMEDIATE
+        def _current_members(session):
+            # A replace-all also EVICTS members the request never named. They must
+            # be in the snapshot or undo would re-add the new members and never
+            # restore the evicted ones — a half-reversible operation.
+            return session.exec(
+                select(PictureSetMember.picture_id).where(PictureSetMember.set_id == id)
+            ).all()
+
+        added, _operation = operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            bulk_replace,
+            id,
+            picture_ids,
+            op_type="picture_sets.members.replace",
+            picture_ids=picture_ids,
+            resolve_picture_ids=_current_members,
+            expand_stacks=True,
+            summary=f"Replaced a set's members with {len(picture_ids)} picture(s)",
+            **operation_log_service.request_context(request),
         )
         if added is None:
             raise HTTPException(status_code=404, detail="Picture set not found")

--- a/pixlstash/routes/pictures/_crud.py
+++ b/pixlstash/routes/pictures/_crud.py
@@ -29,7 +29,7 @@ from pixlstash.db_models import (
 )
 from pixlstash.event_types import EventType
 from pixlstash.pixl_logging import get_logger
-from pixlstash.services import scrapheap_service
+from pixlstash.services import operation_log_service, scrapheap_service
 from pixlstash.services.set_lock_service import (
     enforce_pictures_not_locked,
     locked_by_sets_for_picture,
@@ -446,12 +446,23 @@ def register_routes(router, server):
             missing_ids = [pid for pid in ids if pid not in found_ids]
             return updated_ids, missing_ids
 
-        updated_ids, missing_ids = server.vault.db.run_task(
-            update_picture_projects,
-            picture_ids,
-            project_id_value,
-            mode,
-            priority=DBPriority.IMMEDIATE,
+        # Project membership is stack-atomic, so the snapshot expands to whole
+        # stacks — otherwise undo would restore the clicked picture and leave its
+        # stack siblings on the new project.
+        (updated_ids, missing_ids), _operation = (
+            operation_log_service.run_recorded_metadata_task(
+                server.vault,
+                update_picture_projects,
+                picture_ids,
+                project_id_value,
+                mode,
+                op_type="pictures.project",
+                picture_ids=picture_ids,
+                expand_stacks=True,
+                summary=f"Changed project membership ({mode}) "
+                f"for {len(picture_ids)} picture(s)",
+                **operation_log_service.request_context(request),
+            )
         )
 
         if updated_ids:
@@ -618,14 +629,21 @@ def register_routes(router, server):
                 reset_triggered,
             )
 
-        updated_ids, skipped_ids, missing_ids, reset_triggered = (
-            server.vault.db.run_task(
-                _apply_scores_batch,
-                ordered_picture_ids,
-                parsed_scores,
-                only_unscored,
-                priority=DBPriority.IMMEDIATE,
-            )
+        # Recorded as ONE operation so Ctrl+Z reverts the whole batch of ratings
+        # rather than one picture at a time.
+        (
+            (updated_ids, skipped_ids, missing_ids, reset_triggered),
+            _operation,
+        ) = operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            _apply_scores_batch,
+            ordered_picture_ids,
+            parsed_scores,
+            only_unscored,
+            op_type="pictures.score",
+            picture_ids=ordered_picture_ids,
+            summary=f"Rated {len(ordered_picture_ids)} picture(s)",
+            **operation_log_service.request_context(request),
         )
 
         if updated_ids or reset_triggered:
@@ -980,11 +998,15 @@ def register_routes(router, server):
                         session.add_all([Tag(picture_id=pid, tag=t) for t in new_tags])
                         session.commit()
 
-                    server.vault.db.run_task(
+                    operation_log_service.run_recorded_metadata_task(
+                        server.vault,
                         _replace_tags,
                         pic_id,
                         tag_values,
-                        priority=DBPriority.IMMEDIATE,
+                        op_type="pictures.tags.replace",
+                        picture_ids=[pic_id],
+                        summary="Replaced the picture's tags",
+                        **operation_log_service.request_context(request),
                     )
                     updated = True
                 continue
@@ -1020,11 +1042,17 @@ def register_routes(router, server):
                 return pic_db
 
             try:
-                pic = server.vault.db.run_task(
+                pic, _operation = operation_log_service.run_recorded_metadata_task(
+                    server.vault,
                     apply_picture_updates,
                     picture_id,
                     updated_fields,
-                    priority=DBPriority.IMMEDIATE,
+                    op_type="pictures.fields",
+                    picture_ids=[picture_id],
+                    summary="Edited "
+                    + ", ".join(sorted(updated_fields))
+                    + " on the picture",
+                    **operation_log_service.request_context(request),
                 )
             except KeyError:
                 raise HTTPException(status_code=404, detail="Picture not found")

--- a/pixlstash/routes/stacks.py
+++ b/pixlstash/routes/stacks.py
@@ -8,6 +8,7 @@ from sqlalchemy import case
 from sqlmodel import Session, select
 
 from pixlstash.db_models import Picture, PictureStack, SortMechanism
+from pixlstash.services import operation_log_service
 from pixlstash.services.set_lock_service import enforce_stack_membership_not_locked
 from pixlstash.services.stack_membership import reconcile_stack_membership
 from pixlstash.stacking import normalize_stack_positions
@@ -503,7 +504,20 @@ def create_router(server) -> APIRouter:
                 raise HTTPException(status_code=404, detail="Stack not found")
             return safe_model_dict(stack)
 
-        stack_id = server.vault.db.run_task(create_or_assign_stack, picture_ids, name)
+        # Stacking is stack-atomic: a merge moves every member of the pictures'
+        # pre-existing stacks and reconciles the whole stack's set/project
+        # membership, so the snapshot has to cover those siblings too.
+        stack_id, _operation = operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            create_or_assign_stack,
+            picture_ids,
+            name,
+            op_type="stacks.create",
+            picture_ids=picture_ids,
+            expand_stacks=True,
+            summary=f"Stacked {len(picture_ids)} picture(s)",
+            **operation_log_service.request_context(request),
+        )
         pictures = server.vault.db.run_task(_fetch_stack_pictures, stack_id)
         pictures = _ensure_stack_positions(request, stack_id, pictures)
         payload = server.vault.db.run_task(fetch_stack_payload, stack_id)
@@ -692,7 +706,21 @@ def create_router(server) -> APIRouter:
             session.commit()
             return stack
 
-        stack = server.vault.db.run_task(remove_members, stack_id, picture_ids)
+        # Expanding to the whole stack is what makes the dissolve branch
+        # reversible: when one or fewer members remain the stack row is deleted
+        # and the survivor is unstacked too, and that survivor is not in the
+        # requested picture_ids.
+        stack, _operation = operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            remove_members,
+            stack_id,
+            picture_ids,
+            op_type="stacks.dissolve",
+            picture_ids=picture_ids,
+            expand_stacks=True,
+            summary=f"Unstacked {len(picture_ids)} picture(s)",
+            **operation_log_service.request_context(request),
+        )
         if stack is None:
             return {"status": "success", "stack_id": None, "picture_ids": picture_ids}
 

--- a/pixlstash/routes/tags.py
+++ b/pixlstash/routes/tags.py
@@ -29,6 +29,7 @@ from pixlstash.utils.service.tag_prediction_utils import (
     recompute_anomaly_tag_uncertainty,
 )
 from pixlstash.utils.service.filter_helpers import fetch_scope_allowed_picture_ids
+from pixlstash.services import operation_log_service
 from pixlstash.services.set_lock_service import enforce_pictures_not_locked
 from pixlstash.services.impossible_tag_clear_service import (
     VALID_FILTERS,
@@ -220,7 +221,19 @@ def create_router(server) -> APIRouter:
                     session.refresh(pic)
                     return pic
 
-                server.vault.db.run_task(update_picture, pic.id, tag)
+                # Recorded in the operation log so Ctrl+Z can revert it: the
+                # before/after tag state of this picture is captured inside the
+                # same DB task as the write (see operation_log_service).
+                operation_log_service.run_recorded_metadata_task(
+                    server.vault,
+                    update_picture,
+                    pic.id,
+                    tag,
+                    op_type="pictures.tags.add",
+                    picture_ids=[pic_id],
+                    summary=f"Added tag '{tag}'",
+                    **operation_log_service.request_context(request),
+                )
                 server.vault.notify(
                     EventType.CHANGED_TAGS,
                     {
@@ -333,7 +346,16 @@ def create_router(server) -> APIRouter:
                 session.refresh(pic)
                 return pic
 
-            server.vault.db.run_task(update_picture, pic_id, tag_id_int)
+            operation_log_service.run_recorded_metadata_task(
+                server.vault,
+                update_picture,
+                pic_id,
+                tag_id_int,
+                op_type="pictures.tags.remove",
+                picture_ids=[pic_id],
+                summary="Removed a tag",
+                **operation_log_service.request_context(request),
+            )
             server.vault.notify(
                 EventType.CHANGED_TAGS,
                 {
@@ -407,7 +429,16 @@ def create_router(server) -> APIRouter:
             session.refresh(pic)
             return pic
 
-        server.vault.db.run_task(update_picture, pic_id, tag_value)
+        operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            update_picture,
+            pic_id,
+            tag_value,
+            op_type="pictures.tags.remove_all",
+            picture_ids=[pic_id],
+            summary=f"Removed tag '{tag_value}' from the picture",
+            **operation_log_service.request_context(request),
+        )
         server.vault.notify(
             EventType.CHANGED_TAGS,
             {
@@ -466,7 +497,15 @@ def create_router(server) -> APIRouter:
             session.refresh(pic)
             return pic
 
-        server.vault.db.run_task(do_clear, pic_id)
+        operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            do_clear,
+            pic_id,
+            op_type="pictures.tags.clear",
+            picture_ids=[pic_id],
+            summary="Cleared all tags on the picture",
+            **operation_log_service.request_context(request),
+        )
         server.vault.notify(
             EventType.CHANGED_TAGS,
             {

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -64,6 +64,7 @@ from pixlstash.routes.tag_predictions import (
 from pixlstash.routes.tag_suggestions import (
     create_router as create_tag_suggestions_router,
 )
+from pixlstash.routes.operations import create_router as create_operations_router
 from pixlstash.routes.reviews import create_router as create_reviews_router
 from pixlstash.routes.tag_health import create_router as create_tag_health_router
 from pixlstash.routes.tagger_runs import (
@@ -1098,6 +1099,12 @@ class Server(
             create_reviews_router(self),
             prefix=API_V1_PREFIX,
             tags=["reviews"],
+            dependencies=gate,
+        )
+        self.api.include_router(
+            create_operations_router(self),
+            prefix=API_V1_PREFIX,
+            tags=["operations"],
             dependencies=gate,
         )
         self.api.include_router(

--- a/pixlstash/services/operation_log_service.py
+++ b/pixlstash/services/operation_log_service.py
@@ -1,0 +1,971 @@
+"""The operation log: record metadata changes, then undo/redo them (DAM 1.2).
+
+Design in one paragraph. Instead of teaching every mutating endpoint how to
+invert itself, the log records the **metadata state of the affected pictures
+before and after** the mutation, keeping only the facets that actually changed.
+Undo then means "write the recorded ``before`` back"; redo means "write the
+recorded ``after`` back". That makes the applier uniform, makes a new mutating
+endpoint undoable by wrapping its DB task (no inverse logic to write, none to
+get wrong), and produces exactly the ``{before, after}`` payload the DAM roadmap
+specifies for the audit log.
+
+Scope discipline (DAM 1.2, binding): only the **metadata** facets in
+:data:`FACETS` are captured and reversible — tags, caption/description, rating,
+picture-set / project / character membership, and stacking. File-mutating
+operations may be *recorded* for audit with ``undoable=False``, but they are not
+reversible until copy-on-write versions land (Stage 2 / v2.1).
+
+Atomicity: :func:`run_recorded_metadata_task` runs capture → mutation → capture →
+record inside **one** DB-queue task, so the ``Operation`` row and the change it
+describes commit against the same serialised writer. A separate before-read on
+the caller's thread would leave a window in which another write lands between
+the snapshot and the mutation and gets silently attributed to this operation.
+
+Origin discipline (§15, binding): ``source`` / ``origin_client_id`` are passed in
+**explicitly** by the caller, which read them from the request at request time.
+This module never reads ``origin_client_id_var`` — the contextvar is dead on the
+DB worker thread and on the broadcaster's loop, and a read here would be the same
+silent-attribution bug ``test_source_origin_read_from_data_only`` exists to
+prevent. Events emitted after an undo carry the origin in the event ``data`` dict
+for the same reason.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
+
+from sqlmodel import Session, select
+
+from pixlstash.db_models import (
+    Face,
+    Operation,
+    Picture,
+    PictureProjectMember,
+    PictureSetMember,
+    PictureStack,
+    Tag,
+)
+from pixlstash.db_models.operation import (
+    STATUS_APPLIED,
+    STATUS_SUPERSEDED,
+    STATUS_UNDONE,
+    TARGET_PICTURE,
+)
+from pixlstash.event_types import EventType
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services.set_lock_service import enforce_pictures_not_locked
+from pixlstash.services.stack_membership import expand_picture_ids_to_stacks
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pixlstash.vault import Vault
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Facets — the metadata scope DAM 1.2 makes reversible
+# ---------------------------------------------------------------------------
+
+FACET_TAGS = "tags"
+FACET_DESCRIPTION = "description"
+FACET_SCORE = "score"
+FACET_SETS = "sets"
+FACET_PROJECTS = "projects"
+FACET_PROJECT_ID = "project_id"
+FACET_CHARACTERS = "characters"
+FACET_PENDING_CHARACTER_ID = "pending_character_id"
+FACET_STACK = "stack"
+
+FACETS = (
+    FACET_TAGS,
+    FACET_DESCRIPTION,
+    FACET_SCORE,
+    FACET_SETS,
+    FACET_PROJECTS,
+    FACET_PROJECT_ID,
+    FACET_CHARACTERS,
+    FACET_PENDING_CHARACTER_ID,
+    FACET_STACK,
+)
+
+# How many operations the API will ever return in one page.
+MAX_LIST_LIMIT = 500
+
+# Facet -> the event this facet's restoration should announce. CHANGED_PICTURES
+# is the catch-all the grid listens to; the tag/character events additionally
+# refresh the sidebar counts.
+_FACET_EVENTS = {
+    FACET_TAGS: (EventType.CHANGED_TAGS, EventType.CHANGED_PICTURES),
+    FACET_DESCRIPTION: (EventType.CHANGED_DESCRIPTIONS, EventType.CHANGED_PICTURES),
+    FACET_SCORE: (EventType.CHANGED_PICTURES,),
+    FACET_SETS: (EventType.CHANGED_PICTURES,),
+    FACET_PROJECTS: (EventType.CHANGED_PICTURES,),
+    FACET_PROJECT_ID: (EventType.CHANGED_PICTURES,),
+    FACET_CHARACTERS: (EventType.CHANGED_CHARACTERS, EventType.CHANGED_PICTURES),
+    FACET_PENDING_CHARACTER_ID: (EventType.CHANGED_CHARACTERS,),
+    FACET_STACK: (EventType.CHANGED_PICTURES,),
+}
+
+
+class OperationLogError(Exception):
+    """Raised when an undo/redo request cannot be honoured as asked."""
+
+
+# ---------------------------------------------------------------------------
+# State capture
+# ---------------------------------------------------------------------------
+
+
+def _normalize_ids(picture_ids: Iterable[Any]) -> list[int]:
+    """Sorted, de-duplicated, positive int ids; non-numeric entries dropped."""
+    ids: set[int] = set()
+    for raw in picture_ids or ():
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "operation_log: ignoring non-numeric picture id %r in target list",
+                raw,
+            )
+            continue
+        if value > 0:
+            ids.add(value)
+    return sorted(ids)
+
+
+def capture_state_in_session(session: Session, picture_ids) -> dict[str, dict]:
+    """Snapshot every reversible metadata facet of *picture_ids*.
+
+    Args:
+        session: Pre-opened DB session.
+        picture_ids: Picture ids to snapshot. Missing ids are simply absent from
+            the result (a picture created by the operation has no before-state).
+
+    Returns:
+        ``{"<picture_id>": {facet: value}}`` with string keys, so the structure
+        round-trips through JSON unchanged.
+    """
+    ids = _normalize_ids(picture_ids)
+    if not ids:
+        return {}
+
+    state: dict[str, dict] = {}
+    pictures = session.exec(select(Picture).where(Picture.id.in_(ids))).all()
+    for picture in pictures:
+        if picture.id is None:
+            continue
+        state[str(int(picture.id))] = {
+            FACET_DESCRIPTION: picture.description,
+            FACET_SCORE: picture.score,
+            FACET_PROJECT_ID: picture.project_id,
+            FACET_PENDING_CHARACTER_ID: picture.pending_character_id,
+            FACET_TAGS: [],
+            FACET_SETS: [],
+            FACET_PROJECTS: [],
+            FACET_CHARACTERS: {},
+            FACET_STACK: {
+                "id": picture.stack_id,
+                "name": None,
+                "position": picture.stack_position,
+            },
+        }
+    if not state:
+        return {}
+
+    present = [int(pid) for pid in state]
+
+    for picture_id, tag in session.exec(
+        select(Tag.picture_id, Tag.tag).where(Tag.picture_id.in_(present))
+    ).all():
+        state[str(int(picture_id))][FACET_TAGS].append(tag)
+
+    for picture_id, set_id in session.exec(
+        select(PictureSetMember.picture_id, PictureSetMember.set_id).where(
+            PictureSetMember.picture_id.in_(present)
+        )
+    ).all():
+        state[str(int(picture_id))][FACET_SETS].append(int(set_id))
+
+    for picture_id, project_id in session.exec(
+        select(PictureProjectMember.picture_id, PictureProjectMember.project_id).where(
+            PictureProjectMember.picture_id.in_(present)
+        )
+    ).all():
+        state[str(int(picture_id))][FACET_PROJECTS].append(int(project_id))
+
+    for face_id, picture_id, character_id in session.exec(
+        select(Face.id, Face.picture_id, Face.character_id).where(
+            Face.picture_id.in_(present)
+        )
+    ).all():
+        state[str(int(picture_id))][FACET_CHARACTERS][str(int(face_id))] = (
+            int(character_id) if character_id is not None else None
+        )
+
+    # Stack names, so a dissolved stack can be recreated on undo rather than
+    # leaving the picture pointing at a row that no longer exists.
+    stack_ids = {
+        entry[FACET_STACK]["id"]
+        for entry in state.values()
+        if entry[FACET_STACK]["id"] is not None
+    }
+    if stack_ids:
+        names = dict(
+            session.exec(
+                select(PictureStack.id, PictureStack.name).where(
+                    PictureStack.id.in_(sorted(stack_ids))
+                )
+            ).all()
+        )
+        for entry in state.values():
+            stack_id = entry[FACET_STACK]["id"]
+            if stack_id is not None:
+                entry[FACET_STACK]["name"] = names.get(stack_id)
+
+    for entry in state.values():
+        entry[FACET_TAGS].sort()
+        entry[FACET_SETS].sort()
+        entry[FACET_PROJECTS].sort()
+
+    return state
+
+
+def diff_states(
+    before: dict[str, dict], after: dict[str, dict]
+) -> tuple[dict[str, dict], dict[str, dict]]:
+    """Reduce two full snapshots to only the facets that differ.
+
+    A picture whose facets are all unchanged disappears from both sides, so an
+    endpoint that ran but changed nothing records no operation at all.
+
+    Args:
+        before: Snapshot taken before the mutation.
+        after: Snapshot taken after it.
+
+    Returns:
+        ``(before_delta, after_delta)`` — same keys on both sides, each mapping a
+        picture id to only its changed facets. A facet missing on one side (the
+        picture did not exist yet, or no longer does) is recorded as ``None`` so
+        the applier can tell "unchanged" from "absent".
+    """
+    before_delta: dict[str, dict] = {}
+    after_delta: dict[str, dict] = {}
+    for picture_id in sorted(set(before) | set(after), key=lambda k: int(k)):
+        old = before.get(picture_id)
+        new = after.get(picture_id)
+        if old is None and new is None:
+            continue
+        changed_old: dict[str, Any] = {}
+        changed_new: dict[str, Any] = {}
+        for facet in FACETS:
+            old_value = None if old is None else old.get(facet)
+            new_value = None if new is None else new.get(facet)
+            if old_value == new_value:
+                continue
+            changed_old[facet] = old_value
+            changed_new[facet] = new_value
+        if changed_old or changed_new:
+            before_delta[picture_id] = changed_old
+            after_delta[picture_id] = changed_new
+    return before_delta, after_delta
+
+
+# ---------------------------------------------------------------------------
+# Recording
+# ---------------------------------------------------------------------------
+
+
+def new_batch_id() -> str:
+    """Return a fresh opaque batch id grouping one bulk action's operations."""
+    return uuid.uuid4().hex
+
+
+def request_context(request) -> dict:
+    """Actor + WS-envelope provenance for an operation, read from the request.
+
+    Call this **in the handler**, on the request's own task. The values are then
+    passed explicitly down to the recorder and, later, into the WS event ``data``
+    dict — the §15 threading rule: the ``origin_client_id`` contextvar is dead on
+    the DB worker thread and on the broadcaster's loop, so nothing downstream may
+    read it.
+
+    Args:
+        request: The FastAPI request (duck-typed; only ``request.state`` is used).
+
+    Returns:
+        ``{"actor", "source", "origin_client_id"}``, ready to splat into
+        :func:`run_recorded_metadata_task`. ``source`` is ``"ui"`` when the
+        caller identified itself with an ``X-Client-Id`` (an in-app action) and
+        ``"external"`` otherwise, mirroring the envelope's own default.
+    """
+    state = getattr(request, "state", None)
+    user_id = getattr(state, "auth_user_id", None)
+    origin_client_id = getattr(state, "origin_client_id", None)
+    return {
+        "actor": str(user_id) if user_id is not None else None,
+        "source": "ui" if origin_client_id else "external",
+        "origin_client_id": origin_client_id,
+    }
+
+
+def record_operation_in_session(
+    session: Session,
+    *,
+    op_type: str,
+    before: dict[str, dict],
+    after: dict[str, dict],
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
+    batch_id: Optional[str] = None,
+    summary: Optional[str] = None,
+    undoable: bool = True,
+    target_type: str = TARGET_PICTURE,
+) -> Optional[Operation]:
+    """Append one operation row for the diff between two snapshots.
+
+    Args:
+        session: Pre-opened DB session; the row is added and committed here.
+        op_type: Dotted verb naming the change (``"pictures.tags"``).
+        before: Full or already-diffed before snapshot.
+        after: The matching after snapshot.
+        actor: Who performed the change (user id as a string).
+        source: WS-envelope source, passed in explicitly by the caller.
+        origin_client_id: WS-envelope per-tab origin, likewise explicit.
+        batch_id: Group id when this row is part of a bulk action.
+        summary: Short human sentence for the undo toast / activity feed.
+        undoable: ``False`` records the change for audit without offering undo
+            (the DAM 1.2 rule for file-mutating operations).
+        target_type: Kind of object the target ids refer to.
+
+    Returns:
+        The persisted :class:`Operation`, or ``None`` when nothing changed.
+    """
+    before_delta, after_delta = diff_states(before, after)
+    if not before_delta and not after_delta:
+        return None
+
+    target_ids = sorted(
+        {int(pid) for pid in after_delta} | {int(pid) for pid in before_delta}
+    )
+
+    # A new operation invalidates the redo stack: anything previously undone can
+    # no longer be replayed onto a history that has moved on. The rows stay —
+    # this is an append-only audit log — only their status marker advances.
+    superseded = session.exec(
+        select(Operation).where(Operation.status == STATUS_UNDONE)
+    ).all()
+    for stale in superseded:
+        stale.status = STATUS_SUPERSEDED
+        session.add(stale)
+
+    operation = Operation(
+        batch_id=batch_id,
+        created_at=datetime.utcnow(),
+        actor=actor,
+        op_type=op_type,
+        target_type=target_type,
+        target_ids=json.dumps(target_ids),
+        target_count=len(target_ids),
+        before_state=json.dumps(before_delta),
+        after_state=json.dumps(after_delta),
+        source=source,
+        origin_client_id=origin_client_id,
+        undoable=bool(undoable),
+        status=STATUS_APPLIED,
+        summary=summary,
+    )
+    session.add(operation)
+    session.commit()
+    session.refresh(operation)
+    logger.info(
+        "operation_log: recorded %s id=%s batch=%s targets=%d undoable=%s",
+        op_type,
+        operation.id,
+        batch_id,
+        len(target_ids),
+        undoable,
+    )
+    return operation
+
+
+def run_recorded_metadata_task(
+    vault: "Vault",
+    work: Callable[..., Any],
+    *args,
+    op_type: str,
+    picture_ids,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
+    batch_id: Optional[str] = None,
+    summary: Optional[str] = None,
+    undoable: bool = True,
+    expand_stacks: bool = False,
+    resolve_picture_ids: Optional[Callable[[Session], Iterable[Any]]] = None,
+    **kwargs,
+) -> tuple[Any, Optional[dict]]:
+    """Run a metadata mutation on the DB queue and record it in one task.
+
+    Drop-in replacement for ``vault.db.run_task(work, *args)`` at a metadata
+    mutation site: the surrounding snapshot/diff/record work happens on the same
+    session, in the same queue slot, so no concurrent write can slip between the
+    snapshot and the mutation.
+
+    Args:
+        vault: The vault owning the DB work queue.
+        work: The existing ``(session, *args) -> result`` mutation callable.
+        *args: Positional arguments forwarded to *work* after the session.
+        op_type: Dotted verb naming the change.
+        picture_ids: The pictures the mutation may touch.
+        actor: Who is performing the change.
+        source: WS-envelope source, read from the request by the caller.
+        origin_client_id: WS-envelope per-tab origin, likewise.
+        batch_id: Group id when this call is one step of a bulk action.
+        summary: Short human sentence for the undo toast.
+        undoable: ``False`` records for audit only.
+        expand_stacks: Snapshot the whole stack of every target picture, for
+            mutations that are stack-atomic (project/set membership).
+        resolve_picture_ids: Optional ``(session) -> ids`` run **before** the
+            mutation, on the mutation's own session, for handlers whose targets
+            are not knowable from the request alone — a request addressed by face
+            id, or a replace-all that evicts members it was never told about. Its
+            result is unioned with *picture_ids*; without it those pictures fall
+            outside the snapshot and the operation records a half-change that
+            undo could not fully reverse.
+        **kwargs: Keyword arguments forwarded to *work*.
+
+    Returns:
+        ``(work_result, operation_dict_or_None)``.
+    """
+
+    def _task(session: Session):
+        ids = _normalize_ids(picture_ids)
+        if resolve_picture_ids is not None:
+            ids = _normalize_ids([*ids, *(resolve_picture_ids(session) or ())])
+        if expand_stacks and ids:
+            ids = _normalize_ids(expand_picture_ids_to_stacks(session, ids))
+        before = capture_state_in_session(session, ids)
+        result = work(session, *args, **kwargs)
+        after = capture_state_in_session(session, ids)
+        operation = record_operation_in_session(
+            session,
+            op_type=op_type,
+            before=before,
+            after=after,
+            actor=actor,
+            source=source,
+            origin_client_id=origin_client_id,
+            batch_id=batch_id,
+            summary=summary,
+            undoable=undoable,
+        )
+        return result, (serialize(operation) if operation is not None else None)
+
+    return vault.db.run_task(_task)
+
+
+# ---------------------------------------------------------------------------
+# Applying a recorded state (undo / redo)
+# ---------------------------------------------------------------------------
+
+
+def _apply_tags(session: Session, picture_id: int, tags) -> None:
+    wanted = {str(tag) for tag in tags or []}
+    existing = {
+        row.tag: row
+        for row in session.exec(select(Tag).where(Tag.picture_id == picture_id)).all()
+    }
+    for tag, row in existing.items():
+        if tag not in wanted:
+            session.delete(row)
+    for tag in sorted(wanted - set(existing)):
+        session.add(Tag(picture_id=picture_id, tag=tag))
+
+
+def _apply_sets(session: Session, picture_id: int, set_ids) -> None:
+    wanted = {int(sid) for sid in set_ids or []}
+    existing = {
+        int(row.set_id): row
+        for row in session.exec(
+            select(PictureSetMember).where(PictureSetMember.picture_id == picture_id)
+        ).all()
+    }
+    for set_id, row in existing.items():
+        if set_id not in wanted:
+            session.delete(row)
+    for set_id in sorted(wanted - set(existing)):
+        session.add(PictureSetMember(set_id=set_id, picture_id=picture_id))
+
+
+def _apply_projects(session: Session, picture_id: int, project_ids) -> None:
+    wanted = {int(pid) for pid in project_ids or []}
+    existing = {
+        int(row.project_id): row
+        for row in session.exec(
+            select(PictureProjectMember).where(
+                PictureProjectMember.picture_id == picture_id
+            )
+        ).all()
+    }
+    for project_id, row in existing.items():
+        if project_id not in wanted:
+            session.delete(row)
+    for project_id in sorted(wanted - set(existing)):
+        session.add(PictureProjectMember(picture_id=picture_id, project_id=project_id))
+
+
+def _apply_characters(session: Session, picture_id: int, assignments) -> None:
+    if not isinstance(assignments, dict):
+        return
+    faces = {
+        int(face.id): face
+        for face in session.exec(
+            select(Face).where(Face.picture_id == picture_id)
+        ).all()
+    }
+    for face_id_raw, character_id in assignments.items():
+        try:
+            face_id = int(face_id_raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "operation_log: skipping non-numeric face id %r while restoring "
+                "character assignment on picture %s",
+                face_id_raw,
+                picture_id,
+            )
+            continue
+        face = faces.get(face_id)
+        if face is None:
+            # The face row was re-extracted (or removed) after the operation was
+            # recorded. Nothing to restore; log so the gap is visible rather than
+            # silently dropped.
+            logger.warning(
+                "operation_log: face %d of picture %d no longer exists; its "
+                "character assignment could not be restored",
+                face_id,
+                picture_id,
+            )
+            continue
+        face.character_id = int(character_id) if character_id is not None else None
+        session.add(face)
+
+
+def _apply_stack(session: Session, picture: Picture, stack) -> None:
+    if not isinstance(stack, dict):
+        return
+    stack_id = stack.get("id")
+    if stack_id is not None:
+        stack_id = int(stack_id)
+        if session.get(PictureStack, stack_id) is None:
+            # The stack was dissolved by the operation being undone; recreate the
+            # row under its original id so the restored pointer stays valid.
+            session.add(PictureStack(id=stack_id, name=stack.get("name")))
+            session.flush()
+    picture.stack_id = stack_id
+    position = stack.get("position")
+    picture.stack_position = int(position) if position is not None else None
+    session.add(picture)
+
+
+def apply_state_in_session(
+    session: Session, state: dict[str, dict], action: str = "restore metadata"
+) -> list[int]:
+    """Write a recorded metadata state back onto its pictures.
+
+    A locked picture set is a hard freeze on its members' label data; undo/redo
+    must not become the one write path that walks around it. The guard runs here,
+    at the single sink every restore goes through, and covers every facet.
+
+    Args:
+        session: Pre-opened DB session; the caller commits.
+        state: ``{"<picture_id>": {facet: value}}`` as recorded. A facet value of
+            ``None`` for a collection facet means "the picture did not exist on
+            this side of the change" and is skipped rather than emptied.
+        action: Human verb phrase echoed in the 423 when a target is frozen.
+
+    Returns:
+        The picture ids actually written.
+
+    Raises:
+        HTTPException: ``423`` when a locked picture set freezes any target.
+    """
+    enforce_pictures_not_locked(session, [int(pid) for pid in (state or {})], action)
+    touched: list[int] = []
+    for picture_id_raw, facets in (state or {}).items():
+        picture_id = int(picture_id_raw)
+        picture = session.get(Picture, picture_id)
+        if picture is None:
+            logger.warning(
+                "operation_log: picture %d no longer exists; skipping its part of "
+                "the recorded state",
+                picture_id,
+            )
+            continue
+        for facet, value in (facets or {}).items():
+            if facet == FACET_DESCRIPTION:
+                picture.description = value
+                session.add(picture)
+            elif facet == FACET_SCORE:
+                picture.score = int(value) if value is not None else None
+                session.add(picture)
+            elif facet == FACET_PROJECT_ID:
+                picture.project_id = int(value) if value is not None else None
+                session.add(picture)
+            elif facet == FACET_PENDING_CHARACTER_ID:
+                picture.pending_character_id = int(value) if value is not None else None
+                session.add(picture)
+            elif facet == FACET_TAGS:
+                if value is not None:
+                    _apply_tags(session, picture_id, value)
+            elif facet == FACET_SETS:
+                if value is not None:
+                    _apply_sets(session, picture_id, value)
+            elif facet == FACET_PROJECTS:
+                if value is not None:
+                    _apply_projects(session, picture_id, value)
+            elif facet == FACET_CHARACTERS:
+                if value is not None:
+                    _apply_characters(session, picture_id, value)
+            elif facet == FACET_STACK:
+                if value is not None:
+                    _apply_stack(session, picture, value)
+            else:
+                logger.warning(
+                    "operation_log: unknown facet %r on picture %d was recorded "
+                    "but has no applier; it cannot be restored",
+                    facet,
+                    picture_id,
+                )
+        touched.append(picture_id)
+    return touched
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+def _loads(payload: Optional[str], default):
+    if not payload:
+        return default
+    try:
+        return json.loads(payload)
+    except (TypeError, ValueError) as exc:
+        logger.error(
+            "operation_log: could not parse stored JSON payload (%s); treating it "
+            "as empty. Payload head: %r",
+            exc,
+            (payload or "")[:200],
+        )
+        return default
+
+
+def serialize(operation: Operation, include_state: bool = False) -> dict:
+    """Return the API shape of one operation row.
+
+    Args:
+        operation: The row to serialize.
+        include_state: Include the full ``before``/``after`` payloads. Off by
+            default — the list endpoint would otherwise ship a whole library's
+            metadata to the client.
+    """
+    data = {
+        "id": operation.id,
+        "batch_id": operation.batch_id,
+        "created_at": (
+            operation.created_at.isoformat() if operation.created_at else None
+        ),
+        "actor": operation.actor,
+        "op_type": operation.op_type,
+        "target_type": operation.target_type,
+        "target_ids": _loads(operation.target_ids, []),
+        "target_count": operation.target_count,
+        "source": operation.source,
+        "origin_client_id": operation.origin_client_id,
+        "undoable": bool(operation.undoable),
+        "status": operation.status,
+        "undone_at": (operation.undone_at.isoformat() if operation.undone_at else None),
+        "summary": operation.summary,
+    }
+    if include_state:
+        data["before"] = _loads(operation.before_state, {})
+        data["after"] = _loads(operation.after_state, {})
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Undo / redo
+# ---------------------------------------------------------------------------
+
+
+def _batch_members_in_session(
+    session: Session, operation: Operation, status: str
+) -> list[Operation]:
+    """Every operation of *operation*'s batch in *status*, newest first.
+
+    A bulk action is one undoable unit: undoing any member reverts the whole
+    batch, in reverse order of application, so partially-reverted batches cannot
+    exist.
+    """
+    if not operation.batch_id:
+        return [operation]
+    return list(
+        session.exec(
+            select(Operation)
+            .where(Operation.batch_id == operation.batch_id)
+            .where(Operation.status == status)
+            .order_by(Operation.id.desc())
+        ).all()
+    )
+
+
+def _restore(
+    session: Session,
+    operations: list[Operation],
+    *,
+    to_before: bool,
+) -> tuple[list[int], set[str]]:
+    """Apply the before- (undo) or after- (redo) state of *operations* in order."""
+    action = "undo an operation" if to_before else "redo an operation"
+    touched: set[int] = set()
+    facets: set[str] = set()
+    for operation in operations:
+        state = _loads(
+            operation.before_state if to_before else operation.after_state, {}
+        )
+        touched.update(apply_state_in_session(session, state, action))
+        for picture_facets in state.values():
+            facets.update(picture_facets or {})
+    return sorted(touched), facets
+
+
+def _emit(
+    vault: "Vault", picture_ids: list[int], facets: set[str], origin_client_id
+) -> None:
+    """Announce a restored state on the WS envelope.
+
+    ``origin_client_id`` is carried in the event ``data`` dict, never read from a
+    contextvar — this runs on the DB worker thread where the contextvar is dead
+    (§15, ``test_source_origin_read_from_data_only``).
+    """
+    if not picture_ids:
+        return
+    events: list[EventType] = []
+    for facet in facets:
+        for event in _FACET_EVENTS.get(facet, (EventType.CHANGED_PICTURES,)):
+            if event not in events:
+                events.append(event)
+    if not events:
+        events = [EventType.CHANGED_PICTURES]
+    for event in events:
+        vault.notify(
+            event,
+            {
+                "picture_ids": picture_ids,
+                "origin_client_id": origin_client_id,
+                "change_kind": "updated",
+                "source": "ui",
+            },
+        )
+
+
+def _select_undo_target(session: Session, operation_id: Optional[int]) -> Operation:
+    if operation_id is not None:
+        operation = session.get(Operation, operation_id)
+        if operation is None:
+            raise OperationLogError(f"Operation {operation_id} not found")
+        if operation.status != STATUS_APPLIED:
+            raise OperationLogError(
+                f"Operation {operation_id} is {operation.status}, not applied"
+            )
+        if not operation.undoable:
+            raise OperationLogError(
+                f"Operation {operation_id} ({operation.op_type}) is recorded for "
+                "audit but is not reversible"
+            )
+        return operation
+    operation = session.exec(
+        select(Operation)
+        .where(Operation.status == STATUS_APPLIED)
+        .where(Operation.undoable.is_(True))
+        .order_by(Operation.id.desc())
+    ).first()
+    if operation is None:
+        raise OperationLogError("Nothing to undo")
+    return operation
+
+
+def _mark_undone(session: Session, members: list[Operation]) -> None:
+    now = datetime.utcnow()
+    for member in members:
+        member.status = STATUS_UNDONE
+        member.undone_at = now
+        session.add(member)
+
+
+def undo_in_session(
+    session: Session, operation_id: Optional[int] = None
+) -> tuple[list[dict], list[int], list[str]]:
+    """Undo one operation (and its whole batch), returning what it touched.
+
+    Rows are serialized *inside* the session: the DB worker closes it when the
+    task returns, and a detached SQLModel instance would raise on attribute
+    access in the route.
+    """
+    operation = _select_undo_target(session, operation_id)
+    members = _batch_members_in_session(session, operation, STATUS_APPLIED)
+    members = [member for member in members if member.undoable]
+    if not members:
+        raise OperationLogError("Nothing to undo")
+    touched, facets = _restore(session, members, to_before=True)
+    _mark_undone(session, members)
+    session.commit()
+    return [serialize(member) for member in members], touched, sorted(facets)
+
+
+def undo_batch_in_session(
+    session: Session, batch_id: str
+) -> tuple[list[dict], list[int], list[str]]:
+    """Undo every still-applied operation of one batch (the sweep's Undo)."""
+    members = list(
+        session.exec(
+            select(Operation)
+            .where(Operation.batch_id == batch_id)
+            .where(Operation.status == STATUS_APPLIED)
+            .where(Operation.undoable.is_(True))
+            .order_by(Operation.id.desc())
+        ).all()
+    )
+    if not members:
+        raise OperationLogError(f"Batch {batch_id} has nothing to undo")
+    touched, facets = _restore(session, members, to_before=True)
+    _mark_undone(session, members)
+    session.commit()
+    return [serialize(member) for member in members], touched, sorted(facets)
+
+
+def redo_in_session(session: Session) -> tuple[list[dict], list[int], list[str]]:
+    """Re-apply the most recently undone operation (and its whole batch)."""
+    operation = session.exec(
+        select(Operation)
+        .where(Operation.status == STATUS_UNDONE)
+        .order_by(Operation.id.desc())
+    ).first()
+    if operation is None:
+        raise OperationLogError("Nothing to redo")
+    members = _batch_members_in_session(session, operation, STATUS_UNDONE)
+    # Redo replays in application order, the mirror of undo's reverse order.
+    members = sorted(members, key=lambda op: op.id or 0)
+    touched, facets = _restore(session, members, to_before=False)
+    for member in members:
+        member.status = STATUS_APPLIED
+        member.undone_at = None
+        session.add(member)
+    session.commit()
+    return [serialize(member) for member in members], touched, sorted(facets)
+
+
+def list_operations_in_session(
+    session: Session,
+    *,
+    limit: int = 50,
+    status: Optional[str] = None,
+    batch_id: Optional[str] = None,
+    op_type: Optional[str] = None,
+) -> list[dict]:
+    """Return recorded operations, newest first (the activity feed's read)."""
+    statement = select(Operation)
+    if status:
+        statement = statement.where(Operation.status == status)
+    if batch_id:
+        statement = statement.where(Operation.batch_id == batch_id)
+    if op_type:
+        statement = statement.where(Operation.op_type == op_type)
+    statement = statement.order_by(Operation.id.desc()).limit(
+        max(1, min(int(limit), MAX_LIST_LIMIT))
+    )
+    return [serialize(row) for row in session.exec(statement).all()]
+
+
+def undo_state_in_session(session: Session) -> dict:
+    """What the Ctrl+Z / Ctrl+Shift+Z affordances should show right now."""
+    next_undo = session.exec(
+        select(Operation)
+        .where(Operation.status == STATUS_APPLIED)
+        .where(Operation.undoable.is_(True))
+        .order_by(Operation.id.desc())
+    ).first()
+    next_redo = session.exec(
+        select(Operation)
+        .where(Operation.status == STATUS_UNDONE)
+        .order_by(Operation.id.desc())
+    ).first()
+    return {
+        "can_undo": next_undo is not None,
+        "can_redo": next_redo is not None,
+        "next_undo": serialize(next_undo) if next_undo is not None else None,
+        "next_redo": serialize(next_redo) if next_redo is not None else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Vault wrappers (the thin bridge from a route to the DB work queue)
+# ---------------------------------------------------------------------------
+
+
+def list_operations(vault: "Vault", **kwargs) -> list[dict]:
+    """Vault wrapper for :func:`list_operations_in_session`."""
+    return vault.db.run_task(
+        lambda session: list_operations_in_session(session, **kwargs)
+    )
+
+
+def undo_state(vault: "Vault") -> dict:
+    """Vault wrapper for :func:`undo_state_in_session`."""
+    return vault.db.run_task(undo_state_in_session)
+
+
+def get_operation(vault: "Vault", operation_id: int) -> Optional[dict]:
+    """Return one operation including its recorded before/after payloads."""
+
+    def _fetch(session: Session):
+        operation = session.get(Operation, operation_id)
+        return serialize(operation, include_state=True) if operation else None
+
+    return vault.db.run_task(_fetch)
+
+
+def _finish(vault: "Vault", members, touched, facets, origin_client_id) -> dict:
+    _emit(vault, touched, set(facets), origin_client_id)
+    return {
+        "operations": members,
+        "picture_ids": touched,
+        "picture_count": len(touched),
+    }
+
+
+def undo(
+    vault: "Vault",
+    operation_id: Optional[int] = None,
+    origin_client_id: Optional[str] = None,
+) -> dict:
+    """Undo the newest reversible operation, or a named one, plus its batch."""
+    members, touched, facets = vault.db.run_task(undo_in_session, operation_id)
+    return _finish(vault, members, touched, facets, origin_client_id)
+
+
+def undo_batch(
+    vault: "Vault", batch_id: str, origin_client_id: Optional[str] = None
+) -> dict:
+    """Undo one whole bulk action by its batch id (the sweep's report Undo)."""
+    members, touched, facets = vault.db.run_task(undo_batch_in_session, batch_id)
+    return _finish(vault, members, touched, facets, origin_client_id)
+
+
+def redo(vault: "Vault", origin_client_id: Optional[str] = None) -> dict:
+    """Re-apply the most recently undone operation (and its batch)."""
+    members, touched, facets = vault.db.run_task(redo_in_session)
+    return _finish(vault, members, touched, facets, origin_client_id)

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -155,6 +155,10 @@ def test_services_no_direct_db_calls():
         "pixlstash/services/restore/preview.py",  # vault-injection pattern; restore previews + hash compare
         "pixlstash/services/comfyui_service.py",  # vault-injection pattern; owns ComfyUI output-import orchestration
         "pixlstash/services/scrapheap_service.py",  # vault-injection pattern; thin wrappers around the *_in_session purge/retention functions
+        # The op-log's whole point is that capture -> mutation -> capture ->
+        # record run in ONE queued task; the wrapper owning that submission is
+        # the atomicity guarantee, not transitional debt.
+        "pixlstash/services/operation_log_service.py",  # vault-injection pattern; atomic record-with-mutation task
     }
 
     violations = []
@@ -423,6 +427,12 @@ _LABEL_SINK_EXEMPT = {
     # NB: characters.py::alter_char now SKIPS the description clear for locked pics
     # (keeps character reassignment + text_embedding invalidation), so it is
     # guarded, not exempt.
+    # --- Op-log undo/redo: the guard lives at the single restore sink ---
+    ("pixlstash/services/operation_log_service.py", "_apply_tags"): (
+        "module-private tag reconciliation reached only from "
+        "apply_state_in_session, which calls enforce_pictures_not_locked over "
+        "the whole recorded state (every facet) before dispatching"
+    ),
     # --- CSO-named, documented NON-sinks (no Tag/ledger/label write reaches a
     # picture here). Kept for the record; excluded from the stale-prune below
     # because the scanner never flags them (they don't match a sink pattern). ---
@@ -673,6 +683,7 @@ _EXPECTED_ROUTE_MODULES = frozenset(
         "pixlstash.routes.filesystem",
         "pixlstash.routes.guest_scores",
         "pixlstash.routes.import_folders",
+        "pixlstash.routes.operations",
         "pixlstash.routes.picture_sets",
         "pixlstash.routes.pictures._anomaly",
         "pixlstash.routes.pictures._character_likeness",

--- a/tests/test_operation_log.py
+++ b/tests/test_operation_log.py
@@ -1,0 +1,656 @@
+"""Tests for the append-only operation log and metadata undo/redo (DAM 1.2).
+
+Covers the three things the design rests on:
+
+1. **Recording** — a metadata mutation appends exactly one operation carrying the
+   changed facets, the batch id, and the WS-envelope provenance; a no-op
+   mutation appends nothing.
+2. **Undo / redo** — undo restores the recorded ``before`` state, redo restores
+   ``after``, a bulk action is ONE undoable unit via its batch id, and recording
+   a new operation invalidates the redo stack.
+3. **The invariants** — the log is append-only (undo mutates only the lifecycle
+   markers), the service never reads the origin contextvar, and a locked picture
+   set is not walked around by undo.
+"""
+
+import gc
+import io
+import json
+import os
+import tempfile
+
+from fastapi.testclient import TestClient
+from PIL import Image
+from sqlmodel import select
+
+from pixlstash.db_models import (
+    Operation,
+    Picture,
+    PictureSet,
+    PictureSetMember,
+    Tag,
+    is_tag_sentinel,
+)
+from pixlstash.server import Server
+from pixlstash.services import operation_log_service
+from tests.utils import upload_pictures_and_wait
+
+API = "/api/v1"
+
+
+def _setup():
+    temp_dir = tempfile.TemporaryDirectory()
+    image_root = os.path.join(temp_dir.name, "images")
+    os.makedirs(image_root, exist_ok=True)
+    server_config_path = os.path.join(temp_dir.name, "server-config.json")
+    with open(server_config_path, "w") as fh:
+        fh.write(json.dumps({"port": 8000}))
+    server = Server(server_config_path)
+    client = TestClient(server.api)
+    resp = client.post(
+        "/login", json={"username": "testuser", "password": "testpassword"}
+    )
+    assert resp.status_code == 200
+    return temp_dir, client, server
+
+
+def _teardown(temp_dir, server):
+    server.vault.close()
+    temp_dir.cleanup()
+    gc.collect()
+
+
+_counter = [0]
+
+
+def _upload(client):
+    """Upload a fresh, content-distinct in-memory PNG and return its id."""
+    _counter[0] += 1
+    n = _counter[0]
+    img = Image.new("RGB", (16 + n, 16 + n), color=(n * 7 % 256, n * 13 % 256, 40))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return upload_pictures_and_wait(
+        client, [("file", (f"op{n}.png", buf.getvalue(), "image/png"))]
+    )["results"][0]["picture_id"]
+
+
+def _tags(server, picture_id):
+    """The picture's user-visible tags.
+
+    The pending-retag sentinel (``__tag``) is machine bookkeeping written by the
+    importer, not a user tag; it is filtered out here so the assertions read as
+    the user experiences them. It IS part of the recorded before/after state —
+    see the round-trip assertion in the recording test.
+    """
+    return sorted(
+        server.vault.db.run_task(
+            lambda session: [
+                row.tag
+                for row in session.exec(
+                    select(Tag).where(Tag.picture_id == picture_id)
+                ).all()
+                if not is_tag_sentinel(row.tag)
+            ]
+        )
+    )
+
+
+def _operations(server, **filters):
+    return operation_log_service.list_operations(server.vault, limit=100, **filters)
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests — no server needed
+# ---------------------------------------------------------------------------
+
+
+def test_diff_states_keeps_only_changed_facets():
+    before = {"1": {"tags": ["a"], "score": 3, "description": "x"}}
+    after = {"1": {"tags": ["a", "b"], "score": 3, "description": "x"}}
+    before_delta, after_delta = operation_log_service.diff_states(before, after)
+    assert before_delta == {"1": {"tags": ["a"]}}
+    assert after_delta == {"1": {"tags": ["a", "b"]}}
+
+
+def test_diff_states_drops_unchanged_pictures_entirely():
+    state = {"1": {"tags": ["a"]}, "2": {"tags": []}}
+    before_delta, after_delta = operation_log_service.diff_states(state, state)
+    assert before_delta == {}
+    assert after_delta == {}
+
+
+def test_request_context_reads_the_request_never_a_contextvar():
+    """The §15 rule at the op-log's entry point: provenance comes off the request.
+
+    A live ``origin_client_id_var`` must not leak into the recorded operation —
+    the recorder runs on the DB worker thread where that contextvar is dead, so
+    reading it anywhere downstream is the silent-misattribution bug.
+    """
+    from pixlstash.utils.request_origin import origin_client_id_var
+
+    class _State:
+        auth_user_id = 7
+        origin_client_id = "tab-from-request"
+
+    class _Request:
+        state = _State()
+
+    token = origin_client_id_var.set("contextvar-tab-should-be-ignored")
+    try:
+        context = operation_log_service.request_context(_Request())
+    finally:
+        origin_client_id_var.reset(token)
+
+    assert context == {
+        "actor": "7",
+        "source": "ui",
+        "origin_client_id": "tab-from-request",
+    }
+
+    # No X-Client-Id on the request -> the envelope's own defaults, still not
+    # the (live) contextvar.
+    class _BareState:
+        pass
+
+    class _BareRequest:
+        state = _BareState()
+
+    token = origin_client_id_var.set("contextvar-tab-should-be-ignored")
+    try:
+        bare = operation_log_service.request_context(_BareRequest())
+    finally:
+        origin_client_id_var.reset(token)
+    assert bare == {"actor": None, "source": "external", "origin_client_id": None}
+
+
+def test_service_module_never_reads_the_origin_contextvar():
+    """Structural guard: a future edit cannot reintroduce a contextvar read.
+
+    The same failure shape ``test_source_origin_read_from_data_only`` pins for
+    the broadcaster, pinned here for the operation log — both run off the
+    request's task, so both must take origin from data passed to them.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(operation_log_service))
+    referenced = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)} | {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    }
+    assert "origin_client_id_var" not in referenced, (
+        "operation_log_service reads the origin contextvar. It runs on the DB "
+        "worker thread where that contextvar is dead — origin must be passed in "
+        "explicitly (docs/backend_architecture.md §15)."
+    )
+    imported = {
+        alias_module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias_module in ([node.module] if node.module else [])
+    }
+    assert not any("request_origin" in module for module in imported)
+
+
+# ---------------------------------------------------------------------------
+# Recording
+# ---------------------------------------------------------------------------
+
+
+def test_tag_add_records_one_undoable_operation_with_provenance():
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        resp = client.post(
+            f"{API}/pictures/{picture_id}/tags",
+            json={"tag": "sunset"},
+            headers={"X-Client-Id": "tab-1"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        operations = _operations(server, op_type="pictures.tags.add")
+        assert len(operations) == 1
+        operation = operations[0]
+        assert operation["target_ids"] == [picture_id]
+        assert operation["target_count"] == 1
+        assert operation["undoable"] is True
+        assert operation["status"] == "applied"
+        # WS-envelope provenance, carried from the request header.
+        assert operation["origin_client_id"] == "tab-1"
+        assert operation["source"] == "ui"
+
+        # The recorded state is the RAW tag list, sentinel included: adding the
+        # first real tag also consumes the importer's pending-retag sentinel, and
+        # undo must put that back or the picture silently leaves the retag queue.
+        detail = client.get(f"{API}/operations/{operation['id']}").json()
+        assert detail["before"] == {str(picture_id): {"tags": ["__tag"]}}
+        assert detail["after"] == {str(picture_id): {"tags": ["sunset"]}}
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_no_op_mutation_records_nothing():
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "sunset"})
+        before = len(_operations(server))
+        # Adding the same tag again changes nothing.
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "sunset"})
+        assert len(_operations(server)) == before
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_bulk_rating_is_one_operation_over_many_targets():
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(3)]
+        resp = client.post(
+            f"{API}/pictures/apply-scores",
+            json={"scores": {str(pid): 4 for pid in ids}, "only_unscored": False},
+        )
+        assert resp.status_code == 200, resp.text
+
+        operations = _operations(server, op_type="pictures.score")
+        assert len(operations) == 1
+        assert operations[0]["target_ids"] == sorted(ids)
+        assert operations[0]["target_count"] == 3
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_set_membership_is_recorded_and_undone():
+    """The membership facet, end to end through the real endpoints."""
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        created = client.post(f"{API}/picture_sets", json={"name": "trip"})
+        assert created.status_code == 200, created.text
+        set_id = created.json()["picture_set"]["id"]
+
+        resp = client.post(f"{API}/picture_sets/{set_id}/members/{picture_id}")
+        assert resp.status_code == 200, resp.text
+
+        def members(session):
+            return sorted(
+                int(row.picture_id)
+                for row in session.exec(
+                    select(PictureSetMember).where(PictureSetMember.set_id == set_id)
+                ).all()
+            )
+
+        assert server.vault.db.run_task(members) == [picture_id]
+
+        operations = _operations(server, op_type="picture_sets.members.add")
+        assert len(operations) == 1
+        assert operations[0]["target_ids"] == [picture_id]
+
+        assert client.post(f"{API}/operations/undo").status_code == 200
+        assert server.vault.db.run_task(members) == []
+        assert client.post(f"{API}/operations/redo").status_code == 200
+        assert server.vault.db.run_task(members) == [picture_id]
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_stacking_is_recorded_and_undone():
+    """The stack facet: undo unstacks, redo re-stacks the same pictures."""
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(2)]
+        resp = client.post(f"{API}/stacks", json={"picture_ids": ids})
+        assert resp.status_code == 200, resp.text
+
+        def stack_ids(session):
+            return sorted(
+                (int(row.id), row.stack_id)
+                for row in session.exec(
+                    select(Picture).where(Picture.id.in_(ids))
+                ).all()
+            )
+
+        stacked = server.vault.db.run_task(stack_ids)
+        assert all(stack_id is not None for _pid, stack_id in stacked)
+
+        operations = _operations(server, op_type="stacks.create")
+        assert len(operations) == 1
+        assert operations[0]["target_ids"] == sorted(ids)
+
+        assert client.post(f"{API}/operations/undo").status_code == 200
+        assert all(
+            stack_id is None for _pid, stack_id in server.vault.db.run_task(stack_ids)
+        )
+
+        # Redo re-points the pictures at the same stack row.
+        assert client.post(f"{API}/operations/redo").status_code == 200
+        assert server.vault.db.run_task(stack_ids) == stacked
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ---------------------------------------------------------------------------
+# Undo / redo
+# ---------------------------------------------------------------------------
+
+
+def test_undo_restores_before_state_and_redo_restores_after():
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "sunset"})
+        assert _tags(server, picture_id) == ["sunset"]
+
+        state = client.get(f"{API}/operations/undo-state").json()
+        assert state["can_undo"] is True
+        assert state["can_redo"] is False
+
+        undo = client.post(f"{API}/operations/undo")
+        assert undo.status_code == 200, undo.text
+        assert undo.json()["picture_ids"] == [picture_id]
+        assert _tags(server, picture_id) == []
+
+        state = client.get(f"{API}/operations/undo-state").json()
+        assert state["can_undo"] is False
+        assert state["can_redo"] is True
+
+        redo = client.post(f"{API}/operations/redo")
+        assert redo.status_code == 200, redo.text
+        assert _tags(server, picture_id) == ["sunset"]
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_undo_of_bulk_rating_reverts_every_target():
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(3)]
+        client.post(
+            f"{API}/pictures/apply-scores",
+            json={"scores": {str(pid): 4 for pid in ids}, "only_unscored": False},
+        )
+
+        def scores(session):
+            return sorted(
+                (int(row.id), row.score)
+                for row in session.exec(
+                    select(Picture).where(Picture.id.in_(ids))
+                ).all()
+            )
+
+        assert [score for _pid, score in server.vault.db.run_task(scores)] == [4, 4, 4]
+
+        assert client.post(f"{API}/operations/undo").status_code == 200
+        assert [score for _pid, score in server.vault.db.run_task(scores)] == [
+            None,
+            None,
+            None,
+        ]
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_undo_is_last_in_first_out():
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "one"})
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "two"})
+        assert _tags(server, picture_id) == ["one", "two"]
+
+        client.post(f"{API}/operations/undo")
+        assert _tags(server, picture_id) == ["one"]
+        client.post(f"{API}/operations/undo")
+        assert _tags(server, picture_id) == []
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_recording_a_new_operation_invalidates_the_redo_stack():
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "one"})
+        client.post(f"{API}/operations/undo")
+        assert client.get(f"{API}/operations/undo-state").json()["can_redo"] is True
+
+        # A new change moves the history on; the undone operation can no longer
+        # be replayed onto it.
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "two"})
+        assert client.get(f"{API}/operations/undo-state").json()["can_redo"] is False
+        assert client.post(f"{API}/operations/redo").status_code == 409
+
+        superseded = _operations(server, status="superseded")
+        assert len(superseded) == 1
+        # The row survives — this is an audit log, not a stack that pops.
+        assert superseded[0]["op_type"] == "pictures.tags.add"
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_undo_with_nothing_to_undo_is_409():
+    temp_dir, client, server = _setup()
+    try:
+        assert client.post(f"{API}/operations/undo").status_code == 409
+        assert client.post(f"{API}/operations/redo").status_code == 409
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_batch_undo_reverts_the_whole_bulk_action_in_one_call():
+    """One bulk action = one batch id = one Undo, exactly as the sweep needs.
+
+    Recorded through the service (the sweep's own service does not exist yet),
+    then reverted through the public batch endpoint.
+    """
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(2)]
+        batch_id = operation_log_service.new_batch_id()
+
+        def _tag_one(session, picture_id, tag):
+            session.add(Tag(picture_id=picture_id, tag=tag))
+            session.commit()
+
+        for picture_id in ids:
+            operation_log_service.run_recorded_metadata_task(
+                server.vault,
+                _tag_one,
+                picture_id,
+                "swept",
+                op_type="test.sweep",
+                picture_ids=[picture_id],
+                batch_id=batch_id,
+                summary="Swept",
+                actor="1",
+                source="ui",
+                origin_client_id="tab-sweep",
+            )
+
+        assert all(_tags(server, pid) == ["swept"] for pid in ids)
+        members = _operations(server, batch_id=batch_id)
+        assert len(members) == 2
+
+        resp = client.post(f"{API}/operations/batches/{batch_id}/undo")
+        assert resp.status_code == 200, resp.text
+        assert sorted(resp.json()["picture_ids"]) == sorted(ids)
+        assert all(_tags(server, pid) == [] for pid in ids)
+        assert all(
+            op["status"] == "undone" for op in _operations(server, batch_id=batch_id)
+        )
+
+        # A second call has nothing left to revert.
+        assert (
+            client.post(f"{API}/operations/batches/{batch_id}/undo").status_code == 409
+        )
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_undoing_one_member_of_a_batch_reverts_the_whole_batch():
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(2)]
+        batch_id = operation_log_service.new_batch_id()
+
+        def _tag_one(session, picture_id, tag):
+            session.add(Tag(picture_id=picture_id, tag=tag))
+            session.commit()
+
+        for picture_id in ids:
+            operation_log_service.run_recorded_metadata_task(
+                server.vault,
+                _tag_one,
+                picture_id,
+                "swept",
+                op_type="test.sweep",
+                picture_ids=[picture_id],
+                batch_id=batch_id,
+            )
+
+        newest = _operations(server, batch_id=batch_id)[0]
+        resp = client.post(f"{API}/operations/{newest['id']}/undo")
+        assert resp.status_code == 200, resp.text
+        # Both members reverted — a partially-undone bulk action cannot exist.
+        assert len(resp.json()["operations"]) == 2
+        assert all(_tags(server, pid) == [] for pid in ids)
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_log_is_append_only_across_undo_and_redo():
+    """Undo/redo move the lifecycle marker only; no row is rewritten or removed."""
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "sunset"})
+
+        def snapshot(session):
+            return [
+                (
+                    row.id,
+                    row.op_type,
+                    row.target_ids,
+                    row.before_state,
+                    row.after_state,
+                    row.created_at,
+                )
+                for row in session.exec(select(Operation).order_by(Operation.id)).all()
+            ]
+
+        recorded = server.vault.db.run_task(snapshot)
+        assert len(recorded) == 1
+
+        client.post(f"{API}/operations/undo")
+        client.post(f"{API}/operations/redo")
+
+        assert server.vault.db.run_task(snapshot) == recorded
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_undo_refuses_to_write_a_picture_frozen_by_a_locked_set():
+    """A locked set is a hard freeze; undo must not be the way around it."""
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "sunset"})
+
+        def lock(session):
+            picture_set = PictureSet(name="frozen", locked=True)
+            session.add(picture_set)
+            session.commit()
+            session.refresh(picture_set)
+            session.add(PictureSetMember(set_id=picture_set.id, picture_id=picture_id))
+            session.commit()
+
+        server.vault.db.run_task(lock)
+
+        resp = client.post(f"{API}/operations/undo")
+        assert resp.status_code == 423, resp.text
+        assert _tags(server, picture_id) == ["sunset"]
+        # The operation stays applied — a refused undo must not half-commit.
+        assert _operations(server)[0]["status"] == "applied"
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_list_filters_and_rejects_a_bad_status():
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        client.post(f"{API}/pictures/{picture_id}/tags", json={"tag": "sunset"})
+
+        assert (
+            client.get(f"{API}/operations", params={"status": "bogus"}).status_code
+            == 400
+        )
+
+        applied = client.get(f"{API}/operations", params={"status": "applied"}).json()
+        assert len(applied) == 1
+        # The list omits the (potentially huge) before/after payloads.
+        assert "before" not in applied[0]
+
+        assert client.get(f"{API}/operations", params={"op_type": "nope"}).json() == []
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_get_unknown_operation_is_404():
+    temp_dir, client, server = _setup()
+    try:
+        assert client.get(f"{API}/operations/999999").status_code == 404
+        assert client.post(f"{API}/operations/999999/undo").status_code == 409
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_every_operations_route_is_declared_owner_only():
+    """Both-direction authz record: the gate, not a handler, guards these.
+
+    Arithmetic completeness — every mounted /operations route has a declaration
+    and every declaration is OWNER_ONLY. The positive direction (the owner
+    reaches them) is exercised by every other test in this module.
+    """
+    from pixlstash.authz.policy import AccessPolicy
+    from pixlstash.authz.registry import ROUTE_POLICIES
+
+    declared = {
+        (method, path): policy
+        for (method, path), policy in ROUTE_POLICIES.items()
+        if path.startswith("/api/v1/operations")
+    }
+    assert set(declared) == {
+        ("GET", "/api/v1/operations"),
+        ("GET", "/api/v1/operations/undo-state"),
+        ("GET", "/api/v1/operations/{operation_id}"),
+        ("POST", "/api/v1/operations/undo"),
+        ("POST", "/api/v1/operations/redo"),
+        ("POST", "/api/v1/operations/{operation_id}/undo"),
+        ("POST", "/api/v1/operations/batches/{batch_id}/undo"),
+    }
+    assert all(policy.policy is AccessPolicy.OWNER_ONLY for policy in declared.values())
+
+
+def test_operations_routes_have_no_inline_authz_check():
+    """§16.1: the gate owns object authorization; handlers carry none."""
+    import inspect
+
+    from pixlstash.routes import operations as operations_routes
+
+    source = inspect.getsource(operations_routes)
+    for forbidden in (
+        "enforce_picture_scope",
+        "require_unscoped_owner",
+        "fetch_scope_allowed_picture_ids",
+        "token_scope",
+    ):
+        assert forbidden not in source, (
+            f"{forbidden} is an inline authz check; the AuthzGate owns "
+            "authorization for these routes (docs/backend_architecture.md §16.1)"
+        )

--- a/tests/test_ws_broadcaster.py
+++ b/tests/test_ws_broadcaster.py
@@ -56,3 +56,58 @@ def test_broadcaster_ignores_contextvar_reads_data_only():
         )
     finally:
         origin_client_id_var.reset(token)
+
+
+def test_operation_log_undo_emits_origin_in_data_not_from_the_contextvar():
+    """The same §15 invariant for the operation log's undo/redo emissions.
+
+    Undo runs on the DB worker thread, so the ``origin_client_id`` contextvar is
+    dead there exactly as it is on the broadcaster's loop. The op-log therefore
+    receives the origin explicitly from the handler and puts it in the event
+    ``data`` dict; a contextvar read anywhere on that path would silently
+    misattribute every undo to whichever tab last touched the contextvar. This
+    pins the *producer* side of the contract the assertions above pin for the
+    consumer.
+    """
+    from pixlstash.event_types import EventType
+    from pixlstash.services import operation_log_service
+
+    emitted: list[tuple] = []
+
+    class _Vault:
+        def notify(self, event_type, data=None):
+            emitted.append((event_type, data))
+
+    token = origin_client_id_var.set("contextvar-tab-should-be-ignored")
+    try:
+        operation_log_service._emit(
+            _Vault(), [1, 2], {operation_log_service.FACET_TAGS}, "undo-tab"
+        )
+        # Nothing was emitted with the contextvar's value...
+        operation_log_service._emit(_Vault(), [3], {"score"}, None)
+    finally:
+        origin_client_id_var.reset(token)
+
+    assert emitted, "undo emitted no event"
+    with_origin = [
+        data for _event, data in emitted if data.get("picture_ids") == [1, 2]
+    ]
+    assert with_origin
+    for data in with_origin:
+        assert data["origin_client_id"] == "undo-tab"
+        # And the broadcaster derives the envelope from exactly this dict.
+        assert WsBroadcasterMixin._origin_from(data) == "undo-tab"
+        assert WsBroadcasterMixin._source_from(data) == "ui"
+
+    # An undo with no originating tab defaults to no origin — never the
+    # contextvar's live value.
+    without_origin = [
+        data for _event, data in emitted if data.get("picture_ids") == [3]
+    ]
+    assert without_origin
+    for data in without_origin:
+        assert data["origin_client_id"] is None
+        assert WsBroadcasterMixin._origin_from(data) is None
+
+    # A tag restoration announces both the tag and the grid event.
+    assert EventType.CHANGED_TAGS in {event for event, _data in emitted}


### PR DESCRIPTION
Lane B of v1.9.0. Append-only `operation` table (migration 0086, conditional creation) with `batch_id` from day one so any bulk action is one undoable operation. Undo scope = DAM 1.2 metadata facets only (tags, description/caption, score, set/project membership, character assignment, stacking).

- State-based design: records before/after metadata of affected pictures, not per-endpoint inverses; capture → mutate → capture → record runs in one queued DB task for atomicity.
- 7 new routes (list, get, undo-state, undo/redo, per-op undo, per-batch undo), all owner-only in ROUTE_POLICIES with justifications; a test pins that the module has no handler-level authz.
- Origin discipline: undo emits origin in the event `data`, never from the contextvar — pinned by an AST test and a new ws-broadcaster producer-side test.
- Registry arithmetic re-verified (0 undeclared / 0 dead); coverage matrix updated.

252 targeted tests passed across op-log, migrations, authz gate, ws broadcaster, and touched mutation modules; ruff clean.

Known judgement calls (see review notes): locked-set undo returns 423 refuse-and-report; sentinel-tag round-trip on undo re-enters the retag queue; redo invalidation is global (single-owner correct).

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U