### PR TITLE
Multi-project characters and picture sets (#125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,7 @@ jobs:
           tests/test_many_to_many_face_data.py
           tests/test_metadata_hash.py
           tests/test_migrations.py
+          tests/test_multi_project_membership_authz.py
           tests/test_openapi_response_schemas.py
           tests/test_picture_mutation_scope.py
           tests/test_picture_plugins.py
@@ -572,6 +573,7 @@ jobs:
           tests/test_snapshots_auth.py
           tests/test_metadata_hash.py
           tests/test_architecture_guardrails.py
+          tests/test_multi_project_membership_authz.py
           tests/test_openapi_response_schemas.py
           tests/test_find_orphaned_files.py
           tests/test_server.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [1.9.0]
+
+- Characters and picture sets can belong to more than one project at a time, so a character you use across two shoots no longer has to be duplicated or moved back and forth. Their pictures show up in every project they are shared with, and removing them from one project leaves the others alone. Existing single-project assignments carry over untouched.
+
 # [1.8.0] [Security:Moderate]
 
 Smart Scores are recomputed for your whole library the first time you open 1.8.0, so the grid may re-order compared to 1.7. Part of that is a fix: the built-in reference points that score a library with few ratings of its own had stopped loading, so if you have rated only a handful of pictures your scores should be better than before. This is expected, not a bug: the scoring weights are rebalanced so the top of the 1-5 range is reachable again and your best pictures can score like it. Your originals and snapshots are untouched, and the recompute runs in the background in small batches without re-running any AI models, so it stays out of your way.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -602,6 +602,14 @@ stay, holding the entity's **primary** project (lowest member project id, or
   entity becomes invisible to every project-scoped read and authorization check.
   Member pictures follow via `reconcile_entity_projects_change` (the multi-project
   generalisation of `reconcile_entity_project_change`, which is now a shim).
+- **Write-propagation:** every path that adds a picture to an entity (set member
+  add / bulk add / bulk replace, face assignment, the import task's set and
+  character drop targets) must anchor it in **all** the entity's projects, via
+  `picture_set_project_ids` / `character_project_ids` +
+  `reconcile_entity_projects_change`. Reading the scalar FK there joins the
+  picture to the primary project only, so a secondary project's token is 403'd on
+  a picture its set legitimately shares (finding R2,
+  `docs/reviews/v1.9-authz-signoff.md`).
 - **Read:** use the correlated predicates in
   [`db_models/entity_project.py`](../pixlstash/db_models/entity_project.py) —
   `character_in_project` / `character_in_no_project` /
@@ -611,6 +619,13 @@ stay, holding the entity's **primary** project (lowest member project id, or
   reads and on `POST`/`PATCH` payloads; the legacy scalar `project_id` is still
   accepted on write and still returned on read. `project_ids` wins when both are
   sent. No routes were added.
+- **Serialisation is scope-narrowed.** `project_ids` is membership metadata about
+  *other* projects, not part of the granted object, so every site that serialises
+  it intersects it with `visible_project_ids(server, request)`
+  (`utils/service/filter_helpers.py`) — same ladder as
+  `fetch_scope_allowed_set_ids`: a project token sees only its own id, a
+  character / set / picture token sees `[]`, the owner sees everything (finding
+  R1, `docs/reviews/v1.9-authz-signoff.md`).
 - The FK is retired by a post-1.12 cleanup, not here; migration
   `0086_add_entity_project_membership` is purely additive and backfills the join
   from the existing FKs.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -586,7 +586,34 @@ PictureLikeness: picture_id_a, picture_id_b (a < b), likeness, metric
 PictureSet / PictureSetMember
 PictureStack       (Picture.stack_id links members)
 Project / PictureProjectMember
+CharacterProjectMember     (character ↔ project, many-to-many)
+PictureSetProjectMember    (picture set ↔ project, many-to-many)
 ```
+
+**Multi-project characters and picture sets (issue #125, v1.9).** A character or
+picture set may belong to **several** projects. The join tables above are the read
+model; the scalar `Character.project_id` / `PictureSet.project_id` foreign keys
+stay, holding the entity's **primary** project (lowest member project id, or
+`NULL`). The contract is **write both, read the join**:
+
+- **Write:** only `services/project_membership_service.py::set_character_projects`
+  / `set_picture_set_projects` may change membership. They write the join rows and
+  re-derive the scalar pointer together. Assigning the FK directly is a bug — the
+  entity becomes invisible to every project-scoped read and authorization check.
+  Member pictures follow via `reconcile_entity_projects_change` (the multi-project
+  generalisation of `reconcile_entity_project_change`, which is now a shim).
+- **Read:** use the correlated predicates in
+  [`db_models/entity_project.py`](../pixlstash/db_models/entity_project.py) —
+  `character_in_project` / `character_in_no_project` /
+  `picture_set_in_project` / `picture_set_in_no_project` — never
+  `Character.project_id == pid`, which only matches the primary project.
+- **API:** `project_ids` (a list) is the new field on character / picture-set
+  reads and on `POST`/`PATCH` payloads; the legacy scalar `project_id` is still
+  accepted on write and still returned on read. `project_ids` wins when both are
+  sent. No routes were added.
+- The FK is retired by a post-1.12 cleanup, not here; migration
+  `0086_add_entity_project_membership` is purely additive and backfills the join
+  from the existing FKs.
 
 ### Users & sharing
 
@@ -1022,6 +1049,8 @@ In addition, `READ`-scoped tokens are blocked from non-GET methods (except a sma
 - **An undeclared data route is denied at runtime (403) and fails the build.** The startup assertion (`AuthzGate.enforce_startup`) aborts boot and the CI guardrail (`tests/test_architecture_guardrails.py::test_all_routes_declare_access_policy`) goes red on any undeclared route. There is no "I forgot" state.
 - `PUBLIC` / `LOCAL_OWNER_ONLY` / `LOOPBACK_OWNER_ONLY` declarations require a machine-checked `justification=`. Exemptions are recorded decisions, not blanks.
 - The coverage matrix (`docs/reviews/authz-coverage-matrix.md`) *is* the registry. Both-direction tests (out-of-scope 403 **and** in-scope 200) and independent adversarial sign-off still apply per `CLAUDE.md` / `.github/copilot-instructions.md` (§ *Security & authorization review process*).
+
+**Project scope is membership-based since v1.9 (issue #125).** `enforce_character_scope` and `enforce_set_scope` resolve the `project` branch through `CharacterProjectMember` / `PictureSetProjectMember`, not the scalar `project_id`. A project-scoped token therefore reaches an entity that lists its project among several — the intended widening — while an entity in a different project is still refused. Both directions are pinned in `tests/test_multi_project_membership_authz.py` (in-scope 200 **and** out-of-scope 403, across by-id, by-name, list, locked-members, project-set-listing and the picture-level consequence). Reading the FK instead would *under*-grant, which is its own regression: see §6 *Grouping & scoping*.
 
 **Residual inline exception — 4 name-derived routes.** Four `*_SCOPED` routes resolve their object id from a *name* rather than a numeric path id: `GET /projects/{project_name}/characters/{character_name}`, `GET /projects/{project_name}/picture_sets/{picture_set_name}`, `GET /projects/{id_or_name}`, and `GET /projects/{id_or_name}/picture_sets`. The gate cannot resolve name→id without duplicating each handler's own int-or-name lookup — a gate/handler divergence risk, the exact defect this refactor exists to kill. These carry `resolved_inline=True` in the registry and KEEP their inline `_require_scope_allows_{character,picture_set,project}` check as the live enforcement. This is the only place an inline object check remains; it retires when a shared name→id resolver exists. (Two aggregate-summary handlers, `get_characters_summary` and `get_project_summary`, also retain a small inline `ALL`/`UNASSIGNED` guard that doubles as input validation; the gate independently fails those closed for a scoped token, so the inline guard is defence-in-depth, not the sole enforcement.)
 

--- a/pixlstash/authz/membership.py
+++ b/pixlstash/authz/membership.py
@@ -40,11 +40,11 @@ from fastapi import HTTPException, Request
 from sqlmodel import select
 
 from pixlstash.db_models import (
-    Character,
+    CharacterProjectMember,
     Face,
     PictureProjectMember,
-    PictureSet,
     PictureSetMember,
+    PictureSetProjectMember,
     TagSuggestion,
 )
 from pixlstash.pixl_logging import get_logger
@@ -155,6 +155,11 @@ def enforce_set_scope(server, request: Request, set_id: int) -> None:
     A ``picture_set`` token reaches only its own set; a ``project`` token reaches
     a set that belongs to its project; every other scoped ``resource_type`` is
     refused. An owner / unscoped token (``scope is None``) passes.
+
+    Since issue #125 a set may belong to several projects, so the project branch
+    tests the ``PictureSetProjectMember`` join rather than the scalar
+    ``PictureSet.project_id`` (which now names only the *primary* project and
+    would under-grant a legitimately shared set).
     """
     scope = getattr(request.state, "token_scope", None)
     if scope is None:
@@ -167,17 +172,24 @@ def enforce_set_scope(server, request: Request, set_id: int) -> None:
             )
     elif scope.resource_type == "project":
 
-        def _check_set_in_project(session, sid: int, pid: int):
-            ps = session.get(PictureSet, sid)
-            if ps is None or ps.project_id != pid:
-                raise HTTPException(
-                    status_code=403,
-                    detail="Token is not authorised for this picture set",
-                )
+        def _check_set_in_project(session, sid: int, pid: int) -> bool:
+            return (
+                session.exec(
+                    select(PictureSetProjectMember).where(
+                        PictureSetProjectMember.set_id == sid,
+                        PictureSetProjectMember.project_id == pid,
+                    )
+                ).first()
+                is not None
+            )
 
-        server.vault.db.run_immediate_read_task(
+        if not server.vault.db.run_immediate_read_task(
             _check_set_in_project, set_id, scope.resource_id
-        )
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="Token is not authorised for this picture set",
+            )
     elif scope.resource_type is not None:
         raise HTTPException(
             status_code=403,
@@ -196,6 +208,11 @@ def enforce_character_scope(server, request: Request, character_id: int) -> None
     A ``character`` token reaches only its own character; a ``project`` token
     reaches a character that belongs to its project; every other scoped
     ``resource_type`` is refused. An owner / unscoped token passes.
+
+    Since issue #125 a character may belong to several projects, so the project
+    branch tests the ``CharacterProjectMember`` join rather than the scalar
+    ``Character.project_id`` (which now names only the *primary* project and would
+    under-grant a legitimately shared character).
     """
     scope = getattr(request.state, "token_scope", None)
     if scope is None:
@@ -209,8 +226,15 @@ def enforce_character_scope(server, request: Request, character_id: int) -> None
     elif scope.resource_type == "project":
 
         def check_char_project(session, cid: int, pid: int) -> bool:
-            char = session.get(Character, cid)
-            return char is not None and char.project_id == pid
+            return (
+                session.exec(
+                    select(CharacterProjectMember).where(
+                        CharacterProjectMember.character_id == cid,
+                        CharacterProjectMember.project_id == pid,
+                    )
+                ).first()
+                is not None
+            )
 
         if not server.vault.db.run_immediate_read_task(
             check_char_project, character_id, scope.resource_id

--- a/pixlstash/db_models/__init__.py
+++ b/pixlstash/db_models/__init__.py
@@ -1,5 +1,13 @@
 from .character import Character  # noqa: F401
 from .deleted_file_log import DeletedFileLog  # noqa: F401
+from .entity_project import (  # noqa: F401
+    CharacterProjectMember,
+    PictureSetProjectMember,
+    character_in_no_project,
+    character_in_project,
+    picture_set_in_no_project,
+    picture_set_in_project,
+)
 from .detection import Detection  # noqa: F401
 from .face import Face  # noqa: F401
 from .picture import Picture, SortMechanism  # noqa: F401

--- a/pixlstash/db_models/entity_project.py
+++ b/pixlstash/db_models/entity_project.py
@@ -1,0 +1,159 @@
+"""Many-to-many membership links between projects and the entities they scope.
+
+Issue #125 makes a character or a picture set reachable from **several** projects
+at once. The change is deliberately *additive*: the scalar
+``Character.project_id`` / ``PictureSet.project_id`` foreign keys stay exactly as
+they were and keep pointing at the entity's **primary** project (the lowest member
+project id, or ``NULL`` when the entity belongs to no project), while these two
+join tables carry the full membership set.
+
+**The contract is "write both, read the join".** Every write path goes through
+:mod:`pixlstash.services.project_membership_service`
+(``set_character_projects`` / ``set_picture_set_projects``), which updates the join
+rows *and* re-derives the scalar pointer in one place. Every *read* that asks
+"is this entity in project P?" must use the predicates below rather than comparing
+the scalar column, because the scalar only ever names one of possibly many
+projects. Comparing the FK is now a bug: it silently hides an entity's secondary
+projects, and — in the authorization helpers — under-grants (or, once the FK is
+eventually dropped post-1.12, breaks outright).
+
+The FK removal is explicitly out of scope here; a later cleanup release retires it
+once no reader depends on it.
+"""
+
+from sqlalchemy import exists
+from sqlmodel import Column, Field, ForeignKey, Integer, SQLModel, select
+
+from .character import Character
+from .picture_set import PictureSet
+
+__all__ = [
+    "CharacterProjectMember",
+    "PictureSetProjectMember",
+    "character_in_project",
+    "character_in_no_project",
+    "picture_set_in_project",
+    "picture_set_in_no_project",
+]
+
+
+class CharacterProjectMember(SQLModel, table=True):
+    """Many-to-many membership link between characters and projects.
+
+    Attributes:
+        character_id: FK to ``character.id`` (cascade-deletes with the character).
+        project_id: FK to ``project.id`` (cascade-deletes with the project).
+    """
+
+    character_id: int = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("character.id", ondelete="CASCADE"),
+            primary_key=True,
+            index=True,
+        ),
+    )
+    project_id: int = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("project.id", ondelete="CASCADE"),
+            primary_key=True,
+            index=True,
+        ),
+    )
+
+
+class PictureSetProjectMember(SQLModel, table=True):
+    """Many-to-many membership link between picture sets and projects.
+
+    Attributes:
+        set_id: FK to ``pictureset.id`` (cascade-deletes with the set).
+        project_id: FK to ``project.id`` (cascade-deletes with the project).
+    """
+
+    set_id: int = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("pictureset.id", ondelete="CASCADE"),
+            primary_key=True,
+            index=True,
+        ),
+    )
+    project_id: int = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("project.id", ondelete="CASCADE"),
+            primary_key=True,
+            index=True,
+        ),
+    )
+
+
+def character_in_project(project_id: int):
+    """SQL predicate: the correlated ``Character`` row belongs to ``project_id``.
+
+    Use in any query whose FROM already contains ``Character`` (directly or via a
+    join). Replaces the pre-#125 ``Character.project_id == project_id``, which now
+    only matches the character's *primary* project.
+
+    Args:
+        project_id: The project the character must be a member of.
+
+    Returns:
+        A correlated ``EXISTS`` boolean expression.
+    """
+    return exists(
+        select(CharacterProjectMember.character_id).where(
+            CharacterProjectMember.character_id == Character.id,
+            CharacterProjectMember.project_id == project_id,
+        )
+    )
+
+
+def character_in_no_project():
+    """SQL predicate: the correlated ``Character`` row belongs to no project.
+
+    Replaces ``Character.project_id.is_(None)``.
+
+    Returns:
+        A correlated ``NOT EXISTS`` boolean expression.
+    """
+    return ~exists(
+        select(CharacterProjectMember.character_id).where(
+            CharacterProjectMember.character_id == Character.id
+        )
+    )
+
+
+def picture_set_in_project(project_id: int):
+    """SQL predicate: the correlated ``PictureSet`` row belongs to ``project_id``.
+
+    Args:
+        project_id: The project the picture set must be a member of.
+
+    Returns:
+        A correlated ``EXISTS`` boolean expression.
+    """
+    return exists(
+        select(PictureSetProjectMember.set_id).where(
+            PictureSetProjectMember.set_id == PictureSet.id,
+            PictureSetProjectMember.project_id == project_id,
+        )
+    )
+
+
+def picture_set_in_no_project():
+    """SQL predicate: the correlated ``PictureSet`` row belongs to no project.
+
+    Returns:
+        A correlated ``NOT EXISTS`` boolean expression.
+    """
+    return ~exists(
+        select(PictureSetProjectMember.set_id).where(
+            PictureSetProjectMember.set_id == PictureSet.id
+        )
+    )

--- a/pixlstash/db_models/picture.py
+++ b/pixlstash/db_models/picture.py
@@ -22,6 +22,12 @@ from sqlmodel import (
 from typing import ClassVar, Optional, List, Union, TYPE_CHECKING
 
 from .character import Character
+from .entity_project import (
+    character_in_no_project,
+    character_in_project,
+    picture_set_in_no_project,
+    picture_set_in_project,
+)
 from .face import Face
 from .picture_project import PictureProjectMember
 from .picture_set import PictureSet, PictureSetMember
@@ -1226,14 +1232,16 @@ class Picture(SQLModel, table=True):
         so all pictures in that stack are excluded from unassigned queries.
 
         When assignment project scope is provided, assignment is evaluated only
-        against characters/sets in that same project scope.
+        against characters/sets in that same project scope. Since issue #125 a
+        character or set may belong to several projects, so the scope predicates
+        read the membership join tables rather than the primary-project FK.
         """
         if assignment_unassigned_project:
-            project_scope = Character.project_id.is_(None)
-            set_scope = PictureSet.project_id.is_(None)
+            project_scope = character_in_no_project()
+            set_scope = picture_set_in_no_project()
         elif assignment_project_id is not None:
-            project_scope = Character.project_id == assignment_project_id
-            set_scope = PictureSet.project_id == assignment_project_id
+            project_scope = character_in_project(assignment_project_id)
+            set_scope = picture_set_in_project(assignment_project_id)
         else:
             project_scope = None
             set_scope = None

--- a/pixlstash/migrations/versions/0086_add_entity_project_membership.py
+++ b/pixlstash/migrations/versions/0086_add_entity_project_membership.py
@@ -1,0 +1,153 @@
+"""Add characterprojectmember / picturesetprojectmember join tables (issue #125).
+
+A character or picture set could previously belong to exactly one project, via the
+scalar ``character.project_id`` / ``pictureset.project_id`` foreign keys. Issue
+#125 makes both many-to-many, mirroring the shape ``pictureprojectmember``
+(migration ``0009``) already gives pictures.
+
+The change is deliberately **additive and non-destructive**: both scalar FK columns
+stay, and stay populated — they now hold the entity's *primary* project (the lowest
+member project id, or ``NULL``). Reads move to the join tables; the FKs are retired
+by a later cleanup release once nothing reads them. Nothing is dropped here, so the
+migration is safe to run against a deployed database and reversible without data
+loss (``downgrade`` drops only the new tables — every entity keeps its original
+single-project assignment in the untouched FK).
+
+Backfill inserts one join row per non-``NULL`` scalar FK, so an existing library
+comes up with exactly the membership it had before, expressed in the new shape.
+
+Revision ID: 0086_add_entity_project_membership
+Revises: 0085_recompute_smart_score_restored_builtin_anchors
+Create Date: 2026-07-28 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0086_add_entity_project_membership"
+down_revision: Union[str, None] = "0085_recompute_smart_score_restored_builtin_anchors"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "project" not in existing_tables:
+        # Nothing to link: no project table means no project assignments exist.
+        # A fresh database builds both join tables from the models in
+        # ``0001_baseline``; every real deployed database has had ``project``
+        # since ``0005_add_projects``. This branch only fires for a partially
+        # hand-built database (the migration test fixtures).
+        return
+
+    has_character = "character" in existing_tables
+    has_pictureset = "pictureset" in existing_tables
+
+    if has_character and "characterprojectmember" not in existing_tables:
+        op.create_table(
+            "characterprojectmember",
+            sa.Column("character_id", sa.Integer(), nullable=False),
+            sa.Column("project_id", sa.Integer(), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["character_id"], ["character.id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("character_id", "project_id"),
+        )
+        op.create_index(
+            "ix_characterprojectmember_character_id",
+            "characterprojectmember",
+            ["character_id"],
+            unique=False,
+        )
+        op.create_index(
+            "ix_characterprojectmember_project_id",
+            "characterprojectmember",
+            ["project_id"],
+            unique=False,
+        )
+
+    if has_pictureset and "picturesetprojectmember" not in existing_tables:
+        op.create_table(
+            "picturesetprojectmember",
+            sa.Column("set_id", sa.Integer(), nullable=False),
+            sa.Column("project_id", sa.Integer(), nullable=False),
+            sa.ForeignKeyConstraint(["set_id"], ["pictureset.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("set_id", "project_id"),
+        )
+        op.create_index(
+            "ix_picturesetprojectmember_set_id",
+            "picturesetprojectmember",
+            ["set_id"],
+            unique=False,
+        )
+        op.create_index(
+            "ix_picturesetprojectmember_project_id",
+            "picturesetprojectmember",
+            ["project_id"],
+            unique=False,
+        )
+
+    # Backfill memberships from the legacy single-project foreign keys. The join
+    # is against ``project`` so a dangling FK (a project row deleted without the
+    # pointer being cleared) does not violate the new FK constraint.
+    if has_character:
+        bind.execute(
+            sa.text(
+                """
+                INSERT OR IGNORE INTO characterprojectmember (character_id, project_id)
+                SELECT c.id, c.project_id
+                FROM character AS c
+                JOIN project AS p ON p.id = c.project_id
+                WHERE c.project_id IS NOT NULL
+                """
+            )
+        )
+    if has_pictureset:
+        bind.execute(
+            sa.text(
+                """
+                INSERT OR IGNORE INTO picturesetprojectmember (set_id, project_id)
+                SELECT s.id, s.project_id
+                FROM pictureset AS s
+                JOIN project AS p ON p.id = s.project_id
+                WHERE s.project_id IS NOT NULL
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "picturesetprojectmember" in existing_tables:
+        op.drop_index(
+            "ix_picturesetprojectmember_project_id",
+            table_name="picturesetprojectmember",
+        )
+        op.drop_index(
+            "ix_picturesetprojectmember_set_id", table_name="picturesetprojectmember"
+        )
+        op.drop_table("picturesetprojectmember")
+
+    if "characterprojectmember" in existing_tables:
+        op.drop_index(
+            "ix_characterprojectmember_project_id", table_name="characterprojectmember"
+        )
+        op.drop_index(
+            "ix_characterprojectmember_character_id",
+            table_name="characterprojectmember",
+        )
+        op.drop_table("characterprojectmember")

--- a/pixlstash/routes/_helpers.py
+++ b/pixlstash/routes/_helpers.py
@@ -9,10 +9,12 @@ from sqlmodel import Session, select
 
 from pixlstash.db_models import (
     Character,
+    CharacterProjectMember,
     Face,
     Picture,
     PictureSet,
     PictureSetMember,
+    PictureSetProjectMember,
     Project,
     PictureStack,
 )
@@ -66,13 +68,23 @@ def picture_referenced_by_project(
     (another entity still anchors it there) or can be removed.  The entity being
     moved is excluded from the check via ``exclude_character_id`` /
     ``exclude_set_id`` so it does not count as a reason to keep the picture.
+
+    Since issue #125 an entity may belong to several projects, so "still assigned
+    to ``project_id``" is read from the ``CharacterProjectMember`` /
+    ``PictureSetProjectMember`` join tables rather than the scalar primary-project
+    FK. Reading the FK here would drop a picture out of a project that one of its
+    entities is still (secondarily) a member of.
     """
     char_query = (
         select(Character.id)
         .join(Face, Face.character_id == Character.id)
+        .join(
+            CharacterProjectMember,
+            CharacterProjectMember.character_id == Character.id,
+        )
         .where(
             Face.picture_id == picture_id,
-            Character.project_id == project_id,
+            CharacterProjectMember.project_id == project_id,
         )
     )
     if exclude_character_id is not None:
@@ -83,9 +95,13 @@ def picture_referenced_by_project(
     set_query = (
         select(PictureSet.id)
         .join(PictureSetMember, PictureSetMember.set_id == PictureSet.id)
+        .join(
+            PictureSetProjectMember,
+            PictureSetProjectMember.set_id == PictureSet.id,
+        )
         .where(
             PictureSetMember.picture_id == picture_id,
-            PictureSet.project_id == project_id,
+            PictureSetProjectMember.project_id == project_id,
         )
     )
     if exclude_set_id is not None:

--- a/pixlstash/routes/characters.py
+++ b/pixlstash/routes/characters.py
@@ -59,7 +59,7 @@ from pixlstash.utils.service.filter_helpers import (
     combine_likeness_scores,
     fetch_scope_allowed_character_ids,
     fetch_scope_allowed_picture_ids,
-    filter_visible_project_ids,
+    narrow_project_fields,
     VALID_COMBINE_MODES,
     visible_project_ids,
 )
@@ -848,8 +848,8 @@ def create_router(server) -> APIRouter:
                 if not found:
                     return None
                 payload = safe_model_dict(found[0])
-                payload["project_ids"] = filter_visible_project_ids(
-                    character_project_ids(session, id), visible_projects
+                narrow_project_fields(
+                    payload, character_project_ids(session, id), visible_projects
                 )
                 return payload
 
@@ -883,8 +883,10 @@ def create_router(server) -> APIRouter:
             if character is None:
                 raise HTTPException(status_code=404, detail="Character not found")
             payload = safe_model_dict(character)
-            payload["project_ids"] = filter_visible_project_ids(
-                character_project_ids(session, int(character.id)), visible_projects
+            narrow_project_fields(
+                payload,
+                character_project_ids(session, int(character.id)),
+                visible_projects,
             )
             return payload
 
@@ -1215,13 +1217,14 @@ def create_router(server) -> APIRouter:
                         project_ids_by_char.setdefault(int(cid), []).append(int(pid))
 
                 return [
-                    {
-                        **c.model_dump(exclude_unset=False),
-                        "has_reference_faces": c.id in chars_with_faces,
-                        "project_ids": filter_visible_project_ids(
-                            project_ids_by_char.get(int(c.id), []), visible_projects
-                        ),
-                    }
+                    narrow_project_fields(
+                        {
+                            **c.model_dump(exclude_unset=False),
+                            "has_reference_faces": c.id in chars_with_faces,
+                        },
+                        project_ids_by_char.get(int(c.id), []),
+                        visible_projects,
+                    )
                     for c in characters
                 ]
 

--- a/pixlstash/routes/characters.py
+++ b/pixlstash/routes/characters.py
@@ -59,7 +59,9 @@ from pixlstash.utils.service.filter_helpers import (
     combine_likeness_scores,
     fetch_scope_allowed_character_ids,
     fetch_scope_allowed_picture_ids,
+    filter_visible_project_ids,
     VALID_COMBINE_MODES,
+    visible_project_ids,
 )
 from pixlstash.utils.path_utils import resolve_path_within
 from pixlstash.utils.serialization_utils import safe_model_dict
@@ -837,13 +839,18 @@ def create_router(server) -> APIRouter:
     )
     def get_character_by_id(request: Request, id: int):
         try:
+            # A scoped token may read the character but must not learn which
+            # *other* projects it belongs to (issue #125 / R1).
+            visible_projects = visible_project_ids(server, request)
 
             def fetch(session):
                 found = Character.find(session, id=id)
                 if not found:
                     return None
                 payload = safe_model_dict(found[0])
-                payload["project_ids"] = character_project_ids(session, id)
+                payload["project_ids"] = filter_visible_project_ids(
+                    character_project_ids(session, id), visible_projects
+                )
                 return payload
 
             return server.vault.db.run_immediate_read_task(fetch)
@@ -859,6 +866,8 @@ def create_router(server) -> APIRouter:
     def get_character_by_project_and_name(
         request: Request, project_name: str, character_name: str
     ):
+        visible_projects = visible_project_ids(server, request)
+
         def fetch(session):
             project = session.exec(
                 select(Project).where(func.lower(Project.name) == project_name.lower())
@@ -874,7 +883,9 @@ def create_router(server) -> APIRouter:
             if character is None:
                 raise HTTPException(status_code=404, detail="Character not found")
             payload = safe_model_dict(character)
-            payload["project_ids"] = character_project_ids(session, int(character.id))
+            payload["project_ids"] = filter_visible_project_ids(
+                character_project_ids(session, int(character.id)), visible_projects
+            )
             return payload
 
         result = server.vault.db.run_immediate_read_task(fetch)
@@ -1141,6 +1152,7 @@ def create_router(server) -> APIRouter:
         project_id: str | None = Query(default=None),
     ):
         token_scope = getattr(request.state, "token_scope", None)
+        visible_projects = visible_project_ids(server, request)
         try:
             logger.debug(
                 f"Fetching characters with name: {name}, project_id: {project_id}"
@@ -1206,7 +1218,9 @@ def create_router(server) -> APIRouter:
                     {
                         **c.model_dump(exclude_unset=False),
                         "has_reference_faces": c.id in chars_with_faces,
-                        "project_ids": sorted(project_ids_by_char.get(int(c.id), [])),
+                        "project_ids": filter_visible_project_ids(
+                            project_ids_by_char.get(int(c.id), []), visible_projects
+                        ),
                     }
                     for c in characters
                 ]

--- a/pixlstash/routes/characters.py
+++ b/pixlstash/routes/characters.py
@@ -21,7 +21,7 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse
 from PIL import Image
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field as PydanticField
 from sqlalchemy import case as sa_case, exists, func
 from sqlmodel import Session, select
 
@@ -29,6 +29,7 @@ from pixlstash.authz.membership import enforce_character_scope
 from pixlstash.database import DBPriority
 from pixlstash.db_models import (
     Character,
+    CharacterProjectMember,
     Face,
     Picture,
     PictureProjectMember,
@@ -36,11 +37,15 @@ from pixlstash.db_models import (
     PictureSet,
     PictureSetMember,
     Tag,
+    character_in_no_project,
+    character_in_project,
 )
 from pixlstash.event_types import EventType
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services.project_membership_service import (
-    reconcile_entity_project_change,
+    character_project_ids,
+    reconcile_entity_projects_change,
+    set_character_projects,
 )
 from pixlstash.services.set_lock_service import locked_picture_ids
 from pixlstash.services.stack_membership import expand_picture_ids_to_stacks
@@ -157,8 +162,22 @@ class CharacterResponse(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     extra_metadata: Optional[str] = None
+    project_id: Optional[int] = PydanticField(
+        default=None,
+        description=(
+            "The character's primary project — the lowest id in ``project_ids``, "
+            "or null when it belongs to no project. Kept for backwards "
+            "compatibility; prefer ``project_ids``, which lists every project."
+        ),
+    )
+    project_ids: list[int] = PydanticField(
+        default_factory=list,
+        description=(
+            "Every project this character belongs to, lowest id first. A character "
+            "may be shared across several projects."
+        ),
+    )
     reference_picture_set_id: Optional[int] = None
-    project_id: Optional[int] = None
 
 
 class CharacterListItemResponse(BaseModel):
@@ -170,8 +189,22 @@ class CharacterListItemResponse(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     extra_metadata: Optional[str] = None
+    project_id: Optional[int] = PydanticField(
+        default=None,
+        description=(
+            "The character's primary project — the lowest id in ``project_ids``, "
+            "or null when it belongs to no project. Kept for backwards "
+            "compatibility; prefer ``project_ids``, which lists every project."
+        ),
+    )
+    project_ids: list[int] = PydanticField(
+        default_factory=list,
+        description=(
+            "Every project this character belongs to, lowest id first. A character "
+            "may be shared across several projects."
+        ),
+    )
     reference_picture_set_id: Optional[int] = None
-    project_id: Optional[int] = None
     has_reference_faces: bool = False
 
 
@@ -233,17 +266,28 @@ def create_router(server) -> APIRouter:
     router = APIRouter()
 
     def _ensure_unique_character_name(
-        session, name: str, project_id, exclude_char_id=None
+        session, name: str, project_ids, exclude_char_id=None
     ):
         """Raises 409 if a character with the same name (case-insensitive)
-        already exists in the given project.  Unscoped characters
-        (project_id None) are exempt.
+        already exists in **any** of the given projects.  Unscoped characters
+        (no projects) are exempt.
+
+        Since issue #125 a character can be in several projects at once, so the
+        clash check spans every project it is joining, not just its primary one.
         """
-        if project_id is None:
+        wanted = sorted({int(pid) for pid in (project_ids or []) if pid is not None})
+        if not wanted:
             return
-        stmt = select(Character).where(
-            Character.project_id == project_id,
-            func.lower(Character.name) == name.lower(),
+        stmt = (
+            select(Character.id)
+            .join(
+                CharacterProjectMember,
+                CharacterProjectMember.character_id == Character.id,
+            )
+            .where(
+                CharacterProjectMember.project_id.in_(wanted),
+                func.lower(Character.name) == name.lower(),
+            )
         )
         if exclude_char_id is not None:
             stmt = stmt.where(Character.id != exclude_char_id)
@@ -252,6 +296,51 @@ def create_router(server) -> APIRouter:
                 status_code=409,
                 detail=f"A character named '{name}' already exists in this project.",
             )
+
+    def _resolve_target_project_ids(data: dict, current: list[int] | None):
+        """Resolve the requested project membership set from a request payload.
+
+        Accepts the multi-project ``project_ids`` list (issue #125) and the legacy
+        single ``project_id`` scalar, in that precedence order.
+
+        Args:
+            data: The parsed request body.
+            current: The entity's existing project ids, returned unchanged when
+                the payload mentions neither key. ``None`` for a create.
+
+        Returns:
+            ``(target_project_ids, provided)`` — the full target membership set,
+            and whether the payload asked for a project change at all.
+
+        Raises:
+            HTTPException: ``400`` when either key is not an integer / list of
+                integers.
+        """
+        if "project_ids" in data:
+            raw_ids = data.get("project_ids")
+            if raw_ids is None:
+                return [], True
+            if not isinstance(raw_ids, (list, tuple, set)):
+                raise HTTPException(
+                    status_code=400, detail="project_ids must be a list"
+                )
+            try:
+                return sorted({int(v) for v in raw_ids if v is not None}), True
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(
+                    status_code=400, detail="Invalid project_id"
+                ) from exc
+        if "project_id" in data:
+            raw = data.get("project_id")
+            if raw is None:
+                return [], True
+            try:
+                return [int(raw)], True
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(
+                    status_code=400, detail="Invalid project_id"
+                ) from exc
+        return (list(current) if current is not None else []), False
 
     def _project_membership_exists(project_id_value: int):
         return exists(
@@ -498,7 +587,20 @@ def create_router(server) -> APIRouter:
     @router.patch(
         "/characters/{id}",
         summary="Update character",
-        description="Updates character fields and clears dependent picture text embeddings when identity data changes.",
+        description=(
+            "Updates character fields and clears dependent picture text embeddings "
+            "when identity data changes.\n\n"
+            "**Project membership.** Send ``project_ids`` (a list) to set the full "
+            "set of projects the character belongs to — a character may be in "
+            "several at once. The legacy single ``project_id`` is still accepted "
+            "and means the same as a one-element ``project_ids``; ``null`` on "
+            "either key removes the character from every project. ``project_ids`` "
+            "wins when both are present. Member pictures follow: they join every "
+            "project the character joins, and leave a project it leaves unless "
+            "another character or picture set still anchors them there. Returns "
+            "409 on a name clash inside any target project and 404 for an unknown "
+            "project id."
+        ),
         response_model=CharacterMutationResponse,
     )
     async def patch_character(id: int, request: Request):
@@ -506,44 +608,29 @@ def create_router(server) -> APIRouter:
         data = await request.json()
         name = data.get("name")
         description = data.get("description")
-        raw_project_id = data.get("project_id", _UNSET)
-        project_id = raw_project_id
-        if raw_project_id is not _UNSET:
-            if raw_project_id is None:
-                project_id = None
-            else:
-                try:
-                    project_id = int(raw_project_id)
-                except (TypeError, ValueError) as exc:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="Invalid project_id",
-                    ) from exc
         char = None
         project_membership_updated = False
         try:
 
-            def alter_char(
-                session: Session, id: int, name: str, description: str, project_id
-            ):
+            def alter_char(session: Session, id: int, name: str, description: str):
                 character = session.get(Character, id)
                 if character is None:
                     raise KeyError("Character not found")
-                # Capture the project the character is leaving before we mutate
-                # it, so we can disassociate its pictures from that old project.
-                old_project_id = character.project_id
+                # Capture the projects the character is in before we mutate it, so
+                # we can disassociate its pictures from the ones it leaves.
+                old_project_ids = character_project_ids(session, id)
+                target_project_ids, project_provided = _resolve_target_project_ids(
+                    data, old_project_ids
+                )
                 # Check uniqueness before mutating anything.
                 final_name = name if name is not None else character.name
-                final_project_id = (
-                    project_id if project_id is not _UNSET else character.project_id
-                )
                 name_changing = name is not None and name != character.name
-                project_changing = (
-                    project_id is not _UNSET and project_id != character.project_id
-                )
+                project_changing = project_provided and sorted(
+                    target_project_ids
+                ) != sorted(old_project_ids)
                 if name_changing or project_changing:
                     _ensure_unique_character_name(
-                        session, final_name, final_project_id, exclude_char_id=id
+                        session, final_name, target_project_ids, exclude_char_id=id
                     )
                 updated = False
                 if name is not None and name != character.name:
@@ -552,24 +639,19 @@ def create_router(server) -> APIRouter:
                 if description is not None and description != character.description:
                     character.description = description
                     updated = True
-                project_id_changed = (
-                    project_id is not _UNSET and project_id != character.project_id
-                )
-                if project_id_changed:
-                    if project_id is not None:
-                        project = session.get(Project, project_id)
-                        if project is None:
-                            raise HTTPException(
-                                status_code=404,
-                                detail="Project not found",
-                            )
-                    character.project_id = project_id
-                    updated = True
+                # Single write path for both the join rows and the primary-project
+                # FK; raises 404 for an unknown project id.
+                project_change = None
+                if project_changing:
+                    project_change = set_character_projects(
+                        session, character, target_project_ids
+                    )
+                    updated = updated or project_change.changed
                 local_project_membership_updated = False
                 if updated:
                     session.add(character)
 
-                    if project_id_changed:
+                    if project_change is not None and project_change.changed:
                         picture_ids = list(
                             {
                                 face.picture_id
@@ -582,13 +664,13 @@ def create_router(server) -> APIRouter:
                         # Project membership is stack-atomic: a character on one
                         # member of a stack moves the whole stack's membership.
                         picture_ids = expand_picture_ids_to_stacks(session, picture_ids)
-                        # Reference-aware add/remove/repoint across the old and
-                        # new project — shared with picture set updates.
-                        reconcile_entity_project_change(
+                        # Reference-aware add/remove/repoint across every project
+                        # joined and left — shared with picture set updates.
+                        reconcile_entity_projects_change(
                             session,
                             picture_ids=picture_ids,
-                            old_project_id=old_project_id,
-                            new_project_id=project_id,
+                            ensure_project_ids=project_change.target_project_ids,
+                            remove_project_ids=project_change.removed,
                             exclude_character_id=id,
                         )
                         local_project_membership_updated = bool(picture_ids)
@@ -618,17 +700,15 @@ def create_router(server) -> APIRouter:
                     session.refresh(character)
                 # Serialize while the session is open; the row may be detached
                 # (and its attributes expired) by the time the handler returns.
-                return (
-                    character.model_dump(exclude_unset=False),
-                    local_project_membership_updated,
-                )
+                payload = character.model_dump(exclude_unset=False)
+                payload["project_ids"] = character_project_ids(session, id)
+                return (payload, local_project_membership_updated)
 
             char, project_membership_updated = server.vault.db.run_task(
                 alter_char,
                 id,
                 name,
                 description,
-                project_id,
                 priority=DBPriority.IMMEDIATE,
             )
             server.vault.notify(
@@ -757,10 +837,16 @@ def create_router(server) -> APIRouter:
     )
     def get_character_by_id(request: Request, id: int):
         try:
-            char = server.vault.db.run_immediate_read_task(
-                lambda session: Character.find(session, id=id)
-            )
-            return char[0] if char else None
+
+            def fetch(session):
+                found = Character.find(session, id=id)
+                if not found:
+                    return None
+                payload = safe_model_dict(found[0])
+                payload["project_ids"] = character_project_ids(session, id)
+                return payload
+
+            return server.vault.db.run_immediate_read_task(fetch)
         except KeyError:
             raise HTTPException(status_code=404, detail="Character not found")
 
@@ -781,13 +867,15 @@ def create_router(server) -> APIRouter:
                 raise HTTPException(status_code=404, detail="Project not found")
             character = session.exec(
                 select(Character).where(
-                    Character.project_id == project.id,
+                    character_in_project(project.id),
                     func.lower(Character.name) == character_name.lower(),
                 )
             ).first()
             if character is None:
                 raise HTTPException(status_code=404, detail="Character not found")
-            return safe_model_dict(character)
+            payload = safe_model_dict(character)
+            payload["project_ids"] = character_project_ids(session, int(character.id))
+            return payload
 
         result = server.vault.db.run_immediate_read_task(fetch)
         # Scope guard (BOLA): a resource-scoped token may only read its own
@@ -1076,10 +1164,10 @@ def create_router(server) -> APIRouter:
                     query = query.where(Character.name == name)
                 if project_id is not None:
                     if project_id == "UNASSIGNED":
-                        query = query.where(Character.project_id.is_(None))
+                        query = query.where(character_in_no_project())
                     else:
                         try:
-                            query = query.where(Character.project_id == int(project_id))
+                            query = query.where(character_in_project(int(project_id)))
                         except (TypeError, ValueError):
                             raise HTTPException(
                                 status_code=400, detail="Invalid project_id"
@@ -1102,10 +1190,23 @@ def create_router(server) -> APIRouter:
                 else:
                     chars_with_faces = set()
 
+                # One query for every listed character's project membership, so
+                # the multi-project set is exposed without an N+1 (issue #125).
+                project_ids_by_char: dict[int, list[int]] = {}
+                if char_ids:
+                    for cid, pid in session.exec(
+                        select(
+                            CharacterProjectMember.character_id,
+                            CharacterProjectMember.project_id,
+                        ).where(CharacterProjectMember.character_id.in_(char_ids))
+                    ).all():
+                        project_ids_by_char.setdefault(int(cid), []).append(int(pid))
+
                 return [
                     {
                         **c.model_dump(exclude_unset=False),
                         "has_reference_faces": c.id in chars_with_faces,
+                        "project_ids": sorted(project_ids_by_char.get(int(c.id), [])),
                     }
                     for c in characters
                 ]
@@ -1123,7 +1224,11 @@ def create_router(server) -> APIRouter:
     @router.post(
         "/characters",
         summary="Create character",
-        description="Creates a character and its linked reference picture set.",
+        description=(
+            "Creates a character and its linked reference picture set. Accepts "
+            "``project_ids`` (a list of projects the character joins) or the "
+            "legacy single ``project_id``."
+        ),
         response_model=CharacterMutationResponse,
     )
     def create_character(request: Request, payload: dict = Body(...)):
@@ -1132,13 +1237,29 @@ def create_router(server) -> APIRouter:
 
             def create_character_and_reference_set(session, payload):
                 char_name = payload.get("name")
-                char_project_id = payload.get("project_id")
+                target_project_ids, _provided = _resolve_target_project_ids(
+                    payload, None
+                )
                 if char_name:
-                    _ensure_unique_character_name(session, char_name, char_project_id)
-                character = Character(**payload)
+                    _ensure_unique_character_name(
+                        session, char_name, target_project_ids
+                    )
+                # ``project_id`` / ``project_ids`` are owned by
+                # ``set_character_projects`` below (write both, read the join), so
+                # they must not reach the Character constructor.
+                fields = {
+                    key: value
+                    for key, value in payload.items()
+                    if key not in ("project_id", "project_ids")
+                }
+                character = Character(**fields)
                 session.add(character)
                 session.commit()
                 session.refresh(character)
+                if target_project_ids:
+                    set_character_projects(session, character, target_project_ids)
+                    session.commit()
+                    session.refresh(character)
                 logger.debug("Created character with ID: {}".format(character.id))
                 reference_set = PictureSet(
                     name="reference_pictures", description=str(character.name)
@@ -1150,7 +1271,11 @@ def create_router(server) -> APIRouter:
                 session.add(character)
                 session.commit()
                 session.refresh(character)
-                return character.model_dump(exclude_unset=False)
+                created = character.model_dump(exclude_unset=False)
+                created["project_ids"] = character_project_ids(
+                    session, int(character.id)
+                )
+                return created
 
             char_dict = server.vault.db.run_task(
                 create_character_and_reference_set,
@@ -1163,6 +1288,11 @@ def create_router(server) -> APIRouter:
                 {"origin_client_id": origin_client_id},
             )
             return {"status": "success", "character": char_dict}
+        except HTTPException:
+            # Deliberate, already-typed failures (409 duplicate name, 404 unknown
+            # project, 400 malformed project_ids) must keep their status; the
+            # blanket handler below would otherwise flatten them all to 400.
+            raise
         except Exception as e:
             logger.error(f"Error creating character: {e}")
             raise HTTPException(status_code=400, detail="Invalid character data")

--- a/pixlstash/routes/characters_faces.py
+++ b/pixlstash/routes/characters_faces.py
@@ -23,12 +23,15 @@ from pixlstash.db_models import (
     Character,
     Face,
     Picture,
-    PictureProjectMember,
 )
 from pixlstash.event_types import EventType
 from pixlstash.picture_scoring import (
     compute_character_likeness_for_faces,
     select_reference_faces_for_character,
+)
+from pixlstash.services.project_membership_service import (
+    character_project_ids,
+    reconcile_entity_projects_change,
 )
 from pixlstash.services.stack_membership import expand_picture_ids_to_stacks
 from pixlstash.utils.service.filter_helpers import fetch_scope_allowed_picture_ids
@@ -208,29 +211,21 @@ def create_router(server) -> APIRouter:
             for face in unique_faces:
                 session.refresh(face)
             character = session.get(Character, character_id)
-            if character and character.project_id is not None:
-                for face in unique_faces:
-                    if face.picture_id:
-                        pic = session.get(Picture, face.picture_id)
-                        if pic:
-                            membership = session.exec(
-                                select(PictureProjectMember).where(
-                                    PictureProjectMember.picture_id == pic.id,
-                                    PictureProjectMember.project_id
-                                    == character.project_id,
-                                )
-                            ).first()
-                            if membership is None:
-                                session.add(
-                                    PictureProjectMember(
-                                        picture_id=pic.id,
-                                        project_id=character.project_id,
-                                    )
-                                )
-                            if pic.project_id is None:
-                                pic.project_id = character.project_id
-                                session.add(pic)
-                if any(f.picture_id for f in unique_faces):
+            if character is not None:
+                # Issue #125: a character may belong to several projects, so the
+                # newly assigned pictures join *all* of them. Reading the primary
+                # FK here would leave them out of every secondary project.
+                assigned_picture_ids = [
+                    int(face.picture_id) for face in unique_faces if face.picture_id
+                ]
+                project_ids = character_project_ids(session, character_id)
+                if assigned_picture_ids and project_ids:
+                    reconcile_entity_projects_change(
+                        session,
+                        picture_ids=assigned_picture_ids,
+                        ensure_project_ids=project_ids,
+                        remove_project_ids=[],
+                    )
                     session.commit()
             faces_payload = [
                 {

--- a/pixlstash/routes/picture_sets.py
+++ b/pixlstash/routes/picture_sets.py
@@ -37,7 +37,11 @@ from pixlstash.services.set_lock_service import (
 )
 from pixlstash.services.stack_membership import expand_picture_ids_to_stacks
 from pixlstash.pixl_logging import get_logger
-from pixlstash.utils.service.filter_helpers import fetch_scope_allowed_picture_ids
+from pixlstash.utils.service.filter_helpers import (
+    fetch_scope_allowed_picture_ids,
+    filter_visible_project_ids,
+    visible_project_ids,
+)
 from pixlstash.picture_scoring import (
     find_pictures_by_character_likeness,
     find_pictures_by_smart_score,
@@ -429,6 +433,9 @@ def create_router(server) -> APIRouter:
         elif token_scope is not None and token_scope.resource_type is not None:
             # Any other scoped token (e.g. character) has no access to picture sets
             return []
+        # A scoped token may read the set but must not learn which *other*
+        # projects it belongs to (issue #125 / R1).
+        visible_projects = visible_project_ids(server, request)
         hidden_tags = _get_hidden_tags_from_request(request)
 
         project_filter = None
@@ -488,7 +495,9 @@ def create_router(server) -> APIRouter:
                 )
                 count = len(set(filtered_ids))
                 set_dict = safe_model_dict(s)
-                set_dict["project_ids"] = sorted(project_ids_by_set.get(int(s.id), []))
+                set_dict["project_ids"] = filter_visible_project_ids(
+                    project_ids_by_set.get(int(s.id), []), visible_projects
+                )
                 set_dict["picture_count"] = count
                 top_picture_ids = []
                 if filtered_ids:
@@ -583,6 +592,8 @@ def create_router(server) -> APIRouter:
     def get_picture_set_by_name(
         request: Request, project_name: str, picture_set_name: str
     ):
+        visible_projects = visible_project_ids(server, request)
+
         def fetch(session):
             project = session.exec(
                 select(Project).where(func.lower(Project.name) == project_name.lower())
@@ -598,8 +609,8 @@ def create_router(server) -> APIRouter:
             if picture_set is None:
                 raise HTTPException(status_code=404, detail="Picture set not found")
             payload = safe_model_dict(picture_set)
-            payload["project_ids"] = picture_set_project_ids(
-                session, int(picture_set.id)
+            payload["project_ids"] = filter_visible_project_ids(
+                picture_set_project_ids(session, int(picture_set.id)), visible_projects
             )
             return payload
 
@@ -1122,6 +1133,11 @@ def create_router(server) -> APIRouter:
                 except (TypeError, ValueError):
                     raise HTTPException(status_code=400, detail="Invalid project_id")
 
+        # A scoped token may read the set but must not learn which *other*
+        # projects it belongs to (issue #125 / R1). Both serialisation sites
+        # below reuse the narrowed list returned here.
+        visible_projects = visible_project_ids(server, request)
+
         def fetch_set(session, id):
             picture_set = session.get(PictureSet, id)
             if not picture_set:
@@ -1146,7 +1162,13 @@ def create_router(server) -> APIRouter:
                     continue
                 seen.add(pic_id)
                 picture_ids.append(pic_id)
-            return picture_set, picture_ids, picture_set_project_ids(session, id)
+            return (
+                picture_set,
+                picture_ids,
+                filter_visible_project_ids(
+                    picture_set_project_ids(session, id), visible_projects
+                ),
+            )
 
         picture_set, picture_ids, set_project_ids = (
             server.vault.db.run_immediate_read_task(fetch_set, id)
@@ -1594,23 +1616,15 @@ def create_router(server) -> APIRouter:
                 if exists is None:
                     session.add(PictureSetMember(set_id=id, picture_id=picture.id))
                     added_any = True
-                if picture_set.project_id is not None:
-                    membership = session.exec(
-                        select(PictureProjectMember).where(
-                            PictureProjectMember.picture_id == picture.id,
-                            PictureProjectMember.project_id == picture_set.project_id,
-                        )
-                    ).first()
-                    if membership is None:
-                        session.add(
-                            PictureProjectMember(
-                                picture_id=picture.id,
-                                project_id=picture_set.project_id,
-                            )
-                        )
-                    if picture.project_id != picture_set.project_id:
-                        picture.project_id = picture_set.project_id
-                    session.add(picture)
+            # Issue #125: the set may belong to several projects, so the picture
+            # joins *all* of them. Reading the primary FK here would leave the
+            # picture out of every secondary project the set is shared with.
+            reconcile_entity_projects_change(
+                session,
+                picture_ids=[picture.id for picture in pictures],
+                ensure_project_ids=picture_set_project_ids(session, id),
+                remove_project_ids=[],
+            )
             session.add(picture_set)
             session.commit()
             return added_any
@@ -1742,6 +1756,7 @@ def create_router(server) -> APIRouter:
                 ).all()
             )
             added = 0
+            added_ids: list[int] = []
             for pic_id in picture_ids:
                 if pic_id in existing:
                     continue
@@ -1749,24 +1764,17 @@ def create_router(server) -> APIRouter:
                 if not pic or pic.deleted:
                     continue
                 session.add(PictureSetMember(set_id=set_id, picture_id=pic_id))
-                if picture_set.project_id is not None:
-                    membership = session.exec(
-                        select(PictureProjectMember).where(
-                            PictureProjectMember.picture_id == pic_id,
-                            PictureProjectMember.project_id == picture_set.project_id,
-                        )
-                    ).first()
-                    if membership is None:
-                        session.add(
-                            PictureProjectMember(
-                                picture_id=pic_id,
-                                project_id=picture_set.project_id,
-                            )
-                        )
-                    pic.project_id = picture_set.project_id
-                    session.add(pic)
+                added_ids.append(pic_id)
                 existing.add(pic_id)
                 added += 1
+            # Issue #125: propagate to every project the set belongs to, not just
+            # the primary FK.
+            reconcile_entity_projects_change(
+                session,
+                picture_ids=added_ids,
+                ensure_project_ids=picture_set_project_ids(session, set_id),
+                remove_project_ids=[],
+            )
             session.commit()
             return added
 
@@ -1826,6 +1834,7 @@ def create_router(server) -> APIRouter:
             # Add new members
             added = 0
             seen = set()
+            member_ids: list[int] = []
             for pic_id in picture_ids:
                 if pic_id in seen:
                     continue
@@ -1834,23 +1843,16 @@ def create_router(server) -> APIRouter:
                 if not pic or pic.deleted:
                     continue
                 session.add(PictureSetMember(set_id=set_id, picture_id=pic_id))
-                if picture_set.project_id is not None:
-                    membership = session.exec(
-                        select(PictureProjectMember).where(
-                            PictureProjectMember.picture_id == pic_id,
-                            PictureProjectMember.project_id == picture_set.project_id,
-                        )
-                    ).first()
-                    if membership is None:
-                        session.add(
-                            PictureProjectMember(
-                                picture_id=pic_id,
-                                project_id=picture_set.project_id,
-                            )
-                        )
-                    pic.project_id = picture_set.project_id
-                    session.add(pic)
+                member_ids.append(pic_id)
                 added += 1
+            # Issue #125: propagate to every project the set belongs to, not just
+            # the primary FK.
+            reconcile_entity_projects_change(
+                session,
+                picture_ids=member_ids,
+                ensure_project_ids=picture_set_project_ids(session, set_id),
+                remove_project_ids=[],
+            )
             session.commit()
             return added
 

--- a/pixlstash/routes/picture_sets.py
+++ b/pixlstash/routes/picture_sets.py
@@ -40,6 +40,7 @@ from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.service.filter_helpers import (
     fetch_scope_allowed_picture_ids,
     filter_visible_project_ids,
+    narrow_project_fields,
     visible_project_ids,
 )
 from pixlstash.picture_scoring import (
@@ -495,8 +496,8 @@ def create_router(server) -> APIRouter:
                 )
                 count = len(set(filtered_ids))
                 set_dict = safe_model_dict(s)
-                set_dict["project_ids"] = filter_visible_project_ids(
-                    project_ids_by_set.get(int(s.id), []), visible_projects
+                narrow_project_fields(
+                    set_dict, project_ids_by_set.get(int(s.id), []), visible_projects
                 )
                 set_dict["picture_count"] = count
                 top_picture_ids = []
@@ -609,8 +610,10 @@ def create_router(server) -> APIRouter:
             if picture_set is None:
                 raise HTTPException(status_code=404, detail="Picture set not found")
             payload = safe_model_dict(picture_set)
-            payload["project_ids"] = filter_visible_project_ids(
-                picture_set_project_ids(session, int(picture_set.id)), visible_projects
+            narrow_project_fields(
+                payload,
+                picture_set_project_ids(session, int(picture_set.id)),
+                visible_projects,
             )
             return payload
 
@@ -1219,7 +1222,7 @@ def create_router(server) -> APIRouter:
 
         if info:
             set_dict = picture_set.dict()
-            set_dict["project_ids"] = set_project_ids
+            narrow_project_fields(set_dict, set_project_ids, visible_projects)
             set_dict["picture_count"] = len(picture_ids)
             return set_dict
 
@@ -1239,7 +1242,12 @@ def create_router(server) -> APIRouter:
             if deduplicate_stacks:
                 pictures = deduplicate_by_stack(pictures)
             pictures = _enrich_with_stack_counts(pictures)
-            return {"pictures": pictures, "set": safe_model_dict(picture_set)}
+            return {
+                "pictures": pictures,
+                "set": narrow_project_fields(
+                    safe_model_dict(picture_set), set_project_ids, visible_projects
+                ),
+            }
 
         if sort_mech and sort_mech.key == SortMechanism.Keys.CHARACTER_LIKENESS:
             if not reference_character_id:
@@ -1259,7 +1267,12 @@ def create_router(server) -> APIRouter:
             if deduplicate_stacks:
                 pictures = deduplicate_by_stack(pictures)
             pictures = _enrich_with_stack_counts(pictures)
-            return {"pictures": pictures, "set": safe_model_dict(picture_set)}
+            return {
+                "pictures": pictures,
+                "set": narrow_project_fields(
+                    safe_model_dict(picture_set), set_project_ids, visible_projects
+                ),
+            }
 
         def fetch_pics(session, picture_ids):
             pics = Picture.find(
@@ -1294,7 +1307,7 @@ def create_router(server) -> APIRouter:
         pictures = server.vault.db.run_immediate_read_task(fetch_pics, picture_ids)
         pictures = _enrich_with_stack_counts(pictures)
         set_payload = safe_model_dict(picture_set)
-        set_payload["project_ids"] = set_project_ids
+        narrow_project_fields(set_payload, set_project_ids, visible_projects)
         return {"pictures": pictures, "set": set_payload}
 
     @router.patch(

--- a/pixlstash/routes/picture_sets.py
+++ b/pixlstash/routes/picture_sets.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
 from fastapi.responses import FileResponse
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field as PydanticField
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
 from sqlalchemy import desc, exists, func, nullslast
@@ -20,12 +20,17 @@ from pixlstash.db_models import (
     Project,
     PictureSet,
     PictureSetMember,
+    PictureSetProjectMember,
     SortMechanism,
     Tag,
+    picture_set_in_no_project,
+    picture_set_in_project,
 )
 from pixlstash.event_types import EventType
 from pixlstash.services.project_membership_service import (
-    reconcile_entity_project_change,
+    picture_set_project_ids,
+    reconcile_entity_projects_change,
+    set_picture_set_projects,
 )
 from pixlstash.services.set_lock_service import (
     enforce_set_not_locked,
@@ -58,7 +63,21 @@ class PictureSetResponse(BaseModel):
     id: Optional[int] = None
     name: Optional[str] = None
     description: Optional[str] = None
-    project_id: Optional[int] = None
+    project_id: Optional[int] = PydanticField(
+        default=None,
+        description=(
+            "The set's primary project — the lowest id in ``project_ids``, or null "
+            "when it belongs to no project. Kept for backwards compatibility; "
+            "prefer ``project_ids``, which lists every project."
+        ),
+    )
+    project_ids: list[int] = PydanticField(
+        default_factory=list,
+        description=(
+            "Every project this picture set belongs to, lowest id first. A set may "
+            "be shared across several projects."
+        ),
+    )
     set_icon: Optional[str] = None
     set_color: Optional[str] = None
     locked: bool = False
@@ -91,6 +110,10 @@ class PictureSetPicturesResponse(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     project_id: Optional[int] = None
+    project_ids: list[int] = PydanticField(
+        default_factory=list,
+        description="Every project this picture set belongs to, lowest id first.",
+    )
     set_icon: Optional[str] = None
     set_color: Optional[str] = None
     locked: bool = False
@@ -167,16 +190,27 @@ class LockedSetMembersResponse(BaseModel):
 def create_router(server) -> APIRouter:
     router = APIRouter()
 
-    def _ensure_unique_set_name(session, name: str, project_id, exclude_set_id=None):
+    def _ensure_unique_set_name(session, name: str, project_ids, exclude_set_id=None):
         """Raises 409 if a set with the same name (case-insensitive) already
-        exists in the given project.  Unscoped sets (project_id None) are
+        exists in **any** of the given projects.  Unscoped sets (no projects) are
         exempt — they have no uniqueness requirement.
+
+        Since issue #125 a set can be in several projects at once, so the clash
+        check spans every project it is joining, not just its primary one.
         """
-        if project_id is None:
+        wanted = sorted({int(pid) for pid in (project_ids or []) if pid is not None})
+        if not wanted:
             return
-        stmt = select(PictureSet).where(
-            PictureSet.project_id == project_id,
-            func.lower(PictureSet.name) == name.lower(),
+        stmt = (
+            select(PictureSet.id)
+            .join(
+                PictureSetProjectMember,
+                PictureSetProjectMember.set_id == PictureSet.id,
+            )
+            .where(
+                PictureSetProjectMember.project_id.in_(wanted),
+                func.lower(PictureSet.name) == name.lower(),
+            )
         )
         if exclude_set_id is not None:
             stmt = stmt.where(PictureSet.id != exclude_set_id)
@@ -185,6 +219,51 @@ def create_router(server) -> APIRouter:
                 status_code=409,
                 detail=f"A picture set named '{name}' already exists in this project.",
             )
+
+    def _resolve_target_project_ids(payload: dict, current: list[int] | None):
+        """Resolve the requested project membership set from a request payload.
+
+        Accepts the multi-project ``project_ids`` list (issue #125) and the legacy
+        single ``project_id`` scalar, in that precedence order.
+
+        Args:
+            payload: The parsed request body.
+            current: The set's existing project ids, returned unchanged when the
+                payload mentions neither key. ``None`` for a create.
+
+        Returns:
+            ``(target_project_ids, provided)`` — the full target membership set,
+            and whether the payload asked for a project change at all.
+
+        Raises:
+            HTTPException: ``400`` when either key is not an integer / list of
+                integers.
+        """
+        if "project_ids" in payload:
+            raw_ids = payload.get("project_ids")
+            if raw_ids is None:
+                return [], True
+            if not isinstance(raw_ids, (list, tuple, set)):
+                raise HTTPException(
+                    status_code=400, detail="project_ids must be a list"
+                )
+            try:
+                return sorted({int(v) for v in raw_ids if v is not None}), True
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(
+                    status_code=400, detail="Invalid project_id"
+                ) from exc
+        if "project_id" in payload:
+            raw = payload.get("project_id")
+            if raw is None:
+                return [], True
+            try:
+                return [int(raw)], True
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(
+                    status_code=400, detail="Invalid project_id"
+                ) from exc
+        return (list(current) if current is not None else []), False
 
     def _project_membership_exists(project_id_value: int):
         return exists(
@@ -357,12 +436,12 @@ def create_router(server) -> APIRouter:
         if project_id is not None:
             if project_id == "UNASSIGNED":
                 project_filter = _project_membership_unassigned()
-                set_project_id_filter = PictureSet.project_id.is_(None)
+                set_project_id_filter = picture_set_in_no_project()
             else:
                 try:
                     _pid_int = int(project_id)
                     project_filter = _project_membership_exists(_pid_int)
-                    set_project_id_filter = PictureSet.project_id == _pid_int
+                    set_project_id_filter = picture_set_in_project(_pid_int)
                 except (TypeError, ValueError):
                     raise HTTPException(status_code=400, detail="Invalid project_id")
 
@@ -377,6 +456,18 @@ def create_router(server) -> APIRouter:
             if scope_set_id_filter is not None:
                 sets_query = sets_query.where(PictureSet.id == scope_set_id_filter)
             sets = session.exec(sets_query).all()
+            # One query for every listed set's project membership, so the
+            # multi-project set is exposed without an N+1 (issue #125).
+            listed_ids = [int(s.id) for s in sets if s.id is not None]
+            project_ids_by_set: dict[int, list[int]] = {}
+            if listed_ids:
+                for sid, pid in session.exec(
+                    select(
+                        PictureSetProjectMember.set_id,
+                        PictureSetProjectMember.project_id,
+                    ).where(PictureSetProjectMember.set_id.in_(listed_ids))
+                ).all():
+                    project_ids_by_set.setdefault(int(sid), []).append(int(pid))
             result = []
             for s in sets:
                 members_query = (
@@ -397,6 +488,7 @@ def create_router(server) -> APIRouter:
                 )
                 count = len(set(filtered_ids))
                 set_dict = safe_model_dict(s)
+                set_dict["project_ids"] = sorted(project_ids_by_set.get(int(s.id), []))
                 set_dict["picture_count"] = count
                 top_picture_ids = []
                 if filtered_ids:
@@ -452,7 +544,7 @@ def create_router(server) -> APIRouter:
             if scope_set_id is not None:
                 sets_query = sets_query.where(PictureSet.id == scope_set_id)
             if scope_project_id is not None:
-                sets_query = sets_query.where(PictureSet.project_id == scope_project_id)
+                sets_query = sets_query.where(picture_set_in_project(scope_project_id))
             locked_sets = session.exec(
                 sets_query.order_by(func.lower(PictureSet.name))
             ).all()
@@ -499,13 +591,17 @@ def create_router(server) -> APIRouter:
                 raise HTTPException(status_code=404, detail="Project not found")
             picture_set = session.exec(
                 select(PictureSet).where(
-                    PictureSet.project_id == project.id,
+                    picture_set_in_project(project.id),
                     func.lower(PictureSet.name) == picture_set_name.lower(),
                 )
             ).first()
             if picture_set is None:
                 raise HTTPException(status_code=404, detail="Picture set not found")
-            return safe_model_dict(picture_set)
+            payload = safe_model_dict(picture_set)
+            payload["project_ids"] = picture_set_project_ids(
+                session, int(picture_set.id)
+            )
+            return payload
 
         result = server.vault.db.run_immediate_read_task(fetch)
         # Scope guard (BOLA): a resource-scoped token may only read its own set —
@@ -587,13 +683,25 @@ def create_router(server) -> APIRouter:
         "mdi-gamepad-variant",
     ]
 
-    def _auto_assign_icon_color(session, project_id):
-        """Return (icon, color) not already used by sibling sets."""
+    def _auto_assign_icon_color(session, project_ids):
+        """Return (icon, color) not already used by sibling sets.
+
+        Args:
+            session: A pre-opened session.
+            project_ids: The projects the new set is joining. Siblings are the
+                sets sharing any of them; with no projects, every set is a
+                sibling (the pre-#125 unscoped behaviour).
+        """
+        wanted = sorted({int(pid) for pid in (project_ids or []) if pid is not None})
         existing = session.exec(
-            select(PictureSet.set_icon, PictureSet.set_color).where(
-                PictureSet.project_id == project_id
+            select(PictureSet.set_icon, PictureSet.set_color)
+            .join(
+                PictureSetProjectMember,
+                PictureSetProjectMember.set_id == PictureSet.id,
             )
-            if project_id is not None
+            .where(PictureSetProjectMember.project_id.in_(wanted))
+            .distinct()
+            if wanted
             else select(PictureSet.set_icon, PictureSet.set_color)
         ).all()
         used_icons = {row[0] for row in existing if row[0] and row[0] != "cards"}
@@ -611,38 +719,50 @@ def create_router(server) -> APIRouter:
     @router.post(
         "/picture_sets",
         summary="Create picture set",
-        description="Creates a new picture set with name and optional description.",
+        description=(
+            "Creates a new picture set with name and optional description. Accepts "
+            "``project_ids`` (a list of projects the set joins) or the legacy "
+            "single ``project_id``."
+        ),
         response_model=PictureSetCreateResponse,
     )
     def create_picture_set(payload: dict = Body(...)):
         name = payload.get("name")
         description = payload.get("description", "")
-        project_id = payload.get("project_id") or None
+        project_ids, _provided = _resolve_target_project_ids(payload, None)
         set_icon = payload.get("set_icon", _UNSET)
         set_color = payload.get("set_color", _UNSET)
         if not name:
             raise HTTPException(status_code=400, detail="name is required")
 
-        def create_set(session, name, description, project_id, set_icon, set_color):
-            _ensure_unique_set_name(session, name, project_id)
-            auto_icon, auto_color = _auto_assign_icon_color(session, project_id)
+        def create_set(session, name, description, project_ids, set_icon, set_color):
+            _ensure_unique_set_name(session, name, project_ids)
+            auto_icon, auto_color = _auto_assign_icon_color(session, project_ids)
             picture_set = PictureSet(
                 name=name,
                 description=description,
-                project_id=project_id,
                 set_icon=set_icon if set_icon is not _UNSET else auto_icon,
                 set_color=set_color if set_color is not _UNSET else auto_color,
             )
             session.add(picture_set)
             session.commit()
             session.refresh(picture_set)
-            return picture_set.dict()
+            if project_ids:
+                # Single write path for the join rows and the primary-project FK.
+                set_picture_set_projects(session, picture_set, project_ids)
+                session.commit()
+                session.refresh(picture_set)
+            created = picture_set.dict()
+            created["project_ids"] = picture_set_project_ids(
+                session, int(picture_set.id)
+            )
+            return created
 
         set_dict = server.vault.db.run_task(
             create_set,
             name,
             description,
-            project_id,
+            project_ids,
             set_icon,
             set_color,
             priority=DBPriority.IMMEDIATE,
@@ -1005,7 +1125,7 @@ def create_router(server) -> APIRouter:
         def fetch_set(session, id):
             picture_set = session.get(PictureSet, id)
             if not picture_set:
-                return None, None
+                return None, None, []
             members_query = (
                 select(PictureSetMember.picture_id)
                 .join(Picture, Picture.id == PictureSetMember.picture_id)
@@ -1026,10 +1146,10 @@ def create_router(server) -> APIRouter:
                     continue
                 seen.add(pic_id)
                 picture_ids.append(pic_id)
-            return picture_set, picture_ids
+            return picture_set, picture_ids, picture_set_project_ids(session, id)
 
-        picture_set, picture_ids = server.vault.db.run_immediate_read_task(
-            fetch_set, id
+        picture_set, picture_ids, set_project_ids = (
+            server.vault.db.run_immediate_read_task(fetch_set, id)
         )
         if not picture_set:
             raise HTTPException(status_code=404, detail="Picture set not found")
@@ -1077,6 +1197,7 @@ def create_router(server) -> APIRouter:
 
         if info:
             set_dict = picture_set.dict()
+            set_dict["project_ids"] = set_project_ids
             set_dict["picture_count"] = len(picture_ids)
             return set_dict
 
@@ -1150,46 +1271,50 @@ def create_router(server) -> APIRouter:
 
         pictures = server.vault.db.run_immediate_read_task(fetch_pics, picture_ids)
         pictures = _enrich_with_stack_counts(pictures)
-        return {"pictures": pictures, "set": safe_model_dict(picture_set)}
+        set_payload = safe_model_dict(picture_set)
+        set_payload["project_ids"] = set_project_ids
+        return {"pictures": pictures, "set": set_payload}
 
     @router.patch(
         "/picture_sets/{id}",
         summary="Update picture set",
-        description="Updates picture set name and/or description.",
+        description=(
+            "Updates picture set name and/or description.\n\n"
+            "**Project membership.** Send ``project_ids`` (a list) to set the full "
+            "set of projects the picture set belongs to — a set may be in several "
+            "at once. The legacy single ``project_id`` is still accepted and means "
+            "the same as a one-element ``project_ids``; ``null`` on either key "
+            "removes the set from every project. ``project_ids`` wins when both "
+            "are present. Member pictures follow: they join every project the set "
+            "joins, and leave a project it leaves unless another character or "
+            "picture set still anchors them there. Re-sending the set's existing "
+            "projects is an idempotent repair that heals missing membership rows. "
+            "Returns 409 on a name clash inside any target project and 404 for an "
+            "unknown project id."
+        ),
         response_model=PictureSetUpdateResponse,
     )
     def update_picture_set(id: int, request: Request, payload: dict = Body(...)):
         origin_client_id = getattr(request.state, "origin_client_id", None)
         name = payload.get("name")
         description = payload.get("description")
-        raw_project_id = payload.get("project_id", _UNSET)
         set_icon = payload.get("set_icon", _UNSET)
         set_color = payload.get("set_color", _UNSET)
         locked_param = payload.get("locked", _UNSET)
         if locked_param is not _UNSET:
             locked_param = bool(locked_param)
-        project_id = raw_project_id
-        if raw_project_id is not _UNSET:
-            if raw_project_id is None:
-                project_id = None
-            else:
-                try:
-                    project_id = int(raw_project_id)
-                except (TypeError, ValueError) as exc:
-                    raise HTTPException(
-                        status_code=400, detail="Invalid project_id"
-                    ) from exc
 
-        def update_set(
-            session, id, name, description, project_id, set_icon, set_color, locked
-        ):
+        def update_set(session, id, name, description, set_icon, set_color, locked):
             picture_set = session.get(PictureSet, id)
             if not picture_set:
                 return False
 
-            # Capture the project the set is leaving before we mutate it, so we
-            # can disassociate its member pictures from that old project.
-            old_project_id = picture_set.project_id
+            # Capture the projects the set is in before we mutate it, so we can
+            # disassociate its member pictures from the ones it leaves.
+            old_project_ids = picture_set_project_ids(session, id)
+            target_project_ids, project_provided = _resolve_target_project_ids(
+                payload, old_project_ids
+            )
 
             # Lock rule: while a set is locked the only accepted PATCH is one that
             # changes nothing but `locked` (i.e. an unlock). Compare each field to
@@ -1203,9 +1328,9 @@ def create_router(server) -> APIRouter:
                 set_color is not _UNSET and set_color != picture_set.set_color
             )
             name_effective_change = name is not None and name != picture_set.name
-            project_effective_change = (
-                project_id is not _UNSET and project_id != picture_set.project_id
-            )
+            project_effective_change = project_provided and sorted(
+                target_project_ids
+            ) != sorted(old_project_ids)
             other_effective_change = (
                 name_effective_change
                 or description_changing
@@ -1220,51 +1345,42 @@ def create_router(server) -> APIRouter:
 
             locked_changed = locked is not _UNSET and bool(locked) != picture_set.locked
 
-            # Resolve the final (name, project_id) that would result from this
+            # Resolve the final (name, projects) that would result from this
             # update and check uniqueness before touching anything.
             final_name = name if name is not None else picture_set.name
-            final_project_id = (
-                project_id if project_id is not _UNSET else picture_set.project_id
-            )
             name_changing = name is not None and name != picture_set.name
-            project_changing = (
-                project_id is not _UNSET and project_id != picture_set.project_id
-            )
+            project_changing = project_effective_change
             if name_changing or project_changing:
                 _ensure_unique_set_name(
-                    session, final_name, final_project_id, exclude_set_id=id
+                    session, final_name, target_project_ids, exclude_set_id=id
                 )
 
-            project_id_payload_provided = project_id is not _UNSET
-            project_assignment_requested = (
-                project_id_payload_provided and project_id is not None
-            )
-            project_id_changed = (
-                project_id_payload_provided and project_id != picture_set.project_id
-            )
+            project_assignment_requested = project_provided and bool(target_project_ids)
             pictures_changed = False
             if name is not None:
                 picture_set.name = name
             if description is not None:
                 picture_set.description = description
-            if project_id_payload_provided and project_id is not None:
-                project = session.get(Project, project_id)
-                if not project:
-                    raise HTTPException(status_code=404, detail="Project not found")
 
-            if project_id_changed:
-                picture_set.project_id = project_id
+            # Single write path for both the join rows and the primary-project FK;
+            # raises 404 for an unknown project id.
+            project_change = None
+            if project_provided:
+                project_change = set_picture_set_projects(
+                    session, picture_set, target_project_ids
+                )
             if set_icon is not _UNSET:
                 picture_set.set_icon = set_icon
             if set_color is not _UNSET:
                 picture_set.set_color = set_color
 
             # Reconcile member-picture project membership when this update sets
-            # or changes the project. A same-project re-assign (project provided
+            # or changes the projects. A same-project re-assign (projects provided
             # but unchanged) is the idempotent-repair path that heals historical
-            # drift where members are missing membership rows; a project change
-            # also removes members from the old project (reference-aware). Shared
-            # with character updates via project_membership_service.
+            # drift where members are missing membership rows; leaving a project
+            # also removes members from it (reference-aware). Shared with
+            # character updates via project_membership_service.
+            project_id_changed = bool(project_change and project_change.changed)
             if project_assignment_requested or project_id_changed:
                 member_ids = [
                     pic_id
@@ -1275,11 +1391,13 @@ def create_router(server) -> APIRouter:
                     ).all()
                     if pic_id is not None
                 ]
-                reconcile_result = reconcile_entity_project_change(
+                reconcile_result = reconcile_entity_projects_change(
                     session,
                     picture_ids=member_ids,
-                    old_project_id=old_project_id,
-                    new_project_id=project_id,
+                    ensure_project_ids=target_project_ids,
+                    remove_project_ids=(
+                        project_change.removed if project_change else []
+                    ),
                     exclude_set_id=id,
                 )
                 pictures_changed = reconcile_result.changed
@@ -1313,7 +1431,6 @@ def create_router(server) -> APIRouter:
                 id,
                 name,
                 description,
-                project_id,
                 set_icon,
                 set_color,
                 locked_param,

--- a/pixlstash/routes/projects.py
+++ b/pixlstash/routes/projects.py
@@ -20,15 +20,23 @@ from pixlstash.authz.membership import enforce_project_scope
 from pixlstash.database import DBPriority
 from pixlstash.db_models import (
     Character,
+    CharacterProjectMember,
     Face,
     Picture,
     PictureProjectMember,
     PictureSet,
     PictureSetMember,
+    PictureSetProjectMember,
     Tag,
+    character_in_project,
+    picture_set_in_project,
 )
 from pixlstash.db_models.project import Project, ProjectAttachment
 from pixlstash.pixl_logging import get_logger
+from pixlstash.services.project_membership_service import (
+    character_project_ids,
+    picture_set_project_ids,
+)
 from pixlstash.utils.service.caption_utils import normalize_hidden_tags
 from pixlstash.utils.path_utils import resolve_path_within
 from pixlstash.utils.service.filter_helpers import fetch_scope_allowed_picture_ids
@@ -333,7 +341,7 @@ def create_router(server) -> APIRouter:
             _require_scope_allows_project(request, project.id)
             sets = session.exec(
                 select(PictureSet)
-                .where(PictureSet.project_id == project.id)
+                .where(picture_set_in_project(project.id))
                 .order_by(PictureSet.name)
             ).all()
             return [
@@ -450,30 +458,58 @@ def create_router(server) -> APIRouter:
             # Collect attachment paths before cascade-delete removes the rows.
             attachment_paths = [a.stored_path for a in project.attachments]
 
-            # Null out project_id on characters and picture sets.
-            for character in session.exec(
-                select(Character).where(Character.project_id == pid)
-            ).all():
-                character.project_id = None
+            # Drop the project from every character / picture set that belongs to
+            # it, then re-derive each entity's primary-project pointer from the
+            # memberships that survive (issue #125: an entity may be in several
+            # projects, so losing one does not necessarily unassign it).
+            affected_characters = session.exec(
+                select(Character).where(character_in_project(pid))
+            ).all()
+            affected_sets = session.exec(
+                select(PictureSet).where(picture_set_in_project(pid))
+            ).all()
+
+            session.exec(
+                delete(CharacterProjectMember).where(
+                    CharacterProjectMember.project_id == pid
+                )
+            )
+            session.exec(
+                delete(PictureSetProjectMember).where(
+                    PictureSetProjectMember.project_id == pid
+                )
+            )
+            session.flush()
+
+            for character in affected_characters:
+                remaining = character_project_ids(session, int(character.id))
+                character.project_id = remaining[0] if remaining else None
                 session.add(character)
 
-            for picture_set in session.exec(
-                select(PictureSet).where(PictureSet.project_id == pid)
-            ).all():
-                picture_set.project_id = None
+            for picture_set in affected_sets:
+                remaining = picture_set_project_ids(session, int(picture_set.id))
+                picture_set.project_id = remaining[0] if remaining else None
                 session.add(picture_set)
-
-            for picture in session.exec(
-                select(Picture).where(Picture.project_id == pid)
-            ).all():
-                picture.project_id = None
-                session.add(picture)
 
             session.exec(
                 delete(PictureProjectMember).where(
                     PictureProjectMember.project_id == pid
                 )
             )
+            session.flush()
+
+            for picture in session.exec(
+                select(Picture).where(Picture.project_id == pid)
+            ).all():
+                # The picture's own memberships are gone for this project; fall
+                # back to any project it still belongs to, mirroring the
+                # reconciliation service's repoint rule.
+                picture.project_id = session.exec(
+                    select(PictureProjectMember.project_id)
+                    .where(PictureProjectMember.picture_id == picture.id)
+                    .order_by(PictureProjectMember.project_id.asc())
+                ).first()
+                session.add(picture)
 
             session.delete(project)  # cascade-deletes ProjectAttachment rows
             session.commit()
@@ -675,13 +711,13 @@ def create_router(server) -> APIRouter:
             characters_data = [
                 {"id": c.id, "name": c.name, "description": c.description}
                 for c in session.exec(
-                    select(Character).where(Character.project_id == pid)
+                    select(Character).where(character_in_project(pid))
                 ).all()
             ]
             picture_sets_data = [
                 {"id": s.id, "name": s.name, "description": s.description}
                 for s in session.exec(
-                    select(PictureSet).where(PictureSet.project_id == pid)
+                    select(PictureSet).where(picture_set_in_project(pid))
                 ).all()
             ]
             attachments_data = [

--- a/pixlstash/services/project_membership_service.py
+++ b/pixlstash/services/project_membership_service.py
@@ -34,20 +34,73 @@ The function takes a **pre-opened** ``Session`` (the same threading discipline a
 ``enforce_picture_scope`` and the set-lock guards) and never touches
 ``vault.db`` — per the services DB-access rule (backend_architecture.md §10.1)
 the caller owns the transaction and commit.
+
+**Multi-project entities (issue #125).** A character or picture set may now belong
+to several projects at once. This module also owns the *entity*→project write
+path: :func:`set_character_projects` / :func:`set_picture_set_projects` maintain
+the ``CharacterProjectMember`` / ``PictureSetProjectMember`` join rows **and**
+re-derive the legacy scalar ``project_id`` pointer (lowest member project id, or
+``None``). Nothing else may assign those FKs — see
+:mod:`pixlstash.db_models.entity_project` for the read-side predicates and the
+"write both, read the join" contract. The picture-side reconciliation follows in
+:func:`reconcile_entity_projects_change`, of which the original single-project
+:func:`reconcile_entity_project_change` is now a thin shim.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Iterable, Optional
 
+from fastapi import HTTPException
 from sqlmodel import Session, select
 
-from pixlstash.db_models import Picture, PictureProjectMember
+from pixlstash.db_models import (
+    Character,
+    CharacterProjectMember,
+    Picture,
+    PictureProjectMember,
+    PictureSet,
+    PictureSetProjectMember,
+    Project,
+)
+from pixlstash.pixl_logging import get_logger
 from pixlstash.routes._helpers import picture_referenced_by_project
 
+logger = get_logger(__name__)
+
 __all__ = [
+    "EntityProjectChange",
     "ProjectMembershipReconcileResult",
+    "character_project_ids",
+    "picture_set_project_ids",
     "reconcile_entity_project_change",
+    "reconcile_entity_projects_change",
+    "set_character_projects",
+    "set_picture_set_projects",
 ]
+
+
+@dataclass
+class EntityProjectChange:
+    """Outcome of writing a character's or picture set's project membership set.
+
+    Attributes:
+        added: Project ids the entity newly joined.
+        removed: Project ids the entity left.
+        primary_project_id: The value written to the entity's scalar
+            ``project_id`` pointer — the lowest member project id, or ``None``
+            when the entity now belongs to no project.
+        target_project_ids: The full, normalised membership set after the write.
+    """
+
+    added: list[int] = field(default_factory=list)
+    removed: list[int] = field(default_factory=list)
+    primary_project_id: Optional[int] = None
+    target_project_ids: list[int] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        """True if the entity joined or left at least one project."""
+        return bool(self.added or self.removed)
 
 
 @dataclass
@@ -122,50 +175,120 @@ def reconcile_entity_project_change(
     Returns:
         A :class:`ProjectMembershipReconcileResult` with per-operation counts.
     """
+    return reconcile_entity_projects_change(
+        session,
+        picture_ids=picture_ids,
+        ensure_project_ids=[new_project_id] if new_project_id is not None else [],
+        remove_project_ids=(
+            [old_project_id]
+            if old_project_id is not None and old_project_id != new_project_id
+            else []
+        ),
+        exclude_character_id=exclude_character_id,
+        exclude_set_id=exclude_set_id,
+    )
+
+
+def reconcile_entity_projects_change(
+    session: Session,
+    *,
+    picture_ids: Iterable[int],
+    ensure_project_ids: Iterable[int],
+    remove_project_ids: Iterable[int],
+    exclude_character_id: Optional[int] = None,
+    exclude_set_id: Optional[int] = None,
+) -> ProjectMembershipReconcileResult:
+    """Reconcile per-picture project membership for a **multi-project** entity.
+
+    The multi-project generalisation of :func:`reconcile_entity_project_change`
+    (issue #125). Instead of one old and one new project it takes the entity's
+    **full target project set** and the set of projects it just left, so a
+    character or picture set that belongs to several projects at once anchors its
+    pictures in all of them.
+
+    For every picture in ``picture_ids``:
+
+    1. **Add** a ``PictureProjectMember`` for every id in ``ensure_project_ids``
+       that does not already have one. Passing the entity's *whole* membership set
+       (not just the newly added ids) keeps the historical idempotent-repair path:
+       a drifted picture missing a row is healed.
+    2. **Remove** the ``PictureProjectMember`` for every id in
+       ``remove_project_ids`` — unless another character or picture set still in
+       that project anchors the picture there (reference-aware; the moving entity
+       is excluded via ``exclude_character_id`` / ``exclude_set_id``). Ids present
+       in ``ensure_project_ids`` are never removed.
+    3. **Repoint** the scalar ``Picture.project_id``: when the entity is in at
+       least one project and the picture does not already point at one of them,
+       point it at the lowest such id. When the entity left every project, a
+       picture pointing at one of the departed projects falls back to any
+       remaining membership (lowest ``project_id``) or ``None``.
+
+    Args:
+        session: A pre-opened session owned by the caller; this function does not
+            commit.
+        picture_ids: The entity's member picture ids, already resolved (and
+            stack-expanded where the caller requires it).
+        ensure_project_ids: Every project the entity belongs to *after* the
+            change.
+        remove_project_ids: Every project the entity belonged to *before* the
+            change and no longer does.
+        exclude_character_id: Character to exclude from the reference check (the
+            character being moved).
+        exclude_set_id: Picture set to exclude from the reference check (the set
+            being moved).
+
+    Returns:
+        A :class:`ProjectMembershipReconcileResult` with per-operation counts.
+    """
     result = ProjectMembershipReconcileResult()
 
     pic_id_list = [pid for pid in picture_ids if pid is not None]
     if not pic_id_list:
         return result
 
+    ensure_ids = sorted({int(pid) for pid in ensure_project_ids if pid is not None})
+    remove_ids = sorted(
+        {int(pid) for pid in remove_project_ids if pid is not None} - set(ensure_ids)
+    )
+    if not ensure_ids and not remove_ids:
+        return result
+
     for pic in session.exec(select(Picture).where(Picture.id.in_(pic_id_list))).all():
         if pic.id is None:
             continue
 
-        # 1. Associate the picture with the new project.
-        if new_project_id is not None:
+        # 1. Associate the picture with every project the entity now belongs to.
+        for project_id in ensure_ids:
             membership = session.exec(
                 select(PictureProjectMember).where(
                     PictureProjectMember.picture_id == int(pic.id),
-                    PictureProjectMember.project_id == new_project_id,
+                    PictureProjectMember.project_id == project_id,
                 )
             ).first()
             if membership is None:
                 session.add(
                     PictureProjectMember(
                         picture_id=int(pic.id),
-                        project_id=new_project_id,
+                        project_id=project_id,
                     )
                 )
                 result.memberships_added += 1
 
-        # 2. Disassociate the picture from the old project, unless another
-        #    character or picture set still assigned to that project anchors it.
-        if (
-            old_project_id is not None
-            and old_project_id != new_project_id
-            and not picture_referenced_by_project(
+        # 2. Disassociate the picture from every departed project, unless another
+        #    character or picture set still in that project anchors it.
+        for project_id in remove_ids:
+            if picture_referenced_by_project(
                 session,
                 int(pic.id),
-                old_project_id,
+                project_id,
                 exclude_character_id=exclude_character_id,
                 exclude_set_id=exclude_set_id,
-            )
-        ):
+            ):
+                continue
             old_membership = session.exec(
                 select(PictureProjectMember).where(
                     PictureProjectMember.picture_id == int(pic.id),
-                    PictureProjectMember.project_id == old_project_id,
+                    PictureProjectMember.project_id == project_id,
                 )
             ).first()
             if old_membership is not None:
@@ -173,15 +296,15 @@ def reconcile_entity_project_change(
                 result.memberships_removed += 1
 
         # 3. Update the picture's primary project pointer.
-        if new_project_id is not None:
-            if pic.project_id != new_project_id:
-                pic.project_id = new_project_id
+        if ensure_ids:
+            if pic.project_id not in ensure_ids:
+                pic.project_id = ensure_ids[0]
                 session.add(pic)
                 result.pointers_repointed += 1
-        elif pic.project_id == old_project_id:
-            # Entity left the project entirely; fall back to any project the
-            # picture still belongs to. Flush first so the just-deleted old
-            # membership is not counted as a remaining anchor.
+        elif pic.project_id is not None and pic.project_id in remove_ids:
+            # Entity left every project; fall back to any project the picture
+            # still belongs to. Flush first so the just-deleted memberships are
+            # not counted as remaining anchors.
             session.flush()
             fallback_project_id = session.exec(
                 select(PictureProjectMember.project_id)
@@ -195,3 +318,234 @@ def reconcile_entity_project_change(
             result.pointers_repointed += 1
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Entity → project membership (issue #125): the single write path
+# ---------------------------------------------------------------------------
+
+
+def _normalise_project_ids(project_ids: Optional[Iterable[int]]) -> list[int]:
+    """Coerce a caller-supplied project id list to a sorted, de-duplicated list.
+
+    Args:
+        project_ids: Raw ids (possibly ``None``, duplicated, unsorted, or string
+            encoded).
+
+    Returns:
+        A sorted list of unique ints; empty when ``project_ids`` is ``None`` or
+        contains no usable id.
+
+    Raises:
+        HTTPException: ``400`` when an entry is not an integer.
+    """
+    if project_ids is None:
+        return []
+    normalised: set[int] = set()
+    for raw in project_ids:
+        if raw is None:
+            continue
+        try:
+            normalised.add(int(raw))
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail="Invalid project_id") from exc
+    return sorted(normalised)
+
+
+def _require_projects_exist(session: Session, project_ids: Iterable[int]) -> None:
+    """Raise 404 if any id in ``project_ids`` is not an existing project.
+
+    Args:
+        session: A pre-opened session owned by the caller.
+        project_ids: Project ids to validate.
+
+    Raises:
+        HTTPException: ``404`` with ``detail="Project not found"`` — the same
+            shape the character / picture-set handlers returned before #125, so
+            the API contract is unchanged.
+    """
+    wanted = sorted({int(pid) for pid in project_ids})
+    if not wanted:
+        return
+    found = {
+        int(row)
+        for row in session.exec(select(Project.id).where(Project.id.in_(wanted))).all()
+        if row is not None
+    }
+    missing = [pid for pid in wanted if pid not in found]
+    if missing:
+        logger.warning(
+            "Refusing entity project assignment: project id(s) %s do not exist "
+            "(requested %s)",
+            missing,
+            wanted,
+        )
+        raise HTTPException(status_code=404, detail="Project not found")
+
+
+def character_project_ids(session: Session, character_id: int) -> list[int]:
+    """Return every project a character belongs to, lowest id first.
+
+    Args:
+        session: A pre-opened session owned by the caller.
+        character_id: The character to look up.
+
+    Returns:
+        A sorted list of project ids; empty when the character is unassigned.
+    """
+    return sorted(
+        int(row)
+        for row in session.exec(
+            select(CharacterProjectMember.project_id).where(
+                CharacterProjectMember.character_id == int(character_id)
+            )
+        ).all()
+        if row is not None
+    )
+
+
+def picture_set_project_ids(session: Session, set_id: int) -> list[int]:
+    """Return every project a picture set belongs to, lowest id first.
+
+    Args:
+        session: A pre-opened session owned by the caller.
+        set_id: The picture set to look up.
+
+    Returns:
+        A sorted list of project ids; empty when the set is unassigned.
+    """
+    return sorted(
+        int(row)
+        for row in session.exec(
+            select(PictureSetProjectMember.project_id).where(
+                PictureSetProjectMember.set_id == int(set_id)
+            )
+        ).all()
+        if row is not None
+    )
+
+
+def set_character_projects(
+    session: Session,
+    character: Character,
+    project_ids: Optional[Iterable[int]],
+) -> EntityProjectChange:
+    """Write a character's full project membership set (join rows + FK pointer).
+
+    This is the **only** supported way to change which projects a character
+    belongs to. It writes both representations in one place: the
+    ``CharacterProjectMember`` join rows (the read model) and the legacy scalar
+    ``Character.project_id`` pointer, which is re-derived as the lowest member
+    project id (``None`` when the character joins no project). Assigning the FK
+    directly leaves the join table stale and makes the character invisible to
+    every project-scoped read and authorization check.
+
+    Args:
+        session: A pre-opened session owned by the caller; this function does not
+            commit.
+        character: The character row to update (already loaded in ``session``).
+        project_ids: The complete target membership set. ``None`` and ``[]`` both
+            mean "belongs to no project".
+
+    Returns:
+        An :class:`EntityProjectChange` describing what moved.
+
+    Raises:
+        HTTPException: ``400`` for a non-integer id, ``404`` when a project does
+            not exist.
+    """
+    target = _normalise_project_ids(project_ids)
+    _require_projects_exist(session, target)
+
+    character_id = int(character.id)
+    current = set(character_project_ids(session, character_id))
+    target_set = set(target)
+
+    added = sorted(target_set - current)
+    removed = sorted(current - target_set)
+
+    for project_id in added:
+        session.add(
+            CharacterProjectMember(character_id=character_id, project_id=project_id)
+        )
+    for project_id in removed:
+        row = session.exec(
+            select(CharacterProjectMember).where(
+                CharacterProjectMember.character_id == character_id,
+                CharacterProjectMember.project_id == project_id,
+            )
+        ).first()
+        if row is not None:
+            session.delete(row)
+
+    primary = target[0] if target else None
+    if character.project_id != primary:
+        character.project_id = primary
+    session.add(character)
+
+    return EntityProjectChange(
+        added=added,
+        removed=removed,
+        primary_project_id=primary,
+        target_project_ids=target,
+    )
+
+
+def set_picture_set_projects(
+    session: Session,
+    picture_set: PictureSet,
+    project_ids: Optional[Iterable[int]],
+) -> EntityProjectChange:
+    """Write a picture set's full project membership set (join rows + FK pointer).
+
+    The picture-set twin of :func:`set_character_projects`; see that function for
+    the write-both/read-the-join contract.
+
+    Args:
+        session: A pre-opened session owned by the caller; this function does not
+            commit.
+        picture_set: The picture set row to update (already loaded in
+            ``session``).
+        project_ids: The complete target membership set. ``None`` and ``[]`` both
+            mean "belongs to no project".
+
+    Returns:
+        An :class:`EntityProjectChange` describing what moved.
+
+    Raises:
+        HTTPException: ``400`` for a non-integer id, ``404`` when a project does
+            not exist.
+    """
+    target = _normalise_project_ids(project_ids)
+    _require_projects_exist(session, target)
+
+    set_id = int(picture_set.id)
+    current = set(picture_set_project_ids(session, set_id))
+    target_set = set(target)
+
+    added = sorted(target_set - current)
+    removed = sorted(current - target_set)
+
+    for project_id in added:
+        session.add(PictureSetProjectMember(set_id=set_id, project_id=project_id))
+    for project_id in removed:
+        row = session.exec(
+            select(PictureSetProjectMember).where(
+                PictureSetProjectMember.set_id == set_id,
+                PictureSetProjectMember.project_id == project_id,
+            )
+        ).first()
+        if row is not None:
+            session.delete(row)
+
+    primary = target[0] if target else None
+    if picture_set.project_id != primary:
+        picture_set.project_id = primary
+    session.add(picture_set)
+
+    return EntityProjectChange(
+        added=added,
+        removed=removed,
+        primary_project_id=primary,
+        target_project_ids=target,
+    )

--- a/pixlstash/services/restore/resource_restore.py
+++ b/pixlstash/services/restore/resource_restore.py
@@ -20,11 +20,13 @@ from sqlalchemy import (
 
 from pixlstash.db_models import (
     Character,
+    CharacterProjectMember,
     Face,
     Picture,
     PictureProjectMember,
     PictureSet,
     PictureSetMember,
+    PictureSetProjectMember,
     Project,
     Tag,
 )
@@ -39,6 +41,12 @@ from ._models import (
 )
 
 logger = get_logger(__name__)
+
+# Transport key for an entity's project membership on a candidate-parent dict.
+# Not a column: it is popped before the row is turned back into a model, and it
+# exists only so the join rows travel with the parent from the snapshot session
+# to the live one (issue #125).
+_PROJECT_IDS_KEY = "__project_ids"
 
 
 class ResourceRestoreMixin:
@@ -555,7 +563,13 @@ class ResourceRestoreMixin:
         Returns:
             ``{"characters": [{...}, ...], "picture_sets": [...],
               "projects": [...]}`` — one dict per parent referenced
-            anywhere in ``snap_rows``.
+            anywhere in ``snap_rows``. Character and picture-set dicts carry an
+            extra :data:`_PROJECT_IDS_KEY` entry holding the entity's project
+            membership from the snapshot; :meth:`_restore_parent_rows` pops it
+            and rebuilds the join rows. Without it a restored entity would come
+            back with its scalar ``project_id`` set but no membership row, i.e.
+            invisible to every project-scoped read (issue #125: the join is the
+            read model).
         """
 
         def _as_dict(obj):
@@ -572,13 +586,37 @@ class ResourceRestoreMixin:
         set_ids = {m.set_id for m in snap_rows.get("picture_set_members", [])}
         proj_ids = {m.project_id for m in snap_rows.get("picture_project_members", [])}
 
+        def _with_project_ids(row, membership_model, id_column, entity_id):
+            if row is None:
+                return None
+            row[_PROJECT_IDS_KEY] = sorted(
+                int(pid)
+                for pid in snap_session.execute(
+                    sa_select(membership_model.project_id).where(id_column == entity_id)
+                )
+                .scalars()
+                .all()
+                if pid is not None
+            )
+            return row
+
         characters = [
-            _as_dict(snap_session.get(Character, cid))
+            _with_project_ids(
+                _as_dict(snap_session.get(Character, cid)),
+                CharacterProjectMember,
+                CharacterProjectMember.character_id,
+                cid,
+            )
             for cid in sorted(char_ids)
             if snap_session.get(Character, cid) is not None
         ]
         picture_sets = [
-            _as_dict(snap_session.get(PictureSet, sid))
+            _with_project_ids(
+                _as_dict(snap_session.get(PictureSet, sid)),
+                PictureSetProjectMember,
+                PictureSetProjectMember.set_id,
+                sid,
+            )
             for sid in sorted(set_ids)
             if snap_session.get(PictureSet, sid) is not None
         ]
@@ -639,6 +677,13 @@ class ResourceRestoreMixin:
         are merged; existing live parents (with the same ID) are not
         touched.
 
+        A restored character or picture set also gets its project-membership
+        join rows rebuilt from the snapshot (issue #125). The join is the read
+        model, so merging the row alone would restore an entity that is
+        unreachable from the project it belongs to. Only memberships whose
+        project actually exists live are re-created — a project the user did not
+        restore would violate the foreign key.
+
         Args:
             live_session: Live writer session.
             candidate_parents: Output of ``_collect_candidate_parents``.
@@ -648,6 +693,7 @@ class ResourceRestoreMixin:
             Number of parent rows restored.
         """
         restored = 0
+        pending_memberships: list[tuple[type, str, int, list[int]]] = []
         for plural, model in (
             ("characters", Character),
             ("picture_sets", PictureSet),
@@ -657,9 +703,69 @@ class ResourceRestoreMixin:
             if not wanted:
                 continue
             for parent in candidate_parents.get(plural, []):
-                if parent["id"] in wanted:
-                    live_session.merge(model(**parent))
-                    restored += 1
+                if parent["id"] not in wanted:
+                    continue
+                fields = dict(parent)
+                project_ids = fields.pop(_PROJECT_IDS_KEY, None)
+                live_session.merge(model(**fields))
+                restored += 1
+                if project_ids:
+                    if model is Character:
+                        pending_memberships.append(
+                            (
+                                CharacterProjectMember,
+                                "character_id",
+                                int(fields["id"]),
+                                project_ids,
+                            )
+                        )
+                    elif model is PictureSet:
+                        pending_memberships.append(
+                            (
+                                PictureSetProjectMember,
+                                "set_id",
+                                int(fields["id"]),
+                                project_ids,
+                            )
+                        )
+
+        if pending_memberships:
+            # Flush the parents first so the membership FKs resolve, and only
+            # link projects that exist live.
+            live_session.flush()
+            wanted_projects = {
+                pid for _m, _c, _e, pids in pending_memberships for pid in pids
+            }
+            live_project_ids = set(
+                live_session.execute(
+                    sa_select(Project.id).where(Project.id.in_(wanted_projects))
+                )
+                .scalars()
+                .all()
+            )
+            for (
+                membership_model,
+                id_field,
+                entity_id,
+                project_ids,
+            ) in pending_memberships:
+                for project_id in project_ids:
+                    if project_id not in live_project_ids:
+                        logger.warning(
+                            "Restore: skipping %s membership %s=%s project_id=%s — "
+                            "the project does not exist in the live database, so "
+                            "the entity comes back without that membership",
+                            membership_model.__name__,
+                            id_field,
+                            entity_id,
+                            project_id,
+                        )
+                        continue
+                    live_session.merge(
+                        membership_model(
+                            **{id_field: entity_id, "project_id": project_id}
+                        )
+                    )
         return restored
 
     def _collect_rows_for_upsert(

--- a/pixlstash/tasks/picture_import_task.py
+++ b/pixlstash/tasks/picture_import_task.py
@@ -13,6 +13,11 @@ from pixlstash.db_models.picture_project import PictureProjectMember
 from pixlstash.db_models.picture_set import PictureSet, PictureSetMember
 from pixlstash.db_models.tag import Tag, TAG_PENDING_SENTINEL
 from pixlstash.pixl_logging import get_logger
+from pixlstash.services.project_membership_service import (
+    character_project_ids,
+    picture_set_project_ids,
+    reconcile_entity_projects_change,
+)
 from pixlstash.tasks.base_task import BaseTask, TaskPriority
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 
@@ -319,6 +324,7 @@ class PictureImportTask(BaseTask):
                     self._staging_id,
                 )
                 return
+            member_ids: list[int] = []
             for pic in session.exec(select(Picture).where(Picture.id.in_(ids))).all():
                 exists = session.exec(
                     select(PictureSetMember).where(
@@ -330,23 +336,15 @@ class PictureImportTask(BaseTask):
                     session.add(
                         PictureSetMember(set_id=set_id_value, picture_id=pic.id)
                     )
-                if picture_set.project_id is not None:
-                    member = session.exec(
-                        select(PictureProjectMember).where(
-                            PictureProjectMember.picture_id == pic.id,
-                            PictureProjectMember.project_id == picture_set.project_id,
-                        )
-                    ).first()
-                    if member is None:
-                        session.add(
-                            PictureProjectMember(
-                                picture_id=pic.id,
-                                project_id=picture_set.project_id,
-                            )
-                        )
-                    if pic.project_id != picture_set.project_id:
-                        pic.project_id = picture_set.project_id
-                    session.add(pic)
+                member_ids.append(int(pic.id))
+            # Issue #125: the set may belong to several projects, so the imported
+            # pictures join *all* of them, not just the primary FK.
+            reconcile_entity_projects_change(
+                session,
+                picture_ids=member_ids,
+                ensure_project_ids=picture_set_project_ids(session, set_id_value),
+                remove_project_ids=[],
+            )
             session.commit()
 
         self._db.run_task(
@@ -377,25 +375,19 @@ class PictureImportTask(BaseTask):
                     self._staging_id,
                 )
                 return
+            pending_ids: list[int] = []
             for pic in session.exec(select(Picture).where(Picture.id.in_(ids))).all():
                 pic.pending_character_id = character_id_value
-                if character.project_id is not None:
-                    member = session.exec(
-                        select(PictureProjectMember).where(
-                            PictureProjectMember.picture_id == pic.id,
-                            PictureProjectMember.project_id == character.project_id,
-                        )
-                    ).first()
-                    if member is None:
-                        session.add(
-                            PictureProjectMember(
-                                picture_id=pic.id,
-                                project_id=character.project_id,
-                            )
-                        )
-                    if pic.project_id is None:
-                        pic.project_id = character.project_id
                 session.add(pic)
+                pending_ids.append(int(pic.id))
+            # Issue #125: the character may belong to several projects, so the
+            # imported pictures join *all* of them, not just the primary FK.
+            reconcile_entity_projects_change(
+                session,
+                picture_ids=pending_ids,
+                ensure_project_ids=character_project_ids(session, character_id_value),
+                remove_project_ids=[],
+            )
             session.commit()
 
         self._db.run_task(

--- a/pixlstash/utils/service/filter_helpers.py
+++ b/pixlstash/utils/service/filter_helpers.py
@@ -7,12 +7,12 @@ from sqlmodel import Session
 import numpy as np
 
 from pixlstash.db_models import (
-    Character,
+    CharacterProjectMember,
     Face,
     Picture,
     PictureProjectMember,
-    PictureSet,
     PictureSetMember,
+    PictureSetProjectMember,
 )
 from pixlstash.pixl_logging import get_logger
 
@@ -330,10 +330,14 @@ def fetch_scope_allowed_set_ids(server, request) -> set[int] | None:
     if token_scope.resource_type == "project":
 
         def _fetch_project_sets(session: Session, project_id: int) -> set[int]:
+            # Issue #125: a set may be in several projects, so membership comes
+            # from the join table, not the primary-project FK.
             return {
                 int(r[0])
                 for r in session.exec(
-                    select(PictureSet.id).where(PictureSet.project_id == project_id)
+                    select(PictureSetProjectMember.set_id).where(
+                        PictureSetProjectMember.project_id == project_id
+                    )
                 ).all()
             }
 
@@ -374,10 +378,14 @@ def fetch_scope_allowed_character_ids(server, request) -> set[int] | None:
     if token_scope.resource_type == "project":
 
         def _fetch_project_chars(session: Session, project_id: int) -> set[int]:
+            # Issue #125: a character may be in several projects, so membership
+            # comes from the join table, not the primary-project FK.
             return {
                 int(r[0])
                 for r in session.exec(
-                    select(Character.id).where(Character.project_id == project_id)
+                    select(CharacterProjectMember.character_id).where(
+                        CharacterProjectMember.project_id == project_id
+                    )
                 ).all()
             }
 

--- a/pixlstash/utils/service/filter_helpers.py
+++ b/pixlstash/utils/service/filter_helpers.py
@@ -1,5 +1,7 @@
 """Shared filter helpers for picture query construction."""
 
+from typing import Iterable
+
 from fastapi import HTTPException
 from sqlalchemy import exists, select
 from sqlalchemy.orm import aliased
@@ -436,6 +438,73 @@ def fetch_scope_allowed_character_ids(server, request) -> set[int] | None:
         token_scope.resource_type,
     )
     return set()
+
+
+def visible_project_ids(server, request) -> set[int] | None:
+    """Return project IDs the current token scope may *learn about*.
+
+    A character or picture set may belong to several projects (issue #125) and
+    every serialisation of one carries a ``project_ids`` list. That list is
+    *membership metadata about other projects*, not part of the object the token
+    was granted: a token scoped to one character legitimately reads that
+    character, but the complete membership list tells it how many other projects
+    the character is filed under and what their ids are — facts it can obtain
+    from no endpoint it is allowed to call (``GET /projects/{other_id}`` is
+    project-scoped and 403s). Any handler that serialises ``project_ids`` must
+    intersect it with this function's result first.
+
+    The ladder mirrors :func:`fetch_scope_allowed_set_ids`: a ``project`` token
+    sees exactly its own project, and every other scoped token sees no projects
+    at all.
+
+    Args:
+        server: The server instance (unused; kept for signature symmetry with the
+            other scope helpers, which need it to run a read task).
+        request: The current FastAPI request.
+
+    Returns:
+        ``None`` when the token is unscoped / owner (no restriction — the caller
+        must not filter). ``{project_id}`` for a ``project``-scoped token. An
+        empty ``set`` for a ``character``, ``picture_set``, ``picture``, or
+        unrecognised ``resource_type`` (fail-closed: no project id is disclosed).
+    """
+    token_scope = getattr(request.state, "token_scope", None)
+    if token_scope is None or token_scope.resource_type is None:
+        return None
+
+    if token_scope.resource_type == "project":
+        return {int(token_scope.resource_id)}
+
+    # character / picture_set / picture / anything unrecognised: no project
+    # visibility at all. Deliberately fail-closed rather than defaulting to
+    # disclosure.
+    logger.debug(
+        "visible_project_ids: token_scope resource_type %r has no project"
+        " visibility; returning empty set",
+        token_scope.resource_type,
+    )
+    return set()
+
+
+def filter_visible_project_ids(
+    project_ids: Iterable[int] | None, visible: set[int] | None
+) -> list[int]:
+    """Narrow an entity's ``project_ids`` to what the caller may see.
+
+    Args:
+        project_ids: The entity's full project membership, from the join table.
+        visible: The result of :func:`visible_project_ids` — ``None`` for an
+            owner / unscoped token (no narrowing), otherwise the set of project
+            ids the token may learn about.
+
+    Returns:
+        A sorted list of project ids: the full membership for an owner, the
+        intersection with ``visible`` for a scoped token.
+    """
+    ids = sorted({int(pid) for pid in (project_ids or []) if pid is not None})
+    if visible is None:
+        return ids
+    return [pid for pid in ids if pid in visible]
 
 
 def _project_scope_picture_ids(session: Session, project_id: int) -> set[int]:

--- a/pixlstash/utils/service/filter_helpers.py
+++ b/pixlstash/utils/service/filter_helpers.py
@@ -507,6 +507,32 @@ def filter_visible_project_ids(
     return [pid for pid in ids if pid in visible]
 
 
+def narrow_project_fields(
+    payload: dict, project_ids: Iterable[int] | None, visible: set[int] | None
+) -> dict:
+    """Set scope-narrowed ``project_ids`` *and* ``project_id`` on *payload*.
+
+    The legacy scalar ``project_id`` must be derived from the narrowed list,
+    never serialised straight off the model: the stored scalar names the
+    entity's *primary* project, which a token scoped to a secondary project
+    (or to the entity itself) has no grant to learn (issue #125 / R1b).
+
+    Args:
+        payload: The response dict being built; mutated in place.
+        project_ids: The entity's full project membership, from the join table.
+        visible: The result of :func:`visible_project_ids`.
+
+    Returns:
+        The same *payload*, with ``project_ids`` narrowed and ``project_id``
+        set to the first narrowed id (the primary project when the caller may
+        see it) or ``None`` when none are visible.
+    """
+    narrowed = filter_visible_project_ids(project_ids, visible)
+    payload["project_ids"] = narrowed
+    payload["project_id"] = narrowed[0] if narrowed else None
+    return payload
+
+
 def _project_scope_picture_ids(session: Session, project_id: int) -> set[int]:
     """Picture ids that are members of *project_id* (excluding soft-deleted)."""
     rows = session.exec(

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -318,3 +318,102 @@ def test_alembic_0075_leaves_existing_ground_truth_null():
             assert row[2].startswith("1970-01-01")
         finally:
             conn.close()
+
+
+def test_alembic_0086_backfills_entity_project_membership():
+    """A deployed DB whose characters / picture sets carry the legacy single
+    ``project_id`` FK gains one join row per assignment (issue #125).
+
+    The migration is additive: the scalar FKs must survive untouched, because
+    they stay the "primary project" pointer until a post-1.12 cleanup drops them.
+    A dangling FK (a project row that no longer exists) must be skipped rather
+    than inserted, or the new foreign key would be violated.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "vault.db")
+        db_url = f"sqlite:///{db_path}"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE project (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL,
+                    description VARCHAR,
+                    cover_image_path VARCHAR,
+                    extra_metadata VARCHAR,
+                    created_at DATETIME NOT NULL
+                );
+                CREATE TABLE character (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL,
+                    description VARCHAR,
+                    extra_metadata VARCHAR,
+                    reference_picture_set_id INTEGER,
+                    project_id INTEGER
+                );
+                CREATE TABLE pictureset (
+                    id INTEGER NOT NULL PRIMARY KEY,
+                    name VARCHAR NOT NULL,
+                    description VARCHAR,
+                    project_id INTEGER,
+                    set_icon VARCHAR,
+                    set_color VARCHAR,
+                    locked BOOLEAN NOT NULL DEFAULT 0
+                );
+                CREATE TABLE alembic_version (version_num VARCHAR NOT NULL);
+                INSERT INTO alembic_version (version_num)
+                    VALUES ('0085_recompute_smart_score_restored_builtin_anchors');
+                INSERT INTO project (id, name, created_at)
+                    VALUES (1, 'Alpha', '2026-01-01 00:00:00');
+                INSERT INTO project (id, name, created_at)
+                    VALUES (2, 'Beta', '2026-01-01 00:00:00');
+                INSERT INTO character (id, name, project_id) VALUES (10, 'C1', 1);
+                INSERT INTO character (id, name, project_id) VALUES (11, 'C2', 2);
+                INSERT INTO character (id, name, project_id) VALUES (12, 'C3', NULL);
+                -- Dangling pointer at a project that no longer exists.
+                INSERT INTO character (id, name, project_id) VALUES (13, 'C4', 999);
+                INSERT INTO pictureset (id, name, project_id) VALUES (20, 'S1', 1);
+                INSERT INTO pictureset (id, name, project_id) VALUES (21, 'S2', NULL);
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = _run_alembic(["upgrade", "head"], db_url, _MIGRATIONS_DIR)
+        assert result.returncode == 0, (
+            f"upgrade failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+        conn = sqlite3.connect(db_path)
+        try:
+            char_rows = set(
+                conn.execute(
+                    "SELECT character_id, project_id FROM characterprojectmember"
+                ).fetchall()
+            )
+            assert char_rows == {(10, 1), (11, 2)}, (
+                f"unexpected character membership backfill: {sorted(char_rows)}"
+            )
+
+            set_rows = set(
+                conn.execute(
+                    "SELECT set_id, project_id FROM picturesetprojectmember"
+                ).fetchall()
+            )
+            assert set_rows == {(20, 1)}, (
+                f"unexpected set membership backfill: {sorted(set_rows)}"
+            )
+
+            # Additive: the legacy pointers are untouched, including the dangling
+            # one (the migration never rewrites application data).
+            assert conn.execute(
+                "SELECT project_id FROM character ORDER BY id"
+            ).fetchall() == [(1,), (2,), (None,), (999,)]
+            assert conn.execute(
+                "SELECT project_id FROM pictureset ORDER BY id"
+            ).fetchall() == [(1,), (None,)]
+        finally:
+            conn.close()

--- a/tests/test_multi_project_membership_authz.py
+++ b/tests/test_multi_project_membership_authz.py
@@ -1,0 +1,513 @@
+"""Issue #125 — multi-project characters / picture sets, and what it does to scope.
+
+Making a character or picture set reachable from several projects **widens** what
+a project-scoped share token can see: a token for project B now reaches an entity
+whose *primary* project is A, as long as B is among its memberships. That is the
+intended semantics, and it is exactly the kind of change that must be pinned in
+both directions, because the two failure modes are opposite and both are bugs:
+
+* **Under-grant (over-blocking).** Reading the legacy scalar
+  ``Character.project_id`` / ``PictureSet.project_id`` instead of the new join
+  tables makes a secondary membership invisible: project B's token is refused an
+  entity it legitimately shares, and B's listings silently omit it. Over-blocking
+  is its own regression (CLAUDE.md §Security & authorization review process).
+* **Over-grant (BOLA).** The widening must stop at declared membership: a token
+  for an unrelated project C must still be 403'd on the same routes, and must not
+  learn the entity exists through any sibling vector.
+
+Every assertion below therefore pairs an in-scope 200 with an out-of-scope 403,
+across the sibling vectors that share the semantics: by-id and by-name routes
+(the name-derived routes keep an inline check per §16.1, so they are a genuinely
+separate enforcement path), list and single-item routes, the locked-members
+listing, the project's own set listing, and the picture-level consequence of an
+entity's membership.
+
+Fixture shape (deliberately three projects, not two): set ``S`` and character
+``C`` belong to ``{P1, P2}``; ``P3`` exists solely as the out-of-scope probe, so
+"403" can never be an artefact of the resource simply not existing.
+"""
+
+import contextlib
+import gc
+import json
+import os
+import tempfile
+
+import pytest
+from starlette.testclient import TestClient
+
+from pixlstash.server import Server
+from tests.authz_guard import (  # noqa: F401
+    assert_real_route,
+    no_spa_fallback,
+    resolves_to_real_route,
+)
+from tests.utils import upload_pictures_and_wait
+
+API = "/api/v1"
+
+# Every positive assertion here must reach a real route: the SPA catch-all answers
+# unmatched GETs with 200, which once made a whole-library BOLA vector's test
+# vacuous. See tests/authz_guard.py.
+pytestmark = pytest.mark.usefixtures("no_spa_fallback")
+
+
+@contextlib.contextmanager
+def _enforcing(server):
+    prev = server.authz._enforcing
+    server.authz._enforcing = True
+    try:
+        yield
+    finally:
+        server.authz._enforcing = prev
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _good_picture_files():
+    pictures_dir = os.path.join(os.path.dirname(__file__), "..", "pictures", "good")
+    results = []
+    for name in sorted(os.listdir(pictures_dir)):
+        path = os.path.join(pictures_dir, name)
+        ext = os.path.splitext(name)[1].lower()
+        if ext in {".png", ".jpg", ".jpeg", ".webp"}:
+            ct = "image/png" if ext == ".png" else "image/jpeg"
+            with open(path, "rb") as fh:
+                results.append((name, fh.read(), ct))
+    return results
+
+
+@pytest.fixture
+def env():
+    """Live server with 3 projects, a set and a character shared by P1+P2, and a
+    project-scoped READ token for each project."""
+    temp_dir = tempfile.TemporaryDirectory()
+    config_path = os.path.join(temp_dir.name, "server-config.json")
+    with open(config_path, "w") as fh:
+        fh.write(json.dumps({"port": 8000}))
+    server = Server(config_path)
+    server.__enter__()
+    try:
+        client = TestClient(server.api, raise_server_exceptions=True)
+        anon = TestClient(server.api, raise_server_exceptions=True)
+        r = client.post(
+            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        )
+        assert r.status_code == 200, r.text
+
+        files = [("file", (n, d, c)) for n, d, c in _good_picture_files()[:2]]
+        assert len(files) >= 2, "need >=2 test pictures"
+        st = upload_pictures_and_wait(client, files, timeout_s=30)
+        assert st["status"] == "completed", st
+        pic_ids = [p["id"] for p in client.get(f"{API}/pictures").json()]
+        assert len(pic_ids) >= 2
+        pic_a, pic_b = pic_ids[0], pic_ids[1]
+
+        projects = {}
+        for label in ("P1", "P2", "P3"):
+            r = client.post(f"{API}/projects", json={"name": label})
+            assert r.status_code in (200, 201), r.text
+            projects[label] = r.json()["id"]
+
+        # Set S holds picture A and belongs to BOTH P1 and P2. The member is added
+        # before the project assignment so the PATCH reconciles picture-project
+        # membership for both projects in one pass.
+        r = client.post(f"{API}/picture_sets", json={"name": "SharedSet"})
+        assert r.status_code in (200, 201), r.text
+        set_id = r.json()["picture_set"]["id"]
+        r = client.post(f"{API}/picture_sets/{set_id}/members/{pic_a}")
+        assert r.status_code in (200, 201), r.text
+        r = client.patch(
+            f"{API}/picture_sets/{set_id}",
+            json={"project_ids": [projects["P1"], projects["P2"]]},
+        )
+        assert r.status_code == 200, r.text
+
+        # Character C belongs to BOTH P1 and P2 (created multi-project directly).
+        r = client.post(
+            f"{API}/characters",
+            json={
+                "name": "SharedChar",
+                "project_ids": [projects["P1"], projects["P2"]],
+            },
+        )
+        assert r.status_code == 200, r.text
+        char_id = r.json()["character"]["id"]
+
+        # Single-project control: belongs to P1 only, so a P2 token must be
+        # refused it — proving the widening did not become "any project wins".
+        r = client.post(
+            f"{API}/picture_sets",
+            json={"name": "P1OnlySet", "project_ids": [projects["P1"]]},
+        )
+        assert r.status_code in (200, 201), r.text
+        p1_only_set_id = r.json()["picture_set"]["id"]
+        r = client.post(
+            f"{API}/characters",
+            json={"name": "P1OnlyChar", "project_ids": [projects["P1"]]},
+        )
+        assert r.status_code == 200, r.text
+        p1_only_char_id = r.json()["character"]["id"]
+
+        def mint(resource_type, resource_id):
+            r = client.post(
+                f"{API}/users/me/token",
+                json={
+                    "description": f"{resource_type}:{resource_id}",
+                    "scope": "READ",
+                    "resource_type": resource_type,
+                    "resource_id": resource_id,
+                },
+            )
+            assert r.status_code == 200, r.text
+            return r.json()["token"]
+
+        yield {
+            "server": server,
+            "owner": client,
+            "anon": anon,
+            "pic_a": pic_a,
+            "pic_b": pic_b,
+            "projects": projects,
+            "set_id": set_id,
+            "char_id": char_id,
+            "p1_only_set_id": p1_only_set_id,
+            "p1_only_char_id": p1_only_char_id,
+            "tokens": {label: mint("project", pid) for label, pid in projects.items()},
+        }
+    finally:
+        server.__exit__(None, None, None)
+        temp_dir.cleanup()
+        gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# The write path: both representations stay in sync
+# ---------------------------------------------------------------------------
+
+
+def test_membership_is_written_to_both_representations(env):
+    """``project_ids`` is the read model; the legacy scalar ``project_id`` stays
+    populated with the primary (lowest) project. Neither may drift."""
+    owner, projects = env["owner"], env["projects"]
+    both = sorted([projects["P1"], projects["P2"]])
+
+    body = owner.get(f"{API}/characters/{env['char_id']}").json()
+    assert body["project_ids"] == both
+    assert body["project_id"] == both[0], (
+        "the legacy FK must keep naming the primary project — it is not dropped "
+        "until a later cleanup release"
+    )
+
+    body = owner.get(f"{API}/picture_sets/{env['set_id']}?info=true").json()
+    assert body["project_ids"] == both
+    assert body["project_id"] == both[0]
+
+
+def test_leaving_one_project_keeps_the_other(env):
+    """Dropping P2 leaves the entity in P1 — the FK follows, and the entity does
+    not become unassigned."""
+    owner, projects = env["owner"], env["projects"]
+    r = owner.patch(
+        f"{API}/characters/{env['char_id']}", json={"project_ids": [projects["P1"]]}
+    )
+    assert r.status_code == 200, r.text
+    body = owner.get(f"{API}/characters/{env['char_id']}").json()
+    assert body["project_ids"] == [projects["P1"]]
+    assert body["project_id"] == projects["P1"]
+
+    # Restore, so the fixture's shared state is not left half-torn for readers.
+    r = owner.patch(
+        f"{API}/characters/{env['char_id']}",
+        json={"project_ids": [projects["P1"], projects["P2"]]},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_unknown_project_id_is_404_not_a_silent_partial_write(env):
+    """A membership write naming a missing project is rejected whole."""
+    owner, projects = env["owner"], env["projects"]
+    r = owner.patch(
+        f"{API}/characters/{env['char_id']}",
+        json={"project_ids": [projects["P1"], 9_999_999]},
+    )
+    assert r.status_code == 404, r.text
+    body = owner.get(f"{API}/characters/{env['char_id']}").json()
+    assert body["project_ids"] == sorted([projects["P1"], projects["P2"]])
+
+
+# ---------------------------------------------------------------------------
+# Scope: by-id routes, both directions
+# ---------------------------------------------------------------------------
+
+
+def test_character_by_id_secondary_project_token_reaches_it(env):
+    """CHARACTER_SCOPED ``GET /characters/{id}``: the P2 token reaches a character
+    whose primary project is P1 (in-scope 200, the widening), the P3 token does
+    not (out-of-scope 403), and a P1-only character is refused to P2 (the
+    widening did not degrade into "any project")."""
+    anon, tokens = env["anon"], env["tokens"]
+    path = f"{API}/characters/{env['char_id']}"
+    assert_real_route(env["server"].api, "GET", path)
+    with _enforcing(env["server"]):
+        assert anon.get(path, headers=_bearer(tokens["P1"])).status_code == 200
+        r = anon.get(path, headers=_bearer(tokens["P2"]))
+        assert r.status_code == 200, (
+            f"secondary-project token must not be over-blocked: {r.status_code} "
+            f"{r.text}"
+        )
+        r = anon.get(path, headers=_bearer(tokens["P3"]))
+        assert r.status_code == 403, f"unrelated project must 403: {r.text}"
+
+        r = anon.get(
+            f"{API}/characters/{env['p1_only_char_id']}", headers=_bearer(tokens["P2"])
+        )
+        assert r.status_code == 403, f"P1-only character must 403 for P2: {r.text}"
+
+
+def test_picture_set_by_id_secondary_project_token_reaches_it(env):
+    """SET_SCOPED sibling of the character route, same three directions."""
+    anon, tokens = env["anon"], env["tokens"]
+    path = f"{API}/picture_sets/{env['set_id']}"
+    assert_real_route(env["server"].api, "GET", path)
+    with _enforcing(env["server"]):
+        assert anon.get(path, headers=_bearer(tokens["P1"])).status_code == 200
+        r = anon.get(path, headers=_bearer(tokens["P2"]))
+        assert r.status_code == 200, (
+            f"secondary-project token must not be over-blocked: {r.status_code} "
+            f"{r.text}"
+        )
+        assert anon.get(path, headers=_bearer(tokens["P3"])).status_code == 403
+
+        r = anon.get(
+            f"{API}/picture_sets/{env['p1_only_set_id']}",
+            headers=_bearer(tokens["P2"]),
+        )
+        assert r.status_code == 403, f"P1-only set must 403 for P2: {r.text}"
+
+
+def test_picture_scope_follows_the_shared_set(env):
+    """PICTURE_SCOPED consequence: the set's member picture is anchored in BOTH
+    projects, so the P2 token reaches it; a non-member picture is still 403."""
+    anon, tokens = env["anon"], env["tokens"]
+    with _enforcing(env["server"]):
+        r = anon.get(
+            f"{API}/pictures/{env['pic_a']}/metadata", headers=_bearer(tokens["P2"])
+        )
+        assert r.status_code == 200, f"in-scope picture must pass: {r.text}"
+        r = anon.get(
+            f"{API}/pictures/{env['pic_b']}/metadata", headers=_bearer(tokens["P2"])
+        )
+        assert r.status_code == 403, f"out-of-scope picture must 403: {r.text}"
+        r = anon.get(
+            f"{API}/pictures/{env['pic_a']}/metadata", headers=_bearer(tokens["P3"])
+        )
+        assert r.status_code == 403, f"unrelated project must 403: {r.text}"
+
+
+# ---------------------------------------------------------------------------
+# Scope: the name-derived sibling routes (§16.1 residual inline enforcement)
+# ---------------------------------------------------------------------------
+
+
+def test_character_by_project_and_name_both_directions(env):
+    """``GET /projects/{project_name}/characters/{character_name}`` resolves the
+    character *within* a named project and keeps an inline scope check (§16.1).
+    It must find the shared character under its secondary project's name, admit
+    that project's token, and refuse an unrelated one."""
+    owner, anon, tokens = env["owner"], env["anon"], env["tokens"]
+    path = f"{API}/projects/P2/characters/SharedChar"
+    assert_real_route(env["server"].api, "GET", path)
+    # Owner: the lookup must resolve at all under the secondary project.
+    r = owner.get(path)
+    assert r.status_code == 200, f"secondary-project name lookup must resolve: {r.text}"
+    assert r.json()["id"] == env["char_id"]
+    with _enforcing(env["server"]):
+        assert anon.get(path, headers=_bearer(tokens["P2"])).status_code == 200
+        assert anon.get(path, headers=_bearer(tokens["P3"])).status_code == 403
+
+
+def test_picture_set_by_project_and_name_both_directions(env):
+    """Set twin of the character-by-name route, same three directions."""
+    owner, anon, tokens = env["owner"], env["anon"], env["tokens"]
+    path = f"{API}/projects/P2/picture_sets/SharedSet"
+    assert_real_route(env["server"].api, "GET", path)
+    r = owner.get(path)
+    assert r.status_code == 200, f"secondary-project name lookup must resolve: {r.text}"
+    assert r.json()["id"] == env["set_id"]
+    with _enforcing(env["server"]):
+        assert anon.get(path, headers=_bearer(tokens["P2"])).status_code == 200
+        assert anon.get(path, headers=_bearer(tokens["P3"])).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Scope: list routes (SCOPED_LIST — the token narrows the listing in-handler)
+# ---------------------------------------------------------------------------
+
+
+def test_character_list_is_narrowed_to_the_tokens_project(env):
+    """``GET /characters`` forces a project token's listing to its own project.
+    The shared character appears for P1 and P2 and not for P3, and the P1-only
+    character never appears for P2."""
+    anon, tokens = env["anon"], env["tokens"]
+    path = f"{API}/characters"
+    assert_real_route(env["server"].api, "GET", path)
+    with _enforcing(env["server"]):
+        for label in ("P1", "P2"):
+            r = anon.get(path, headers=_bearer(tokens[label]))
+            assert r.status_code == 200, r.text
+            ids = {c["id"] for c in r.json()}
+            assert env["char_id"] in ids, (
+                f"{label} token must see the shared character; got {sorted(ids)}"
+            )
+        r = anon.get(path, headers=_bearer(tokens["P2"]))
+        assert env["p1_only_char_id"] not in {c["id"] for c in r.json()}
+
+        r = anon.get(path, headers=_bearer(tokens["P3"]))
+        assert r.status_code == 200, r.text
+        assert env["char_id"] not in {c["id"] for c in r.json()}, (
+            "an unrelated project's token must not learn the character exists"
+        )
+
+
+def test_picture_set_list_is_narrowed_to_the_tokens_project(env):
+    """``GET /picture_sets`` twin of the character listing."""
+    anon, tokens = env["anon"], env["tokens"]
+    path = f"{API}/picture_sets"
+    assert_real_route(env["server"].api, "GET", path)
+    with _enforcing(env["server"]):
+        for label in ("P1", "P2"):
+            r = anon.get(path, headers=_bearer(tokens[label]))
+            assert r.status_code == 200, r.text
+            ids = {s["id"] for s in r.json()}
+            assert env["set_id"] in ids, (
+                f"{label} token must see the shared set; got {sorted(ids)}"
+            )
+        r = anon.get(path, headers=_bearer(tokens["P2"]))
+        assert env["p1_only_set_id"] not in {s["id"] for s in r.json()}
+
+        r = anon.get(path, headers=_bearer(tokens["P3"]))
+        assert r.status_code == 200, r.text
+        assert env["set_id"] not in {s["id"] for s in r.json()}
+
+
+def test_owner_project_filters_read_the_join(env):
+    """Owner-side listing filters: ``?project_id=`` matches a secondary membership,
+    and ``UNASSIGNED`` must not swallow a multi-project entity."""
+    owner, projects = env["owner"], env["projects"]
+    for label in ("P1", "P2"):
+        chars = owner.get(f"{API}/characters?project_id={projects[label]}").json()
+        assert env["char_id"] in {c["id"] for c in chars}, label
+        sets = owner.get(f"{API}/picture_sets?project_id={projects[label]}").json()
+        assert env["set_id"] in {s["id"] for s in sets}, label
+
+    chars = owner.get(f"{API}/characters?project_id={projects['P3']}").json()
+    assert env["char_id"] not in {c["id"] for c in chars}
+    sets = owner.get(f"{API}/picture_sets?project_id={projects['P3']}").json()
+    assert env["set_id"] not in {s["id"] for s in sets}
+
+    chars = owner.get(f"{API}/characters?project_id=UNASSIGNED").json()
+    assert env["char_id"] not in {c["id"] for c in chars}
+    sets = owner.get(f"{API}/picture_sets?project_id=UNASSIGNED").json()
+    assert env["set_id"] not in {s["id"] for s in sets}
+
+
+def test_project_picture_sets_listing_both_directions(env):
+    """``GET /projects/{id_or_name}/picture_sets`` (PROJECT_SCOPED, name-derived
+    inline check): P2 lists the shared set, P3's token is refused P2's listing."""
+    owner, anon, tokens, projects = (
+        env["owner"],
+        env["anon"],
+        env["tokens"],
+        env["projects"],
+    )
+    path = f"{API}/projects/{projects['P2']}/picture_sets"
+    assert_real_route(env["server"].api, "GET", path)
+    r = owner.get(path)
+    assert r.status_code == 200, r.text
+    assert env["set_id"] in {s["id"] for s in r.json()}
+    with _enforcing(env["server"]):
+        r = anon.get(path, headers=_bearer(tokens["P2"]))
+        assert r.status_code == 200, r.text
+        assert env["set_id"] in {s["id"] for s in r.json()}
+        assert anon.get(path, headers=_bearer(tokens["P3"])).status_code == 403
+
+
+def test_locked_members_listing_both_directions(env):
+    """``GET /picture_sets/locked-members`` narrows by project too — a locked
+    shared set is visible to its secondary project's token and to nobody else."""
+    owner, anon, tokens = env["owner"], env["anon"], env["tokens"]
+    r = owner.patch(f"{API}/picture_sets/{env['set_id']}", json={"locked": True})
+    assert r.status_code == 200, r.text
+    path = f"{API}/picture_sets/locked-members"
+    assert_real_route(env["server"].api, "GET", path)
+    with _enforcing(env["server"]):
+        for label in ("P1", "P2"):
+            r = anon.get(path, headers=_bearer(tokens[label]))
+            assert r.status_code == 200, r.text
+            assert env["set_id"] in {s["id"] for s in r.json()["sets"]}, label
+        r = anon.get(path, headers=_bearer(tokens["P3"]))
+        assert r.status_code == 200, r.text
+        assert env["set_id"] not in {s["id"] for s in r.json()["sets"]}
+
+
+def test_scoped_list_pictures_not_over_blocked(env):
+    """SCOPED_LIST pass-through must survive the change, including the
+    ``character_id=UNASSIGNED`` branch that was a historical leak vector."""
+    anon, tok = env["anon"], env["tokens"]["P2"]
+    paths = (
+        f"{API}/pictures",
+        f"{API}/pictures/stream",
+        f"{API}/pictures?character_id=UNASSIGNED",
+    )
+    for path in paths:
+        assert_real_route(env["server"].api, "GET", path.split("?")[0])
+    with _enforcing(env["server"]):
+        for path in paths:
+            r = anon.get(path, headers=_bearer(tok))
+            assert r.status_code == 200, (
+                f"SCOPED_LIST {path} must not be over-blocked; got "
+                f"{r.status_code}: {r.text}"
+            )
+
+
+def test_deleting_a_project_leaves_the_other_membership_intact(env):
+    """Deleting P2 removes only P2's rows: the entities stay in P1 and the picture
+    keeps P1's membership. The P1 token still reaches them."""
+    owner, anon, tokens, projects = (
+        env["owner"],
+        env["anon"],
+        env["tokens"],
+        env["projects"],
+    )
+    r = owner.delete(f"{API}/projects/{projects['P2']}")
+    assert r.status_code == 200, r.text
+
+    body = owner.get(f"{API}/characters/{env['char_id']}").json()
+    assert body["project_ids"] == [projects["P1"]]
+    assert body["project_id"] == projects["P1"]
+    body = owner.get(f"{API}/picture_sets/{env['set_id']}?info=true").json()
+    assert body["project_ids"] == [projects["P1"]]
+
+    with _enforcing(env["server"]):
+        assert (
+            anon.get(
+                f"{API}/characters/{env['char_id']}", headers=_bearer(tokens["P1"])
+            ).status_code
+            == 200
+        )
+        assert (
+            anon.get(
+                f"{API}/picture_sets/{env['set_id']}", headers=_bearer(tokens["P1"])
+            ).status_code
+            == 200
+        )
+        assert (
+            anon.get(
+                f"{API}/pictures/{env['pic_a']}/metadata",
+                headers=_bearer(tokens["P1"]),
+            ).status_code
+            == 200
+        )

--- a/tests/test_multi_project_membership_authz.py
+++ b/tests/test_multi_project_membership_authz.py
@@ -636,6 +636,94 @@ def test_project_ids_is_empty_for_entity_scoped_tokens(env):
             )
 
 
+def _char_payloads(client, env, headers=None, project_label=None):
+    """Every character payload that serialises the scalar ``project_id``."""
+    kw = {"headers": headers} if headers else {}
+    out = {}
+    r = client.get(f"{API}/characters/{env['char_id']}", **kw)
+    assert r.status_code == 200, r.text
+    out["by_id"] = r.json()
+    listed = {c["id"]: c for c in client.get(f"{API}/characters", **kw).json()}
+    out["list"] = listed[env["char_id"]]
+    if project_label is not None:
+        r = client.get(f"{API}/projects/{project_label}/characters/SharedChar", **kw)
+        assert r.status_code == 200, r.text
+        out["by_name"] = r.json()
+    return out
+
+
+def _set_payloads(client, env, headers=None, project_label=None):
+    """Every picture-set payload that serialises the scalar ``project_id``,
+    including the sort-variant siblings of ``GET /picture_sets/{id}`` which
+    build their ``set`` payload on separate return paths."""
+    kw = {"headers": headers} if headers else {}
+    out = {}
+    r = client.get(f"{API}/picture_sets/{env['set_id']}?info=true", **kw)
+    assert r.status_code == 200, r.text
+    out["info"] = r.json()
+    r = client.get(f"{API}/picture_sets/{env['set_id']}", **kw)
+    assert r.status_code == 200, r.text
+    out["pictures"] = r.json()["set"]
+    r = client.get(f"{API}/picture_sets/{env['set_id']}?sort=SMART_SCORE", **kw)
+    assert r.status_code == 200, r.text
+    out["pictures_smart_sort"] = r.json()["set"]
+    listed = {s["id"]: s for s in client.get(f"{API}/picture_sets", **kw).json()}
+    out["list"] = listed[env["set_id"]]
+    if project_label is not None:
+        r = client.get(f"{API}/projects/{project_label}/picture_sets/SharedSet", **kw)
+        assert r.status_code == 200, r.text
+        out["by_name"] = r.json()
+    return out
+
+
+def test_scalar_project_id_is_derived_from_the_narrowed_list(env):
+    """R1b: the legacy scalar ``project_id`` must never name a project the token
+    has no grant for. It is derived from the narrowed ``project_ids`` at every
+    serialisation site — the primary project for the owner, the token's own
+    project for a project token, ``None`` for an entity-scoped token — never
+    read straight off the model."""
+    owner, anon, tokens, projects, mint = (
+        env["owner"],
+        env["anon"],
+        env["tokens"],
+        env["projects"],
+        env["mint"],
+    )
+    both = sorted([projects["P1"], projects["P2"]])
+
+    for site, payload in {
+        **_char_payloads(owner, env, project_label="P1"),
+        **_set_payloads(owner, env, project_label="P1"),
+    }.items():
+        assert payload["project_ids"] == both, f"owner narrowed on {site}"
+        assert payload["project_id"] == both[0], (
+            f"{site}: the owner's scalar must stay the primary project"
+        )
+
+    with _enforcing(env["server"]):
+        headers = _bearer(tokens["P2"])
+        for site, payload in {
+            **_char_payloads(anon, env, headers, project_label="P2"),
+            **_set_payloads(anon, env, headers, project_label="P2"),
+        }.items():
+            assert payload["project_ids"] == [projects["P2"]], site
+            assert payload["project_id"] == projects["P2"], (
+                f"{site}: scalar project_id named a project the P2 token has "
+                f"no grant for ({payload['project_id']})"
+            )
+
+        char_headers = _bearer(mint("character", env["char_id"]))
+        for site, payload in _char_payloads(anon, env, char_headers).items():
+            assert payload["project_id"] is None, (
+                f"characters.{site}: scalar leaked to a character token"
+            )
+        set_headers = _bearer(mint("picture_set", env["set_id"]))
+        for site, payload in _set_payloads(anon, env, set_headers).items():
+            assert payload["project_id"] is None, (
+                f"picture_sets.{site}: scalar leaked to a set token"
+            )
+
+
 # ---------------------------------------------------------------------------
 # R2 — a picture added to an already-multi-project entity joins *every* project
 # ---------------------------------------------------------------------------

--- a/tests/test_multi_project_membership_authz.py
+++ b/tests/test_multi_project_membership_authz.py
@@ -29,13 +29,17 @@ Fixture shape (deliberately three projects, not two): set ``S`` and character
 
 import contextlib
 import gc
+import io
 import json
 import os
 import tempfile
+import time
 
 import pytest
+from PIL import Image
 from starlette.testclient import TestClient
 
+from pixlstash.db_models import Face
 from pixlstash.server import Server
 from tests.authz_guard import (  # noqa: F401
     assert_real_route,
@@ -176,6 +180,9 @@ def env():
             "p1_only_set_id": p1_only_set_id,
             "p1_only_char_id": p1_only_char_id,
             "tokens": {label: mint("project", pid) for label, pid in projects.items()},
+            # Exposed so a test can mint a character- / set-scoped token too: the
+            # `project_ids` narrowing (R1) has a different rung for those.
+            "mint": mint,
         }
     finally:
         server.__exit__(None, None, None)
@@ -511,3 +518,300 @@ def test_deleting_a_project_leaves_the_other_membership_intact(env):
             ).status_code
             == 200
         )
+
+
+# ---------------------------------------------------------------------------
+# R1 — `project_ids` is membership metadata about *other* projects
+# ---------------------------------------------------------------------------
+#
+# Every serialisation of a multi-project entity carries the full membership list.
+# The entity itself is in scope for the token reading it; the ids of the *other*
+# projects it is filed under are not, and are obtainable from no endpoint that
+# token may call (``GET /projects/{other_id}`` is project-scoped and 403s). So the
+# list is intersected with the token's visible projects, on the same ladder
+# ``fetch_scope_allowed_set_ids`` implements. The owner is never narrowed.
+
+
+def _char_project_ids(client, env, headers=None):
+    """``project_ids`` for the shared character on every route that serialises it."""
+    kw = {"headers": headers} if headers else {}
+    out = {}
+    r = client.get(f"{API}/characters/{env['char_id']}", **kw)
+    assert r.status_code == 200, r.text
+    out["by_id"] = r.json()["project_ids"]
+    listed = {c["id"]: c for c in client.get(f"{API}/characters", **kw).json()}
+    assert env["char_id"] in listed, "the shared character must still be listed"
+    out["list"] = listed[env["char_id"]]["project_ids"]
+    return out
+
+
+def _set_project_ids(client, env, headers=None):
+    """``project_ids`` for the shared set on every route that serialises it."""
+    kw = {"headers": headers} if headers else {}
+    out = {}
+    r = client.get(f"{API}/picture_sets/{env['set_id']}?info=true", **kw)
+    assert r.status_code == 200, r.text
+    out["info"] = r.json()["project_ids"]
+    r = client.get(f"{API}/picture_sets/{env['set_id']}", **kw)
+    assert r.status_code == 200, r.text
+    out["pictures"] = r.json()["set"]["project_ids"]
+    listed = {s["id"]: s for s in client.get(f"{API}/picture_sets", **kw).json()}
+    assert env["set_id"] in listed, "the shared set must still be listed"
+    out["list"] = listed[env["set_id"]]["project_ids"]
+    return out
+
+
+def test_project_ids_narrowed_to_the_tokens_own_project(env):
+    """A project-scoped token reads the shared entity (200 — over-blocking would
+    be its own regression) but learns only its own project id from
+    ``project_ids``; the owner keeps the full membership list."""
+    owner, anon, tokens, projects = (
+        env["owner"],
+        env["anon"],
+        env["tokens"],
+        env["projects"],
+    )
+    both = sorted([projects["P1"], projects["P2"]])
+
+    for site, ids in _char_project_ids(owner, env).items():
+        assert ids == both, f"owner must not be narrowed on characters.{site}"
+    for site, ids in _set_project_ids(owner, env).items():
+        assert ids == both, f"owner must not be narrowed on picture_sets.{site}"
+    assert (
+        owner.get(f"{API}/projects/P1/characters/SharedChar").json()["project_ids"]
+        == both
+    )
+    assert (
+        owner.get(f"{API}/projects/P1/picture_sets/SharedSet").json()["project_ids"]
+        == both
+    )
+
+    with _enforcing(env["server"]):
+        for label in ("P1", "P2"):
+            headers = _bearer(tokens[label])
+            mine = [projects[label]]
+
+            for site, ids in _char_project_ids(anon, env, headers).items():
+                assert ids == mine, (
+                    f"{label} token must not learn the other project's id from "
+                    f"characters.{site}; got {ids}"
+                )
+            for site, ids in _set_project_ids(anon, env, headers).items():
+                assert ids == mine, (
+                    f"{label} token must not learn the other project's id from "
+                    f"picture_sets.{site}; got {ids}"
+                )
+
+            # The name-derived siblings serialise it too.
+            r = anon.get(
+                f"{API}/projects/{label}/characters/SharedChar", headers=headers
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["project_ids"] == mine
+            r = anon.get(
+                f"{API}/projects/{label}/picture_sets/SharedSet", headers=headers
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["project_ids"] == mine
+
+
+def test_project_ids_is_empty_for_entity_scoped_tokens(env):
+    """The other rung of the ladder: a character- or picture-set-scoped token has
+    no project visibility at all, so ``project_ids`` serialises as ``[]``. It
+    still reads its own entity — the narrowing must not turn into a refusal."""
+    anon, mint = env["anon"], env["mint"]
+    char_headers = _bearer(mint("character", env["char_id"]))
+    set_headers = _bearer(mint("picture_set", env["set_id"]))
+
+    with _enforcing(env["server"]):
+        for site, ids in _char_project_ids(anon, env, char_headers).items():
+            assert ids == [], (
+                f"a character token has no project visibility; characters.{site} "
+                f"leaked {ids}"
+            )
+        for site, ids in _set_project_ids(anon, env, set_headers).items():
+            assert ids == [], (
+                f"a set token has no project visibility; picture_sets.{site} "
+                f"leaked {ids}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# R2 — a picture added to an already-multi-project entity joins *every* project
+# ---------------------------------------------------------------------------
+#
+# Six write paths used to read the scalar primary FK to decide which
+# ``PictureProjectMember`` row to create, so a picture added *after* the entity
+# went multi-project silently joined the primary project only: the secondary
+# project's token was 403'd and the owner's own ``?project_id=`` listing omitted
+# it. That is an under-grant, never a leak — but it is the feature's headline case
+# and invisible to the operator. Each path is pinned in both directions.
+
+
+def _assert_picture_reaches_both_projects(env, picture_id, where):
+    """The picture is anchored in P1 *and* P2 — and still not in P3."""
+    owner, anon, tokens, projects = (
+        env["owner"],
+        env["anon"],
+        env["tokens"],
+        env["projects"],
+    )
+    for label in ("P1", "P2"):
+        r = owner.get(f"{API}/pictures?project_id={projects[label]}")
+        assert r.status_code == 200, r.text
+        ids = {p["id"] for p in r.json()}
+        assert picture_id in ids, (
+            f"{where}: the owner's {label} listing must contain picture "
+            f"{picture_id}; got {sorted(ids)}"
+        )
+    ids = {
+        p["id"] for p in owner.get(f"{API}/pictures?project_id={projects['P3']}").json()
+    }
+    assert picture_id not in ids, (
+        f"{where}: an unrelated project must not gain the picture"
+    )
+
+    with _enforcing(env["server"]):
+        for label in ("P1", "P2"):
+            r = anon.get(
+                f"{API}/pictures/{picture_id}/metadata", headers=_bearer(tokens[label])
+            )
+            assert r.status_code == 200, (
+                f"{where}: the {label} token must reach the picture; got "
+                f"{r.status_code}: {r.text}"
+            )
+        r = anon.get(
+            f"{API}/pictures/{picture_id}/metadata", headers=_bearer(tokens["P3"])
+        )
+        assert r.status_code == 403, f"{where}: unrelated project must 403: {r.text}"
+
+
+def test_add_member_to_shared_set_joins_every_project(env):
+    """``POST /picture_sets/{id}/members/{picture_id}`` — the reviewer's original
+    reproduction: a picture added *after* the set became P1+P2."""
+    r = env["owner"].post(f"{API}/picture_sets/{env['set_id']}/members/{env['pic_b']}")
+    assert r.status_code in (200, 201), r.text
+    _assert_picture_reaches_both_projects(
+        env, env["pic_b"], "POST /picture_sets/{id}/members/{picture_id}"
+    )
+
+
+def test_bulk_add_to_shared_set_joins_every_project(env):
+    """``POST /picture_sets/{id}/members`` (bulk add), same semantics."""
+    r = env["owner"].post(
+        f"{API}/picture_sets/{env['set_id']}/members",
+        json={"picture_ids": [env["pic_b"]]},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["added"] >= 1, r.text
+    _assert_picture_reaches_both_projects(
+        env, env["pic_b"], "POST /picture_sets/{id}/members"
+    )
+
+
+def test_bulk_replace_members_joins_every_project(env):
+    """``PUT /picture_sets/{id}/members`` (replace) rebuilds the whole member
+    list, so every member must be re-anchored in every project."""
+    r = env["owner"].put(
+        f"{API}/picture_sets/{env['set_id']}/members",
+        json={"picture_ids": [env["pic_a"], env["pic_b"]]},
+    )
+    assert r.status_code == 200, r.text
+    for pic_id in (env["pic_a"], env["pic_b"]):
+        _assert_picture_reaches_both_projects(
+            env, pic_id, "PUT /picture_sets/{id}/members"
+        )
+
+
+def _make_face(server, picture_id: int) -> int:
+    """Insert a synthetic face row on *picture_id*.
+
+    The face-assign path is exercised through its ``face_ids`` branch so the test
+    does not depend on the detector finding a face in the CPU test profile (the
+    reviewer's own probe failed twice for exactly that reason). ``face_index`` is
+    deliberately far outside the detector's range so a real extraction running in
+    the background cannot collide with the (picture, frame, face) unique
+    constraint.
+    """
+
+    def _do(session):
+        face = Face(
+            picture_id=int(picture_id),
+            frame_index=0,
+            face_index=900,
+            bbox=[0, 0, 16, 16],
+        )
+        session.add(face)
+        session.commit()
+        session.refresh(face)
+        return int(face.id)
+
+    return server.vault.db.run_task(_do)
+
+
+def test_face_assignment_to_shared_character_joins_every_project(env):
+    """``POST /characters/{id}/faces`` — the character twin of the set paths."""
+    face_id = _make_face(env["server"], env["pic_b"])
+    r = env["owner"].post(
+        f"{API}/characters/{env['char_id']}/faces", json={"face_ids": [face_id]}
+    )
+    assert r.status_code == 200, r.text
+    _assert_picture_reaches_both_projects(
+        env, env["pic_b"], "POST /characters/{id}/faces"
+    )
+
+
+def _png_bytes(color=(11, 99, 200)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (48, 48), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _staged_import(client, open_body, filename, timeout_s=60) -> None:
+    """Run one staging import (open → stream → commit → wait) to completion."""
+    r = client.post(f"{API}/pictures/import/staging", json=open_body)
+    assert r.status_code == 200, r.text
+    staging_id = r.json()["staging_id"]
+    r = client.post(
+        f"{API}/pictures/import/staging/{staging_id}/files",
+        files=[("file", (filename, _png_bytes(), "image/png"))],
+    )
+    assert r.status_code == 200, r.text
+    r = client.post(f"{API}/pictures/import/staging/{staging_id}/commit")
+    assert r.status_code == 200, r.text
+    deadline = time.time() + timeout_s
+    last = None
+    while time.time() < deadline:
+        last = client.get(f"{API}/pictures/import/staging/{staging_id}/status").json()
+        if last["stage"] in ("completed", "failed"):
+            assert last["stage"] == "completed", last
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"staging {staging_id} never finished: {last}")
+
+
+def _imported_picture_id(env):
+    """The one picture id that is not part of the fixture's two uploads."""
+    ids = {p["id"] for p in env["owner"].get(f"{API}/pictures").json()}
+    fresh = ids - {env["pic_a"], env["pic_b"]}
+    assert len(fresh) == 1, f"expected exactly one newly imported picture, got {fresh}"
+    return fresh.pop()
+
+
+def test_import_into_shared_set_joins_every_project(env):
+    """``PictureImportTask._apply_set`` — the drop-target import path must read the
+    same membership as the route it mirrors."""
+    _staged_import(env["owner"], {"set_id": env["set_id"]}, "import-into-set.png")
+    _assert_picture_reaches_both_projects(
+        env, _imported_picture_id(env), "import with set_id drop target"
+    )
+
+
+def test_import_into_shared_character_joins_every_project(env):
+    """``PictureImportTask._apply_character`` — the character drop target."""
+    _staged_import(
+        env["owner"], {"character_id": env["char_id"]}, "import-into-char.png"
+    )
+    _assert_picture_reaches_both_projects(
+        env, _imported_picture_id(env), "import with character_id drop target"
+    )

--- a/tests/test_multi_project_membership_authz.py
+++ b/tests/test_multi_project_membership_authz.py
@@ -667,6 +667,13 @@ def _set_payloads(client, env, headers=None, project_label=None):
     r = client.get(f"{API}/picture_sets/{env['set_id']}?sort=SMART_SCORE", **kw)
     assert r.status_code == 200, r.text
     out["pictures_smart_sort"] = r.json()["set"]
+    r = client.get(
+        f"{API}/picture_sets/{env['set_id']}?sort=CHARACTER_LIKENESS"
+        f"&reference_character_id={env['char_id']}",
+        **kw,
+    )
+    assert r.status_code == 200, r.text
+    out["pictures_likeness_sort"] = r.json()["set"]
     listed = {s["id"]: s for s in client.get(f"{API}/picture_sets", **kw).json()}
     out["list"] = listed[env["set_id"]]
     if project_label is not None:

--- a/tests/test_project_membership_service.py
+++ b/tests/test_project_membership_service.py
@@ -26,6 +26,7 @@ import os
 import tempfile
 
 import pytest
+from fastapi import HTTPException
 from sqlmodel import select
 
 from pixlstash.database import DBPriority
@@ -40,7 +41,12 @@ from pixlstash.db_models import (
 )
 from pixlstash.server import Server
 from pixlstash.services.project_membership_service import (
+    character_project_ids,
+    picture_set_project_ids,
     reconcile_entity_project_change,
+    reconcile_entity_projects_change,
+    set_character_projects,
+    set_picture_set_projects,
 )
 
 
@@ -77,13 +83,23 @@ def _memberships(session, pic_id):
 def _make_anchor(session, kind, project_id, pic_id, name, face_index=0):
     """Create an entity of *kind* assigned to *project_id* anchoring *pic_id*.
 
+    Since issue #125 the assignment is written in both representations — the
+    scalar primary-project FK *and* the membership join row — via
+    ``set_character_projects`` / ``set_picture_set_projects``, because
+    ``picture_referenced_by_project`` now reads the join. A fixture that only set
+    the FK would leave the anchor invisible and silently weaken every
+    reference-aware retention assertion below.
+
     Returns the entity id, so the caller can pass it as the excluded (moving)
     entity to the reference-aware check.
     """
     if kind == "character":
-        entity = Character(name=name, project_id=project_id)
+        entity = Character(name=name)
         session.add(entity)
         session.flush()
+        set_character_projects(
+            session, entity, [project_id] if project_id is not None else []
+        )
         session.add(
             Face(
                 picture_id=pic_id,
@@ -94,9 +110,12 @@ def _make_anchor(session, kind, project_id, pic_id, name, face_index=0):
             )
         )
     else:
-        entity = PictureSet(name=name, project_id=project_id)
+        entity = PictureSet(name=name)
         session.add(entity)
         session.flush()
+        set_picture_set_projects(
+            session, entity, [project_id] if project_id is not None else []
+        )
         session.add(PictureSetMember(set_id=entity.id, picture_id=pic_id))
     session.flush()
     return entity.id
@@ -260,3 +279,255 @@ def test_reconcile_reference_aware_retention(server, kind):
     memberships, pointer, p1_id, p2_id = _run(server, scenario)
     assert memberships == {p1_id, p2_id}
     assert pointer == p2_id
+
+
+# ===========================================================================
+# Issue #125 — multi-project entity membership
+# ===========================================================================
+
+
+def _entity_project_ids(session, kind, entity_id):
+    if kind == "character":
+        return character_project_ids(session, entity_id)
+    return picture_set_project_ids(session, entity_id)
+
+
+def _set_entity_projects(session, kind, entity, project_ids):
+    if kind == "character":
+        return set_character_projects(session, entity, project_ids)
+    return set_picture_set_projects(session, entity, project_ids)
+
+
+def _load_entity(session, kind, entity_id):
+    return session.get(Character if kind == "character" else PictureSet, entity_id)
+
+
+@pytest.mark.parametrize("kind", ["character", "set"])
+def test_entity_joins_second_project_keeps_both(server, kind):
+    """An entity in A that also joins B is a member of both, and its legacy
+    primary-project FK settles on the lowest member id."""
+
+    def scenario(session):
+        p1 = Project(name=f"multi-a-{kind}")
+        p2 = Project(name=f"multi-b-{kind}")
+        session.add(p1)
+        session.add(p2)
+        session.flush()
+        pic = Picture(file_path="multi.jpg")
+        session.add(pic)
+        session.flush()
+        entity_id = _make_anchor(session, kind, p1.id, pic.id, f"multi-{kind}")
+        entity = _load_entity(session, kind, entity_id)
+
+        change = _set_entity_projects(session, kind, entity, [p1.id, p2.id])
+        session.flush()
+        reconcile_entity_projects_change(
+            session,
+            picture_ids=[pic.id],
+            ensure_project_ids=change.target_project_ids,
+            remove_project_ids=change.removed,
+            **_exclude_kwargs(kind, entity_id),
+        )
+        return (
+            _entity_project_ids(session, kind, entity_id),
+            entity.project_id,
+            _memberships(session, pic.id),
+            pic.project_id,
+            sorted([p1.id, p2.id]),
+            change.added,
+            change.removed,
+        )
+
+    (
+        entity_projects,
+        entity_primary,
+        pic_memberships,
+        pic_pointer,
+        both,
+        added,
+        removed,
+    ) = _run(server, scenario)
+    assert entity_projects == both
+    assert entity_primary == both[0]
+    # The picture is anchored in BOTH projects, not just the primary one.
+    assert pic_memberships == set(both)
+    assert pic_pointer == both[0]
+    assert added == [both[1]]
+    assert removed == []
+
+
+@pytest.mark.parametrize("kind", ["character", "set"])
+def test_entity_leaves_one_of_two_projects(server, kind):
+    """Dropping B from {A, B} removes only B's picture membership; A survives and
+    the entity stays assigned to A."""
+
+    def scenario(session):
+        p1 = Project(name=f"drop-a-{kind}")
+        p2 = Project(name=f"drop-b-{kind}")
+        session.add(p1)
+        session.add(p2)
+        session.flush()
+        pic = Picture(file_path="drop.jpg")
+        session.add(pic)
+        session.flush()
+        entity_id = _make_anchor(session, kind, p1.id, pic.id, f"drop-{kind}")
+        entity = _load_entity(session, kind, entity_id)
+        change = _set_entity_projects(session, kind, entity, [p1.id, p2.id])
+        session.flush()
+        reconcile_entity_projects_change(
+            session,
+            picture_ids=[pic.id],
+            ensure_project_ids=change.target_project_ids,
+            remove_project_ids=change.removed,
+            **_exclude_kwargs(kind, entity_id),
+        )
+
+        change = _set_entity_projects(session, kind, entity, [p1.id])
+        session.flush()
+        reconcile_entity_projects_change(
+            session,
+            picture_ids=[pic.id],
+            ensure_project_ids=change.target_project_ids,
+            remove_project_ids=change.removed,
+            **_exclude_kwargs(kind, entity_id),
+        )
+        return (
+            _entity_project_ids(session, kind, entity_id),
+            entity.project_id,
+            _memberships(session, pic.id),
+            pic.project_id,
+            p1.id,
+            p2.id,
+            change.removed,
+        )
+
+    entity_projects, entity_primary, memberships, pointer, p1_id, p2_id, removed = _run(
+        server, scenario
+    )
+    assert entity_projects == [p1_id]
+    assert entity_primary == p1_id
+    assert removed == [p2_id]
+    assert memberships == {p1_id}
+    assert pointer == p1_id
+
+
+@pytest.mark.parametrize("kind", ["character", "set"])
+def test_entity_leaving_all_projects_unassigns_it(server, kind):
+    """Clearing the membership set nulls the legacy FK and drops every picture
+    membership the entity was the only anchor for."""
+
+    def scenario(session):
+        p1 = Project(name=f"clear-a-{kind}")
+        p2 = Project(name=f"clear-b-{kind}")
+        session.add(p1)
+        session.add(p2)
+        session.flush()
+        pic = Picture(file_path="clear.jpg")
+        session.add(pic)
+        session.flush()
+        entity_id = _make_anchor(session, kind, p1.id, pic.id, f"clear-{kind}")
+        entity = _load_entity(session, kind, entity_id)
+        change = _set_entity_projects(session, kind, entity, [p1.id, p2.id])
+        session.flush()
+        reconcile_entity_projects_change(
+            session,
+            picture_ids=[pic.id],
+            ensure_project_ids=change.target_project_ids,
+            remove_project_ids=change.removed,
+            **_exclude_kwargs(kind, entity_id),
+        )
+
+        change = _set_entity_projects(session, kind, entity, [])
+        session.flush()
+        reconcile_entity_projects_change(
+            session,
+            picture_ids=[pic.id],
+            ensure_project_ids=change.target_project_ids,
+            remove_project_ids=change.removed,
+            **_exclude_kwargs(kind, entity_id),
+        )
+        return (
+            _entity_project_ids(session, kind, entity_id),
+            entity.project_id,
+            _memberships(session, pic.id),
+            pic.project_id,
+        )
+
+    entity_projects, entity_primary, memberships, pointer = _run(server, scenario)
+    assert entity_projects == []
+    assert entity_primary is None
+    assert memberships == set()
+    assert pointer is None
+
+
+@pytest.mark.parametrize("kind", ["character", "set"])
+def test_secondary_membership_anchors_a_picture(server, kind):
+    """Reference-aware retention must see an anchor's *secondary* project.
+
+    The regression this pins: reading the primary-project FK instead of the join
+    would miss an entity whose membership in the departed project is not its
+    lowest one, and would evict the picture from a project it still belongs to.
+    """
+
+    def scenario(session):
+        p1 = Project(name=f"anchor-a-{kind}")
+        p2 = Project(name=f"anchor-b-{kind}")
+        session.add(p1)
+        session.add(p2)
+        session.flush()
+        pic = Picture(file_path="anchor.jpg")
+        session.add(pic)
+        session.flush()
+
+        # Anchor entity: primary project p1, secondary p2.
+        anchor_id = _make_anchor(session, kind, p1.id, pic.id, f"anchor-{kind}", 0)
+        anchor = _load_entity(session, kind, anchor_id)
+        _set_entity_projects(session, kind, anchor, [p1.id, p2.id])
+        session.flush()
+
+        # Moving entity: in p2 only, then leaves it. p2 must survive because the
+        # anchor is still (secondarily) in p2.
+        moving_id = _make_anchor(session, kind, p2.id, pic.id, f"moving-{kind}", 1)
+        moving = _load_entity(session, kind, moving_id)
+        session.add(PictureProjectMember(picture_id=pic.id, project_id=p2.id))
+        session.flush()
+
+        change = _set_entity_projects(session, kind, moving, [])
+        session.flush()
+        reconcile_entity_projects_change(
+            session,
+            picture_ids=[pic.id],
+            ensure_project_ids=change.target_project_ids,
+            remove_project_ids=change.removed,
+            **_exclude_kwargs(kind, moving_id),
+        )
+        return _memberships(session, pic.id), p2.id
+
+    memberships, p2_id = _run(server, scenario)
+    assert p2_id in memberships
+
+
+@pytest.mark.parametrize("kind", ["character", "set"])
+def test_unknown_project_id_is_rejected(server, kind):
+    """A membership write naming a non-existent project fails with 404 and leaves
+    the entity untouched."""
+
+    def scenario(session):
+        p1 = Project(name=f"reject-{kind}")
+        session.add(p1)
+        session.flush()
+        pic = Picture(file_path="reject.jpg")
+        session.add(pic)
+        session.flush()
+        entity_id = _make_anchor(session, kind, p1.id, pic.id, f"reject-{kind}")
+        entity = _load_entity(session, kind, entity_id)
+        status = None
+        try:
+            _set_entity_projects(session, kind, entity, [p1.id, p1.id + 9999])
+        except HTTPException as exc:
+            status = exc.status_code
+        return status, _entity_project_ids(session, kind, entity_id), p1.id
+
+    status, entity_projects, p1_id = _run(server, scenario)
+    assert status == 404
+    assert entity_projects == [p1_id]

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -3228,3 +3228,86 @@ def test_restore_does_not_resurrect_a_picture_whose_ledger_row_survived_a_collis
         "picture A's content was genuinely destroyed; restore must never "
         "resurrect it and bind it to whatever now occupies that path"
     )
+
+
+def test_restore_resource_rebuilds_entity_project_membership(server):
+    """A restored parent character comes back with its project membership rows,
+    not just its scalar ``project_id`` (issue #125).
+
+    The join table is the read model: a character restored with the FK alone
+    would be silently invisible to ``GET /characters?project_id=…`` and refused
+    by a project-scoped share token, which is the same "restored but unusable"
+    failure class as the 2026-07-22 snapshot-restore incident.
+    """
+    from pixlstash.db_models import CharacterProjectMember, Project
+    from pixlstash.services.project_membership_service import set_character_projects
+
+    _create_file(server, "membership_restore.jpg")
+    pic = _add_picture(server, filename="membership_restore.jpg")
+
+    def _setup_snapshot_state(session):
+        p1 = Project(name="restore-proj-1")
+        p2 = Project(name="restore-proj-2")
+        session.add(p1)
+        session.add(p2)
+        session.flush()
+        c = Character(name="multi-project-char")
+        session.add(c)
+        session.flush()
+        set_character_projects(session, c, [p1.id, p2.id])
+        session.add(
+            Face(
+                picture_id=pic.id,
+                frame_index=0,
+                face_index=0,
+                character_id=c.id,
+                bbox_="[0,0,20,20]",
+            )
+        )
+        session.commit()
+        return c.id, sorted([p1.id, p2.id])
+
+    char_id, project_ids = server.vault.db.run_task(_setup_snapshot_state)
+    cp = server.vault.snapshot_service.create_snapshot("MANUAL")
+
+    def _delete_char(session):
+        session.exec(
+            delete(CharacterProjectMember).where(
+                CharacterProjectMember.character_id == char_id
+            )
+        )
+        session.exec(delete(Character).where(Character.id == char_id))
+        session.commit()
+
+    server.vault.db.run_task(_delete_char)
+
+    report = server.vault.restore_service.restore_resource(
+        cp.id,
+        "picture",
+        pic.id,
+        confirm_restore_dependencies=True,
+    )
+    assert report.upserted_count > 0
+
+    restored = server.vault.db.run_immediate_read_task(
+        lambda s: (
+            s.get(Character, char_id),
+            sorted(
+                int(r)
+                for r in s.exec(
+                    select(CharacterProjectMember.project_id).where(
+                        CharacterProjectMember.character_id == char_id
+                    )
+                ).all()
+            ),
+        )
+    )
+    char_after, membership_after = restored
+    assert char_after is not None
+    assert membership_after == project_ids, (
+        "restored character must regain BOTH project memberships; got "
+        f"{membership_after}"
+    )
+    assert char_after.project_id == project_ids[0], (
+        "the legacy primary-project FK must survive the restore too"
+    )


### PR DESCRIPTION
Lane C of v1.9.0, closes #125. Additive join tables `characterprojectmember` / `picturesetprojectmember` (migration 0086, conditional, backfilled with `INSERT OR IGNORE`); the single `project_id` FK stays populated as the primary project. Contract: **write both, read the join** — membership writes only via `set_character_projects` / `set_picture_set_projects` in the membership service, reads via correlated join predicates in `authz/membership.py` and `filter_helpers.py`.

- No routes added; ROUTE_POLICIES unchanged (0 undeclared / 0 dead). What changed is what "belongs to project P" resolves to — the full affected-route matrix seed is in the review doc for the CSO.
- New both-direction authz suite (15 tests): primary and secondary project → 200, unrelated project → 403, plus a control entity proving the widening isn't "any project wins". Anti-vacuity checked (test fails when the helper is reverted).
- 431 targeted tests passed; the single failure is a pre-existing stale 403-detail assertion in `test_reviews_api.py`, reproduced identically on clean develop.

**Merge is gated on the independent adversarial CSO sign-off** (access-scope change; running now).

Known merge-order note: this branch and #626 both mint migration `0086` off head `0085`; whichever merges second renumbers.

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U