### PR TITLE
Make moves to the Scrapheap undoable

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1513,7 +1513,7 @@ Instead of teaching each mutating endpoint how to invert itself, the log snapsho
 - The stored payload is exactly the `{before, after}` shape the roadmap specifies for the audit log, so the feed needs no second representation.
 - Restoring is idempotent: applying a state twice is a no-op, so a retried undo cannot corrupt anything.
 
-**Reversible facets** (the DAM 1.2 metadata scope, `FACETS` in [services/operation_log_service.py](../pixlstash/services/operation_log_service.py)): tags, description/caption, score (rating), picture-set membership, project membership (`PictureProjectMember` + the `Picture.project_id` FK), per-face character assignment + `pending_character_id`, and stacking (`stack_id` / `stack_position`, with the stack's name so a dissolved stack can be recreated on undo). A file-mutating operation may be *recorded* with `undoable=False` for audit, but it is not reversible until copy-on-write versions land (v2.1).
+**Reversible facets** (the DAM 1.2 metadata scope, `FACETS` in [services/operation_log_service.py](../pixlstash/services/operation_log_service.py)): tags, description/caption, score (rating), picture-set membership, project membership (`PictureProjectMember` + the `Picture.project_id` FK), per-face character assignment + `pending_character_id`, stacking (`stack_id` / `stack_position`, with the stack's name so a dissolved stack can be recreated on undo), and the scrapheap soft-delete state (`deleted` + `deleted_at`, see §21.1). A file-mutating operation may be *recorded* with `undoable=False` for audit, but it is not reversible until copy-on-write versions land (v2.1).
 
 ### Recording a change
 
@@ -1538,6 +1538,31 @@ A locked picture set is a hard freeze on its members' label data. `apply_state_i
 ### Endpoints and authorization
 
 `GET /operations`, `GET /operations/undo-state`, `GET /operations/{operation_id}`, `POST /operations/undo`, `POST /operations/redo`, `POST /operations/{operation_id}/undo`, `POST /operations/batches/{batch_id}/undo` — all declared **`OWNER_ONLY`** in `ROUTE_POLICIES` (§16.1). The log enumerates every change to the whole library and undo writes metadata back onto arbitrary pictures across the vault, so no resource-scoped grant can bound either. The handlers carry **no** authorization code; the gate is the sole enforcement.
+
+### 21.1 The Scrapheap is undoable; a permanent delete is not
+
+A move to the Scrapheap is a *metadata* change — the file is untouched — so it goes through the same state-capture machinery as everything else rather than getting bespoke inverse logic. The soft-delete flag and its retention stamp are one facet, `deleted`, recorded as `{"deleted": bool, "deleted_at": "<naive-UTC ISO>" | null}`. They travel together deliberately: restoring the flag without the stamp would either lose the purge deadline or leave a live picture carrying a stale one. `deleted_at` is written back **verbatim**, never re-stamped to "now", so an undo cannot silently extend (or invent) a retention window.
+
+**Op types** (`OP_SCRAPHEAP_MOVE` / `OP_SCRAPHEAP_RESTORE` — stable, part of the API contract the frontend keys its affordances off):
+
+| `op_type` | Recorded by | Undo | Redo | `summary` |
+|---|---|---|---|---|
+| `pictures.scrapheap.move` | `DELETE /pictures/{id}` (single) and `DELETE /pictures` (bulk, one row + a `batch_id`) | restores the pictures | moves them back, same `deleted_at` | "Moved 5 pictures to the Scrapheap" |
+| `pictures.scrapheap.restore` | `POST /pictures/scrapheap/restore` (one row + a `batch_id`) | returns them to the Scrapheap with the stamp they had | restores them again | "Restored 5 pictures from the Scrapheap" |
+
+The two are symmetric on purpose: without the restore side, undoing a restore would be impossible and the history stack would have a hole in it.
+
+Summaries are built from the **recorded diff**, not from the request — `summary` accepts a `(before_delta, after_delta) -> str | None` builder (`SummarySpec`) evaluated inside `record_operation_in_session` once the real extent of the change is known. A bulk move silently skips pictures frozen by a locked set, and "restore everything" never names an id at all, so counting the request would produce a toast that lies.
+
+Both sites pass `expand_stacks=True, expand_stacks_include_deleted=True`. `normalize_stack_positions` renumbers **every** member of an affected stack, soft-deleted ones included, and the default stack expansion excludes deleted members — without the flag those renumbers would be unsnapshotted changes that undo could not reverse. The restore site additionally uses `resolve_picture_ids=` because an absent `picture_ids` means "the entire Scrapheap": the targets are only knowable on the mutation's own session.
+
+**Permanent deletes are not recorded and are not undoable.** `DELETE /pictures/scrapheap` (purge / Empty Scrapheap) and the `ScrapheapRetentionPurgeTask` destroy the row and the file; there is nothing an undo could put back, so they append no operation row at all. They keep their own irreversibility guard, the `confirm_token` minted by `POST /pictures/scrapheap/delete-preview`.
+
+**Undoing a move whose picture has since been purged is refused (410).** This is the one lifecycle edge the metadata facets do not have, and it follows the locked-set guard's fail-closed contract exactly: `_enforce_scrapheap_targets_exist` runs beside `enforce_pictures_not_locked` at the single `apply_state_in_session` sink, **before** anything is written, and raises `410 Gone` with `detail = {"code": "pictures_purged", "action", "picture_ids", "message"}`. The whole request is refused — a partially-purged batch is refused in full, not partially restored — nothing commits (the DB worker rolls the session back), and the operation stays `applied` with `undone_at` null, so the user can retry after the purged pictures are re-imported rather than being left with a batch they must reconcile by hand. The guard is scoped to pictures whose recorded state carries the `deleted` facet; a purged picture appearing in some *other* operation's state (a tag edit, a stack renumber) keeps the long-standing skip-with-a-warning behaviour, because no lifecycle promise is being broken there.
+
+`change_kind` on the WS envelope follows the lifecycle rather than a blanket `"updated"`: `_emit` announces restored pictures as `added` and re-scrapheaped ones as `removed`, matching what the delete/restore endpoints themselves broadcast — telling the grid that a vanished picture was "updated" leaves a 404-clickable thumbnail behind. The undo/redo responses carry the same split as `scrapheaped_picture_ids` / `restored_picture_ids` alongside `picture_ids`.
+
+No new routes and no migration: the existing undo/redo endpoints carry all of it, and `operation` is generic over `op_type`.
 
 ---
 

--- a/pixlstash/openapi_custom.py
+++ b/pixlstash/openapi_custom.py
@@ -77,6 +77,9 @@ curl "https://your-pixlstash-host/api/v1/pictures/export/download/$task" \\
 
 > **Trash:** `DELETE /pictures/{id}` moves a picture to the *scrapheap* (recoverable via
 > `POST /pictures/scrapheap/restore`); `DELETE /pictures/scrapheap` purges it for good.
+> Both scrapheap *moves* and *restores* are recorded in the operation log
+> (`pictures.scrapheap.move` / `pictures.scrapheap.restore`) and are reversible with
+> `POST /operations/undo`. A purge is **not** recorded and cannot be undone.
 """
 
 

--- a/pixlstash/routes/operations.py
+++ b/pixlstash/routes/operations.py
@@ -67,6 +67,11 @@ class UndoResultResponse(BaseModel):
     operations: list[OperationResponse] = []
     picture_ids: list[int] = []
     picture_count: int = 0
+    # The scrapheap lifecycle subset of ``picture_ids``: pictures this call moved
+    # INTO the scrapheap (they left the active grid) and pictures it brought back
+    # OUT of it. Both are empty for a pure metadata undo.
+    scrapheaped_picture_ids: list[int] = []
+    restored_picture_ids: list[int] = []
 
 
 class UndoRequest(BaseModel):
@@ -161,7 +166,10 @@ def create_router(server) -> APIRouter:
             "**whole batch** is reverted, so a partially-undone bulk action "
             "cannot exist. 409 when there is nothing to undo or the named "
             "operation is not reversible; 423 when a locked picture set freezes "
-            "one of the targets."
+            "one of the targets; 410 when undoing a move to the Scrapheap whose "
+            "picture has since been permanently purged (retention sweep or Empty "
+            "Scrapheap) — the whole request is refused, the operation stays "
+            "applied, and nothing is written."
         ),
         response_model=UndoResultResponse,
     )

--- a/pixlstash/routes/pictures/_crud.py
+++ b/pixlstash/routes/pictures/_crud.py
@@ -1087,7 +1087,16 @@ def register_routes(router, server):
     @router.post(
         "/pictures/scrapheap/restore",
         summary="Restore deleted pictures",
-        description="Restores deleted pictures from scrapheap, either all deleted pictures or a provided picture id subset.",
+        description=(
+            "Restores deleted pictures from scrapheap, either all deleted "
+            "pictures or a provided picture id subset.\n\n"
+            "Recorded in the operation log as a single "
+            "`pictures.scrapheap.restore` operation with a `batch_id`, and it is "
+            "the symmetric partner of `pictures.scrapheap.move`: undoing a "
+            "restore puts the pictures back in the Scrapheap with the retention "
+            "stamp they had, so the history stack stays coherent in both "
+            "directions."
+        ),
         response_model=ScrapheapRestoreResponse,
     )
     def restore_scrapheap(request: Request, payload: dict | None = Body(None)):
@@ -1130,10 +1139,31 @@ def register_routes(router, server):
             session.commit()
             return restored_count
 
-        restored_count = server.vault.db.run_task(
+        def _scrapheaped_targets(session: Session):
+            # The endpoint's targets are not knowable from the request: an absent
+            # picture_ids means "restore the entire scrapheap", and even a named
+            # subset may include already-live ids that will not change. Resolve
+            # the real set on the mutation's own session so the snapshot covers
+            # exactly what the write is about to touch.
+            query = select(Picture.id).where(Picture.deleted.is_(True))
+            if picture_ids is not None:
+                query = query.where(Picture.id.in_(picture_ids))
+            return list(session.exec(query).all())
+
+        restored_count, _operation = operation_log_service.run_recorded_metadata_task(
+            server.vault,
             restore_pictures,
             picture_ids,
-            priority=DBPriority.IMMEDIATE,
+            op_type=operation_log_service.OP_SCRAPHEAP_RESTORE,
+            picture_ids=[],
+            resolve_picture_ids=_scrapheaped_targets,
+            batch_id=operation_log_service.new_batch_id(),
+            # Same stack caveat as the soft-delete: normalize_stack_positions
+            # renumbers every member of an affected stack, deleted ones included.
+            expand_stacks=True,
+            expand_stacks_include_deleted=True,
+            summary=operation_log_service.scrapheap_restore_summary,
+            **operation_log_service.request_context(request),
         )
         # A restored picture re-enters active views. ``picture_ids`` is the
         # caller-supplied subset (None == "restore all"); pass it through when
@@ -1333,7 +1363,13 @@ def register_routes(router, server):
     @router.delete(
         "/pictures/{id}",
         summary="Move picture to scrapheap",
-        description="Soft-deletes a picture by marking it deleted, making it appear in scrapheap views.",
+        description=(
+            "Soft-deletes a picture by marking it deleted, making it appear in "
+            "scrapheap views. Recorded in the operation log as "
+            "`pictures.scrapheap.move` and **undoable**: undo restores the "
+            "picture, redo moves it back. (A *permanent* delete — "
+            "`DELETE /pictures/scrapheap` — is not recorded and cannot be undone.)"
+        ),
         response_model=PictureDeleteResponse,
     )
     def delete_picture(request: Request, id: str):
@@ -1366,7 +1402,23 @@ def register_routes(router, server):
             session.commit()
             return True
 
-        success = server.vault.db.run_task(delete_pic, id)
+        # The soft-delete is a recorded, reversible operation: the `deleted`
+        # facet carries the flag and the retention stamp, so undo puts the
+        # picture back with the purge deadline it had. The snapshot expands to
+        # the whole stack INCLUDING its scrapheaped members, because
+        # normalize_stack_positions renumbers every member and an unsnapshotted
+        # renumber is a change undo could not reverse.
+        success, _operation = operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            delete_pic,
+            id,
+            op_type=operation_log_service.OP_SCRAPHEAP_MOVE,
+            picture_ids=[id],
+            expand_stacks=True,
+            expand_stacks_include_deleted=True,
+            summary=operation_log_service.scrapheap_move_summary,
+            **operation_log_service.request_context(request),
+        )
         if not success:
             raise HTTPException(status_code=404, detail="Picture not found")
         # Soft-delete removes the card from active grid views. Broadcast a
@@ -1399,7 +1451,13 @@ def register_routes(router, server):
             "Soft-deletes multiple pictures in one request by marking them deleted "
             '(they appear in scrapheap views). Body: {"picture_ids": [int, ...]}. '
             "Single-round-trip replacement for issuing one DELETE /pictures/{id} per "
-            "id, which floods the client connection pool on large selections."
+            "id, which floods the client connection pool on large selections.\n\n"
+            "Recorded in the operation log as a single `pictures.scrapheap.move` "
+            "operation carrying a `batch_id`, so the whole bulk move is **one** "
+            "undo: `POST /operations/undo` or "
+            "`POST /operations/batches/{batch_id}/undo` restores every picture it "
+            "moved. Pictures skipped for a locked set are not in the recorded "
+            "change and are unaffected by the undo."
         ),
         response_model=BulkPictureDeleteResponse,
     )
@@ -1458,7 +1516,23 @@ def register_routes(router, server):
             session.commit()
             return newly_deleted, sorted(locked)
 
-        deleted_ids, skipped_locked = server.vault.db.run_task(delete_pics, pic_ids)
+        # One bulk action, one operation row, one batch id — so the client can
+        # offer a single "Undo" for the whole move, by batch id or by simply
+        # popping the newest operation.
+        (deleted_ids, skipped_locked), _operation = (
+            operation_log_service.run_recorded_metadata_task(
+                server.vault,
+                delete_pics,
+                pic_ids,
+                op_type=operation_log_service.OP_SCRAPHEAP_MOVE,
+                picture_ids=pic_ids,
+                batch_id=operation_log_service.new_batch_id(),
+                expand_stacks=True,
+                expand_stacks_include_deleted=True,
+                summary=operation_log_service.scrapheap_move_summary,
+                **operation_log_service.request_context(request),
+            )
+        )
         # Soft-delete removes the cards from active grid views. Broadcast a single
         # ``removed`` event so other tabs drop the stale cards in one update.
         if deleted_ids:

--- a/pixlstash/services/operation_log_service.py
+++ b/pixlstash/services/operation_log_service.py
@@ -11,9 +11,12 @@ specifies for the audit log.
 
 Scope discipline (DAM 1.2, binding): only the **metadata** facets in
 :data:`FACETS` are captured and reversible — tags, caption/description, rating,
-picture-set / project / character membership, and stacking. File-mutating
-operations may be *recorded* for audit with ``undoable=False``, but they are not
-reversible until copy-on-write versions land (Stage 2 / v2.1).
+picture-set / project / character membership, stacking, and the scrapheap
+soft-delete state. File-mutating operations may be *recorded* for audit with
+``undoable=False``, but they are not reversible until copy-on-write versions land
+(Stage 2 / v2.1). A **permanent** delete (scrapheap purge, Empty Scrapheap,
+retention auto-purge) destroys the file and is deliberately *not* recorded here:
+there is nothing an undo could put back.
 
 Atomicity: :func:`run_recorded_metadata_task` runs capture → mutation → capture →
 record inside **one** DB-queue task, so the ``Operation`` row and the change it
@@ -34,9 +37,10 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Union
 
+from fastapi import HTTPException
 from sqlmodel import Session, select
 
 from pixlstash.db_models import (
@@ -77,6 +81,7 @@ FACET_PROJECT_ID = "project_id"
 FACET_CHARACTERS = "characters"
 FACET_PENDING_CHARACTER_ID = "pending_character_id"
 FACET_STACK = "stack"
+FACET_DELETED = "deleted"
 
 FACETS = (
     FACET_TAGS,
@@ -88,7 +93,19 @@ FACETS = (
     FACET_CHARACTERS,
     FACET_PENDING_CHARACTER_ID,
     FACET_STACK,
+    FACET_DELETED,
 )
+
+# Operation types the scrapheap lifecycle records. Named constants because the
+# frontend keys its undo affordances off them and they are part of the API
+# contract (docs/backend_architecture.md §21).
+OP_SCRAPHEAP_MOVE = "pictures.scrapheap.move"
+OP_SCRAPHEAP_RESTORE = "pictures.scrapheap.restore"
+
+# HTTP status for "an undo target was permanently purged and cannot come back".
+# 410 Gone, not 404: the picture demonstrably existed and was destroyed, and the
+# operation row that named it is still there.
+PURGED_STATUS_CODE = 410
 
 # How many operations the API will ever return in one page.
 MAX_LIST_LIMIT = 500
@@ -106,6 +123,7 @@ _FACET_EVENTS = {
     FACET_CHARACTERS: (EventType.CHANGED_CHARACTERS, EventType.CHANGED_PICTURES),
     FACET_PENDING_CHARACTER_ID: (EventType.CHANGED_CHARACTERS,),
     FACET_STACK: (EventType.CHANGED_PICTURES,),
+    FACET_DELETED: (EventType.CHANGED_PICTURES,),
 }
 
 
@@ -133,6 +151,45 @@ def _normalize_ids(picture_ids: Iterable[Any]) -> list[int]:
         if value > 0:
             ids.add(value)
     return sorted(ids)
+
+
+def _naive_utc_iso(value: Optional[datetime]) -> Optional[str]:
+    """Serialise a ``deleted_at`` stamp for the recorded state.
+
+    Every ``Picture.deleted_at`` in the DB is **naive UTC** (SQLAlchemy's SQLite
+    ``DateTime`` drops the offset on write — see ``scrapheap_service._naive_utc``),
+    but a value just assigned in-session is still aware. Normalising both to
+    naive-UTC ISO here keeps the before/after comparison honest: without it the
+    same instant would compare unequal across a commit boundary and every capture
+    would look like a change.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is not None:
+        value = value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value.isoformat()
+
+
+def _parse_naive_utc(value) -> Optional[datetime]:
+    """Inverse of :func:`_naive_utc_iso`, tolerant of a malformed stored value."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.fromisoformat(str(value))
+        except (TypeError, ValueError):
+            logger.error(
+                "operation_log: could not parse recorded deleted_at %r; restoring "
+                "the picture without a retention stamp (it will never auto-purge "
+                "until it is re-deleted)",
+                value,
+            )
+            return None
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
 
 
 def capture_state_in_session(session: Session, picture_ids) -> dict[str, dict]:
@@ -169,6 +226,14 @@ def capture_state_in_session(session: Session, picture_ids) -> dict[str, dict]:
                 "id": picture.stack_id,
                 "name": None,
                 "position": picture.stack_position,
+            },
+            # The scrapheap lifecycle: the soft-delete flag and the retention
+            # stamp travel together, because restoring one without the other
+            # either loses the purge deadline or leaves a live picture carrying
+            # a stale one.
+            FACET_DELETED: {
+                "deleted": bool(picture.deleted),
+                "deleted_at": _naive_utc_iso(picture.deleted_at),
             },
         }
     if not state:
@@ -277,9 +342,62 @@ def diff_states(
 # ---------------------------------------------------------------------------
 
 
+# A summary is either a fixed sentence or a ``(before_delta, after_delta) -> str``
+# builder evaluated once the diff is known. The callable form exists for handlers
+# whose real target count is not knowable at call time — a bulk soft-delete that
+# skips locked pictures, or a "restore everything" that never named an id.
+SummarySpec = Union[str, Callable[[dict, dict], Optional[str]], None]
+
+
 def new_batch_id() -> str:
     """Return a fresh opaque batch id grouping one bulk action's operations."""
     return uuid.uuid4().hex
+
+
+def lifecycle_split(state: dict[str, dict]) -> tuple[list[int], list[int]]:
+    """Split *state* into the pictures it scrapheaps and the ones it restores.
+
+    Args:
+        state: A recorded (already-diffed) state — the side about to be written.
+
+    Returns:
+        ``(scrapheaped_ids, restored_ids)``: pictures whose :data:`FACET_DELETED`
+        target value is ``True`` and ``False`` respectively. Pictures the state
+        does not move in or out of the scrapheap appear in neither list.
+    """
+    scrapheaped: list[int] = []
+    restored: list[int] = []
+    for picture_id, facets in (state or {}).items():
+        lifecycle = (facets or {}).get(FACET_DELETED)
+        if not isinstance(lifecycle, dict):
+            continue
+        (scrapheaped if lifecycle.get("deleted") else restored).append(int(picture_id))
+    return sorted(scrapheaped), sorted(restored)
+
+
+def _pictures(count: int) -> str:
+    return f"{count} picture" if count == 1 else f"{count} pictures"
+
+
+def scrapheap_move_summary(before: dict, after: dict) -> Optional[str]:
+    """Build ``Moved 5 pictures to the Scrapheap`` from the recorded diff.
+
+    Counting the diff rather than the request is what makes the sentence true:
+    a bulk soft-delete silently skips pictures frozen by a locked set and
+    already-scrapheaped ones, and neither shows up in the recorded change.
+    """
+    moved, _restored = lifecycle_split(after)
+    if not moved:
+        return None
+    return f"Moved {_pictures(len(moved))} to the Scrapheap"
+
+
+def scrapheap_restore_summary(before: dict, after: dict) -> Optional[str]:
+    """Build ``Restored 5 pictures from the Scrapheap`` from the recorded diff."""
+    _moved, restored = lifecycle_split(after)
+    if not restored:
+        return None
+    return f"Restored {_pictures(len(restored))} from the Scrapheap"
 
 
 def request_context(request) -> dict:
@@ -320,7 +438,7 @@ def record_operation_in_session(
     source: str = "external",
     origin_client_id: Optional[str] = None,
     batch_id: Optional[str] = None,
-    summary: Optional[str] = None,
+    summary: SummarySpec = None,
     undoable: bool = True,
     target_type: str = TARGET_PICTURE,
 ) -> Optional[Operation]:
@@ -335,7 +453,9 @@ def record_operation_in_session(
         source: WS-envelope source, passed in explicitly by the caller.
         origin_client_id: WS-envelope per-tab origin, likewise explicit.
         batch_id: Group id when this row is part of a bulk action.
-        summary: Short human sentence for the undo toast / activity feed.
+        summary: Short human sentence for the undo toast / activity feed, or a
+            ``(before_delta, after_delta) -> str | None`` builder evaluated here,
+            once the real extent of the change is known (see :data:`SummarySpec`).
         undoable: ``False`` records the change for audit without offering undo
             (the DAM 1.2 rule for file-mutating operations).
         target_type: Kind of object the target ids refer to.
@@ -346,6 +466,18 @@ def record_operation_in_session(
     before_delta, after_delta = diff_states(before, after)
     if not before_delta and not after_delta:
         return None
+
+    if callable(summary):
+        try:
+            summary = summary(before_delta, after_delta)
+        except Exception:
+            logger.exception(
+                "operation_log: summary builder for %s failed over %d changed "
+                "picture(s); recording the operation without a summary",
+                op_type,
+                len(after_delta),
+            )
+            summary = None
 
     target_ids = sorted(
         {int(pid) for pid in after_delta} | {int(pid) for pid in before_delta}
@@ -401,9 +533,10 @@ def run_recorded_metadata_task(
     source: str = "external",
     origin_client_id: Optional[str] = None,
     batch_id: Optional[str] = None,
-    summary: Optional[str] = None,
+    summary: SummarySpec = None,
     undoable: bool = True,
     expand_stacks: bool = False,
+    expand_stacks_include_deleted: bool = False,
     resolve_picture_ids: Optional[Callable[[Session], Iterable[Any]]] = None,
     **kwargs,
 ) -> tuple[Any, Optional[dict]]:
@@ -424,10 +557,15 @@ def run_recorded_metadata_task(
         source: WS-envelope source, read from the request by the caller.
         origin_client_id: WS-envelope per-tab origin, likewise.
         batch_id: Group id when this call is one step of a bulk action.
-        summary: Short human sentence for the undo toast.
+        summary: Short human sentence for the undo toast, or a
+            ``(before_delta, after_delta) -> str | None`` builder (:data:`SummarySpec`).
         undoable: ``False`` records for audit only.
         expand_stacks: Snapshot the whole stack of every target picture, for
             mutations that are stack-atomic (project/set membership).
+        expand_stacks_include_deleted: With *expand_stacks*, also pull in
+            soft-deleted stack members. The scrapheap operations need it because
+            ``normalize_stack_positions`` renumbers deleted members too, and an
+            unsnapshotted renumber is a change undo could not reverse.
         resolve_picture_ids: Optional ``(session) -> ids`` run **before** the
             mutation, on the mutation's own session, for handlers whose targets
             are not knowable from the request alone — a request addressed by face
@@ -446,7 +584,11 @@ def run_recorded_metadata_task(
         if resolve_picture_ids is not None:
             ids = _normalize_ids([*ids, *(resolve_picture_ids(session) or ())])
         if expand_stacks and ids:
-            ids = _normalize_ids(expand_picture_ids_to_stacks(session, ids))
+            ids = _normalize_ids(
+                expand_picture_ids_to_stacks(
+                    session, ids, include_deleted=expand_stacks_include_deleted
+                )
+            )
         before = capture_state_in_session(session, ids)
         result = work(session, *args, **kwargs)
         after = capture_state_in_session(session, ids)
@@ -570,6 +712,84 @@ def _apply_stack(session: Session, picture: Picture, stack) -> None:
     session.add(picture)
 
 
+def _apply_deleted(session: Session, picture: Picture, lifecycle) -> None:
+    """Restore a picture's scrapheap state (the soft-delete flag + its stamp)."""
+    if not isinstance(lifecycle, dict):
+        return
+    picture.deleted = bool(lifecycle.get("deleted"))
+    # Written back verbatim rather than re-stamped to "now": the recorded value
+    # IS the retention deadline this state had, and re-stamping would silently
+    # extend (or invent) a purge window on every undo.
+    picture.deleted_at = _parse_naive_utc(lifecycle.get("deleted_at"))
+    session.add(picture)
+
+
+def _enforce_scrapheap_targets_exist(
+    session: Session, state: dict[str, dict], action: str
+) -> None:
+    """Raise ``410`` if a picture this state would move in/out of the scrapheap is gone.
+
+    The one edge case a scrapheap undo has that a metadata undo does not: the
+    picture may have been **permanently purged** since — by the 30-day retention
+    sweep or by Empty Scrapheap — and a purge destroys the file, so no undo can
+    bring it back. Fail closed and refuse the whole request, exactly as the
+    locked-set guard above does: the operation stays ``applied``, nothing is
+    committed, and the caller is told which pictures are gone rather than being
+    handed a half-restored batch it would have to reconcile itself.
+
+    Only pictures carrying the :data:`FACET_DELETED` facet are checked. A purged
+    picture that merely appears in some *other* operation's recorded state (a tag
+    edit, a stack renumber) keeps the long-standing skip-with-a-warning
+    behaviour — there is no lifecycle promise to break there.
+
+    Args:
+        session: Pre-opened DB session.
+        state: The recorded state about to be applied.
+        action: Human verb phrase echoed in the error detail.
+
+    Raises:
+        HTTPException: :data:`PURGED_STATUS_CODE` naming the missing pictures.
+    """
+    wanted = sorted(
+        int(picture_id)
+        for picture_id, facets in (state or {}).items()
+        if isinstance((facets or {}).get(FACET_DELETED), dict)
+    )
+    if not wanted:
+        return
+    alive = {
+        int(picture_id)
+        for picture_id in session.exec(
+            select(Picture.id).where(Picture.id.in_(wanted))
+        ).all()
+        if picture_id is not None
+    }
+    missing = [picture_id for picture_id in wanted if picture_id not in alive]
+    if not missing:
+        return
+    logger.warning(
+        "operation_log: refusing to %s — %d of %d scrapheap target(s) %s were "
+        "permanently purged and cannot be brought back; the operation stays "
+        "applied and nothing was written",
+        action,
+        len(missing),
+        len(wanted),
+        missing,
+    )
+    raise HTTPException(
+        status_code=PURGED_STATUS_CODE,
+        detail={
+            "code": "pictures_purged",
+            "action": action,
+            "picture_ids": missing,
+            "message": (
+                f"{len(missing)} of these pictures were permanently deleted from "
+                "the Scrapheap and cannot be restored. Nothing was changed."
+            ),
+        },
+    )
+
+
 def apply_state_in_session(
     session: Session, state: dict[str, dict], action: str = "restore metadata"
 ) -> list[int]:
@@ -577,7 +797,9 @@ def apply_state_in_session(
 
     A locked picture set is a hard freeze on its members' label data; undo/redo
     must not become the one write path that walks around it. The guard runs here,
-    at the single sink every restore goes through, and covers every facet.
+    at the single sink every restore goes through, and covers every facet. The
+    purged-target guard (:func:`_enforce_scrapheap_targets_exist`) sits beside it
+    on the same fail-closed contract.
 
     Args:
         session: Pre-opened DB session; the caller commits.
@@ -590,9 +812,11 @@ def apply_state_in_session(
         The picture ids actually written.
 
     Raises:
-        HTTPException: ``423`` when a locked picture set freezes any target.
+        HTTPException: ``423`` when a locked picture set freezes any target;
+            ``410`` when a scrapheap target has since been permanently purged.
     """
     enforce_pictures_not_locked(session, [int(pid) for pid in (state or {})], action)
+    _enforce_scrapheap_targets_exist(session, state, action)
     touched: list[int] = []
     for picture_id_raw, facets in (state or {}).items():
         picture_id = int(picture_id_raw)
@@ -632,6 +856,9 @@ def apply_state_in_session(
             elif facet == FACET_STACK:
                 if value is not None:
                     _apply_stack(session, picture, value)
+            elif facet == FACET_DELETED:
+                if value is not None:
+                    _apply_deleted(session, picture, value)
             else:
                 logger.warning(
                     "operation_log: unknown facet %r on picture %d was recorded "
@@ -727,11 +954,20 @@ def _restore(
     operations: list[Operation],
     *,
     to_before: bool,
-) -> tuple[list[int], set[str]]:
-    """Apply the before- (undo) or after- (redo) state of *operations* in order."""
+) -> tuple[list[int], set[str], dict[str, list[int]]]:
+    """Apply the before- (undo) or after- (redo) state of *operations* in order.
+
+    Returns:
+        ``(touched_ids, facets, lifecycle)`` where *lifecycle* is
+        ``{"scrapheaped": [...], "restored": [...]}`` — the pictures this
+        restoration moves into and out of the scrapheap, so the caller can
+        announce them as ``removed`` / ``added`` instead of ``updated``.
+    """
     action = "undo an operation" if to_before else "redo an operation"
     touched: set[int] = set()
     facets: set[str] = set()
+    scrapheaped: set[int] = set()
+    restored: set[int] = set()
     for operation in operations:
         state = _loads(
             operation.before_state if to_before else operation.after_state, {}
@@ -739,20 +975,42 @@ def _restore(
         touched.update(apply_state_in_session(session, state, action))
         for picture_facets in state.values():
             facets.update(picture_facets or {})
-    return sorted(touched), facets
+        moved_out, moved_in = lifecycle_split(state)
+        scrapheaped.update(moved_out)
+        restored.update(moved_in)
+    lifecycle = {
+        "scrapheaped": sorted(scrapheaped),
+        "restored": sorted(restored),
+    }
+    return sorted(touched), facets, lifecycle
 
 
 def _emit(
-    vault: "Vault", picture_ids: list[int], facets: set[str], origin_client_id
+    vault: "Vault",
+    picture_ids: list[int],
+    facets: set[str],
+    origin_client_id,
+    lifecycle: Optional[dict[str, list[int]]] = None,
 ) -> None:
     """Announce a restored state on the WS envelope.
 
     ``origin_client_id`` is carried in the event ``data`` dict, never read from a
     contextvar — this runs on the DB worker thread where the contextvar is dead
     (§15, ``test_source_origin_read_from_data_only``).
+
+    ``change_kind`` follows the scrapheap lifecycle rather than being a blanket
+    ``"updated"``: undoing a move-to-Scrapheap puts a card back (``added``) and
+    redoing it takes the card away (``removed``), which is what the delete and
+    restore endpoints themselves broadcast. Telling the grid a vanished picture
+    was merely "updated" leaves a 404-clickable thumbnail behind.
     """
     if not picture_ids:
         return
+    scrapheaped = list((lifecycle or {}).get("scrapheaped") or [])
+    restored = list((lifecycle or {}).get("restored") or [])
+    moved = set(scrapheaped) | set(restored)
+    updated = [picture_id for picture_id in picture_ids if picture_id not in moved]
+
     events: list[EventType] = []
     for facet in facets:
         for event in _FACET_EVENTS.get(facet, (EventType.CHANGED_PICTURES,)):
@@ -760,16 +1018,24 @@ def _emit(
                 events.append(event)
     if not events:
         events = [EventType.CHANGED_PICTURES]
-    for event in events:
+
+    def _notify(event: EventType, ids: list[int], change_kind: str) -> None:
+        if not ids:
+            return
         vault.notify(
             event,
             {
-                "picture_ids": picture_ids,
+                "picture_ids": ids,
                 "origin_client_id": origin_client_id,
-                "change_kind": "updated",
+                "change_kind": change_kind,
                 "source": "ui",
             },
         )
+
+    for event in events:
+        _notify(event, updated, "updated")
+    _notify(EventType.CHANGED_PICTURES, scrapheaped, "removed")
+    _notify(EventType.CHANGED_PICTURES, restored, "added")
 
 
 def _select_undo_target(session: Session, operation_id: Optional[int]) -> Operation:
@@ -808,7 +1074,7 @@ def _mark_undone(session: Session, members: list[Operation]) -> None:
 
 def undo_in_session(
     session: Session, operation_id: Optional[int] = None
-) -> tuple[list[dict], list[int], list[str]]:
+) -> tuple[list[dict], list[int], list[str], dict[str, list[int]]]:
     """Undo one operation (and its whole batch), returning what it touched.
 
     Rows are serialized *inside* the session: the DB worker closes it when the
@@ -820,15 +1086,15 @@ def undo_in_session(
     members = [member for member in members if member.undoable]
     if not members:
         raise OperationLogError("Nothing to undo")
-    touched, facets = _restore(session, members, to_before=True)
+    touched, facets, lifecycle = _restore(session, members, to_before=True)
     _mark_undone(session, members)
     session.commit()
-    return [serialize(member) for member in members], touched, sorted(facets)
+    return [serialize(member) for member in members], touched, sorted(facets), lifecycle
 
 
 def undo_batch_in_session(
     session: Session, batch_id: str
-) -> tuple[list[dict], list[int], list[str]]:
+) -> tuple[list[dict], list[int], list[str], dict[str, list[int]]]:
     """Undo every still-applied operation of one batch (the sweep's Undo)."""
     members = list(
         session.exec(
@@ -841,13 +1107,15 @@ def undo_batch_in_session(
     )
     if not members:
         raise OperationLogError(f"Batch {batch_id} has nothing to undo")
-    touched, facets = _restore(session, members, to_before=True)
+    touched, facets, lifecycle = _restore(session, members, to_before=True)
     _mark_undone(session, members)
     session.commit()
-    return [serialize(member) for member in members], touched, sorted(facets)
+    return [serialize(member) for member in members], touched, sorted(facets), lifecycle
 
 
-def redo_in_session(session: Session) -> tuple[list[dict], list[int], list[str]]:
+def redo_in_session(
+    session: Session,
+) -> tuple[list[dict], list[int], list[str], dict[str, list[int]]]:
     """Re-apply the most recently undone operation (and its whole batch)."""
     operation = session.exec(
         select(Operation)
@@ -859,13 +1127,13 @@ def redo_in_session(session: Session) -> tuple[list[dict], list[int], list[str]]
     members = _batch_members_in_session(session, operation, STATUS_UNDONE)
     # Redo replays in application order, the mirror of undo's reverse order.
     members = sorted(members, key=lambda op: op.id or 0)
-    touched, facets = _restore(session, members, to_before=False)
+    touched, facets, lifecycle = _restore(session, members, to_before=False)
     for member in members:
         member.status = STATUS_APPLIED
         member.undone_at = None
         session.add(member)
     session.commit()
-    return [serialize(member) for member in members], touched, sorted(facets)
+    return [serialize(member) for member in members], touched, sorted(facets), lifecycle
 
 
 def list_operations_in_session(
@@ -938,12 +1206,18 @@ def get_operation(vault: "Vault", operation_id: int) -> Optional[dict]:
     return vault.db.run_task(_fetch)
 
 
-def _finish(vault: "Vault", members, touched, facets, origin_client_id) -> dict:
-    _emit(vault, touched, set(facets), origin_client_id)
+def _finish(
+    vault: "Vault", members, touched, facets, lifecycle, origin_client_id
+) -> dict:
+    _emit(vault, touched, set(facets), origin_client_id, lifecycle)
     return {
         "operations": members,
         "picture_ids": touched,
         "picture_count": len(touched),
+        # Which of those pictures left / re-entered the scrapheap, so the client
+        # can drop or re-add cards without diffing the whole grid.
+        "scrapheaped_picture_ids": list((lifecycle or {}).get("scrapheaped") or []),
+        "restored_picture_ids": list((lifecycle or {}).get("restored") or []),
     }
 
 
@@ -953,19 +1227,23 @@ def undo(
     origin_client_id: Optional[str] = None,
 ) -> dict:
     """Undo the newest reversible operation, or a named one, plus its batch."""
-    members, touched, facets = vault.db.run_task(undo_in_session, operation_id)
-    return _finish(vault, members, touched, facets, origin_client_id)
+    members, touched, facets, lifecycle = vault.db.run_task(
+        undo_in_session, operation_id
+    )
+    return _finish(vault, members, touched, facets, lifecycle, origin_client_id)
 
 
 def undo_batch(
     vault: "Vault", batch_id: str, origin_client_id: Optional[str] = None
 ) -> dict:
     """Undo one whole bulk action by its batch id (the sweep's report Undo)."""
-    members, touched, facets = vault.db.run_task(undo_batch_in_session, batch_id)
-    return _finish(vault, members, touched, facets, origin_client_id)
+    members, touched, facets, lifecycle = vault.db.run_task(
+        undo_batch_in_session, batch_id
+    )
+    return _finish(vault, members, touched, facets, lifecycle, origin_client_id)
 
 
 def redo(vault: "Vault", origin_client_id: Optional[str] = None) -> dict:
     """Re-apply the most recently undone operation (and its batch)."""
-    members, touched, facets = vault.db.run_task(redo_in_session)
-    return _finish(vault, members, touched, facets, origin_client_id)
+    members, touched, facets, lifecycle = vault.db.run_task(redo_in_session)
+    return _finish(vault, members, touched, facets, lifecycle, origin_client_id)

--- a/pixlstash/services/stack_membership.py
+++ b/pixlstash/services/stack_membership.py
@@ -29,12 +29,24 @@ from pixlstash.db_models import (
 )
 
 
-def expand_picture_ids_to_stacks(session: Session, picture_ids) -> list[int]:
+def expand_picture_ids_to_stacks(
+    session: Session, picture_ids, include_deleted: bool = False
+) -> list[int]:
     """Return *picture_ids* plus every non-deleted co-member of any stack they
     belong to.
 
     Grouping mutations call this first so an action on a single stacked picture
     (e.g. a collapsed-stack leader) is applied to the whole stack.
+
+    Args:
+        session: Pre-opened DB session.
+        picture_ids: Seed ids whose stacks should be expanded.
+        include_deleted: Also return soft-deleted (scrapheaped) co-members.
+            Grouping mutations leave those alone and keep the default; the
+            scrapheap operations pass ``True`` because
+            :func:`~pixlstash.stacking.normalize_stack_positions` renumbers
+            **every** member of a stack, deleted ones included, so the operation
+            log has to snapshot them or an undo would restore the wrong order.
     """
     ids: set[int] = {int(pid) for pid in picture_ids if pid is not None}
     if not ids:
@@ -51,12 +63,10 @@ def expand_picture_ids_to_stacks(session: Session, picture_ids) -> list[int]:
         if stack_id is not None
     }
     if stack_ids:
-        member_ids = session.exec(
-            select(Picture.id).where(
-                Picture.stack_id.in_(stack_ids),
-                Picture.deleted.is_(False),
-            )
-        ).all()
+        member_query = select(Picture.id).where(Picture.stack_id.in_(stack_ids))
+        if not include_deleted:
+            member_query = member_query.where(Picture.deleted.is_(False))
+        member_ids = session.exec(member_query).all()
         ids.update(int(mid) for mid in member_ids if mid is not None)
 
     return sorted(ids)

--- a/tests/test_operation_log.py
+++ b/tests/test_operation_log.py
@@ -11,6 +11,11 @@ Covers the three things the design rests on:
 3. **The invariants** — the log is append-only (undo mutates only the lifecycle
    markers), the service never reads the origin contextvar, and a locked picture
    set is not walked around by undo.
+4. **The scrapheap lifecycle** — a move to the Scrapheap and a restore out of it
+   are recorded symmetrically and are reversible in both directions, a bulk move
+   is one batch and one Undo, a **permanent** delete is recorded nowhere, and
+   undoing a move whose picture has since been purged is refused outright
+   (410) rather than half-applied.
 """
 
 import gc
@@ -98,6 +103,41 @@ def _tags(server, picture_id):
 
 def _operations(server, **filters):
     return operation_log_service.list_operations(server.vault, limit=100, **filters)
+
+
+def _lifecycle(server, picture_id):
+    """``(deleted, deleted_at)`` straight off the row, or ``None`` if purged."""
+
+    def _read(session):
+        picture = session.get(Picture, picture_id)
+        if picture is None:
+            return None
+        return (bool(picture.deleted), picture.deleted_at)
+
+    return server.vault.db.run_task(_read)
+
+
+def _visible(client, picture_id):
+    """Whether the picture shows up in the ordinary (non-scrapheap) listing."""
+    resp = client.get(f"{API}/pictures", params={"limit": 500})
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    pictures = payload["pictures"] if isinstance(payload, dict) else payload
+    return picture_id in {int(pic["id"]) for pic in pictures}
+
+
+def _purge_forever(client, ids):
+    """Permanently destroy scrapheap rows through the real preview->confirm flow."""
+    preview = client.post(f"{API}/pictures/scrapheap/delete-preview", json={"ids": ids})
+    assert preview.status_code == 200, preview.text
+    token = preview.json()["confirm_token"]
+    resp = client.request(
+        "DELETE",
+        f"{API}/pictures/scrapheap",
+        json={"picture_ids": ids, "include_protected": True, "confirm_token": token},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
 
 
 # ---------------------------------------------------------------------------
@@ -573,6 +613,306 @@ def test_undo_refuses_to_write_a_picture_frozen_by_a_locked_set():
         assert _operations(server)[0]["status"] == "applied"
     finally:
         _teardown(temp_dir, server)
+
+
+# ---------------------------------------------------------------------------
+# Scrapheap lifecycle (soft delete / restore)
+# ---------------------------------------------------------------------------
+
+
+def test_scrapheap_move_is_recorded_and_undo_brings_the_picture_back():
+    """The core promise: a move to the Scrapheap is reversible from the log."""
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        assert _visible(client, picture_id) is True
+
+        resp = client.delete(
+            f"{API}/pictures/{picture_id}", headers={"X-Client-Id": "tab-1"}
+        )
+        assert resp.status_code == 200, resp.text
+        deleted, deleted_at = _lifecycle(server, picture_id)
+        assert deleted is True
+        assert deleted_at is not None
+        assert _visible(client, picture_id) is False
+
+        operations = _operations(server, op_type="pictures.scrapheap.move")
+        assert len(operations) == 1
+        operation = operations[0]
+        assert operation["target_ids"] == [picture_id]
+        assert operation["undoable"] is True
+        assert operation["summary"] == "Moved 1 picture to the Scrapheap"
+        assert operation["origin_client_id"] == "tab-1"
+
+        # The recorded facet is the soft-delete state itself, retention stamp
+        # included, so undo restores the deadline rather than inventing one.
+        detail = client.get(f"{API}/operations/{operation['id']}").json()
+        assert detail["before"][str(picture_id)]["deleted"] == {
+            "deleted": False,
+            "deleted_at": None,
+        }
+        assert detail["after"][str(picture_id)]["deleted"]["deleted"] is True
+        assert detail["after"][str(picture_id)]["deleted"]["deleted_at"] is not None
+
+        undo = client.post(f"{API}/operations/undo")
+        assert undo.status_code == 200, undo.text
+        assert undo.json()["restored_picture_ids"] == [picture_id]
+        assert undo.json()["scrapheaped_picture_ids"] == []
+        assert _lifecycle(server, picture_id) == (False, None)
+        assert _visible(client, picture_id) is True
+
+        # Redo puts it back in the Scrapheap, with the SAME retention stamp.
+        redo = client.post(f"{API}/operations/redo")
+        assert redo.status_code == 200, redo.text
+        assert redo.json()["scrapheaped_picture_ids"] == [picture_id]
+        assert redo.json()["restored_picture_ids"] == []
+        assert _lifecycle(server, picture_id) == (True, deleted_at)
+        assert _visible(client, picture_id) is False
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_bulk_scrapheap_move_is_one_batch_and_one_undo():
+    """Bulk = one batch id = one Undo, matching the log's grouping rule."""
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(3)]
+        resp = client.request("DELETE", f"{API}/pictures", json={"picture_ids": ids})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["deleted_count"] == 3
+
+        operations = _operations(server, op_type="pictures.scrapheap.move")
+        assert len(operations) == 1
+        operation = operations[0]
+        assert operation["target_ids"] == sorted(ids)
+        assert operation["target_count"] == 3
+        assert operation["batch_id"]
+        assert operation["summary"] == "Moved 3 pictures to the Scrapheap"
+        assert all(_lifecycle(server, pid)[0] is True for pid in ids)
+
+        # The batch endpoint reverts the whole move in one call.
+        undo = client.post(f"{API}/operations/batches/{operation['batch_id']}/undo")
+        assert undo.status_code == 200, undo.text
+        assert sorted(undo.json()["restored_picture_ids"]) == sorted(ids)
+        assert all(_lifecycle(server, pid) == (False, None) for pid in ids)
+
+        redo = client.post(f"{API}/operations/redo")
+        assert redo.status_code == 200, redo.text
+        assert all(_lifecycle(server, pid)[0] is True for pid in ids)
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_restore_from_the_scrapheap_is_recorded_symmetrically():
+    """Undoing a restore puts the pictures back — the history stays coherent."""
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(2)]
+        client.request("DELETE", f"{API}/pictures", json={"picture_ids": ids})
+        stamps = {pid: _lifecycle(server, pid)[1] for pid in ids}
+        assert all(stamp is not None for stamp in stamps.values())
+
+        resp = client.post(f"{API}/pictures/scrapheap/restore")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["restored_count"] == 2
+        assert all(_lifecycle(server, pid) == (False, None) for pid in ids)
+
+        operations = _operations(server, op_type="pictures.scrapheap.restore")
+        assert len(operations) == 1
+        restore_op = operations[0]
+        assert restore_op["target_ids"] == sorted(ids)
+        assert restore_op["batch_id"]
+        assert restore_op["summary"] == "Restored 2 pictures from the Scrapheap"
+
+        # Undoing the restore is a re-scrapheap, stamp and all.
+        undo = client.post(f"{API}/operations/undo")
+        assert undo.status_code == 200, undo.text
+        assert sorted(undo.json()["scrapheaped_picture_ids"]) == sorted(ids)
+        for pid in ids:
+            assert _lifecycle(server, pid) == (True, stamps[pid])
+
+        # And redoing it restores them again.
+        assert client.post(f"{API}/operations/redo").status_code == 200
+        assert all(_lifecycle(server, pid) == (False, None) for pid in ids)
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_restore_of_an_id_that_is_not_scrapheaped_records_nothing():
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        before = len(_operations(server))
+        resp = client.post(
+            f"{API}/pictures/scrapheap/restore", json={"picture_ids": [picture_id]}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["restored_count"] == 0
+        assert len(_operations(server)) == before
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_undoing_a_move_whose_picture_was_purged_refuses_and_changes_nothing():
+    """The fail-closed edge case: a purge is permanent, so the undo is refused.
+
+    Same contract as the locked-set guard — the WHOLE request is refused with a
+    specific error, nothing is written, and the operation stays ``applied``
+    rather than being marked undone over a change that did not happen.
+    """
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+        assert client.delete(f"{API}/pictures/{picture_id}").status_code == 200
+        assert _operations(server, op_type="pictures.scrapheap.move")
+
+        purged = _purge_forever(client, [picture_id])
+        assert purged["deleted_count"] == 1
+        assert _lifecycle(server, picture_id) is None
+
+        resp = client.post(f"{API}/operations/undo")
+        assert resp.status_code == 410, resp.text
+        detail = resp.json()["detail"]
+        assert detail["code"] == "pictures_purged"
+        assert detail["picture_ids"] == [picture_id]
+        assert "permanently deleted" in detail["message"]
+
+        # Refused, not half-applied.
+        move = _operations(server, op_type="pictures.scrapheap.move")[0]
+        assert move["status"] == "applied"
+        assert move["undone_at"] is None
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_partially_purged_bulk_move_refuses_the_whole_undo():
+    """No silent partial success: one purged target refuses the entire batch."""
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(3)]
+        client.request("DELETE", f"{API}/pictures", json={"picture_ids": ids})
+        _purge_forever(client, [ids[1]])
+        assert _lifecycle(server, ids[1]) is None
+
+        resp = client.post(f"{API}/operations/undo")
+        assert resp.status_code == 410, resp.text
+        assert resp.json()["detail"]["picture_ids"] == [ids[1]]
+
+        # The survivors are untouched — the refusal rolled the whole thing back.
+        assert _lifecycle(server, ids[0])[0] is True
+        assert _lifecycle(server, ids[2])[0] is True
+        assert (
+            _operations(server, op_type="pictures.scrapheap.move")[0]["status"]
+            == "applied"
+        )
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_permanent_deletes_record_no_operation():
+    """Purge / Empty Scrapheap are NOT undoable and must leave no log row."""
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(2)]
+        client.request("DELETE", f"{API}/pictures", json={"picture_ids": ids})
+        before = {op["id"] for op in _operations(server)}
+
+        # Named selection, then "Empty Scrapheap" (no ids at all).
+        _purge_forever(client, [ids[0]])
+        preview = client.post(f"{API}/pictures/scrapheap/delete-preview", json=None)
+        assert preview.status_code == 200, preview.text
+        emptied = client.request(
+            "DELETE",
+            f"{API}/pictures/scrapheap",
+            json={
+                "include_protected": True,
+                "confirm_token": preview.json()["confirm_token"],
+            },
+        )
+        assert emptied.status_code == 200, emptied.text
+
+        assert {op["id"] for op in _operations(server)} == before
+        assert _operations(server, op_type="pictures.scrapheap.purge") == []
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_scrapheap_move_of_a_stack_member_snapshots_the_whole_stack():
+    """normalize_stack_positions renumbers siblings; undo must put them back."""
+    temp_dir, client, server = _setup()
+    try:
+        ids = [_upload(client) for _ in range(3)]
+        stacked = client.post(f"{API}/stacks", json={"picture_ids": ids})
+        assert stacked.status_code == 200, stacked.text
+
+        def positions(session):
+            return {
+                int(row.id): row.stack_position
+                for row in session.exec(
+                    select(Picture).where(Picture.id.in_(ids))
+                ).all()
+            }
+
+        before = server.vault.db.run_task(positions)
+        leader = next(pid for pid, pos in before.items() if pos == 0)
+
+        assert client.delete(f"{API}/pictures/{leader}").status_code == 200
+        after = server.vault.db.run_task(positions)
+        assert after != before, "deleting the leader should promote a sibling"
+
+        operation = _operations(server, op_type="pictures.scrapheap.move")[0]
+        # Every renumbered sibling is in the snapshot, not just the deleted one.
+        assert set(operation["target_ids"]) >= {
+            pid for pid in ids if before[pid] != after[pid]
+        }
+
+        assert client.post(f"{API}/operations/undo").status_code == 200
+        assert server.vault.db.run_task(positions) == before
+        assert _lifecycle(server, leader) == (False, None)
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_scrapheap_move_of_a_locked_picture_is_refused_and_records_nothing():
+    temp_dir, client, server = _setup()
+    try:
+        picture_id = _upload(client)
+
+        def lock(session):
+            picture_set = PictureSet(name="frozen", locked=True)
+            session.add(picture_set)
+            session.commit()
+            session.refresh(picture_set)
+            session.add(PictureSetMember(set_id=picture_set.id, picture_id=picture_id))
+            session.commit()
+
+        server.vault.db.run_task(lock)
+
+        assert client.delete(f"{API}/pictures/{picture_id}").status_code == 423
+        assert _lifecycle(server, picture_id) == (False, None)
+        assert _operations(server, op_type="pictures.scrapheap.move") == []
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_scrapheap_summaries_count_the_recorded_change_not_the_request():
+    """A skipped (locked / already-deleted) picture must not inflate the toast."""
+    move = operation_log_service.scrapheap_move_summary
+    restore = operation_log_service.scrapheap_restore_summary
+    facet = operation_log_service.FACET_DELETED
+
+    after = {
+        "1": {facet: {"deleted": True, "deleted_at": "2026-07-29T00:00:00"}},
+        "2": {facet: {"deleted": True, "deleted_at": "2026-07-29T00:00:00"}},
+        # A stack sibling that was only renumbered is not a move.
+        "3": {"stack": {"id": 1, "name": None, "position": 0}},
+    }
+    assert move({}, after) == "Moved 2 pictures to the Scrapheap"
+    assert restore({}, after) is None
+
+    restored = {"9": {facet: {"deleted": False, "deleted_at": None}}}
+    assert restore({}, restored) == "Restored 1 picture from the Scrapheap"
+    assert move({}, restored) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Owner-decided scope extension to the operation log (stacked on #626): Scrapheap moves and restores are now recorded as undoable operations through the existing state-capture sink — one new `deleted` facet carrying flag + retention stamp as a unit, so undo never re-stamps or extends a retention window. Bulk move = one batch id = one undo.

- Undoing a move whose picture was since purged refuses in full with 410 (`pictures_purged` detail), mirroring the locked-set 423 contract; the operation stays applied, nothing partially commits.
- Permanent deletes (purge, Empty Scrapheap) remain unrecorded and non-undoable.
- Stack-sibling renumbering on scrapheap/restore is snapshot-covered (expansion includes soft-deleted members), so undo restores exact positions.
- WS events derive `change_kind` from the lifecycle (restored → added, re-scrapheaped → removed) so grids drop vanished thumbnails.
- Summaries count the actual diff, not the request (bulk moves skip locked pictures silently).

10 new tests; 369 targeted tests green; ruff clean. No new routes, no authz changes, no migration.

Known cost flagged, not capped: restore-all on a very large scrapheap snapshots every deleted picture's metadata (bulk delete is already capped at 1000; restore-all is not).

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U