### PR TITLE
v1.9 authz sign-off (independent adversarial review)

### DIFF
--- a/docs/reviews/v1.9-authz-signoff.md
+++ b/docs/reviews/v1.9-authz-signoff.md
@@ -9,7 +9,11 @@
   - `feature/dedup-sweep-backend` (PR #625)
 - **Method:** each branch checked out detached, diffed with `git diff develop...<branch>`, read in full for the authz-relevant surface, then exercised with the shipped both-direction suites **plus** eight purpose-written adversarial probes on a live server. Every finding below was reproduced against running code before it was written down; the two observations that could **not** be reproduced are labelled as such and are not counted as findings.
 
-## Verdicts
+> **FINAL VERDICTS ARE IN §7 (Re-verification, 2026-07-28, round 2).** The table
+> immediately below is the *first-round* verdict that produced the required
+> changes; it is kept for the record. §7 certifies the fixes.
+
+## Verdicts (round 1 — superseded by §7)
 
 | Branch | PR | Verdict |
 |---|---|---|
@@ -407,3 +411,237 @@ The probe files were deliberately not committed: they are throwaway attack
 scripts, and the durable versions belong in
 `tests/test_multi_project_membership_authz.py` as part of the R1/R2 fixes, written
 by someone other than this reviewer.
+
+---
+
+## 7. Re-verification (round 2, 2026-07-28) — final verdicts
+
+Both fix authors landed and pushed. This section is the certification pass. The
+reviewer is unchanged and is **not** either fix author. Nothing here was taken on
+the authors' word: every claim was re-derived from the code and re-exercised
+against a running server, including two deliberate **mutations** of the shipped
+fixes to prove the new tests are not vacuous.
+
+### 7.1 Final verdicts
+
+| Branch | PR | Head reviewed | Final verdict |
+|---|---|---|---|
+| `feature/125-multi-project-membership` | #629 | `b7c36d69` | **APPROVE**, conditional on the one-line **R1b** follow-up on the same branch |
+| `feature/operation-log` | #626 | `8a966562` | **APPROVE** — authz surface unchanged since round 1 |
+| `feature/remix-v1` | #627 | `803e79d9` | **APPROVE** — R3 closed; **R3b** is hardening, not a gate |
+| `feature/dedup-sweep-backend` | #625 | `d58200aa` | **APPROVE** — authz surface unchanged since round 1 |
+
+**No BLOCK.** R1, R2 and R3 are all closed by controls that are enforced
+server-side and pinned by tests that fail when the fix is removed. The two
+residuals below (R1b, R3b) are LOW-severity and neither reopens the finding class
+in a way that warrants holding a release.
+
+**X1 (migration `0086` collision + coverage-matrix totals) stands unchanged** as a
+merge-order note. Re-confirmed: `feature/125-multi-project-membership` and
+`feature/operation-log` still both declare `revision="0086_*"` on
+`down_revision="0085_..."`; #625 and #627 each still claim matrix total **219** and
+#626 claims **224** (combined should be **228**). Neither is a fix on these
+branches; the last merger owns both.
+
+### 7.2 PR #629 — R1 (`project_ids` disclosure): **CLOSED**
+
+The fix adds `visible_project_ids` / `filter_visible_project_ids` to
+`filter_helpers.py:443-509`. The ladder is correct and fail-closed by
+construction: `None` (no narrowing) only for `token_scope is None or
+resource_type is None`; `{resource_id}` for a `project` token; **empty set** for
+`character` / `picture_set` / `picture` / anything unrecognised.
+
+Applied at 8 serialisation sites. **The authors' claim that the 3 remaining
+unfiltered sites are OWNER_ONLY was checked against `ROUTE_POLICIES`, not
+accepted** — all three verified:
+
+| Unfiltered site | Route | Declared policy (registry line) |
+|---|---|---|
+| `characters.py:706` | `PATCH /api/v1/characters/{id}` | `_OWNER` (registry:487) |
+| `characters.py:1289` | `POST /api/v1/characters` | `_OWNER` (registry:483) |
+| `picture_sets.py:767` | `POST /api/v1/picture_sets` | `_OWNER` (registry:526) |
+
+Re-run of the round-1 P1 disclosure probe, on a fixture where the shared entity
+is in `{P1, P2}`:
+
+```
+V1 owner char: 1 [1, 2]
+V1 project-P2 token char: project_id=1 project_ids=[2]      <- narrowed
+V1 character token char: project_id=1 project_ids=[]        <- narrowed
+V1 P2 token set:  project_id=1 project_ids=[2]
+V1 set token set: project_id=1 project_ids=[]
+V1 P2 token /characters:   [(1, [2])]
+V1 P2 token /picture_sets: [(1, [2])]
+V1 by-name char via P2: 200 {... 'project_id': 1, 'project_ids': [2] ...}
+```
+
+`project_ids` is correct on every route, in both directions, including the
+name-derived siblings. **R1 is closed.**
+
+---
+
+#### R1b — the legacy scalar `project_id` still discloses a foreign project id
+
+- **Severity:** LOW (CWE-200). **Required follow-up on the same branch** — it is the same finding in a sibling field, and this review's own rule says a fix verified only on the default path is not verified. It is **not** a release blocker in the severity sense.
+- **Location:** the same 5 narrowed sites — `characters.py:851`, `:886`, `:1221`; `picture_sets.py:498`, `:612`, plus the two consumers of the narrowed list at `:1222` / `:1297`. The scalar comes straight off the model via `safe_model_dict` / `model_dump` and is never narrowed.
+- **Exploit:** identical to R1, one field over. A **project-P2** token reading a character whose *primary* project is P1 gets `project_ids: [2]` (correctly narrowed) but `project_id: 1` — a project it holds no grant for. A **character**- or **set**-scoped token gets `project_ids: []` and `project_id: 1`, which is self-contradictory as well as disclosing.
+- **Why it is a #125 regression and not pre-existing:** before #125 an entity had exactly one project, so a P2-scoped token could never reach an entity whose `project_id` named P1 — it would not have been in P2 at all. Multi-project membership is what makes the scalar able to name a project the reader cannot see.
+- **Evidence:** the probe output above — `project_id=1` on every scoped row.
+- **Fix:** derive the scalar from the narrowed list at the same 5 sites: `payload["project_id"] = payload["project_ids"][0] if payload["project_ids"] else None`. That keeps the documented invariant (`project_id` is the lowest id in `project_ids`) true *from the caller's point of view*, which it currently is not for a scoped token.
+- **Verification:** extend `test_project_ids_narrowed_to_the_tokens_own_project` / `test_project_ids_is_empty_for_entity_scoped_tokens` to assert `project_id` as well as `project_ids` — the tests already walk every site, so this is an added assertion, not a new test.
+
+### 7.3 PR #629 — R2 (secondary-project propagation): **CLOSED**
+
+All six write paths now read the join and delegate to
+`reconcile_entity_projects_change(..., remove_project_ids=[])`:
+`picture_sets.py:1616` (single add), `:1764` (bulk add), `:1843` (`PUT` replace),
+`characters_faces.py:214-231` (face assignment), `picture_import_task.py:339-347`
+and `:380-390` (import into set / character). The face-assignment path's
+`session.commit()` was correctly narrowed to the reconcile only — the face rows
+are committed earlier at `characters_faces.py:209`, so no write is lost when the
+character belongs to no project.
+
+Re-run of the round-1 propagation probe, extended to all three set paths:
+
+```
+V2 single-add:  pic=2 token_status={'P1': 200, 'P2': 200, 'P3': 403} owner_lists={'P1': [1,2],   'P2': [1,2],   'P3': []}
+V2 bulk-add:    pic=3 token_status={'P1': 200, 'P2': 200, 'P3': 403} owner_lists={'P1': [1,2,3], 'P2': [1,2,3], 'P3': []}
+V2 put-replace: pic=1 token_status={'P1': 200, 'P2': 200, 'P3': 403} owner_lists={'P1': [1,2,3], 'P2': [1,2,3], 'P3': []}
+```
+
+Both directions on every path: the secondary project's token now reaches the
+picture (was 403), the owner's `?project_id=` listing contains it (was missing),
+and the unrelated project is still refused. **R2 is closed.**
+
+**The intentional semantic change — the scalar `Picture.project_id` re-point moved
+into the service's step 3 (lowest member id, only when not already pointing at a
+member project) — cannot widen or narrow access.** Proven two ways:
+
+1. **Structurally.** Project picture scope resolves exclusively through
+   `PictureProjectMember`: `_project_scope_picture_ids`
+   (`filter_helpers.py:510-517`) filters on `project_membership_exists_clause`
+   (`:189-205`), which is an `EXISTS` over the join table. `Picture.project_id`
+   appears in no scope path, so re-pointing the scalar changes no authorization
+   decision in either direction.
+2. **Empirically** (probe V3). A picture placed in **P3 only**, then added to the
+   `{P1, P2}` set — the case where the re-point fires and moves the scalar away
+   from P3:
+   ```
+   V3 before adding to the shared set: {'P1': 403, 'P2': 403, 'P3': 200}
+   V3 after  adding to the shared set: {'P1': 200, 'P2': 200, 'P3': 200}
+   ```
+   It gains P1 and P2 and **keeps** P3. No revocation, no widening beyond the
+   entity's declared membership.
+
+### 7.4 PR #629 — non-vacuity spot-check of the new tests
+
+8 durable tests were added. Rather than read them for plausibility, the shipped
+fixes were **mutated** and the tests re-run. Both mutations were caught:
+
+| Mutation | Tests run | Result |
+|---|---|---|
+| `filter_visible_project_ids` returns the unnarrowed list (R1 fix disabled) | `-k "project_ids_narrowed or project_ids_is_empty"` | **2 failed**, 21 deselected — `FAILED test_project_ids_narrowed_to_the_tokens_own_project`, `FAILED test_project_ids_is_empty_for_entity_scoped_tokens` |
+| single-add path reverted to `ensure_project_ids=[picture_set.project_id]` (R2 fix disabled on one path) | `-k "add_member_to_shared_set"` | **1 failed** — `FAILED test_add_member_to_shared_set_joins_every_project` |
+
+Both mutations were reverted with `git checkout --` immediately after; the working
+tree was left clean.
+
+Reading them as well: `_assert_picture_reaches_both_projects` asserts the owner's
+listing for P1 *and* P2, the **P3 negative**, and the scoped-token 200/200/403
+triple under `_enforcing`. `test_project_ids_narrowed_to_the_tokens_own_project`
+asserts the owner is **not** narrowed before it asserts the token is —
+over-blocking is checked as its own regression, as the process requires.
+
+### 7.5 PR #627 — R3: **CLOSED**, with one residual
+
+**R3.1 — disclosure.** `collect_node_classes`
+(`comfyui_recipe_service.py:239-266`) is populated from the local file and wired
+into the recipe response *before* any pre-flight branch, so it survives an
+unreachable ComfyUI — the case where it matters most. Verified end-to-end that
+**what is disclosed is what runs**:
+
+```
+DISCLOSE node_classes:       ['CheckpointLoaderSimple', 'CLIPTextEncode', 'KSampler', 'SaveImage']
+DISCLOSE actually submitted: ['CLIPTextEncode', 'CheckpointLoaderSimple', 'KSampler', 'SaveImage']
+DISCLOSE source: True 'Imported file'
+```
+
+(The two orderings differ only by sort key — case-insensitive for display vs.
+default for the assertion; the sets are identical, and the non-node
+`pixlstash_output_nodes` key is absent from the submitted graph.)
+
+**R3.2 — fail-closed on an uninspected graph.** Enforced in the handler, not the
+dialog. Nine independent bypass attempts, all against an unreachable ComfyUI,
+with the submit call captured:
+
+```
+BYPASS 'no flag':                    400 "PixlStash could not reach ComfyUI to check this workflow…"
+BYPASS 'flag as query param only':   400   (?allow_unchecked=true — body-only, correctly ignored)
+BYPASS 'spoofed preflight in body':  400   ({"preflight": {"checked": true, …}})
+BYPASS 'spoofed checked key':        400   ({"checked": true})
+BYPASS 'client-supplied graph':      400   ({"prompt": <graph>} — never read)
+BYPASS 'nested flag':                400   ({"options": {"allow_unchecked": true}})
+BYPASS 'null flag':                  400
+BYPASS 'zero flag':                  400
+BYPASS 'empty string flag':          400
+submissions after all nine refusals: []    <- nothing reached ComfyUI
+```
+
+The refusal is a refusal: the captured submit list stayed empty. The graph
+genuinely cannot be supplied by the client, and the pre-flight state genuinely
+cannot be spoofed — both are recomputed server-side on every call.
+
+**R3.3 — the imported-source warning gates nothing: ACCEPTABLE, no change
+required.** The ui-ux rationale is sound and this reviewer endorses it on security
+grounds, not merely deference: in a library where most pictures are imported, a
+gate on "imported" fires on nearly every run, and a near-universal confirmation is
+trained away within a week — which would degrade the *one* gate that must keep
+working (the uninspected-graph refusal). The residual risk it leaves is real and
+is recorded in 7.6: a graph built entirely from installed node classes passes the
+pre-flight and runs on one click, with the node-class disclosure as the only
+control. That is the right trade — a capability allowlist would break every
+legitimate custom pack — and the disclosure is unconditional, which is what makes
+the owner a real trust anchor rather than a rubber stamp.
+
+---
+
+#### R3b — `allow_unchecked` uses `bool()`, so the string `"false"` approves the run
+
+- **Severity:** LOW (consent-signal coercion). **Hardening, not a gate** — the caller must already be sending a key named `allow_unchecked`, so this is a robustness bug in the owner's own consent signal, not a third-party bypass.
+- **Location:** `routes/comfyui.py:1127-1129` — `allow_unchecked = bool(payload.get("allow_unchecked") or payload.get("allowUnchecked"))`.
+- **Exploit:** `bool("false")` is `True` in Python. A client that serialises booleans as strings (or a hand-written cURL) sending `{"picture_id": N, "allow_unchecked": "false"}` — i.e. explicitly *declining* — has the graph run anyway.
+- **Evidence:**
+  ```
+  BYPASS 'allow_unchecked="false"' (string): 200 {"status":"success","prompts":[{"prompt_id":"p1",…}]}
+  submissions after the string-false attempt: 1
+  ```
+  Every falsy-in-Python variant (`false`, `null`, `0`, `""`) correctly refuses; only the truthy *string* inverts the consent.
+- **Fix:** accept only a real boolean — `payload.get("allow_unchecked") is True or payload.get("allowUnchecked") is True` — or parse strings strictly (`in {"true", "1", "yes"}`). One line.
+- **Verification:** add `{"allow_unchecked": "false"}` to `TestRunRecipeRefusesAnUncheckedPreflight` alongside the existing `False` case.
+
+### 7.6 Accepted risks added in round 2
+
+| ID | Risk | Blast radius | Compensating control | Owner | Revisit |
+|---|---|---|---|---|---|
+| R3-res | A recipe built entirely from **installed** node classes passes the pre-flight and replays on one click | The owner's ComfyUI host, bounded by installed node packs | unconditional `node_classes` disclosure in the confirm step; `source_is_imported` warning; hard refusal on an *uninspected* graph; the run is logged with its class list | ComfyUI/backend maintainer | when a node-capability signal exists in ComfyUI, or on the first report of a malicious embedded graph in the wild |
+| R3.3 | The imported-source warning is advisory and gates nothing | Owner may click past it | it is *disclosure*, deliberately not a gate, so the one real gate stays meaningful; node classes are shown regardless | ui-ux + backend | if the uninspected-graph acknowledgement is ever observed being ticked reflexively |
+
+Round-1 accepted risks (a), (b), (c)/N1 and N2 are unchanged and still stand. Risk
+(a)'s standing improves: the six FK-read instances that made it concrete are now
+gone, so the remaining exposure is purely hypothetical future code — the AST
+guardrail stays *hardening*, mandatory at FK removal (post-1.12).
+
+### 7.7 Tests re-run in round 2
+
+| Suite / probe | Branch | Result |
+|---|---|---|
+| `tests/test_multi_project_membership_authz.py` + `tests/test_project_membership_service.py` | #629 `b7c36d69` | **43 passed** in 127.11s (was 35) |
+| Mutation 1 — R1 narrowing disabled | #629 | **2 failed, 21 deselected** in 8.72s (non-vacuity proven) |
+| Mutation 2 — R2 single-add reverted to the primary FK | #629 | **1 failed, 22 deselected** in 4.70s (non-vacuity proven) |
+| Reviewer's re-verification probes V1/V2/V3 | #629 | **3 passed** in 15.70s — R1 closed, R2 closed on all 3 set paths, scalar re-point proven access-neutral; **surfaced R1b** |
+| `tests/test_comfyui_recipe_route.py` + `test_comfyui_recipe_preflight.py` + `test_picture_mutation_scope.py` | #627 `803e79d9` | **84 passed** in 156.62s |
+| Reviewer's R3 bypass probes (9 attempts + scope check + disclosure-matches-submission) | #627 | **3 passed** in 8.53s — gate held on all 9; **surfaced R3b** |
+
+Both reviewer probe files were deleted rather than committed, as in round 1; the
+durable assertions belong in the authors' suites (see the Verification lines under
+R1b and R3b).

--- a/docs/reviews/v1.9-authz-signoff.md
+++ b/docs/reviews/v1.9-authz-signoff.md
@@ -1,0 +1,409 @@
+# v1.9.0 — independent adversarial authz sign-off
+
+- **Reviewer:** CSO persona, independent of every branch author. None of the code under review was written by this reviewer (CLAUDE.md § *Security & authorization review process*: "the author of a security fix must not be the one who certifies it complete").
+- **Date:** 2026-07-28
+- **Branches reviewed (all against `develop` @ `cd643c4b`):**
+  - `feature/125-multi-project-membership` (PR #629, issue #125) — **primary, deepest scrutiny**
+  - `feature/operation-log` (PR #626)
+  - `feature/remix-v1` (PR #627)
+  - `feature/dedup-sweep-backend` (PR #625)
+- **Method:** each branch checked out detached, diffed with `git diff develop...<branch>`, read in full for the authz-relevant surface, then exercised with the shipped both-direction suites **plus** eight purpose-written adversarial probes on a live server. Every finding below was reproduced against running code before it was written down; the two observations that could **not** be reproduced are labelled as such and are not counted as findings.
+
+## Verdicts
+
+| Branch | PR | Verdict |
+|---|---|---|
+| `feature/125-multi-project-membership` | #629 | **APPROVE-WITH-REQUIRED-CHANGES** (R1, R2, X1) |
+| `feature/operation-log` | #626 | **APPROVE** (X1 applies; N1/N2 to be recorded) |
+| `feature/remix-v1` | #627 | **APPROVE-WITH-REQUIRED-CHANGES** (R3) |
+| `feature/dedup-sweep-backend` | #625 | **APPROVE** |
+
+No branch introduces a BOLA / broken-object-authorization hole. The central gate
+(`pixlstash/authz/gate.py`), the policy enum, the membership helpers and
+`auth.py` are **untouched by all four branches** — verified by empty diffs on
+`pixlstash/auth.py`, `pixlstash/authz/{gate,policy,membership}.py` for the three
+secondary branches, and by reading the one changed helper file on the primary.
+
+---
+
+## 1. Primary — `feature/125-multi-project-membership` (PR #629)
+
+### 1.1 What changes, in security terms
+
+A character or picture set may now belong to several projects. The scalar
+`Character.project_id` / `PictureSet.project_id` FKs stay as the **primary**
+pointer; two new join tables (`CharacterProjectMember`, `PictureSetProjectMember`)
+are the **read model**. The security consequence is a deliberate **widening**: a
+`project`-scoped share token now reaches an entity whose primary project is a
+*different* project, provided the token's project is among the entity's
+memberships. Every place that answers "is this entity in project P?" had to move
+from the FK to the join; a missed site is either an under-grant (over-blocking —
+a regression in its own right) or, if the two representations could ever diverge
+in the *other* direction, an over-grant.
+
+**The divergence direction was measured, not assumed** (probe P5, §1.4): a direct
+FK write with no join row is **fail-closed** — the entity becomes invisible, never
+extra-visible. This is the single most important fact in this review, because it
+downgrades the author's own risk (a) from "possible silent BOLA" to "possible
+silent data-hiding". See §1.5.
+
+### 1.2 Coverage matrix — every route whose scope resolution flows through a changed helper
+
+Arithmetic, not judgement. The changed helpers are enumerated first; then **every**
+route that reaches them. An empty "where the check lives now" cell would be a bug;
+there are none.
+
+**Changed enforcement helpers (5):**
+
+| Helper | File | Change |
+|---|---|---|
+| `enforce_set_scope` (`project` branch) | `pixlstash/authz/membership.py:172-192` | FK compare → `PictureSetProjectMember` lookup |
+| `enforce_character_scope` (`project` branch) | `pixlstash/authz/membership.py:226-241` | FK compare → `CharacterProjectMember` lookup |
+| `fetch_scope_allowed_set_ids` (`project` branch) | `pixlstash/utils/service/filter_helpers.py:330-345` | FK select → join select |
+| `fetch_scope_allowed_character_ids` (`project` branch) | `pixlstash/utils/service/filter_helpers.py:378-393` | FK select → join select |
+| `picture_referenced_by_project` | `pixlstash/routes/_helpers.py:68-110` | FK join → membership join |
+
+**Changed read predicates (4, new):** `character_in_project` /
+`character_in_no_project` / `picture_set_in_project` / `picture_set_in_no_project`
+in `pixlstash/db_models/entity_project.py`.
+
+**Routes reaching them — 22 rows, no empty cells:**
+
+| # | Route | Declared policy | Where the check lives now | Verified |
+|---|---|---|---|---|
+| 1 | `GET /api/v1/characters/{id}` | `character_scoped` | gate → `enforce_character_scope` (join) | P1, P5, P7; author test |
+| 2 | `GET /api/v1/characters/{id}/summary` | `character_scoped` | gate → `enforce_character_scope`; + inline `ALL/UNASSIGNED` aggregate guard (defence in depth) | code read + gate suite |
+| 3 | `GET /api/v1/characters/{id}/reference_pictures` | `character_scoped` | gate → `enforce_character_scope` | gate suite |
+| 4 | `GET /api/v1/characters/{id}/{field}` | `character_scoped` | gate → `enforce_character_scope` | gate suite |
+| 5 | `GET /api/v1/projects/{project_name}/characters/{character_name}` | `character_scoped`, `resolved_inline` | **inline** `_require_scope_allows_character` (`characters.py:883`) → same helper; lookup narrowed by `character_in_project` | P8 (200 in-scope / 403 out-of-scope) |
+| 6 | `GET /api/v1/picture_sets/{id}` | `set_scoped` | gate → `enforce_set_scope` (join) | P1, P5 |
+| 7 | `GET /api/v1/picture_sets/{id}/thumbnail` | `set_scoped` | gate → `enforce_set_scope` | gate suite |
+| 8 | `GET /api/v1/picture_sets/{id}/members` | `set_scoped` | gate → `enforce_set_scope` | gate suite |
+| 9 | `GET /api/v1/projects/{project_name}/picture_sets/{picture_set_name}` | `set_scoped`, `resolved_inline` | **inline** `_require_scope_allows_picture_set` (`picture_sets.py`) ; lookup narrowed by `picture_set_in_project` | author test |
+| 10 | `GET /api/v1/characters` | `scoped_list` (aware) | handler forces `project_id` to the token's project, then `character_in_project` / `character_in_no_project` | P3 (both `UNASSIGNED` and foreign-id variants return `[]`) |
+| 11 | `GET /api/v1/picture_sets` | `scoped_list` (aware) | handler `scope_set_id_filter` + `picture_set_in_project` / `picture_set_in_no_project` | P1, author test |
+| 12 | `GET /api/v1/picture_sets/locked-members` | `scoped_list` (aware) | handler `scope_project_id` → `picture_set_in_project` (`picture_sets.py:547`) | author test |
+| 13 | `GET /api/v1/projects/{id_or_name}/picture_sets` | `project_scoped`, `resolved_inline` | **inline** `_require_scope_allows_project` **before** the listing query (`projects.py:341-345`) | author test |
+| 14 | `GET /api/v1/projects/{project_id}/summary` | `project_scoped` | gate → `enforce_project_scope`; listing uses `character_in_project` / `picture_set_in_project` (`projects.py:714,720`) | code read |
+| 15 | `GET /api/v1/projects/{id_or_name}` | `project_scoped`, `resolved_inline` | **inline** `_require_scope_allows_project` (unchanged) | code read |
+| 16 | `POST /api/v1/characters/likeness-search` | `scoped_list` (aware) | handler `fetch_scope_allowed_character_ids` (join) | code read |
+| 17 | `GET /api/v1/pictures/{id}/character_likeness` | `picture_scoped` | gate + handler `fetch_scope_allowed_character_ids` (join) | code read |
+| 18 | `GET /api/v1/pictures/{id}/metadata` (`locked_by_sets` name redaction) | `picture_scoped` | gate + handler `fetch_scope_allowed_set_ids` (join), `_crud.py:793` | **P2** — a P1-only locked set's name is **not** disclosed to a P2 token |
+| 19 | `GET /api/v1/pictures` (`character_id=UNASSIGNED` branch) | `scoped_list` (aware) | `fetch_scope_allowed_picture_ids` narrows ids **before** `build_unassigned_conditions` (`_listing.py:823-846`) | P3 |
+| 20 | `GET /api/v1/pictures/search`, `_misc` stack-assignment, `picture_stats` (`UNASSIGNED` branches) | `scoped_list` (aware) | same id-narrowing chokepoint; `build_unassigned_conditions` now uses `character_in_no_project` / `picture_set_in_no_project` | code read + P3 |
+| 21 | Write paths: `POST/PATCH /characters`, `POST/PATCH /picture_sets`, `DELETE /projects/{id}` | `owner_only` | gate → `require_unscoped_owner`; middleware also blocks non-GET for every READ (⇒ every resource-scoped) token | author tests + P4 |
+| 22 | Snapshot restore (`resource_restore.py`) | `owner_only` (snapshots routes) | gate; membership rows rebuilt from the snapshot, skipping projects absent live | author test `tests/test_restore.py` |
+
+**Registry delta: zero.** No route was added, removed or re-declared by this
+branch (`git diff develop...HEAD -- pixlstash/authz/registry.py` is empty), so the
+coverage-matrix arithmetic in `docs/reviews/authz-coverage-matrix.md` is unchanged
+and remains correct. What changed is the *semantics inside* two `*_SCOPED`
+branches, which §16.1 of `docs/backend_architecture.md` now documents.
+
+### 1.3 Input-space traversal
+
+Every variant named in the review brief was exercised:
+
+| Vector | Result |
+|---|---|
+| `character_id=UNASSIGNED` | narrowed by `fetch_scope_allowed_picture_ids` before the unassigned query; `[]` for an unrelated project token (P3) |
+| `project_id=UNASSIGNED` on `/characters` | handler **forces** `project_id` to the token's project for a project token, so `UNASSIGNED` is unreachable; `[]` (P3) |
+| `project_id=UNASSIGNED` + `character_id=UNASSIGNED` on `/pictures` | `[]` (P3) |
+| `?token=` query param vs `Authorization:` header | identical scope decisions — 200 in-scope, 403 out-of-scope (P7) |
+| by-name vs by-id siblings | both enforce; by-name via the inline check (P8), by-id via the gate (P1) |
+| list vs single-item vs `{field}` | all covered, rows 1-15 above |
+| Character-scoped token on `/characters?project_id=<foreign>` | returns only its own character (scope filter is an `AND`, not a replacement) — no leak (P3) |
+| FK/join divergence (drift) | **fail-closed** — see P5 |
+| Entity delete → recycled id | join rows cascade-delete (`PRAGMA foreign_keys=ON`, `database.py:514`); a re-created character does **not** inherit membership (P4) |
+
+### 1.4 Adversarial probes (written by this reviewer, run on a live server)
+
+All eight passed. Raw output:
+
+```
+PROBE project_ids via project-P2 token: [1, 2]        <- FINDING R1
+PROBE project_ids via character token: [1, 2]         <- FINDING R1
+PROBE set project_ids via P2 token: [1, 2]            <- FINDING R1
+PROBE /characters list via P2 token: [{... 'project_id': 1, 'project_ids': [1, 2] ...}]
+PROBE /picture_sets list via P2 token: [(1, 'SharedSet', [1, 2])]
+PROBE locked_by_sets seen by P2 token: set()          <- redaction OK
+PROBE /characters?project_id=UNASSIGNED via P3: 200 []
+PROBE pictures UNASSIGNED/UNASSIGNED via P3: 200 []
+PROBE membership rows before delete: [(1, 1), (1, 2)]
+PROBE membership rows after delete: []                <- cascade OK
+PROBE deleted char via P2 token: 403
+PROBE recycled character id: 3 (deleted was 1)        <- no id reuse; no inherited membership
+PROBE recycled char via P2 token: 403
+PROBE forced Character.project_id -> 3
+PROBE FK-drifted char via P3 token: 403               <- drift is UNDER-grant
+PROBE FK-drifted set via P3 token: 403                <- drift is UNDER-grant
+PROBE pic_a via P2 token after set left P2: 403       <- revocation propagates
+PROBE ?token= P2 on shared char: 200
+PROBE ?token= P3 on shared char: 403
+PROBE by-name via P1 name with P2 token: 200
+PROBE by-name via P1 name with P3 token: 403
+PROBE oracle: existing project -> 404 {"detail":"Character not found"}
+PROBE oracle: missing project -> 404 {"detail":"Project not found"}
+8 passed in 38.36s
+```
+
+Separate propagation probe:
+
+```
+PROBE P1 token: pic_a(added before assignment)=200 pic_b(added after assignment)=200
+PROBE P2 token: pic_a(added before assignment)=200 pic_b(added after assignment)=403   <- FINDING R2
+PROBE owner ?project_id=P2 picture ids: [1] (expected both 1 2)                        <- FINDING R2
+1 passed in 4.60s
+```
+
+### 1.5 Findings
+
+---
+
+#### R1 — Scoped share tokens learn the ids of projects they have no grant for
+
+- **Severity:** LOW (confidentiality; information disclosure, CWE-200). **Required before merge** — the fix is small and the regression is a clean break of the share model's own promise.
+- **Location:** `pixlstash/routes/characters.py:1193-1211` (list), `:846`, `:877`; `pixlstash/routes/picture_sets.py:459-470` (list), `:604`, `:1149`, `:1200`, `:1276`.
+- **Exploit:** the holder of a **project**- or **character**- or **set**-scoped READ share token reads any entity it is legitimately granted and receives `project_ids`, the *complete* membership list. Nothing filters it to the projects the token may see. The recipient of a link to one character learns how many other projects that character is filed under, and their numeric ids — facts obtainable from no other endpoint available to that token (`GET /projects/{other_id}` is `project_scoped` and 403s).
+- **Evidence:** probe P1. A token scoped to project **2** reading character 1 gets `"project_ids": [1, 2]`; a token scoped to **character 1** gets the same. The list routes repeat it (`/characters`, `/picture_sets`).
+- **Fix:** intersect `project_ids` with the token's visible projects before serialising — for a `project` token that is `[scope.resource_id]`; for a `character`/`picture_set`/`picture` token it is `[]` (they have no project visibility at all, exactly the ladder `fetch_scope_allowed_set_ids` already implements). Owner/unscoped (`token_scope is None`) keeps the full list. The cleanest home is a small `visible_project_ids(server, request)` helper next to the other `fetch_scope_allowed_*` functions, so this becomes one call at each of the 8 serialisation sites rather than an inline ladder.
+- **Verification:** a both-direction test — owner sees `[P1, P2]`, a P2 token sees `[P2]`, and (over-blocking is its own regression) a P2 token still gets the entity itself with 200.
+
+---
+
+#### R2 — A picture added to an already-multi-project set/character joins only the **primary** project
+
+- **Severity:** LOW security (this is an **under**-grant, never a leak) / **HIGH functional**. **Required before merge** — the feature's headline use case is silently broken and the failure is invisible to the operator.
+- **Location:** `pixlstash/routes/picture_sets.py:1597-1612` (add one member), `:1752-1765` (bulk add), `:1837-1850` (`PUT` replace); `pixlstash/routes/characters_faces.py:211-228` (assign face → character); `pixlstash/tasks/picture_import_task.py:333-345` and `:382-394` (import into a set / character).
+- **Exploit / impact:** these six sites still read the scalar `picture_set.project_id` / `character.project_id` — the *primary* project — to decide which `PictureProjectMember` row to create. For an entity in `{P1, P2}` the picture joins **P1 only**. The owner believes the picture is shared with P2 (the set is), the P2 share-token holder gets a 403, and the owner's own `?project_id=P2` filter omits it. It is the exact mistake `db_models/entity_project.py` warns about ("Comparing the FK is now a bug"), on the write-propagation side rather than the read side. `picture_sets.py:1611` additionally re-points `picture.project_id` at the primary project unconditionally.
+- **Evidence:** propagation probe. Set `S` assigned to `{P1, P2}`; `pic_b` added afterwards. P1 token: 200. P2 token: **403**. Owner `GET /pictures?project_id=P2` returns `[1]`, missing `pic_b`.
+- **Fix:** replace the FK read at each site with `picture_set_project_ids(session, set_id)` / `character_project_ids(session, character_id)` and call `reconcile_entity_projects_change(..., ensure_project_ids=<all>, remove_project_ids=[])` — the service already does exactly this and is already imported by both route modules. The `picture.project_id` re-point should use the lowest member id, matching `reconcile_entity_projects_change` step 3.
+- **Verification:** extend `tests/test_multi_project_membership_authz.py` with the probe above — add a member *after* the multi-project assignment and assert 200 for **both** project tokens, plus the owner's `?project_id=` filter returning it for both.
+
+---
+
+#### X1 — Two branches both add migration `0086` on top of `0085` (Alembic will have two heads)
+
+- **Severity:** MEDIUM release/operational (not security). **Blocks whichever of #629 / #626 merges second.**
+- **Location:** `pixlstash/migrations/versions/0086_add_entity_project_membership.py` (`revision="0086_add_entity_project_membership"`, `down_revision="0085_..."`) and, on `feature/operation-log`, `pixlstash/migrations/versions/0086_add_operation_log.py` (`revision="0086_add_operation_log"`, same `down_revision`).
+- **Impact:** after both merge, `alembic upgrade head` fails with multiple head revisions and the server cannot boot. CLAUDE.md's Alembic rule ("place schema upgrade steps in strictly increasing version order") is violated by the pair, not by either alone.
+- **Fix:** the second branch to merge renumbers to `0087_*` and re-points `down_revision` at the first branch's `0086_*`. Both migrations are on feature branches, so amending is explicitly allowed by CLAUDE.md.
+- **Same class, docs:** `feature/remix-v1` and `feature/dedup-sweep-backend` each rewrite the coverage matrix's "Arithmetic completeness" line to **219**, and `feature/operation-log` to **224**. All three are correct in isolation and wrong in combination (`217 + 2 + 2 + 7 = 228`). A naive conflict resolution will leave the matrix arithmetically wrong — precisely the failure the matrix exists to prevent. **Required:** whoever merges last re-derives the totals and the per-policy distribution from `ROUTE_POLICIES` rather than merging the prose.
+
+---
+
+#### O1 — Project-name existence oracle on the by-name routes (pre-existing, **not** introduced here)
+
+- **Severity:** INFORMATIONAL. No action required for v1.9.
+- **Location:** `pixlstash/routes/characters.py:862-878`, `pixlstash/routes/picture_sets.py:586-600`.
+- **Detail:** the project name→row lookup runs *before* any scope check, and the two 404s differ: `{"detail":"Project not found"}` vs `{"detail":"Character not found"}`. A scoped token can therefore enumerate project *names*. Reproduced (probe P8). Present identically on `develop`; this branch changes only the entity lookup that follows. Recorded so it is not mistaken for new.
+
+---
+
+#### O2 — Character names on `POST /pictures/thumbnails` are not scope-filtered (**not reproduced**)
+
+- **Severity:** unrated — **this reviewer could not reproduce it** and is not claiming it.
+- **Location:** `pixlstash/routes/pictures/_thumbnails.py:479-490`.
+- **Detail:** the batch thumbnail handler correctly narrows the *picture ids* through `fetch_scope_allowed_picture_ids` (`:346`), then builds `character_name_map` from every `face.character_id` on those pictures with **no** `fetch_scope_allowed_character_ids` filter — unlike the `locked_by_sets` name redaction two files away, which exists for exactly this reason. On paper a project-scoped token reading an in-scope picture would learn the name of an out-of-scope character assigned to a face on it. **Two probe attempts failed to produce a detected face in the CPU test fixtures, so the leak was never observed.** The code path is unchanged by #125 (it is on `develop` too), so this is a follow-up for the pictures owner to confirm or refute — not a gate on any of these four PRs. It is written down because §"Mind the decomposition seams" says a risk class that spans files must not fall between mandates.
+
+### 1.6 Adjudication of the author's declared risks
+
+| # | Author's risk | Ruling |
+|---|---|---|
+| (a) | No machine guard against future code writing `Character.project_id` / `PictureSet.project_id` directly, hiding entities from reads | **Accepted risk — a guardrail test is NOT required before merge, but IS required before the FK is dropped.** Measured, not assumed: probe P5 forced `Character.project_id = P3` and `PictureSet.project_id = P3` with no join row, and the P3 token was **403** on both while the legitimate P2 token stayed 200. Drift is therefore **fail-closed**: the failure mode is data-hiding, never a BOLA. That is the safe direction and it is why this does not block. **However** — finding R2 shows the drift is not hypothetical, it is *already present* in six write paths on this very branch. So: fix R2 (required), and add the guardrail as hardening. Recommended shape: extend `tests/test_architecture_guardrails.py` with an AST check that assignment to `Character.project_id` / `PictureSet.project_id` occurs only in `services/project_membership_service.py` and the `DELETE /projects/{id}` re-derivation in `routes/projects.py`, and a companion check that no module outside `db_models/entity_project.py` compares those columns. Owner: backend/auth maintainer. Revisit: **mandatory at the FK-removal release (post-1.12)**. |
+| (b) | Cross-project name uniqueness is app-level only for secondary projects | **Accepted risk.** Not a security property — no authorization decision anywhere reads an entity *name*, and the by-name routes resolve to an id and then run the normal scope check (probe P8 confirms the 403). The consequence of a race is a duplicate name inside a project, i.e. a UX defect. Compensating control: `_ensure_unique_character_name` / `_ensure_unique_set_name` now check every target project inside the same transaction as the write. Owner: backend maintainer. Revisit: if a DB-level unique constraint is ever added for the join. |
+| (c) | Restore drops memberships of non-restored projects with a warning | **Accepted risk, with one addition.** The behaviour is correct (an FK to an absent project cannot be written) and is logged loudly (the `logger.warning` in
+`resource_restore.py::_restore_parent_rows`). The addition the record needs: membership restore is **merge-only** — `_restore_parent_rows` adds snapshot memberships and never prunes live ones, so restoring a deleted character re-grants every project it was in at snapshot time, including one the owner had deliberately removed it from. That is defensible restore semantics, but it means **membership removal is not a durable revocation**. Compensating control: it is owner-initiated and owner-only (`snapshots` routes are `owner_only`). **Required documentation, not a code change:** state in the sharing docs that revoking a share is done by deleting the token, never by moving an entity out of a project. Owner: backend/restore maintainer. Revisit: next snapshot/restore change. |
+
+---
+
+## 2. `feature/operation-log` (PR #626) — **APPROVE**
+
+**Scope-declaration audit.** 7 new routes, all `OWNER_ONLY`, all mounted through
+`include_router(..., dependencies=gate)` (`server.py:1104-1109`). Declarations
+reviewed line by line against the handlers; the coverage matrix is updated with a
+dedicated `operations.py` section and the arithmetic (`owner_only` 83 → 90, total
+224). Two guardrail tests pin the declarations and the absence of inline authz.
+
+**The three questions in the brief, answered:**
+
+1. **Can a scoped share token read `GET /operations/{id}`'s before/after state?**
+   No. `OWNER_ONLY` resolves to `AuthService.require_unscoped_owner`
+   (`auth.py:909-928`), which rejects on `request.state.token_scope is not None`
+   — every resource-scoped token — *and* on `matched_token.resource_type is not
+   None`. Both legs fire before the handler body.
+2. **Can undo/redo be driven by a scoped token?** No, twice over. The gate denies
+   it, and independently the middleware blocks every non-GET for a READ token
+   unless the path is in `READ_SAFE_POST_PATHS` (`auth.py:79-96`) — which this
+   branch does not touch (empty diff on `auth.py`) and which contains no
+   `/operations` entry. Every resource-scoped token is a READ token by
+   construction (`ALL`+`resource_type` is refused at mint and rejected at the
+   middleware, §16.2 item 4).
+3. **Can undo move data across a scope boundary?** Not by a scoped caller — it
+   cannot reach the endpoint. See N1 for what an *owner's* undo can do.
+
+**N1 (LOW, accepted-risk to record).** `apply_state_in_session` restores
+`FACET_SETS`, `FACET_PROJECTS` and `FACET_PROJECT_ID`
+(the facet dispatch in `services/operation_log_service.py::apply_state_in_session`,
+around lines 608-636). An owner who revoked a share
+token's reach by removing a picture from a set or project can therefore
+**re-grant it by pressing Ctrl+Z**, with no warning. Blast radius: one already-issued
+share token regains pictures it previously had. Compensating control: owner-only,
+explicit, and reversible by redo. **This is the same class as primary-branch risk
+(c) and takes the same remedy — one sentence in the sharing documentation that
+revocation means deleting the token.** Owner: backend maintainer. Revisit: when
+share-link management next changes.
+
+**N2 (INFORMATIONAL).** `OWNER_ONLY` rejects *resource-scoped* tokens but admits
+an **unscoped `READ`** token, so such a token can read the vault-wide change
+history including recorded before/after metadata. This is the pre-existing
+"unscoped-READ nuance" the matrix already flags for `reviews` and `tag_health`,
+and an unscoped READ token can already read every picture and its metadata
+directly, so the marginal disclosure is small. Consistent with precedent — no
+change required. If the team wants it tightened, `/api/v1/operations` belongs in
+`READ_BLOCKED_GET_PATHS`, alongside the other "not content, but configuration and
+history" GETs.
+
+**X1 applies** (migration `0086` collision with #629).
+
+---
+
+## 3. `feature/remix-v1` (PR #627) — **APPROVE-WITH-REQUIRED-CHANGES**
+
+**Scope-declaration audit.** 2 new routes:
+`GET /api/v1/comfyui/pictures/{picture_id}/recipe` → `PICTURE_SCOPED`,
+`id_param="picture_id"`; `POST /api/v1/comfyui/run_recipe` → `PICTURE_SCOPED`,
+`body_ids="picture_id"`. Both are the correct policy and mirror the existing
+`/comfyui/pictures/{id}/workflow` and `run_i2i` siblings. The matrix is updated
+(`picture_scoped` 33 → 35, total 219). Both directions are tested
+(four tests appended to `tests/test_picture_mutation_scope.py`): scoped token 403 on both routes;
+owner reaches both and fails for the *real* reason, asserted by exact status and
+message rather than a bare `!= 403`.
+
+**The claim to refute — "run_recipe re-extracts the graph server-side on every
+call and never accepts a client-supplied graph" — is TRUE.** Verified by reading
+the whole `run_comfyui_recipe` handler: the graph comes only from
+`_load_embedded_api_prompt(server, pic_id)`, which resolves the picture's on-disk
+path and reads its embedded metadata. The request body is consumed for exactly
+`picture_id`, `client_id`/`clientId`, `stack`, `seed_mode`, `seed`, and the
+pre-existing `_extract_output_node_ids` node-id selection. There is no code path
+by which a caller-supplied graph, node, or input value enters the submitted
+prompt.
+
+**Outputs-land-in-source-stack path:** `get_or_create_stack_for_picture(pic_id)`
+and `_process_comfyui_outputs(..., stack_id, pic_id, is_i2i=True)` — byte-identical
+to `run_i2i`, which copies the source's character/set/project associations onto
+the outputs. Since only an unscoped owner can reach the endpoint, no scope
+boundary is crossed. No finding.
+
+**Recipe-endpoint metadata:** `positive_prompt`, `models`, `loras`, `seed`,
+`node_count`, `seed_inputs` — all derived from the scoped picture's own file, and
+strictly less than what the already-shipped `PICTURE_SCOPED`
+`/comfyui/pictures/{id}/workflow` returns for the same token. No finding.
+
+---
+
+#### R3 — Untrusted file metadata is executed as a ComfyUI graph on one click, with no graph disclosure
+
+- **Severity:** MEDIUM (CWE-829, inclusion of functionality from an untrusted control sphere; OWASP A08 software & data integrity failures). **Required before merge.**
+- **Location:** `pixlstash/routes/comfyui.py::run_comfyui_recipe` (`workflow_instance = sanitize_prompt_graph(prompt_graph)` → `_submit_comfyui_prompt`); `pixlstash/services/comfyui_recipe_service.py:537` (`sanitize_prompt_graph`); `frontend/src/components/io/RemixDialog.vue:122-140`.
+- **Exploit:** the graph is authored by whoever made the image file, not by the owner. PixlStash's whole premise is importing images from elsewhere — watch folders, uploads, downloads from model sites. An attacker publishes an attractive PNG whose `prompt` chunk carries an arbitrary API-format graph; the owner imports it and clicks "Generate from this"; PixlStash submits the attacker's graph to the owner's ComfyUI. What that graph can do is bounded only by which node packs the owner has installed — file reads/writes via loader and save nodes, outbound fetches, and outright code execution with several popular packs.
+- **Why the existing controls do not close it:** `sanitize_prompt_graph` is a **shape** filter only — it drops non-node top-level entries and `pixlstash_*` keys and deep-copies the rest; there is no node-class allowlist and no input validation. `preflight_prompt` is explicitly documented as *advisory*, and when ComfyUI is unreachable `unchecked_preflight` returns `ok=True`, so the run proceeds unchecked. The confirm dialog shows only the positive prompt, model names, LoRA names and a node **count** — the owner never sees *which* node classes will run.
+- **Evidence:** code read of the full submit path plus `sanitize_prompt_graph` (quoted above) and the dialog template. Not exercised end-to-end — doing so would require standing up a ComfyUI instance, which is out of scope for a review and would mean building the attack rather than describing it.
+- **Fix (smallest that closes the decision gap):**
+  1. Surface the **distinct `class_type` list** in the recipe response and render it in the confirm dialog — the owner is the only trust anchor and currently cannot see what they are approving.
+  2. Refuse to run when `preflight.checked is False` (ComfyUI unreachable ⇒ the graph was never inspected) unless the user explicitly overrides; today an unreachable ComfyUI silently becomes "ok".
+  3. Mark recipes whose source picture was **imported** rather than generated by this PixlStash instance, and warn on those specifically.
+- **Verification:** a test asserting the recipe response carries the class list; a test asserting `run_recipe` 400s (or requires an explicit override flag) when the pre-flight is `checked: false`; a UI test that the class list renders before the run button is enabled.
+
+---
+
+#### O3 — Uncached `/object_info` fetch reachable by a picture-scoped share token
+
+- **Severity:** LOW (resource amplification). Hardening, not a blocker.
+- **Location:** `routes/comfyui.py:1044-1049` → `services/comfyui_recipe_service.py:98` (`fetch_object_info`, `OBJECT_INFO_TIMEOUT_S = 15.0`).
+- **Detail:** `GET /comfyui/pictures/{id}/recipe` is `PICTURE_SCOPED`, so a share-link holder can call it. Each call makes an uncached server→ComfyUI HTTP request for the full `/object_info` payload with a 15 s timeout. The URL is the owner's configured `comfyui_url`, so this is **not** SSRF; it is an unauthenticated-by-anyone-with-a-link way to tie up a request slot and hammer the owner's ComfyUI.
+- **Fix:** cache `object_info` per `comfyui_url` with a short TTL (30-60 s), or skip the fetch entirely on the read endpoint when the caller is a scoped token.
+
+---
+
+## 4. `feature/dedup-sweep-backend` (PR #625) — **APPROVE**
+
+**Scope-declaration audit.** 2 new routes, both `OWNER_ONLY` with justifications:
+`GET /api/v1/dedup/sweep/policy`, `POST /api/v1/dedup/sweep/dry-run`. Router
+mounted with `dependencies=gate` (`server.py:1075-1080`). Matrix updated with a
+`dedup.py` section and the arithmetic (`owner_only` 83 → 85, total 219).
+
+**The two questions in the brief, answered:**
+
+1. **Can the dry-run run under any share token?** No, and belt-and-braces. The
+   gate's `OWNER_ONLY` → `require_unscoped_owner` rejects every resource-scoped
+   token; independently the middleware blocks the POST for any READ token
+   (`/api/v1/dedup/sweep/dry-run` is not in `READ_SAFE_POST_PATHS`, which this
+   branch does not modify). Structurally reinforcing: **neither handler takes a
+   `Request` parameter at all** (`routes/dedup.py:389`, `:416`), so there is no
+   inline authz to get wrong and no request state to mis-read — the gate is
+   provably the only decision point.
+2. **Can the report counts be reached another way?** Not through this branch.
+   `plan_near_duplicate_sweep` is called from exactly one place (the dry-run
+   handler); nothing else imports `dedup_sweep_service` into a route. The service
+   is on the `_direct_db_call_service_allowlist` for its vault-injection wrapper,
+   which is an architecture-guardrail concession, not an authz one.
+
+The `operation_batch_id` field is accepted and echoed back verbatim in the JSON
+report. It is inert (a dry run writes nothing) and owner-only, so it is not a
+finding; it is noted only so a future consumer does not render it as HTML.
+
+**Marked correct — no required changes.**
+
+---
+
+## 5. Release blockers, accepted risks, hardening
+
+### Release blockers (must land before the respective PR merges)
+
+| ID | PR | What |
+|---|---|---|
+| R1 | #629 | Filter `project_ids` to the token's visible projects on all 8 serialisation sites, with a both-direction test |
+| R2 | #629 | Six write paths must propagate to **all** member projects, not the primary FK, with a both-direction test |
+| R3 | #627 | Disclose the recipe's node classes before the run; refuse (or require override on) an unchecked pre-flight |
+| X1 | #629 + #626 | Renumber the second `0086` migration to `0087`; re-derive the coverage-matrix totals when the last of #625/#626/#627 merges |
+
+### Accepted risks (recorded per the CLAUDE.md accepted-risk rule)
+
+| ID | Risk | Blast radius | Compensating control | Owner | Revisit |
+|---|---|---|---|---|---|
+| (a) | FK/join drift hides entities | Data invisible to project reads; **never** an over-grant (measured, probe P5) | "write both, read the join" contract documented in §6 and §16.1; fix R2 removes the current instances | backend/auth | **Mandatory at FK removal (post-1.12)** — add the AST guardrail then |
+| (b) | App-level cross-project name uniqueness | Duplicate names inside a project under a race; no authz decision reads a name | in-transaction check across every target project | backend | if a DB-level constraint is added |
+| (c) / N1 | Restore and undo re-grant memberships that were removed | One already-issued share token regains pictures | owner-only, explicit; both are `owner_only` surfaces | backend/restore | next snapshot or share-link change; **document that revocation = delete the token** |
+| N2 | Unscoped `READ` token can read `/operations*` | Vault change history to a token that can already read every picture | consistent with `reviews` / `tag_health` precedent | backend/auth | if `READ_BLOCKED_GET_PATHS` is next revisited |
+
+### Hardening that can wait
+
+- **O2** — confirm or refute the unfiltered `character_name_map` on
+  `POST /pictures/thumbnails` (`_thumbnails.py:479-490`) and, if confirmed, route
+  it through `fetch_scope_allowed_character_ids` as `locked_by_sets` already is.
+  Pre-existing on `develop`; owner is the pictures maintainer, not any of these
+  four PRs.
+- **O3** — cache ComfyUI `/object_info` per URL with a short TTL.
+- **O1** — equalise the by-name 404s so a scoped token cannot enumerate project
+  names. Pre-existing; retire it together with the shared name→id resolver that
+  §16.1 says will remove the four `resolved_inline` exceptions.
+
+## 6. Tests run
+
+All on `feature/125-multi-project-membership` @ `70d5fc14` unless noted, with
+`PYTHONPATH=<worktree> .venv/bin/python -m pytest -s --fast-captions --force-cpu`.
+
+| Suite | Result |
+|---|---|
+| `tests/test_multi_project_membership_authz.py` + `tests/test_project_membership_service.py` | **35 passed** in 84.26s |
+| `tests/test_read_token_security.py`, `test_picture_mutation_scope.py`, `test_architecture_guardrails.py`, `test_authz_gate_step3.py`, `test_authz_gate_step4.py`, `test_authz_host_capability_16_3.py` | **157 passed** in 480.94s |
+| Reviewer's adversarial probe suite (8 probes, P1-P8) | **8 passed** in 38.36s |
+| Reviewer's secondary-project propagation probe | **1 passed** in 4.60s — reproduced R2 |
+| Reviewer's character-name probe (O2) | **skipped** — no face detected in the CPU fixtures; finding therefore **not** claimed |
+
+The probe files were deliberately not committed: they are throwaway attack
+scripts, and the durable versions belong in
+`tests/test_multi_project_membership_authz.py` as part of the R1/R2 fixes, written
+by someone other than this reviewer.

--- a/docs/reviews/v1.9-authz-signoff.md
+++ b/docs/reviews/v1.9-authz-signoff.md
@@ -9,9 +9,10 @@
   - `feature/dedup-sweep-backend` (PR #625)
 - **Method:** each branch checked out detached, diffed with `git diff develop...<branch>`, read in full for the authz-relevant surface, then exercised with the shipped both-direction suites **plus** eight purpose-written adversarial probes on a live server. Every finding below was reproduced against running code before it was written down; the two observations that could **not** be reproduced are labelled as such and are not counted as findings.
 
-> **FINAL VERDICTS ARE IN §7 (Re-verification, 2026-07-28, round 2).** The table
-> immediately below is the *first-round* verdict that produced the required
-> changes; it is kept for the record. §7 certifies the fixes.
+> **FINAL VERDICTS ARE IN §8 (round 3, 2026-07-29): all four branches APPROVE,
+> unconditional.** §7 is the round-2 pass that certified R1/R2/R3 and raised the
+> two residuals R1b/R3b; §8 certifies those. The table immediately below is the
+> *first-round* verdict that produced the required changes, kept for the record.
 
 ## Verdicts (round 1 — superseded by §7)
 
@@ -645,3 +646,146 @@ guardrail stays *hardening*, mandatory at FK removal (post-1.12).
 Both reviewer probe files were deleted rather than committed, as in round 1; the
 durable assertions belong in the authors' suites (see the Verification lines under
 R1b and R3b).
+
+---
+
+## 8. Final certification (round 3, 2026-07-29) — R1b and R3b
+
+Targeted pass on the two residuals from §7. **Both fixes were authored by the
+orchestrator, not by this reviewer**, so the independence requirement holds. As in
+round 2, nothing was taken on the author's word: each fix was re-derived from the
+code, exercised with fresh probes, and **mutated** to prove its durable test fails
+without it.
+
+### 8.1 Final verdicts — all four branches
+
+| Branch | PR | Head certified | Verdict |
+|---|---|---|---|
+| `feature/125-multi-project-membership` | #629 | `c58133f1` | **APPROVE** — unconditional |
+| `feature/operation-log` | #626 | `8a966562` | **APPROVE** |
+| `feature/remix-v1` | #627 | `d492f6cd` | **APPROVE** — unconditional |
+| `feature/dedup-sweep-backend` | #625 | `d58200aa` | **APPROVE** |
+
+**No BLOCK, and no outstanding required change on any branch.** Every finding
+raised in rounds 1 and 2 (R1, R1b, R2, R3, R3b) is closed, enforced server-side,
+and pinned by a test that fails when the fix is removed. X1 (the `0086` migration
+collision between #629 and #626, and the coverage-matrix totals across #625/#626/#627)
+is unchanged and remains a **merge-order** obligation on whoever merges last — it
+is not a defect on any branch.
+
+### 8.2 R1b — **CLOSED**
+
+`narrow_project_fields(payload, project_ids, visible)`
+(`filter_helpers.py:510-535`) sets `project_ids` to the narrowed list *and*
+derives `project_id` from it (`narrowed[0] if narrowed else None`), so the scalar
+can never name a project outside the caller's grant. It replaces the bare
+`filter_visible_project_ids` assignment at every site.
+
+**It also fixes two sites this reviewer's R1b location list missed.** The
+`SMART_SCORE` and `CHARACTER_LIKENESS` sort variants of `GET /picture_sets/{id}`
+build their `set` payload on their own `return` statements and previously
+serialised `safe_model_dict(picture_set)` **raw** — no `project_ids` key at all
+and an unnarrowed scalar. Recorded plainly: my round-2 enumeration of the
+serialisation sites was incomplete, and the author found the gap. Re-verified that
+the enumeration is now complete: all four return branches of that handler
+(`info` at `picture_sets.py:1225`, `SMART_SCORE` at `:1247`, `CHARACTER_LIKENESS`
+at `:1272`, default at `:1310`) go through `narrow_project_fields`, and no
+`safe_model_dict(picture_set)` / `picture_set.dict()` reaches a response without
+it except `create_picture_set` (`:769`), which is `OWNER_ONLY`.
+
+Probe across 9 payload sites × 4 principals:
+
+```
+V1b      owner char.by_id/list/by_name        project_id=1    project_ids=[1, 2]
+V1b      owner set.info/default/smart_sort/likeness_sort/list/by_name
+                                              project_id=1    project_ids=[1, 2]
+V1b   P2-token char.by_id/list/by_name        project_id=2    project_ids=[2]
+V1b   P2-token set.info/default/smart_sort/likeness_sort/list/by_name
+                                              project_id=2    project_ids=[2]
+V1b char-token char.by_id/list/by_name        project_id=None project_ids=[]
+V1b char-token set.*                          HTTP 403 / not listed
+V1b  set-token set.info/default/smart_sort/likeness_sort/list/by_name
+                                              project_id=None project_ids=[]
+V1b  set-token char.*                         HTTP 403 / not listed
+1 passed in 4.78s
+```
+
+All three directions hold: the owner is not narrowed (`project_id=1`,
+`project_ids=[1,2]`), the project token sees only its own id in **both** fields,
+the entity tokens see `None`/`[]` — and each entity token still reaches its own
+entity, so the narrowing did not become a refusal.
+
+**On the untested `CHARACTER_LIKENESS` sibling — the concern is unfounded, and it
+should simply be tested.** The author's note says that branch needs face data. It
+does not, for this assertion: the probe above exercised
+`?sort=CHARACTER_LIKENESS&reference_character_id=<id>` on a fixture with **no face
+embeddings at all**, got 200 on every principal, and the `set` payload was
+narrowed correctly in all four rows. The branch builds its `set` payload
+unconditionally; only the `pictures` ordering depends on face data. **Recommended
+(hardening, not a gate):** add the one line to `_set_payloads` in
+`test_scalar_project_id_is_derived_from_the_narrowed_list` so the sibling is
+covered rather than accepted-untested — the two call sites are byte-identical
+today, but "identical today, 20 lines apart, one tested" is exactly the shape that
+drifts.
+
+**Vacuity:** stubbing the scalar derivation out of `narrow_project_fields` (leaving
+`project_ids` narrowing intact) →
+`FAILED test_scalar_project_id_is_derived_from_the_narrowed_list`, 23 deselected.
+The test is load-bearing. Mutation reverted; tree clean.
+
+### 8.3 R3b — **CLOSED**
+
+`routes/comfyui.py:1127-1131` now requires the literal JSON `true`:
+`payload.get("allow_unchecked") is True or payload.get("allowUnchecked") is True`.
+
+Probe sweeping 15 values × both spellings against an unreachable ComfyUI, with the
+submit call captured:
+
+```
+R3b allow_unchecked / allowUnchecked = 'false' 'true' 'True' '0' '1' 'yes'
+                                       1  1.0  [True]  {'v': True}  {}  []
+                                       None  False  0            -> 400  (all 30)
+submissions after all 30 refusals: []
+R3b allow_unchecked=True (literal)                                -> 200 (1 submission)
+R3b allowUnchecked=True  (literal)                                -> 200 (1 submission)
+1 passed in 3.86s
+```
+
+The round-2 reproduction (`{"allow_unchecked": "false"}` → 200 + a submission) now
+refuses with 400 and **zero** submissions. Note the strictness extends past the
+reported case: the integer `1` and the truthy containers `[True]` / `{"v": True}`
+are refused too, so no JSON shape other than a real boolean reads as consent.
+Both spellings of the literal `true` still run it, so the gate did not become
+over-blocking.
+
+**Vacuity:** reverting the check to the original
+`bool(payload.get(...) or payload.get(...))` →
+`FAILED TestRunRecipeRefusesAnUncheckedPreflight::test_only_the_literal_true_is_consent`,
+10 deselected. Mutation reverted; tree clean.
+
+### 8.4 Standing items after certification
+
+Nothing blocks. Carried forward unchanged:
+
+- **X1** — merge-order only: renumber the second `0086` migration to `0087`, and
+  re-derive the coverage-matrix totals from `ROUTE_POLICIES` when the last of
+  #625/#626/#627 merges (`217 + 2 + 2 + 7 = 228`).
+- **Accepted risks** (a), (b), (c)/N1, N2 from §1.6 / §2, and R3-res / R3.3 from
+  §7.6 — all still stand with their recorded owners and revisit triggers.
+- **Hardening backlog** — O1 (by-name project-name oracle), O2 (unconfirmed
+  `character_name_map` scope filter on `POST /pictures/thumbnails`), O3 (uncached
+  `/object_info` fetch), the FK-drift AST guardrail (mandatory at FK removal,
+  post-1.12), and the `CHARACTER_LIKENESS` test line from §8.2.
+
+### 8.5 Tests re-run in round 3
+
+| Suite / probe | Branch | Result |
+|---|---|---|
+| `tests/test_multi_project_membership_authz.py` + `tests/test_project_membership_service.py` | #629 `c58133f1` | **44 passed** in 126.66s (was 43) |
+| Mutation — scalar derivation removed from `narrow_project_fields` | #629 | **1 failed, 23 deselected** in 4.65s (non-vacuity proven) |
+| Reviewer's R1b probe (9 payload sites × 4 principals) | #629 | **1 passed** in 4.78s |
+| `tests/test_comfyui_recipe_route.py` + `test_comfyui_recipe_preflight.py` + `test_picture_mutation_scope.py` | #627 `d492f6cd` | **85 passed** in 157.02s (was 84) |
+| Mutation — `allow_unchecked` back to loose truthiness | #627 | **1 failed, 10 deselected** in 2.92s (non-vacuity proven) |
+| Reviewer's R3b probe (30 refusals + 2 literal-true runs) | #627 | **1 passed** in 3.86s |
+
+Reviewer probe files deleted, not committed, as in rounds 1 and 2.


### PR DESCRIPTION
Independent adversarial CSO review of the four v1.9 lanes. Verdicts: #625 APPROVE, #626 APPROVE, #629 and #627 APPROVE-WITH-REQUIRED-CHANGES. Full coverage matrix, findings with reproductions, and adjudicated accepted risks in docs/reviews/v1.9-authz-signoff.md.

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U