### PR TITLE
Undo/redo UI: action receipt + toolbar history control

### DIFF
--- a/docs/design/design-tokens.css
+++ b/docs/design/design-tokens.css
@@ -142,6 +142,12 @@
   --badge-size: 16px;      /* min height / min-width of a count pill (on-grid; was an ad-hoc 15px) */
   --badge-size-dot: 8px;   /* the no-count activity dot (on-grid; was an ad-hoc 7px) */
 
+  /* The countdown drain hairline on a self-dismissing transient surface: the
+     action receipt today, and the notice card is the obvious second consumer.
+     It is a rendered height rather than padding, so it cannot borrow from the
+     spacing scale; naming it is what stops the next surface picking 3px. */
+  --countdown-h: 2px;
+
   /* Contextual action bar / toolbar band — the full-width bar that holds a count
      + actions above the content area (selection bar, Trash restore/purge bar,
      overlay top bar). One height so these bands align. Desktop chrome compresses

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -56,6 +56,7 @@ frontend/src/
 │   ├── useLockedSetsStore.js    # which pictures are frozen by a locked picture set
 │   ├── useReviewSessionsStore.js # tag-review sessions, health board, and sticker gamification
 │   ├── useEntityNamesStore.js   # id→name maps for the ImageGrid breadcrumb
+│   ├── useOperationStore.js     # the undo/redo stack + the action receipt (backend §21)
 │   └── useTasksStore.js         # active background work (workers + ComfyUI runs); app-wide activity light
 │
 ├── composables/                 # Extracted logic composables (Phase 8.1 — complete)
@@ -90,6 +91,7 @@ frontend/src/
 │   ├── pictureSets.js           # /picture_sets + membership + locked members
 │   ├── tags.js                  # /tags, /pictures/{id}/tags, tag predictions
 │   ├── pictureImport.js         # streaming-staging import session (was useImportService)
+│   ├── operations.js            # /operations — the undo/redo log, undo-state, undo/redo
 │   ├── stacks.js                # /stacks — create, order, members
 │   └── pictures.js              # /pictures — reads, count, stream, searches, stats
 │                                # every module has a co-located *.test.js
@@ -113,7 +115,7 @@ frontend/src/
     ├── TitleBar.vue             # Desktop-only custom window title bar (Electron): wordmark, breadcrumb, window controls, update alert
     ├── WordmarkLogo.vue         # "PixlStash" brand wordmark in the Tiny5 pixel font (two-tone via --wordmark-accent)
     ├── views/       # Full-page / full-screen UI surfaces: ImageGrid, ImageOverlay + extracted OverlayTagsPanel/OverlayDescriptionPanel/OverlayMetadataPanel/OverlayFilmstrip, ReviewSessionsOverlay, LoginScreen
-    ├── panels/      # Large structural panels that form the app shell: SideBar, Toolbar + extracted TbTagPanel/TbComfyPanel/TbExportPanel/TbImportPanel/GbFilterPanel, SelectionBar, SelectionMenu, StatsSidebar, ProjectFiles, …
+    ├── panels/      # Large structural panels that form the app shell: SideBar, Toolbar + extracted TbTagPanel/TbComfyPanel/TbExportPanel/TbImportPanel/GbFilterPanel/UndoControl, SelectionBar, SelectionMenu, StatsSidebar, ProjectFiles, …
     ├── reviews/     # Tag-review surfaces (see below)
     │   ├── ReviewSessionView.vue      # One open review session: header, rail, and card queue
     │   ├── ReviewRail.vue             # Rail of open review sessions
@@ -129,7 +131,7 @@ frontend/src/
     ├── editors/     # Entity create / edit / delete dialogs
     ├── settings/    # UserSettingsDialog, its section sub-components (Appearance, Behaviour, SmartScore, Workflows, Account, Snapshots, Compute), and the Settings* layout primitives (SettingsRow, SettingsSection, SettingsChip/ChipGrid, SettingsFieldBlock, SettingsSliderRow, SettingsTwoCol, SettingsInfoCard, SettingsAddTagRow)
     ├── io/          # Import / export / external-service connection
-    └── widgets/     # Reusable primitives, including the App* design-system layer (AppButton/AppDialog/AppInput/AppSelect/AppStepper/AppTextarea + FieldLabel)
+    └── widgets/     # Reusable primitives, including the App* design-system layer (AppButton/AppDialog/AppInput/AppSelect/AppStepper/AppTextarea + FieldLabel) and ActionReceipt (the transient undo pill)
 ```
 
 ---
@@ -140,7 +142,7 @@ frontend/src/
 |---------|--------|
 | Framework | Vue 3 (Composition API, `<script setup>`) |
 | UI component library | Vuetify 3 |
-| State management | **Pinia** — 16 domain stores in `src/stores/`; `App.vue` owns only UI-shell state |
+| State management | **Pinia** — 21 domain stores in `src/stores/`; `App.vue` owns only UI-shell state |
 | HTTP client | Axios (singleton `apiClient`) |
 | Routing | **Vue Router 4** (`createWebHistory`). `Root.vue` gates on `isAuthenticated`; all authenticated views (`/`, `/character/:id`, `/set/:id`, `/project/:id`, `/scrapheap`) render `App.vue` via `<RouterView>`. `App.vue` watches the route and syncs params to Pinia stores; nav handlers call `router.push()` to update the URL. **The route is the single source of truth for what the grid shows** — only explicit entry clicks push routes; sidebar tab/category switches never do (see Key Design Principles). |
 | Build tool | Vite 5 |
@@ -184,7 +186,7 @@ The application shell. Responsibilities:
 - Renders the three-panel layout: `SideBar` | `ImageGrid` (+ `Toolbar`) | `StatsSidebar`.
 - Manages the `PhotosImportDialog`.
 - Owns the **WebSocket lifecycle only** (connect / reconnect / close / `set_filters`); the picture-event decision table is delegated to `useGridRealtimeSync` (see §9).
-- Handles global keyboard shortcuts, window drag/drop, paste events.
+- Handles global keyboard shortcuts, window drag/drop, paste events. Undo/redo (`Ctrl+Z` / `Ctrl+Y` / `Ctrl+Shift+Z`, Meta accepted everywhere) lives in `handleGlobalKeydown` and declines in four cases, each for its own reason: while typing (a text field keeps its native undo stack), in a read-only session, on key auto-repeat (a held `Ctrl+Z` must not walk the stack), and while a modal overlay owns the screen — the receipt sits on `--z-floating`, under the lightbox and under every dialog, so an undo fired from there would mutate the library with no visible narration. Promoting the receipt above those layers is the recorded follow-up that would lift the last guard.
 - Fetches user config on startup (`GET /users/me/config`) and applies persisted preferences via the relevant stores.
 - Persists sidebar/stats open state to `localStorage`.
 
@@ -215,6 +217,7 @@ All state consumed by more than one component lives in a Pinia store. The stores
 | `useLockedSetsStore` | `useLockedSetsStore.js` | Which pictures are frozen by a locked picture set. Fed by `GET /picture_sets/locked-members`; refreshed on app start and on the same sidebar-refresh / `pictures_changed` ws triggers the sidebar uses. Single source of the lock-tooltip copy reused by the grid badge, overlay chip, and context-menu gating. |
 | `useGenStackPrefsStore` | `useGenStackPrefsStore.js` | Remembered client prefs for whether newly generated / filtered images stack with their source: `stackI2IOutputs` (ComfyUI image-to-image) and `stackFilterOutputs` (plugin "Filters" runs), both default ON and persisted to `localStorage`. |
 | `useEntityNamesStore` | `useEntityNamesStore.js` | `characterNames`, `setNames`, `projectNames`, `refFolderLabels`, `importFolderLabels` (id→name maps). One-directional id→name only (names aren't unique). `SideBar` publishes via `merge*` setters after each fetch; `ImageGrid`'s breadcrumb consumes them to label the route's IDs. |
+| `useOperationStore` | `useOperationStore.js` | The undo/redo stack, mirrored from the backend's append-only operation log (`backend_architecture.md` §21): `operations` (newest 50, newest first), `canUndo`/`canRedo`/`nextUndo`/`nextRedo` from `GET /operations/undo-state`, and the single live `receipt` that narrates what just happened. Computeds `past` (applied steps), `future` (undone, redoable), `historyCount`, `nextUndoIsExternal`. Owns the receipt's dwell timer (5s, 8s destructive, paused on hover/focus/hidden tab) and the multi-step `undoTo` walk. Refreshed on a debounced WS picture/tag/character/description event; the receipt narrates THIS client's operations only (origin read from the event `data`), so another tab's work updates the stack silently. |
 | `useTasksStore` | `useTasksStore.js` | `workerSnapshots`, `series` (per-worker throughput history), `systemUsage` (CPU/RAM/VRAM), `comfyuiRuns` (frontend-driven run progress keyed by run id); computeds `activeEntries` (backend workers + ComfyUI runs, merged), `hasActiveTasks`, `activeCount`. The **single poller** of `GET /workers/progress` (adaptive cadence — see §4.4) and the single source of truth for the app-wide "is the app working" indicators. |
 
 Components import stores directly (`import { useFilterStore } from '../../stores/useFilterStore'`) — no prop drilling required.
@@ -480,6 +483,12 @@ Actual file upload engine. Props: `backendUrl`, `selectedCharacterId`, `allPictu
 
 #### App* design-system layer (`widgets/`)
 The house-styled form/control primitives that wrap Vuetify with the PixlStash tokens (`styles/design-tokens.css`), so new UI composes from one consistent kit instead of raw Vuetify: `AppButton.vue` (~140 lines), `AppDialog.vue` (~165 lines), `AppInput.vue` (~95 lines), `AppSelect.vue` (~95 lines), `AppStepper.vue` (~125 lines), `AppTextarea.vue` (~60 lines), plus `FieldLabel.vue` (~15 lines) for consistent field labelling. Presentational; each takes `v-model` / props and emits the matching update events.
+
+#### `ActionReceipt.vue` (465 lines, `widgets/`)
+The transient undo pill, built to the owner's "Undo / Redo System" design. One instance, mounted by `ImageGrid` in the selection pill's slot; reads `useOperationStore` directly (the receipt is inherently singular, so there is nothing to prop-drill). Props: `liftPx` — how far to sit above the selection bar, MEASURED by the caller via `useAnchorHeight("selection-bar")`, never assumed. States: default / coalesced (`+N`, grouped by the server's `batch_id`) / undone-with-Redo / not-undoable ("Can't be undone", never a dead button). A `--countdown-h` hairline drains over the dwell window (5s, 8s destructive) as a `scaleX` animation whose `animation-play-state` pauses on hover and focus-within in lockstep with the store's timer (WCAG 2.2.1); it is the one animation that deliberately survives `prefers-reduced-motion`, because it is the time-remaining readout rather than decoration. Sits on `--z-floating` and registers `"action-receipt"` with `useBottomAnchor` — the measured element is the pointer-transparent wrapper (pill + lift), so the notice stack clears the whole thing. Announces through ONE persistent `role="status"` region rather than the remounted pill, throttled so a burst of actions reads once.
+
+#### `UndoControl.vue` (511 lines, `panels/`)
+The toolbar undo/redo pair plus a chevron opening the History popover. Mounted by `Toolbar` next to the sort split-button — the same position in the Electron shell and in the browser, which is why it is not in the breadcrumb. Buttons use `aria-disabled` + a guarded handler rather than the native `disabled`, so they stay tabbable and keep naming the step ("Nothing to undo"), and carry `aria-keyshortcuts`. The popover reuses the shared `.tbm*` menu chrome and is labelled `role="dialog"` (not `menu`): it is a list of ordinary tab-order buttons with no roving arrow-key navigation, so claiming a menu would promise a contract it does not honour. Rows are newest-first, undone steps struck through and inert; hovering **or focusing** a row previews how far back you would go (`--active-wash` + an `--active-bar` inset rail across the whole range), and activating it walks the stack via `undoTo`. Enter is handled explicitly because Vuetify's menu `preventDefault`s it. Focus returns to the chevron on a programmatic close. Exposes `openHistory()`.
 
 #### `AddToEntityControl.vue` (966 lines)
 Reusable control for assigning images to/from characters and sets. Props: `type` (`'character'`|`'set'`), `imageIds`, `selectedCharacter`, `selectedSet`. Emits: `added`, `removed`, `selected`. Used in `Toolbar`, `ImageOverlay`, `ImageGridContextMenu`.
@@ -825,6 +834,7 @@ For `<img :src="...">` bindings and similar direct browser requests that bypass 
 | `api/pictureSets.js` | `/picture_sets`, membership, and locked members |
 | `api/tags.js` | `/tags` vocabulary, per-picture tag edits, and tag predictions |
 | `api/pictureImport.js` | the streaming-staging import session (`/pictures/import/staging/*`) |
+| `api/operations.js` | `/operations`: the append-only change log, `undo-state`, and undo / redo / per-operation undo / batch undo (all OWNER_ONLY — callers guard on `isReadOnly`) |
 | `api/stacks.js` | `/stacks`: grouping, ordering, dissolving |
 | `api/pictures.js` | `/pictures`, the largest resource: reads, count, stream, the searches, stats |
 
@@ -873,6 +883,10 @@ Both reuse the primary-coloured `pending-imports-pill` styling and never reshuff
 
 - **"New pictures"** — raised for `source: "external", change_kind: "added"` (or foreign-UI adds that arrive mid-streaming-fetch). Backed by `useWsStore.pendingExternalImportIds`; click splices the new ids in. Replaces the old import-only "pending imports" pill.
 - **"View changed externally — click to refresh"** — a sibling pill raised when an external `updated` event has `pictureChangeAffectsView(fields) === true`, **or** when an external `tags_changed` arrives while a tag filter is active (`ImageGrid`'s `wsTagUpdate` watcher emits `flag-sort-changed`; `App.vue` skips ids already queued in the "New pictures" pill so a just-imported batch being tagged doesn't double-pill). Backed by `useWsStore.sortChangedExternalIds`; click reconciles/re-sorts.
+
+### The undo stack's WS hook
+
+The operation log has **no WS event of its own** — a recorded metadata mutation announces itself as an ordinary `pictures_changed` / `tags_changed` / `characters_changed` / `descriptions_changed` event, and that is the signal the undo stack may have moved. `App.vue` routes those four types (and deliberately not `picture_imported`: imports are not undoable in v1.9) to `useOperationStore.onPictureEvent`, which re-reads `GET /operations` + `GET /operations/undo-state` on a 400 ms trailing edge, because a bulk action over thousands of pictures would otherwise poll back to back for the whole run. Origin is read from the event `data` and used for one thing only: whether the change may narrate itself. An own-origin event raises the receipt; anything external updates the stack **silently**, and the toolbar tooltip then says "Changed elsewhere: …" so a later `Ctrl+Z` cannot revert another tab's work unannounced.
 
 ### 9.1 Overlay-open deferral contract
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -571,6 +571,20 @@ kbd {
 .tbm-spacer {
   flex: 1 1 auto;
 }
+
+/* Hint strip closing a menu — `.tbm-header` mirrored (same padding and gap, a
+   top rule instead of a bottom one) with quieter type, because it states what a
+   click would do rather than titling the panel. Lives here beside the header so
+   the next menu that needs a footer finds it instead of rolling its own. */
+.tbm-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid rgb(var(--v-theme-divider));
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-panel), 0.6);
+}
 .tbm-count {
   font-family: var(--font-mono);
   font-size: var(--text-xs);

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1633,15 +1633,35 @@ async function patchConfigUIOptions() {
   }
 }
 
+/**
+ * Is a modal surface (a dialog, the lightbox) currently covering the app?
+ *
+ * There is no shared flag for this — every dialog owns its own `open` ref —
+ * so the honest single source is the scrim Vuetify renders for every active
+ * overlay. Used to decline global shortcuts whose feedback would be invisible
+ * behind it.
+ */
+function isModalOverlayOpen() {
+  if (typeof document === "undefined") return false;
+  return document.querySelector(".v-overlay--active .v-overlay__scrim") != null;
+}
+
 function handleGlobalKeydown(e) {
   // The review overlay is modal and owns its own keyboard handler; don't
   // run the app/grid shortcuts (scroll, search, help) behind it.
   if (reviewSessionsStore.overlayOpen) return;
-  const tag = document.activeElement?.tagName?.toLowerCase();
-  const isEditable =
-    tag === "input" ||
-    tag === "textarea" ||
-    document.activeElement?.isContentEditable;
+  const target = e.target;
+  const active = document.activeElement;
+  // Match the strictness the grid and the lightbox already use: a SELECT and an
+  // ARIA textbox are typing surfaces too, and the event target matters as much
+  // as `document.activeElement` (a Vuetify combobox moves focus around).
+  const isEditable = [target, active].some(
+    (el) =>
+      el instanceof HTMLElement &&
+      (el.isContentEditable ||
+        ["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName) ||
+        el.getAttribute("role") === "textbox"),
+  );
 
   // The auto-hide sidebar is revealed by hover (or tap), so WCAG 2.1 SC 1.4.13
   // "Content on Hover or Focus" applies: it must be dismissible without moving
@@ -1663,13 +1683,24 @@ function handleGlobalKeydown(e) {
   // screen, and every undo raises one, so the result is always narrated. Ctrl
   // and Meta are both accepted (the HINT is platform-specific, the binding is
   // not); Ctrl+Shift+Z is the macOS redo convention and is accepted everywhere.
-  // Skipped while typing, so a text field keeps its own native undo stack, and
-  // skipped for a read-only session, where the endpoints are owner-only anyway.
+  //
+  // Four guards, each for its own reason:
+  //   • typing — a text field keeps its own native undo stack;
+  //   • read-only — the endpoints are owner-only anyway;
+  //   • auto-repeat — a HELD Ctrl+Z must not walk the whole stack;
+  //   • a modal overlay owns the screen — the receipt lives on --z-floating,
+  //     under the lightbox and under any dialog, so an undo fired from there
+  //     would mutate the library with no visible narration. That breaks the
+  //     design's own "every undo raises a receipt" invariant, so the shortcut
+  //     declines rather than acting blind. Promoting the receipt above those
+  //     layers is the recorded follow-up.
   if (
     (e.ctrlKey || e.metaKey) &&
     !e.altKey &&
+    !e.repeat &&
     !isEditable &&
-    !isReadOnly.value
+    !isReadOnly.value &&
+    !isModalOverlayOpen()
   ) {
     const key = e.key?.toLowerCase();
     if (key === "z" && !e.shiftKey) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -346,7 +346,7 @@ function connectUpdatesSocket() {
     // announces itself as a picture/tag/character change, and that is the
     // signal the undo stack may have moved. Origin is read from the event
     // `data` (never a contextvar) and only decides whether the change may
-    // narrate itself — an external one updates the stack silently.
+    // narrate itself; an external one updates the stack silently.
     if (OPERATION_BEARING_EVENTS.has(payload?.type)) {
       operationStore.onPictureEvent(payload);
     }
@@ -1478,7 +1478,9 @@ async function fetchConfig() {
       cfg.similarity_character ?? cfg.selected_similarity_character;
     sortStore.selectedSimilarityCharacter =
       similarityValue ?? sortStore.selectedSimilarityCharacter ?? null;
-    const newHiddenTags = Array.isArray(cfg.hidden_tags) ? cfg.hidden_tags : [];
+    const newHiddenTags = Array.isArray(cfg.hidden_tags)
+      ? cfg.hidden_tags
+      : [];
     if (
       userPrefsStore.hiddenTags.length !== newHiddenTags.length ||
       userPrefsStore.hiddenTags.some((tag, i) => tag !== newHiddenTags[i])
@@ -1526,7 +1528,9 @@ async function fetchConfig() {
       theme_mode: userPrefsStore.themeMode,
       similarity_character: sortStore.selectedSimilarityCharacter,
       stack_strictness:
-        cfg.stack_strictness != null ? Number(cfg.stack_strictness) : null,
+        cfg.stack_strictness != null
+          ? Number(cfg.stack_strictness)
+          : null,
       hidden_tags: userPrefsStore.hiddenTags,
       apply_tag_filter: userPrefsStore.applyTagFilter,
     };
@@ -1636,8 +1640,8 @@ async function patchConfigUIOptions() {
 /**
  * Is a modal surface (a dialog, the lightbox) currently covering the app?
  *
- * There is no shared flag for this — every dialog owns its own `open` ref —
- * so the honest single source is the scrim Vuetify renders for every active
+ * There is no shared flag for this: every dialog owns its own `open` ref, so
+ * the honest single source is the scrim Vuetify renders for every active
  * overlay. Used to decline global shortcuts whose feedback would be invisible
  * behind it.
  */
@@ -1650,12 +1654,10 @@ function handleGlobalKeydown(e) {
   // The review overlay is modal and owns its own keyboard handler; don't
   // run the app/grid shortcuts (scroll, search, help) behind it.
   if (reviewSessionsStore.overlayOpen) return;
-  const target = e.target;
-  const active = document.activeElement;
   // Match the strictness the grid and the lightbox already use: a SELECT and an
   // ARIA textbox are typing surfaces too, and the event target matters as much
   // as `document.activeElement` (a Vuetify combobox moves focus around).
-  const isEditable = [target, active].some(
+  const isEditable = [e.target, document.activeElement].some(
     (el) =>
       el instanceof HTMLElement &&
       (el.isContentEditable ||
@@ -1685,10 +1687,10 @@ function handleGlobalKeydown(e) {
   // not); Ctrl+Shift+Z is the macOS redo convention and is accepted everywhere.
   //
   // Four guards, each for its own reason:
-  //   • typing — a text field keeps its own native undo stack;
-  //   • read-only — the endpoints are owner-only anyway;
-  //   • auto-repeat — a HELD Ctrl+Z must not walk the whole stack;
-  //   • a modal overlay owns the screen — the receipt lives on --z-floating,
+  //   * typing: a text field keeps its own native undo stack;
+  //   * read-only: the endpoints are owner-only anyway;
+  //   * auto-repeat: a HELD Ctrl+Z must not walk the whole stack;
+  //   * a modal overlay owns the screen: the receipt lives on --z-floating,
   //     under the lightbox and under any dialog, so an undo fired from there
   //     would mutate the library with no visible narration. That breaks the
   //     design's own "every undo raises a receipt" invariant, so the shortcut
@@ -2495,108 +2497,108 @@ defineExpose({
         <!-- Peer of the left sidebar, NOT nested in the grid column: both rails
              then span the full height of `.file-manager` and nothing stacked in
              the main area can push one rail down without the other. -->
-        <StatsSidebar
-          ref="statsSidebarRef"
-          :open="sidebarStore.statsOpen"
-          :backendUrl="BACKEND_URL"
-          :selectedCharacter="selectionStore.selectedCharacter"
-          :selectedCharacterIds="selectionStore.selectedCharacterIds"
-          :characterMode="selectionStore.characterMultiMode"
-          :selectedSet="selectionStore.selectedSet"
-          :selectedSetIds="selectionStore.selectedSetIds"
-          :setMode="selectionStore.setMultiMode"
-          :setDifferenceBaseId="selectionStore.setDifferenceBaseId"
-          :projectViewMode="projectStore.projectViewMode"
-          :selectedProjectId="projectStore.selectedProjectId"
-          :tagFilter="filterStore.tagFilter"
-          :tagRejectedFilter="filterStore.tagRejectedFilter"
-          :mediaTypeFilter="filterStore.mediaTypeFilter"
-          :minScoreFilter="filterStore.minScoreFilter"
-          :maxScoreFilter="filterStore.maxScoreFilter"
-          :smartScoreBucketFilter="filterStore.smartScoreBucketFilter"
-          :resolutionBucketFilter="filterStore.resolutionBucketFilter"
-          :faceBboxFilter="filterStore.faceBboxFilter"
-          :sharedOnlyFilter="filterStore.sharedOnlyFilter"
-          :unassignedOnlyFilter="filterStore.unassignedOnlyFilter"
-          :filePathPrefixFilter="
-            selectionStore.selectedFolderFilter?.pathPrefix ?? null
-          "
-          :importSourceFolderFilter="
-            selectionStore.selectedFolderFilter?.importSourceFolder ?? null
-          "
-          :allPicturesId="ALL_PICTURES_ID"
-          :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
-          :scrapheapPicturesId="SCRAPHEAP_PICTURES_ID"
-          :penalisedTagWeights="userPrefsStore.penalisedTagWeights"
-          :tagConfidenceAboveFilter="filterStore.tagConfidenceAboveFilter"
-          :tagConfidenceBelowFilter="filterStore.tagConfidenceBelowFilter"
-          :wsTagUpdate="wsStore.wsTagUpdate"
-          @filter-tag="
-            (tag) => {
-              if (filterStore.tagFilter.includes(tag))
-                filterStore.tagFilter = filterStore.tagFilter.filter(
-                  (t) => t !== tag,
+          <StatsSidebar
+            ref="statsSidebarRef"
+            :open="sidebarStore.statsOpen"
+            :backendUrl="BACKEND_URL"
+            :selectedCharacter="selectionStore.selectedCharacter"
+            :selectedCharacterIds="selectionStore.selectedCharacterIds"
+            :characterMode="selectionStore.characterMultiMode"
+            :selectedSet="selectionStore.selectedSet"
+            :selectedSetIds="selectionStore.selectedSetIds"
+            :setMode="selectionStore.setMultiMode"
+            :setDifferenceBaseId="selectionStore.setDifferenceBaseId"
+            :projectViewMode="projectStore.projectViewMode"
+            :selectedProjectId="projectStore.selectedProjectId"
+            :tagFilter="filterStore.tagFilter"
+            :tagRejectedFilter="filterStore.tagRejectedFilter"
+            :mediaTypeFilter="filterStore.mediaTypeFilter"
+            :minScoreFilter="filterStore.minScoreFilter"
+            :maxScoreFilter="filterStore.maxScoreFilter"
+            :smartScoreBucketFilter="filterStore.smartScoreBucketFilter"
+            :resolutionBucketFilter="filterStore.resolutionBucketFilter"
+            :faceBboxFilter="filterStore.faceBboxFilter"
+            :sharedOnlyFilter="filterStore.sharedOnlyFilter"
+            :unassignedOnlyFilter="filterStore.unassignedOnlyFilter"
+            :filePathPrefixFilter="
+              selectionStore.selectedFolderFilter?.pathPrefix ?? null
+            "
+            :importSourceFolderFilter="
+              selectionStore.selectedFolderFilter?.importSourceFolder ?? null
+            "
+            :allPicturesId="ALL_PICTURES_ID"
+            :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
+            :scrapheapPicturesId="SCRAPHEAP_PICTURES_ID"
+            :penalisedTagWeights="userPrefsStore.penalisedTagWeights"
+            :tagConfidenceAboveFilter="filterStore.tagConfidenceAboveFilter"
+            :tagConfidenceBelowFilter="filterStore.tagConfidenceBelowFilter"
+            :wsTagUpdate="wsStore.wsTagUpdate"
+            @filter-tag="
+              (tag) => {
+                if (filterStore.tagFilter.includes(tag))
+                  filterStore.tagFilter = filterStore.tagFilter.filter(
+                    (t) => t !== tag,
+                  );
+                else filterStore.tagFilter = [...filterStore.tagFilter, tag];
+              }
+            "
+            @filter-tags="
+              (tags) => {
+                const allPresent = tags.every((t) =>
+                  filterStore.tagFilter.includes(t),
                 );
-              else filterStore.tagFilter = [...filterStore.tagFilter, tag];
-            }
-          "
-          @filter-tags="
-            (tags) => {
-              const allPresent = tags.every((t) =>
-                filterStore.tagFilter.includes(t),
-              );
-              if (allPresent)
+                if (allPresent)
+                  filterStore.tagFilter = filterStore.tagFilter.filter(
+                    (t) => !tags.includes(t),
+                  );
+                else
+                  filterStore.tagFilter = [
+                    ...new Set([...filterStore.tagFilter, ...tags]),
+                  ];
+              }
+            "
+            @filter-confidence-above="
+              (entry) => {
+                if (filterStore.tagConfidenceAboveFilter.includes(entry))
+                  filterStore.tagConfidenceAboveFilter =
+                    filterStore.tagConfidenceAboveFilter.filter(
+                      (e) => e !== entry,
+                    );
+                else
+                  filterStore.tagConfidenceAboveFilter = [
+                    ...filterStore.tagConfidenceAboveFilter,
+                    entry,
+                  ];
+              }
+            "
+            @clear-tag-filter="
+              (tags) => {
                 filterStore.tagFilter = filterStore.tagFilter.filter(
                   (t) => !tags.includes(t),
                 );
-              else
-                filterStore.tagFilter = [
-                  ...new Set([...filterStore.tagFilter, ...tags]),
-                ];
-            }
-          "
-          @filter-confidence-above="
-            (entry) => {
-              if (filterStore.tagConfidenceAboveFilter.includes(entry))
+              }
+            "
+            @clear-confidence-filter="
+              (entries) => {
                 filterStore.tagConfidenceAboveFilter =
                   filterStore.tagConfidenceAboveFilter.filter(
-                    (e) => e !== entry,
+                    (e) => !entries.includes(e),
                   );
-              else
-                filterStore.tagConfidenceAboveFilter = [
-                  ...filterStore.tagConfidenceAboveFilter,
-                  entry,
-                ];
-            }
-          "
-          @clear-tag-filter="
-            (tags) => {
-              filterStore.tagFilter = filterStore.tagFilter.filter(
-                (t) => !tags.includes(t),
-              );
-            }
-          "
-          @clear-confidence-filter="
-            (entries) => {
-              filterStore.tagConfidenceAboveFilter =
-                filterStore.tagConfidenceAboveFilter.filter(
-                  (e) => !entries.includes(e),
-                );
-            }
-          "
-          @update:minScoreFilter="(v) => (filterStore.minScoreFilter = v)"
-          @update:maxScoreFilter="(v) => (filterStore.maxScoreFilter = v)"
-          @update:smartScoreBucketFilter="
-            (v) => (filterStore.smartScoreBucketFilter = v)
-          "
-          @update:resolutionBucketFilter="
-            (v) => (filterStore.resolutionBucketFilter = v)
-          "
-          @toggle="
-            sidebarStore.toggleStats();
-            updateIsMobile();
-          "
-        />
+              }
+            "
+            @update:minScoreFilter="(v) => (filterStore.minScoreFilter = v)"
+            @update:maxScoreFilter="(v) => (filterStore.maxScoreFilter = v)"
+            @update:smartScoreBucketFilter="
+              (v) => (filterStore.smartScoreBucketFilter = v)
+            "
+            @update:resolutionBucketFilter="
+              (v) => (filterStore.resolutionBucketFilter = v)
+            "
+            @toggle="
+              sidebarStore.toggleStats();
+              updateIsMobile();
+            "
+          />
       </div>
       <ReviewSessionsOverlay
         v-if="reviewSessionsStore.overlayOpen"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -32,6 +32,8 @@ import { useReviewSessionsStore } from "./stores/useReviewSessionsStore";
 import { useSnapshotsStore } from "./stores/useSnapshotsStore";
 import { useTasksStore } from "./stores/useTasksStore";
 import { useLockedSetsStore } from "./stores/useLockedSetsStore";
+import { useOperationStore } from "./stores/useOperationStore";
+import { redoKeyHint, undoKeyHint } from "./utils/shortcutHints";
 import { useGridRealtimeSync } from "./composables/useGridRealtimeSync";
 
 import SideBar from "./components/panels/SideBar.vue";
@@ -71,6 +73,11 @@ const reviewSessionsStore = useReviewSessionsStore();
 const snapshotsStore = useSnapshotsStore();
 const tasksStore = useTasksStore();
 const lockedSetsStore = useLockedSetsStore();
+const operationStore = useOperationStore();
+// Keycap labels for the shortcuts dialog. The binding accepts Ctrl and Meta
+// everywhere; only the hint is platform-specific.
+const undoKeyHintKeys = undoKeyHint();
+const redoKeyHintKeys = redoKeyHint();
 
 // --- Router ---
 const route = useRoute();
@@ -199,6 +206,16 @@ const activeCategoryLabel = computed(() => {
 });
 
 // --- WebSocket ---
+// Event types that can carry a recorded operation (the reversible metadata
+// facets of backend_architecture.md §21). `picture_imported` is deliberately
+// absent: imports are not undoable in v1.9, so they never appear in the stack.
+const OPERATION_BEARING_EVENTS = new Set([
+  "pictures_changed",
+  "tags_changed",
+  "characters_changed",
+  "descriptions_changed",
+]);
+
 function buildUpdatesSocketUrl() {
   if (!BACKEND_URL) return "";
   const wsBase = BACKEND_URL.replace(/^http/i, "ws");
@@ -324,6 +341,14 @@ function connectUpdatesSocket() {
       payload = JSON.parse(event.data);
     } catch {
       return;
+    }
+    // The operation log has no WS event of its own: a metadata mutation
+    // announces itself as a picture/tag/character change, and that is the
+    // signal the undo stack may have moved. Origin is read from the event
+    // `data` (never a contextvar) and only decides whether the change may
+    // narrate itself — an external one updates the stack silently.
+    if (OPERATION_BEARING_EVENTS.has(payload?.type)) {
+      operationStore.onPictureEvent(payload);
     }
     const isPictureChange =
       payload?.type === "pictures_changed" ||
@@ -1453,9 +1478,7 @@ async function fetchConfig() {
       cfg.similarity_character ?? cfg.selected_similarity_character;
     sortStore.selectedSimilarityCharacter =
       similarityValue ?? sortStore.selectedSimilarityCharacter ?? null;
-    const newHiddenTags = Array.isArray(cfg.hidden_tags)
-      ? cfg.hidden_tags
-      : [];
+    const newHiddenTags = Array.isArray(cfg.hidden_tags) ? cfg.hidden_tags : [];
     if (
       userPrefsStore.hiddenTags.length !== newHiddenTags.length ||
       userPrefsStore.hiddenTags.some((tag, i) => tag !== newHiddenTags[i])
@@ -1503,9 +1526,7 @@ async function fetchConfig() {
       theme_mode: userPrefsStore.themeMode,
       similarity_character: sortStore.selectedSimilarityCharacter,
       stack_strictness:
-        cfg.stack_strictness != null
-          ? Number(cfg.stack_strictness)
-          : null,
+        cfg.stack_strictness != null ? Number(cfg.stack_strictness) : null,
       hidden_tags: userPrefsStore.hiddenTags,
       apply_tag_filter: userPrefsStore.applyTagFilter,
     };
@@ -1636,6 +1657,28 @@ function handleGlobalKeydown(e) {
     sidebarStore.sidebarVisible
   ) {
     sidebarStore.hideAutoSidebar();
+  }
+
+  // Undo / redo. Global by design: the shortcut has to work with no receipt on
+  // screen, and every undo raises one, so the result is always narrated. Ctrl
+  // and Meta are both accepted (the HINT is platform-specific, the binding is
+  // not); Ctrl+Shift+Z is the macOS redo convention and is accepted everywhere.
+  // Skipped while typing, so a text field keeps its own native undo stack, and
+  // skipped for a read-only session, where the endpoints are owner-only anyway.
+  if (
+    (e.ctrlKey || e.metaKey) &&
+    !e.altKey &&
+    !isEditable &&
+    !isReadOnly.value
+  ) {
+    const key = e.key?.toLowerCase();
+    if (key === "z" && !e.shiftKey) {
+      e.preventDefault();
+      operationStore.undo();
+    } else if (key === "y" || (key === "z" && e.shiftKey)) {
+      e.preventDefault();
+      operationStore.redo();
+    }
   }
 
   const keys = ["Home", "End", "PageUp", "PageDown"];
@@ -2016,6 +2059,11 @@ onMounted(async () => {
   // would 403 on every fetch otherwise.
   if (!isReadOnly.value) {
     snapshotsStore.fetchSnapshots();
+    // Seed the undo stack so the toolbar control is correctly enabled on the
+    // first frame. This read establishes the "already seen" watermark, so the
+    // history it returns cannot pop a receipt for something that happened
+    // before the tab existed.
+    operationStore.refresh({ narrate: false });
   }
   // Navigate to the scoped resource when a share token is active
   const ctx = sessionContext.value;
@@ -2416,108 +2464,108 @@ defineExpose({
         <!-- Peer of the left sidebar, NOT nested in the grid column: both rails
              then span the full height of `.file-manager` and nothing stacked in
              the main area can push one rail down without the other. -->
-          <StatsSidebar
-            ref="statsSidebarRef"
-            :open="sidebarStore.statsOpen"
-            :backendUrl="BACKEND_URL"
-            :selectedCharacter="selectionStore.selectedCharacter"
-            :selectedCharacterIds="selectionStore.selectedCharacterIds"
-            :characterMode="selectionStore.characterMultiMode"
-            :selectedSet="selectionStore.selectedSet"
-            :selectedSetIds="selectionStore.selectedSetIds"
-            :setMode="selectionStore.setMultiMode"
-            :setDifferenceBaseId="selectionStore.setDifferenceBaseId"
-            :projectViewMode="projectStore.projectViewMode"
-            :selectedProjectId="projectStore.selectedProjectId"
-            :tagFilter="filterStore.tagFilter"
-            :tagRejectedFilter="filterStore.tagRejectedFilter"
-            :mediaTypeFilter="filterStore.mediaTypeFilter"
-            :minScoreFilter="filterStore.minScoreFilter"
-            :maxScoreFilter="filterStore.maxScoreFilter"
-            :smartScoreBucketFilter="filterStore.smartScoreBucketFilter"
-            :resolutionBucketFilter="filterStore.resolutionBucketFilter"
-            :faceBboxFilter="filterStore.faceBboxFilter"
-            :sharedOnlyFilter="filterStore.sharedOnlyFilter"
-            :unassignedOnlyFilter="filterStore.unassignedOnlyFilter"
-            :filePathPrefixFilter="
-              selectionStore.selectedFolderFilter?.pathPrefix ?? null
-            "
-            :importSourceFolderFilter="
-              selectionStore.selectedFolderFilter?.importSourceFolder ?? null
-            "
-            :allPicturesId="ALL_PICTURES_ID"
-            :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
-            :scrapheapPicturesId="SCRAPHEAP_PICTURES_ID"
-            :penalisedTagWeights="userPrefsStore.penalisedTagWeights"
-            :tagConfidenceAboveFilter="filterStore.tagConfidenceAboveFilter"
-            :tagConfidenceBelowFilter="filterStore.tagConfidenceBelowFilter"
-            :wsTagUpdate="wsStore.wsTagUpdate"
-            @filter-tag="
-              (tag) => {
-                if (filterStore.tagFilter.includes(tag))
-                  filterStore.tagFilter = filterStore.tagFilter.filter(
-                    (t) => t !== tag,
-                  );
-                else filterStore.tagFilter = [...filterStore.tagFilter, tag];
-              }
-            "
-            @filter-tags="
-              (tags) => {
-                const allPresent = tags.every((t) =>
-                  filterStore.tagFilter.includes(t),
+        <StatsSidebar
+          ref="statsSidebarRef"
+          :open="sidebarStore.statsOpen"
+          :backendUrl="BACKEND_URL"
+          :selectedCharacter="selectionStore.selectedCharacter"
+          :selectedCharacterIds="selectionStore.selectedCharacterIds"
+          :characterMode="selectionStore.characterMultiMode"
+          :selectedSet="selectionStore.selectedSet"
+          :selectedSetIds="selectionStore.selectedSetIds"
+          :setMode="selectionStore.setMultiMode"
+          :setDifferenceBaseId="selectionStore.setDifferenceBaseId"
+          :projectViewMode="projectStore.projectViewMode"
+          :selectedProjectId="projectStore.selectedProjectId"
+          :tagFilter="filterStore.tagFilter"
+          :tagRejectedFilter="filterStore.tagRejectedFilter"
+          :mediaTypeFilter="filterStore.mediaTypeFilter"
+          :minScoreFilter="filterStore.minScoreFilter"
+          :maxScoreFilter="filterStore.maxScoreFilter"
+          :smartScoreBucketFilter="filterStore.smartScoreBucketFilter"
+          :resolutionBucketFilter="filterStore.resolutionBucketFilter"
+          :faceBboxFilter="filterStore.faceBboxFilter"
+          :sharedOnlyFilter="filterStore.sharedOnlyFilter"
+          :unassignedOnlyFilter="filterStore.unassignedOnlyFilter"
+          :filePathPrefixFilter="
+            selectionStore.selectedFolderFilter?.pathPrefix ?? null
+          "
+          :importSourceFolderFilter="
+            selectionStore.selectedFolderFilter?.importSourceFolder ?? null
+          "
+          :allPicturesId="ALL_PICTURES_ID"
+          :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
+          :scrapheapPicturesId="SCRAPHEAP_PICTURES_ID"
+          :penalisedTagWeights="userPrefsStore.penalisedTagWeights"
+          :tagConfidenceAboveFilter="filterStore.tagConfidenceAboveFilter"
+          :tagConfidenceBelowFilter="filterStore.tagConfidenceBelowFilter"
+          :wsTagUpdate="wsStore.wsTagUpdate"
+          @filter-tag="
+            (tag) => {
+              if (filterStore.tagFilter.includes(tag))
+                filterStore.tagFilter = filterStore.tagFilter.filter(
+                  (t) => t !== tag,
                 );
-                if (allPresent)
-                  filterStore.tagFilter = filterStore.tagFilter.filter(
-                    (t) => !tags.includes(t),
-                  );
-                else
-                  filterStore.tagFilter = [
-                    ...new Set([...filterStore.tagFilter, ...tags]),
-                  ];
-              }
-            "
-            @filter-confidence-above="
-              (entry) => {
-                if (filterStore.tagConfidenceAboveFilter.includes(entry))
-                  filterStore.tagConfidenceAboveFilter =
-                    filterStore.tagConfidenceAboveFilter.filter(
-                      (e) => e !== entry,
-                    );
-                else
-                  filterStore.tagConfidenceAboveFilter = [
-                    ...filterStore.tagConfidenceAboveFilter,
-                    entry,
-                  ];
-              }
-            "
-            @clear-tag-filter="
-              (tags) => {
+              else filterStore.tagFilter = [...filterStore.tagFilter, tag];
+            }
+          "
+          @filter-tags="
+            (tags) => {
+              const allPresent = tags.every((t) =>
+                filterStore.tagFilter.includes(t),
+              );
+              if (allPresent)
                 filterStore.tagFilter = filterStore.tagFilter.filter(
                   (t) => !tags.includes(t),
                 );
-              }
-            "
-            @clear-confidence-filter="
-              (entries) => {
+              else
+                filterStore.tagFilter = [
+                  ...new Set([...filterStore.tagFilter, ...tags]),
+                ];
+            }
+          "
+          @filter-confidence-above="
+            (entry) => {
+              if (filterStore.tagConfidenceAboveFilter.includes(entry))
                 filterStore.tagConfidenceAboveFilter =
                   filterStore.tagConfidenceAboveFilter.filter(
-                    (e) => !entries.includes(e),
+                    (e) => e !== entry,
                   );
-              }
-            "
-            @update:minScoreFilter="(v) => (filterStore.minScoreFilter = v)"
-            @update:maxScoreFilter="(v) => (filterStore.maxScoreFilter = v)"
-            @update:smartScoreBucketFilter="
-              (v) => (filterStore.smartScoreBucketFilter = v)
-            "
-            @update:resolutionBucketFilter="
-              (v) => (filterStore.resolutionBucketFilter = v)
-            "
-            @toggle="
-              sidebarStore.toggleStats();
-              updateIsMobile();
-            "
-          />
+              else
+                filterStore.tagConfidenceAboveFilter = [
+                  ...filterStore.tagConfidenceAboveFilter,
+                  entry,
+                ];
+            }
+          "
+          @clear-tag-filter="
+            (tags) => {
+              filterStore.tagFilter = filterStore.tagFilter.filter(
+                (t) => !tags.includes(t),
+              );
+            }
+          "
+          @clear-confidence-filter="
+            (entries) => {
+              filterStore.tagConfidenceAboveFilter =
+                filterStore.tagConfidenceAboveFilter.filter(
+                  (e) => !entries.includes(e),
+                );
+            }
+          "
+          @update:minScoreFilter="(v) => (filterStore.minScoreFilter = v)"
+          @update:maxScoreFilter="(v) => (filterStore.maxScoreFilter = v)"
+          @update:smartScoreBucketFilter="
+            (v) => (filterStore.smartScoreBucketFilter = v)
+          "
+          @update:resolutionBucketFilter="
+            (v) => (filterStore.resolutionBucketFilter = v)
+          "
+          @toggle="
+            sidebarStore.toggleStats();
+            updateIsMobile();
+          "
+        />
       </div>
       <ReviewSessionsOverlay
         v-if="reviewSessionsStore.overlayOpen"
@@ -2572,6 +2620,22 @@ defineExpose({
               <tr>
                 <td><kbd>Ctrl</kbd>+<kbd>A</kbd></td>
                 <td>Select all images</td>
+              </tr>
+              <tr :class="{ 'shortcut-disabled': isReadOnly }">
+                <td>
+                  <template v-for="(key, i) in undoKeyHintKeys" :key="key"
+                    ><span v-if="i > 0">+</span><kbd>{{ key }}</kbd></template
+                  >
+                </td>
+                <td>Undo the last change</td>
+              </tr>
+              <tr :class="{ 'shortcut-disabled': isReadOnly }">
+                <td>
+                  <template v-for="(key, i) in redoKeyHintKeys" :key="key"
+                    ><span v-if="i > 0">+</span><kbd>{{ key }}</kbd></template
+                  >
+                </td>
+                <td>Redo the change you just undid</td>
               </tr>
               <tr>
                 <td><kbd>G</kbd></td>

--- a/frontend/src/api/operations.js
+++ b/frontend/src/api/operations.js
@@ -1,0 +1,148 @@
+// Operations resource: the append-only operation log behind undo and redo.
+//
+// Every user-visible change is recorded as one operation, newest first. The log
+// is the undo/redo stack today and the audit / activity feed later, so a caller
+// reading it is reading history, not a queue it may reorder.
+//
+// All of these routes are OWNER_ONLY on the backend: a share or read-only
+// session must never enumerate the owner's whole change history, and must never
+// revert a change. Guarding that is the caller's job, not this module's; the
+// module is pure transport and a call made in a read-only session will simply
+// come back 403.
+
+import { apiClient } from "../utils/apiClient";
+
+/**
+ * List recorded operations, newest first.
+ *
+ * Returns what changed, how many targets it touched, who did it, where it came
+ * from and whether it is still reversible. The before/after payloads are
+ * omitted here; fetch a single operation to see them.
+ *
+ * @param {Object} [options]
+ * @param {number} [options.limit=50] - how many operations to return.
+ * @param {string} [options.status] - filter to one status: `"applied"`,
+ *   `"undone"` or `"superseded"`.
+ * @param {string} [options.batchId] - filter to all operations of one bulk
+ *   action.
+ * @param {string} [options.opType] - filter to one operation type.
+ * @param {string} [options.baseUrl=""] - explicit backend base, for callers
+ *   that do not talk to the default backend.
+ * @returns {Promise<Array<Object>>} the operations (the response body).
+ */
+export async function listOperations({
+  limit = 50,
+  status,
+  batchId,
+  opType,
+  baseUrl = "",
+} = {}) {
+  const params = { limit };
+  if (status) params.status = status;
+  if (batchId) params.batch_id = batchId;
+  if (opType) params.op_type = opType;
+  const res = await apiClient.get(`${baseUrl}/operations`, { params });
+  return res.data;
+}
+
+/**
+ * Read what undo and redo would do next.
+ *
+ * Lets the UI label and enable its undo affordances without fetching the whole
+ * log.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.baseUrl=""] - explicit backend base.
+ * @returns {Promise<Object>} the response body:
+ *   `{ can_undo, can_redo, next_undo, next_redo }`, where the two operations
+ *   are `null` when there is nothing to act on.
+ */
+export async function getUndoState({ baseUrl = "" } = {}) {
+  const res = await apiClient.get(`${baseUrl}/operations/undo-state`);
+  return res.data;
+}
+
+/**
+ * Undo the newest reversible operation, or a named one.
+ *
+ * Restores the recorded *before* state. If the operation belongs to a batch
+ * (one bulk action) the whole batch is reverted, so a partially-undone bulk
+ * action cannot exist. The server answers 409 when there is nothing to undo or
+ * the named operation is not reversible, and 423 when a locked picture set
+ * freezes one of the targets.
+ *
+ * @param {Object} [options]
+ * @param {number|null} [options.operationId=null] - undo this specific
+ *   operation instead of the newest reversible one. Sent as a body only when
+ *   given.
+ * @param {string} [options.baseUrl=""] - explicit backend base.
+ * @returns {Promise<Object>} the response body:
+ *   `{ operations, picture_ids, picture_count }`.
+ */
+export async function undoLastOperation({
+  operationId = null,
+  baseUrl = "",
+} = {}) {
+  const url = `${baseUrl}/operations/undo`;
+  const res =
+    operationId === null
+      ? await apiClient.post(url)
+      : await apiClient.post(url, { operation_id: operationId });
+  return res.data;
+}
+
+/**
+ * Re-apply the most recently undone operation.
+ *
+ * Restores the recorded *after* state of that operation and its whole batch.
+ * Recording any new operation invalidates the redo stack, so redo only ever
+ * replays onto the history it was undone from. 409 when there is nothing to
+ * redo.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.baseUrl=""] - explicit backend base.
+ * @returns {Promise<Object>} the response body:
+ *   `{ operations, picture_ids, picture_count }`.
+ */
+export async function redoOperation({ baseUrl = "" } = {}) {
+  const res = await apiClient.post(`${baseUrl}/operations/redo`);
+  return res.data;
+}
+
+/**
+ * Undo one specific operation, addressed by path.
+ *
+ * Same semantics as {@link undoLastOperation} with an `operationId`: undoing
+ * any member of a batch reverts the whole batch.
+ *
+ * @param {number|string} operationId - the operation to revert.
+ * @param {Object} [options]
+ * @param {string} [options.baseUrl=""] - explicit backend base.
+ * @returns {Promise<Object>} the response body:
+ *   `{ operations, picture_ids, picture_count }`.
+ */
+export async function undoOperation(operationId, { baseUrl = "" } = {}) {
+  const res = await apiClient.post(`${baseUrl}/operations/${operationId}/undo`);
+  return res.data;
+}
+
+/**
+ * Undo one whole bulk action by its batch id.
+ *
+ * The single-call revert behind a bulk action's report ("Collapsed 2,700
+ * groups. Undo"). Reverts every still-applied, reversible operation carrying
+ * this batch id, newest first. 409 when the batch has nothing left to undo.
+ *
+ * @param {string} batchId - the batch id shared by the bulk action's
+ *   operations. URL-encoded here, since it is a server-issued opaque string.
+ * @param {Object} [options]
+ * @param {string} [options.baseUrl=""] - explicit backend base.
+ * @returns {Promise<Object>} the response body:
+ *   `{ operations, picture_ids, picture_count }`.
+ */
+export async function undoBatch(batchId, { baseUrl = "" } = {}) {
+  const res = await apiClient.post(
+    `${baseUrl}/operations/batches/${encodeURIComponent(batchId)}/undo`,
+  );
+  return res.data;
+}

--- a/frontend/src/api/operations.test.js
+++ b/frontend/src/api/operations.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Pattern for API-module tests: mock the singleton apiClient, assert the module
+// builds the right URL and returns response.data (never the axios envelope).
+vi.mock("../utils/apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn() },
+}));
+
+import { apiClient } from "../utils/apiClient";
+import {
+  listOperations,
+  getUndoState,
+  undoLastOperation,
+  redoOperation,
+  undoOperation,
+  undoBatch,
+} from "./operations";
+
+beforeEach(() => {
+  apiClient.get.mockReset();
+  apiClient.post.mockReset();
+});
+
+describe("api/operations", () => {
+  it("listOperations GETs /operations with the default limit only", async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 1 }] });
+    const result = await listOperations();
+    expect(apiClient.get).toHaveBeenCalledWith("/operations", {
+      params: { limit: 50 },
+    });
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it("listOperations sends only the filters it was given", async () => {
+    apiClient.get.mockResolvedValue({ data: [] });
+    await listOperations({
+      limit: 10,
+      status: "undone",
+      batchId: "b-1",
+      opType: "tag_add",
+    });
+    expect(apiClient.get).toHaveBeenCalledWith("/operations", {
+      params: {
+        limit: 10,
+        status: "undone",
+        batch_id: "b-1",
+        op_type: "tag_add",
+      },
+    });
+  });
+
+  it("getUndoState GETs /operations/undo-state and returns the body", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        can_undo: true,
+        can_redo: false,
+        next_undo: null,
+        next_redo: null,
+      },
+    });
+    const result = await getUndoState();
+    expect(apiClient.get).toHaveBeenCalledWith("/operations/undo-state");
+    expect(result).toEqual({
+      can_undo: true,
+      can_redo: false,
+      next_undo: null,
+      next_redo: null,
+    });
+  });
+
+  it("undoLastOperation POSTs with no body when no operation is named", async () => {
+    apiClient.post.mockResolvedValue({ data: { picture_count: 2 } });
+    const result = await undoLastOperation();
+    expect(apiClient.post).toHaveBeenCalledWith("/operations/undo");
+    expect(result).toEqual({ picture_count: 2 });
+  });
+
+  it("undoLastOperation POSTs the operation id when one is named", async () => {
+    apiClient.post.mockResolvedValue({ data: {} });
+    await undoLastOperation({ operationId: 7 });
+    expect(apiClient.post).toHaveBeenCalledWith("/operations/undo", {
+      operation_id: 7,
+    });
+  });
+
+  it("redoOperation POSTs /operations/redo with no body", async () => {
+    apiClient.post.mockResolvedValue({ data: { operations: [] } });
+    const result = await redoOperation();
+    expect(apiClient.post).toHaveBeenCalledWith("/operations/redo");
+    expect(result).toEqual({ operations: [] });
+  });
+
+  it("undoOperation POSTs the per-operation undo path", async () => {
+    apiClient.post.mockResolvedValue({ data: { picture_ids: [3] } });
+    const result = await undoOperation(42);
+    expect(apiClient.post).toHaveBeenCalledWith("/operations/42/undo");
+    expect(result).toEqual({ picture_ids: [3] });
+  });
+
+  it("undoBatch POSTs the batch undo path with the id encoded", async () => {
+    apiClient.post.mockResolvedValue({ data: {} });
+    await undoBatch("batch/1 2");
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/operations/batches/batch%2F1%202/undo",
+    );
+  });
+
+  it("every call accepts an explicit backend base", async () => {
+    apiClient.get.mockResolvedValue({ data: {} });
+    apiClient.post.mockResolvedValue({ data: {} });
+    await listOperations({ baseUrl: "/be" });
+    await getUndoState({ baseUrl: "/be" });
+    await undoLastOperation({ baseUrl: "/be" });
+    await redoOperation({ baseUrl: "/be" });
+    await undoOperation(5, { baseUrl: "/be" });
+    await undoBatch("b-2", { baseUrl: "/be" });
+    expect(apiClient.get).toHaveBeenCalledWith("/be/operations", {
+      params: { limit: 50 },
+    });
+    expect(apiClient.get).toHaveBeenCalledWith("/be/operations/undo-state");
+    expect(apiClient.post).toHaveBeenCalledWith("/be/operations/undo");
+    expect(apiClient.post).toHaveBeenCalledWith("/be/operations/redo");
+    expect(apiClient.post).toHaveBeenCalledWith("/be/operations/5/undo");
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/be/operations/batches/b-2/undo",
+    );
+  });
+
+  it("propagates a rejected request instead of swallowing it", async () => {
+    apiClient.post.mockRejectedValue(new Error("409 nothing to undo"));
+    await expect(undoLastOperation()).rejects.toThrow("409 nothing to undo");
+  });
+});

--- a/frontend/src/components/panels/Toolbar.vue
+++ b/frontend/src/components/panels/Toolbar.vue
@@ -860,8 +860,7 @@ watch(
 );
 
 watch(gbViewMenuOpen, (isOpen) => {
-  if (isOpen)
-    gbPendingSize.value = gridStore.sizeLevel ?? DEFAULT_THUMBNAIL_SIZE_LEVEL;
+  if (isOpen) gbPendingSize.value = gridStore.sizeLevel ?? DEFAULT_THUMBNAIL_SIZE_LEVEL;
 });
 
 function gbCommitSize() {

--- a/frontend/src/components/panels/Toolbar.vue
+++ b/frontend/src/components/panels/Toolbar.vue
@@ -169,6 +169,11 @@
             </div>
           </div>
         </v-menu>
+        <!-- ── Undo / redo + History ──────────────────────────────── -->
+        <!-- Same position in the Electron shell and in the browser, which is
+             the whole reason it is here and not in the breadcrumb. Owner-only
+             on the server, so a read-only session never sees it. -->
+        <UndoControl v-if="!isReadOnly" />
         <!-- ── Filter button ──────────────────────────────────────── -->
         <v-menu
           v-model="gbFilterMenuOpen"
@@ -548,6 +553,7 @@ import GbFilterPanel from "./GbFilterPanel.vue";
 import TbComfyPanel from "./TbComfyPanel.vue";
 import TbExportPanel from "./TbExportPanel.vue";
 import TbImportPanel from "./TbImportPanel.vue";
+import UndoControl from "./UndoControl.vue";
 const props = defineProps({
   selectedCount: Number,
   selectedCharacter: String,
@@ -854,7 +860,8 @@ watch(
 );
 
 watch(gbViewMenuOpen, (isOpen) => {
-  if (isOpen) gbPendingSize.value = gridStore.sizeLevel ?? DEFAULT_THUMBNAIL_SIZE_LEVEL;
+  if (isOpen)
+    gbPendingSize.value = gridStore.sizeLevel ?? DEFAULT_THUMBNAIL_SIZE_LEVEL;
 });
 
 function gbCommitSize() {

--- a/frontend/src/components/panels/UndoControl.test.js
+++ b/frontend/src/components/panels/UndoControl.test.js
@@ -133,6 +133,17 @@ describe("UndoControl — enablement", () => {
     );
   });
 
+  it("says when the undo target came from somewhere else", () => {
+    const store = useOperationStore();
+    seed(store, [op({ origin_client_id: "another-tab" })]);
+    const wrapper = mount(UndoControl, globalOpts);
+    // External operations update the stack silently, so the control has to say
+    // so before it reverts something this user never did.
+    expect(wrapper.find(".uc-btn--undo").attributes("title")).toContain(
+      "Changed elsewhere:",
+    );
+  });
+
   it("names the exact step and its shortcut once there is history", () => {
     const store = useOperationStore();
     seed(store, [op()]);
@@ -196,7 +207,7 @@ describe("UndoControl — the History popover", () => {
     const { wrapper } = await mountOpen([op({ id: 12 }), op({ id: 11 })]);
     expect(wrapper.find(".uc-count").text()).toBe("2 steps");
     expect(wrapper.find(".tbm-footer").text()).toContain(
-      "Click a step to undo back to it",
+      "Choose a step to undo back to it",
     );
   });
 
@@ -233,11 +244,33 @@ describe("UndoControl — the hover preview", () => {
     expect(wrapper.find(".tbm-footer").text()).toContain("Undo 1 step");
   });
 
-  it("clears the preview when the pointer leaves the list", async () => {
+  it("clears the preview only when the pointer leaves the whole panel", async () => {
     const { wrapper } = await mountOpen([op({ id: 13 }), op({ id: 12 })]);
     await wrapper.findAll(".uc-row")[1].trigger("mouseenter");
+    // Moving from a row toward the footer must not wipe the readout the user
+    // is moving to read, so the reset lives on the panel, not on the list.
     await wrapper.find(".uc-list").trigger("mouseleave");
+    expect(wrapper.findAll(".uc-row--willundo")).toHaveLength(2);
+
+    await wrapper.find(".uc-panel").trigger("mouseleave");
     expect(wrapper.findAll(".uc-row--willundo")).toHaveLength(0);
+  });
+
+  it("keeps the preview pinned to the step, not to its position", async () => {
+    const { store, wrapper } = await mountOpen([
+      op({ id: 13 }),
+      op({ id: 12 }),
+      op({ id: 11 }),
+    ]);
+    await wrapper.findAll(".uc-row")[1].trigger("mouseenter");
+    expect(wrapper.find(".tbm-footer").text()).toContain("Undo 2 steps");
+
+    // Another tab records a step while the popover is open. A positional index
+    // would now describe a different range than the user is looking at.
+    store.operations = [op({ id: 14 }), ...store.operations];
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".tbm-footer").text()).toContain("Undo 3 steps");
+    expect(wrapper.findAll(".uc-row--willundo")).toHaveLength(3);
   });
 });
 
@@ -282,18 +315,61 @@ describe("UndoControl — keyboard reachability", () => {
     }
   });
 
-  it("labels each history row with what activating it would do", async () => {
+  it("labels each history row with what activating it would do, and how far", async () => {
+    const { wrapper } = await mountOpen([op({ id: 13 }), op({ id: 12 })]);
+    const labels = wrapper
+      .findAll(".uc-row")
+      .map((r) => r.attributes("aria-label"));
+    // The step count rides the row rather than a chatty live region in the
+    // footer, which would read one sentence per row swept.
+    expect(labels[0]).toBe("Undo back to: Added tag 'portrait' · 12 (1 step)");
+    expect(labels[1]).toBe("Undo back to: Added tag 'portrait' · 12 (2 steps)");
+  });
+
+  it("activates a row from the keyboard", async () => {
+    const { store, wrapper } = await mountOpen([
+      op({ id: 13 }),
+      op({ id: 12 }),
+    ]);
+    const undoTo = vi.spyOn(store, "undoTo").mockResolvedValue(1);
+    // Vuetify's menu preventDefaults Enter on its content, which suppresses
+    // the synthesized click, so the row has to handle Enter itself.
+    await wrapper.findAll(".uc-row")[0].trigger("keydown.enter");
+    expect(undoTo).toHaveBeenCalledWith(13);
+  });
+
+  it("labels the popover as a dialog, not as a menu it does not implement", async () => {
     const { wrapper } = await mountOpen([op({ id: 13 })]);
-    expect(wrapper.find(".uc-row").attributes("aria-label")).toBe(
-      "Undo back to: Added tag 'portrait' · 12",
+    // No roving arrow-key navigation is implemented, so claiming role=menu
+    // would promise a keyboard contract that is not owed and not honoured.
+    const panel = wrapper.find(".uc-panel");
+    expect(panel.attributes("role")).toBe("dialog");
+    expect(panel.attributes("aria-label")).toBe("History");
+    expect(wrapper.find(".uc-btn--chevron").attributes("aria-expanded")).toBe(
+      "true",
     );
   });
 
-  it("announces the popover as an expandable menu", () => {
-    useOperationStore();
-    const wrapper = mount(UndoControl, globalOpts);
-    const chevron = wrapper.find(".uc-btn--chevron");
-    expect(chevron.attributes("aria-haspopup")).toBe("menu");
-    expect(chevron.attributes("aria-expanded")).toBe("false");
+  it("returns focus to the chevron when the popover closes on a pick", async () => {
+    const store = useOperationStore();
+    seed(store, [op({ id: 13 }), op({ id: 12 })]);
+    const wrapper = mount(UndoControl, {
+      ...globalOpts,
+      attachTo: document.body,
+    });
+    vi.spyOn(store, "undoTo").mockResolvedValue(1);
+    await wrapper.find(".uc-btn--chevron").trigger("click");
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.findAll(".uc-row")[0].trigger("click");
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+    // Vuetify restores focus on Esc and Tab-past-last, but not on a
+    // programmatic close: without this the row is unmounted under the keyboard
+    // and focus lands on <body>.
+    expect(document.activeElement).toBe(
+      wrapper.find(".uc-btn--chevron").element,
+    );
   });
 });

--- a/frontend/src/components/panels/UndoControl.test.js
+++ b/frontend/src/components/panels/UndoControl.test.js
@@ -1,0 +1,299 @@
+// The toolbar history control — the persistent half of undo/redo.
+//
+// These tests pin what the CONTROL owns: enablement and its labels, that the
+// buttons stay reachable when there is nothing to do (the design's "always
+// tabbable" rule, which the native `disabled` attribute would break), the
+// History popover's row states, and that the hover/focus preview and the
+// undo-to-step call describe the same range.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { h } from "vue";
+import { setActivePinia, createPinia } from "pinia";
+import { mount } from "@vue/test-utils";
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref } = await import("vue");
+  return {
+    apiClient: { get: vi.fn(), post: vi.fn() },
+    isReadOnly: ref(false),
+    setRequestClientId: vi.fn(),
+  };
+});
+
+vi.mock("../../api/operations", () => ({
+  listOperations: vi.fn().mockResolvedValue([]),
+  getUndoState: vi.fn().mockResolvedValue({ can_undo: false, can_redo: false }),
+  undoLastOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  redoOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  undoOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  undoBatch: vi.fn().mockResolvedValue({ operations: [] }),
+}));
+
+import UndoControl from "./UndoControl.vue";
+import { getUndoState, listOperations } from "../../api/operations";
+import { useOperationStore } from "../../stores/useOperationStore";
+
+// Vuetify is not installed in the test app (importing it pulls raw .css), so
+// `v-menu` is stubbed with the two behaviours this component relies on: the
+// activator slot receives props carrying the toggle, and the default slot is
+// rendered inline (rather than teleported) while the menu is open.
+const VMenuStub = {
+  name: "VMenu",
+  props: { modelValue: { type: Boolean, default: false } },
+  emits: ["update:modelValue"],
+  setup(props, { slots, emit }) {
+    return () =>
+      h("div", { class: "v-menu-stub" }, [
+        slots.activator?.({
+          props: {
+            onClick: () => emit("update:modelValue", !props.modelValue),
+          },
+        }),
+        props.modelValue ? slots.default?.() : null,
+      ]);
+  },
+};
+
+const globalOpts = {
+  global: { stubs: { "v-icon": true, "v-menu": VMenuStub } },
+};
+
+function op(overrides = {}) {
+  return {
+    id: 10,
+    batch_id: null,
+    created_at: "2026-07-29T12:00:00",
+    op_type: "pictures.tags.add",
+    target_count: 12,
+    origin_client_id: "me",
+    undoable: true,
+    status: "applied",
+    summary: "Added tag 'portrait'",
+    ...overrides,
+  };
+}
+
+function seed(store, rows, state = {}) {
+  const undoState = {
+    can_undo: rows.some((r) => r.status === "applied"),
+    can_redo: rows.some((r) => r.status === "undone"),
+    next_undo: rows.find((r) => r.status === "applied") ?? null,
+    next_redo: rows.find((r) => r.status === "undone") ?? null,
+  };
+  store.operations = rows;
+  store.canUndo = undoState.can_undo;
+  store.canRedo = undoState.can_redo;
+  store.nextUndo = undoState.next_undo;
+  store.nextRedo = undoState.next_redo;
+  Object.assign(store, state);
+  // Opening the popover re-reads the log (Vuetify keeps menu content mounted,
+  // so the component drives its read off the open flag). Serve the same rows,
+  // or that read would overwrite the seed with an empty stack.
+  listOperations.mockResolvedValue(rows);
+  getUndoState.mockResolvedValue(undoState);
+}
+
+/** Mount with the popover already open, so the list is in the DOM. */
+async function mountOpen(rows) {
+  const store = useOperationStore();
+  seed(store, rows);
+  const wrapper = mount(UndoControl, globalOpts);
+  await wrapper.find(".uc-btn--chevron").trigger("click");
+  await wrapper.vm.$nextTick();
+  await wrapper.vm.$nextTick();
+  return { store, wrapper };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe("UndoControl — enablement", () => {
+  it("marks both buttons unavailable when there is no history", () => {
+    useOperationStore();
+    const wrapper = mount(UndoControl, globalOpts);
+    expect(wrapper.find(".uc-btn--undo").attributes("aria-disabled")).toBe(
+      "true",
+    );
+    expect(wrapper.find(".uc-btn--redo").attributes("aria-disabled")).toBe(
+      "true",
+    );
+  });
+
+  it("keeps the buttons focusable and tooltip-bearing when unavailable", () => {
+    useOperationStore();
+    const wrapper = mount(UndoControl, globalOpts);
+    const undo = wrapper.find(".uc-btn--undo");
+    // `aria-disabled`, never the native attribute: a `disabled` button is not
+    // in the tab order and shows no tooltip, and the design requires both.
+    expect(undo.attributes("disabled")).toBeUndefined();
+    expect(undo.attributes("title")).toContain("Nothing to undo");
+    expect(wrapper.find(".uc-btn--redo").attributes("title")).toContain(
+      "Nothing to redo",
+    );
+  });
+
+  it("names the exact step and its shortcut once there is history", () => {
+    const store = useOperationStore();
+    seed(store, [op()]);
+    const wrapper = mount(UndoControl, globalOpts);
+
+    const title = wrapper.find(".uc-btn--undo").attributes("title");
+    expect(title).toContain("Added tag 'portrait' · 12");
+    expect(title).toMatch(/Ctrl\+Z|⌘\+Z/);
+    expect(wrapper.find(".uc-btn--undo").attributes("aria-disabled")).toBe(
+      "false",
+    );
+  });
+
+  it("does not call the server when the button is unavailable", async () => {
+    const store = useOperationStore();
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    const wrapper = mount(UndoControl, globalOpts);
+
+    await wrapper.find(".uc-btn--undo").trigger("click");
+    expect(undo).not.toHaveBeenCalled();
+  });
+
+  it("undoes and redoes when they are available", async () => {
+    const store = useOperationStore();
+    seed(store, [op(), op({ id: 9, status: "undone" })]);
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    const redo = vi.spyOn(store, "redo").mockResolvedValue(null);
+    const wrapper = mount(UndoControl, globalOpts);
+
+    await wrapper.find(".uc-btn--undo").trigger("click");
+    await wrapper.find(".uc-btn--redo").trigger("click");
+    expect(undo).toHaveBeenCalledTimes(1);
+    expect(redo).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("UndoControl — the History popover", () => {
+  it("lists the stack newest first with the redo side above it", async () => {
+    const { wrapper } = await mountOpen([
+      op({ id: 13, status: "undone", summary: "Scored" }),
+      op({ id: 12, summary: "Assigned Walter" }),
+      op({ id: 11, summary: "Added tag 'studio'" }),
+    ]);
+
+    const rows = wrapper.findAll(".uc-row");
+    expect(rows).toHaveLength(3);
+    expect(rows[0].classes()).toContain("uc-row--future");
+    expect(rows[1].text()).toContain("Assigned Walter");
+    expect(rows[2].text()).toContain("Added tag 'studio'");
+  });
+
+  it("shows undone steps struck through and inert", async () => {
+    const { wrapper } = await mountOpen([op({ id: 13, status: "undone" })]);
+    const row = wrapper.find(".uc-row--future");
+    // Not clickable: the redo side is reached with the Redo button, not by
+    // clicking forward through the list.
+    expect(row.attributes("disabled")).toBeDefined();
+  });
+
+  it("counts the steps in the header and prompts in the footer", async () => {
+    const { wrapper } = await mountOpen([op({ id: 12 }), op({ id: 11 })]);
+    expect(wrapper.find(".uc-count").text()).toBe("2 steps");
+    expect(wrapper.find(".tbm-footer").text()).toContain(
+      "Click a step to undo back to it",
+    );
+  });
+
+  it("says so when the stack is empty rather than showing a blank panel", async () => {
+    const { wrapper } = await mountOpen([]);
+    expect(wrapper.find(".uc-empty").exists()).toBe(true);
+    expect(wrapper.find(".uc-count").text()).toBe("0 steps");
+  });
+});
+
+describe("UndoControl — the hover preview", () => {
+  it("highlights every step that would be undone, not only the hovered one", async () => {
+    const { wrapper } = await mountOpen([
+      op({ id: 13 }),
+      op({ id: 12 }),
+      op({ id: 11 }),
+    ]);
+
+    await wrapper.findAll(".uc-row")[1].trigger("mouseenter");
+    const flagged = wrapper
+      .findAll(".uc-row")
+      .map((r) => r.classes().includes("uc-row--willundo"));
+    expect(flagged).toEqual([true, true, false]);
+    expect(wrapper.find(".tbm-footer").text()).toContain("Undo 2 steps");
+  });
+
+  it("previews on focus too, so the keyboard sees the same range", async () => {
+    const { wrapper } = await mountOpen([op({ id: 13 }), op({ id: 12 })]);
+
+    await wrapper.findAll(".uc-row")[1].trigger("focus");
+    expect(wrapper.find(".tbm-footer").text()).toContain("Undo 2 steps");
+    // Singular for one step: "Undo 1 steps" is the kind of copy that gets read.
+    await wrapper.findAll(".uc-row")[0].trigger("focus");
+    expect(wrapper.find(".tbm-footer").text()).toContain("Undo 1 step");
+  });
+
+  it("clears the preview when the pointer leaves the list", async () => {
+    const { wrapper } = await mountOpen([op({ id: 13 }), op({ id: 12 })]);
+    await wrapper.findAll(".uc-row")[1].trigger("mouseenter");
+    await wrapper.find(".uc-list").trigger("mouseleave");
+    expect(wrapper.findAll(".uc-row--willundo")).toHaveLength(0);
+  });
+});
+
+describe("UndoControl — undo to a step", () => {
+  it("undoes back to the clicked step and closes the popover", async () => {
+    const { store, wrapper } = await mountOpen([
+      op({ id: 13 }),
+      op({ id: 12 }),
+      op({ id: 11 }),
+    ]);
+    const undoTo = vi.spyOn(store, "undoTo").mockResolvedValue(2);
+
+    await wrapper.findAll(".uc-row")[1].trigger("click");
+    expect(undoTo).toHaveBeenCalledWith(12);
+    expect(wrapper.find(".uc-btn--chevron").attributes("aria-expanded")).toBe(
+      "false",
+    );
+  });
+
+  it("does nothing when an undone row is activated", async () => {
+    const { store, wrapper } = await mountOpen([
+      op({ id: 13, status: "undone" }),
+      op({ id: 12 }),
+    ]);
+    const undoTo = vi.spyOn(store, "undoTo").mockResolvedValue(0);
+
+    await wrapper.find(".uc-row--future").trigger("click");
+    expect(undoTo).not.toHaveBeenCalled();
+  });
+});
+
+describe("UndoControl — keyboard reachability", () => {
+  it("renders every control as a real button in the natural tab order", async () => {
+    const { wrapper } = await mountOpen([op({ id: 13 }), op({ id: 12 })]);
+    const buttons = wrapper.findAll("button");
+    // undo + redo + chevron + 2 history rows, all real buttons, none of which
+    // carries a tabindex that would pull it out of document order.
+    expect(buttons.length).toBe(5);
+    for (const button of buttons) {
+      expect(button.attributes("type")).toBe("button");
+      expect(button.attributes("tabindex")).toBeUndefined();
+    }
+  });
+
+  it("labels each history row with what activating it would do", async () => {
+    const { wrapper } = await mountOpen([op({ id: 13 })]);
+    expect(wrapper.find(".uc-row").attributes("aria-label")).toBe(
+      "Undo back to: Added tag 'portrait' · 12",
+    );
+  });
+
+  it("announces the popover as an expandable menu", () => {
+    useOperationStore();
+    const wrapper = mount(UndoControl, globalOpts);
+    const chevron = wrapper.find(".uc-btn--chevron");
+    expect(chevron.attributes("aria-haspopup")).toBe("menu");
+    expect(chevron.attributes("aria-expanded")).toBe("false");
+  });
+});

--- a/frontend/src/components/panels/UndoControl.vue
+++ b/frontend/src/components/panels/UndoControl.vue
@@ -1,0 +1,446 @@
+<script setup>
+/**
+ * The toolbar history control — the persistent half of undo/redo.
+ *
+ * An undo/redo icon pair plus a chevron, in the main toolbar, which is in the
+ * same place in the Electron shell and in the browser. The receipt is transient
+ * and lives over the grid; this is what carries undo once the pill is gone, and
+ * it is where the shortcut gets taught after that.
+ *
+ * Behaviour from the owner's "Undo / Redo System" design:
+ *
+ *   • Disabled-looking until there is history, but never `disabled`: the design
+ *     requires the buttons to stay tabbable and to keep their tooltip
+ *     ("Nothing to undo"), both of which the native attribute discards. So
+ *     `aria-disabled` + a guarded handler, with the repo's own 35% disabled
+ *     treatment applied by hand.
+ *   • The tooltip names the exact step and its shortcut.
+ *   • The chevron opens a History popover: newest first, hovering (or arrowing
+ *     onto) a step previews how far back you would go by highlighting every
+ *     step that would be undone, and activating it undoes to that step.
+ *   • Steps that have been undone stay visible, struck through, until a new
+ *     action supersedes them.
+ *
+ * Keyboard: the list is a real listbox-style menu of buttons in tab order, and
+ * the preview follows focus as well as hover, so a keyboard user sees the same
+ * range a mouse user does.
+ */
+import { computed, nextTick, ref, watch } from "vue";
+
+import {
+  formatOperationTime,
+  iconForOpType,
+  summarizeOperation,
+  useOperationStore,
+} from "../../stores/useOperationStore";
+import { redoKeyHint, undoKeyHint } from "../../utils/shortcutHints";
+
+const store = useOperationStore();
+
+const menuOpen = ref(false);
+/** Index into `past` of the oldest step the pointer/focus is previewing. */
+const previewIndex = ref(null);
+const listEl = ref(null);
+
+const past = computed(() => store.past);
+const future = computed(() => store.future);
+
+const undoKeys = undoKeyHint();
+const redoKeys = redoKeyHint();
+
+const canUndo = computed(() => store.canUndo && !store.busy);
+const canRedo = computed(() => store.canRedo && !store.busy);
+
+/** What one Ctrl+Z would take back right now, for the tooltip. */
+const undoLabel = computed(() =>
+  store.nextUndo ? summarizeOperation(store.nextUndo) : "Nothing to undo",
+);
+const redoLabel = computed(() =>
+  store.nextRedo ? summarizeOperation(store.nextRedo) : "Nothing to redo",
+);
+
+const undoTitle = computed(
+  () => `Undo: ${undoLabel.value} (${undoKeys.join("+")})`,
+);
+const redoTitle = computed(
+  () => `Redo: ${redoLabel.value} (${redoKeys.join("+")})`,
+);
+
+/** Rows, newest first: the redo side struck through, then the undo stack. */
+const rows = computed(() => {
+  const undoneRows = future.value.map((op) => ({
+    op,
+    kind: "future",
+    index: -1,
+  }));
+  const appliedRows = past.value.map((op, index) => ({
+    op,
+    kind: "past",
+    index,
+  }));
+  return [...undoneRows, ...appliedRows];
+});
+
+/** How many steps the footer says the current preview would undo. */
+const previewSteps = computed(() =>
+  previewIndex.value == null ? 0 : previewIndex.value + 1,
+);
+
+const footerText = computed(() => {
+  if (previewSteps.value === 0) return "Click a step to undo back to it";
+  return `Undo ${previewSteps.value} step${previewSteps.value === 1 ? "" : "s"}`;
+});
+
+/** A past row is in the preview range when it is at or above the hovered one. */
+function willUndo(row) {
+  if (row.kind !== "past") return false;
+  if (previewIndex.value == null) return false;
+  return row.index <= previewIndex.value;
+}
+
+function rowIcon(op) {
+  return iconForOpType(op?.op_type);
+}
+
+function rowLabel(op) {
+  return summarizeOperation(op);
+}
+
+function rowTime(op) {
+  return formatOperationTime(op?.created_at);
+}
+
+function onUndo() {
+  if (!canUndo.value) return;
+  store.undo();
+}
+
+function onRedo() {
+  if (!canRedo.value) return;
+  store.redo();
+}
+
+async function onPick(row) {
+  if (row.kind !== "past") return;
+  menuOpen.value = false;
+  previewIndex.value = null;
+  await store.undoTo(row.op.id);
+}
+
+/**
+ * The popover is opened long after mount, and Vuetify keeps menu content in the
+ * DOM once it has been opened, so the read is driven by the open flag rather
+ * than by `onMounted` — otherwise the list would show whatever the stack looked
+ * like the first time it was opened.
+ */
+watch(menuOpen, async (isOpen) => {
+  previewIndex.value = null;
+  if (!isOpen) return;
+  store.refresh({ narrate: false });
+  await nextTick();
+  // Focus the newest undoable step so the popover is operable from the keyboard
+  // the moment it opens.
+  listEl.value?.querySelector?.("button.uc-row--past")?.focus?.();
+});
+
+defineExpose({
+  /** Open the History popover (for a future menu/command-palette entry). */
+  openHistory() {
+    menuOpen.value = true;
+  },
+});
+</script>
+
+<template>
+  <div class="uc" role="group" aria-label="History">
+    <div class="uc-group" :class="{ 'uc-group--open': menuOpen }">
+      <button
+        type="button"
+        class="uc-btn uc-btn--undo"
+        :aria-disabled="!canUndo"
+        :title="undoTitle"
+        :aria-label="undoTitle"
+        @click="onUndo"
+      >
+        <v-icon size="19">mdi-undo-variant</v-icon>
+      </button>
+      <button
+        type="button"
+        class="uc-btn uc-btn--redo"
+        :aria-disabled="!canRedo"
+        :title="redoTitle"
+        :aria-label="redoTitle"
+        @click="onRedo"
+      >
+        <v-icon size="19">mdi-redo-variant</v-icon>
+      </button>
+      <v-menu
+        v-model="menuOpen"
+        :close-on-content-click="false"
+        location="bottom start"
+        origin="top start"
+        :offset="8"
+        transition="scale-transition"
+      >
+        <template #activator="{ props: menuProps }">
+          <button
+            v-bind="menuProps"
+            type="button"
+            class="uc-btn uc-btn--chevron"
+            title="History"
+            aria-label="History"
+            aria-haspopup="menu"
+            :aria-expanded="menuOpen"
+          >
+            <v-icon size="18" class="uc-chevron">mdi-menu-down</v-icon>
+          </button>
+        </template>
+        <div class="tbm uc-panel">
+          <span class="tbm-caret tbm-caret--start"></span>
+          <div class="tbm-header">
+            <v-icon size="18" class="tbm-header-icon">mdi-history</v-icon>
+            <span class="tbm-title">History</span>
+            <span class="tbm-spacer"></span>
+            <span class="uc-count"
+              >{{ store.historyCount }} step{{
+                store.historyCount === 1 ? "" : "s"
+              }}</span
+            >
+          </div>
+          <div ref="listEl" class="uc-list" @mouseleave="previewIndex = null">
+            <p v-if="!rows.length" class="uc-empty">
+              Nothing recorded yet. Your next change lands here.
+            </p>
+            <button
+              v-for="row in rows"
+              :key="`${row.kind}-${row.op.id}`"
+              type="button"
+              class="uc-row"
+              :class="{
+                'uc-row--past': row.kind === 'past',
+                'uc-row--future': row.kind === 'future',
+                'uc-row--willundo': willUndo(row),
+              }"
+              :disabled="row.kind !== 'past'"
+              :aria-label="
+                row.kind === 'past'
+                  ? `Undo back to: ${rowLabel(row.op)}`
+                  : `${rowLabel(row.op)} (undone)`
+              "
+              @mouseenter="previewIndex = row.index >= 0 ? row.index : null"
+              @focus="previewIndex = row.index >= 0 ? row.index : null"
+              @click="onPick(row)"
+            >
+              <v-icon size="18" class="uc-row-icon">{{
+                rowIcon(row.op)
+              }}</v-icon>
+              <span class="uc-row-label">{{ rowLabel(row.op) }}</span>
+              <span class="uc-row-time">{{ rowTime(row.op) }}</span>
+            </button>
+          </div>
+          <div class="tbm-footer" aria-live="polite">
+            <v-icon size="16">mdi-cursor-default-click-outline</v-icon>
+            <span>{{ footerText }}</span>
+          </div>
+        </div>
+      </v-menu>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.uc {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+/* Mirrors `.bar-split-button` / `.bar-btn` from the toolbar. Deliberately its
+   own class names rather than reusing those: they live in Toolbar.vue's SCOPED
+   style block, so a child component gets none of them, and promoting them into
+   App.css is a toolbar-wide refactor that belongs to the lane that owns this
+   area — not to this change. Recorded as a follow-up. */
+.uc-group {
+  display: flex;
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+}
+
+/* Open: the whole group adopts the panel fill + border so it reads as one
+   object with its menu, exactly as the sort split button does. */
+.uc-group--open {
+  border-color: rgb(var(--v-theme-border));
+  background: rgb(var(--v-theme-panel));
+}
+
+.uc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* 32×32, not the design's 18px-wide chevron: an 18px target is under the
+     WCAG 2.5.8 24×24 floor. */
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  flex-shrink: 0;
+  color: rgb(var(--v-theme-toolbar-text));
+  background: transparent;
+  /* A transparent 1px border is reserved so the open state does not resize the
+     button and make the group jump. */
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.uc-btn:hover {
+  background: rgba(var(--v-theme-toolbar-text), 0.1);
+}
+
+.uc-btn:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+/* `aria-disabled`, not the `disabled` attribute: the design requires the
+   buttons to stay tabbable and to keep naming the step ("Nothing to undo"),
+   and a `disabled` button is neither focusable nor tooltip-bearing. The visual
+   is the repo's own disabled treatment minus the pointer-events kill. */
+.uc-btn[aria-disabled="true"] {
+  opacity: 0.35;
+  filter: grayscale(30%);
+  cursor: default;
+}
+.uc-btn[aria-disabled="true"]:hover {
+  background: transparent;
+}
+
+.uc-group--open .uc-chevron {
+  transform: rotate(180deg);
+  transition: transform var(--dur-1) var(--ease-standard);
+}
+
+/* ── History popover ─────────────────────────────────────────────────────── */
+/* Width invents nothing: 280px is the notice card's min-width and the max is
+   the notice surface's own `--notice-max-w`. Content sizes between. */
+.uc-panel {
+  min-width: 280px;
+  max-width: var(--notice-max-w);
+}
+
+.uc-count {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-panel), 0.6);
+  white-space: nowrap;
+}
+
+/* 50 steps needs a scroll region. */
+.uc-list {
+  max-height: 40vh;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--v-theme-on-panel), 0.4) transparent;
+  scrollbar-gutter: stable;
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.uc-empty {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  color: rgba(var(--v-theme-on-panel), 0.6);
+}
+
+/* The row recipe, mirroring the toolbar's `.gb-recent-row`: leading icon,
+   flexible ellipsised label, trailing meta. */
+.uc-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: rgb(var(--v-theme-on-panel));
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--dur-1) var(--ease-standard);
+}
+
+.uc-row:hover:not(:disabled) {
+  background: var(--hover-wash);
+}
+
+.uc-row:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+.uc-row-icon {
+  color: rgba(var(--v-theme-on-panel), 0.5);
+  flex-shrink: 0;
+}
+
+.uc-row-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.uc-row-time {
+  color: rgba(var(--v-theme-on-panel), 0.35);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.uc-row:hover:not(:disabled) .uc-row-time {
+  color: rgba(var(--v-theme-on-panel), 0.7);
+}
+
+/* The hover preview: every step that would be undone. Built from the shipped
+   selected vocabulary (--active-wash + --active-bar) rather than a new
+   highlight; the rail is what makes the EXTENT of the range read as one
+   contiguous block, which a fill alone does not. */
+.uc-row--willundo,
+.uc-row--willundo:hover:not(:disabled) {
+  background: var(--active-wash);
+  box-shadow: inset var(--space-1) 0 0 0 var(--active-bar);
+}
+/* Focus must still win over the range highlight, or a keyboard user loses the
+   cursor inside the previewed block. */
+.uc-row--willundo:focus-visible {
+  box-shadow:
+    inset var(--space-1) 0 0 0 var(--active-bar),
+    var(--focus-ring);
+}
+
+/* Undone steps: visible, struck through, inert. Mirrors the shortcuts dialog's
+   own disabled-row treatment rather than inventing a second one. */
+.uc-row--future {
+  opacity: 0.35;
+  text-decoration: line-through;
+  text-decoration-color: rgba(var(--v-theme-on-panel), 0.4);
+  cursor: default;
+}
+.uc-row--future:hover {
+  background: transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .uc-group--open .uc-chevron,
+  .uc-row {
+    transition: none;
+  }
+}
+</style>

--- a/frontend/src/components/panels/UndoControl.vue
+++ b/frontend/src/components/panels/UndoControl.vue
@@ -33,14 +33,32 @@ import {
   summarizeOperation,
   useOperationStore,
 } from "../../stores/useOperationStore";
-import { redoKeyHint, undoKeyHint } from "../../utils/shortcutHints";
+import {
+  isApplePlatform,
+  redoKeyHint,
+  undoKeyHint,
+} from "../../utils/shortcutHints";
 
 const store = useOperationStore();
 
 const menuOpen = ref(false);
-/** Index into `past` of the oldest step the pointer/focus is previewing. */
-const previewIndex = ref(null);
+/**
+ * The oldest step the pointer/focus is previewing, held by operation ID rather
+ * than by list position: a refresh landing while the popover is open would
+ * otherwise leave the highlight describing a different range than the one the
+ * user is looking at.
+ */
+const previewId = ref(null);
 const listEl = ref(null);
+// The chevron cannot carry its own template ref: Vuetify's activator slot props
+// already bind one (`mergeProps({ ref: activatorRef }, …)` in VOverlay), and a
+// literal `ref` on the same element would win and break the menu's anchoring.
+// Reach it through the component root instead.
+const rootEl = ref(null);
+
+function focusChevron() {
+  rootEl.value?.querySelector?.(".uc-btn--chevron")?.focus?.();
+}
 
 const past = computed(() => store.past);
 const future = computed(() => store.future);
@@ -59,12 +77,26 @@ const redoLabel = computed(() =>
   store.nextRedo ? summarizeOperation(store.nextRedo) : "Nothing to redo",
 );
 
-const undoTitle = computed(
-  () => `Undo: ${undoLabel.value} (${undoKeys.join("+")})`,
+// The undo target can quietly become another tab's action: an external
+// operation updates the stack silently (the receipt only narrates this
+// client's own work), so the affordance has to say so before it reverts
+// something the user never did.
+const undoTitle = computed(() => {
+  if (!store.nextUndo) return `Nothing to undo (${undoKeys.join("+")})`;
+  const where = store.nextUndoIsExternal ? "Changed elsewhere: " : "";
+  return `Undo: ${where}${undoLabel.value} (${undoKeys.join("+")})`;
+});
+const redoTitle = computed(() =>
+  store.nextRedo
+    ? `Redo: ${redoLabel.value} (${redoKeys.join("+")})`
+    : `Nothing to redo (${redoKeys.join("+")})`,
 );
-const redoTitle = computed(
-  () => `Redo: ${redoLabel.value} (${redoKeys.join("+")})`,
-);
+
+// The standard attribute for "this control has a keyboard shortcut". It
+// survives the visual keycaps being aria-hidden and is read on focus, which
+// `title` never is.
+const undoKeyShortcut = isApplePlatform() ? "Meta+Z" : "Control+Z";
+const redoKeyShortcut = isApplePlatform() ? "Shift+Meta+Z" : "Control+Y";
 
 /** Rows, newest first: the redo side struck through, then the undo stack. */
 const rows = computed(() => {
@@ -81,21 +113,39 @@ const rows = computed(() => {
   return [...undoneRows, ...appliedRows];
 });
 
-/** How many steps the footer says the current preview would undo. */
+/** Where the previewed step currently sits in the stack, or -1. */
+const previewIndex = computed(() =>
+  previewId.value == null
+    ? -1
+    : past.value.findIndex((op) => op?.id === previewId.value),
+);
+
+/** How many steps the current preview would undo. */
 const previewSteps = computed(() =>
-  previewIndex.value == null ? 0 : previewIndex.value + 1,
+  previewIndex.value < 0 ? 0 : previewIndex.value + 1,
 );
 
 const footerText = computed(() => {
-  if (previewSteps.value === 0) return "Click a step to undo back to it";
+  // "Choose", not "Click": the list is fully keyboard-operable and this is the
+  // only sentence that says how to use it.
+  if (previewSteps.value === 0) return "Choose a step to undo back to it";
   return `Undo ${previewSteps.value} step${previewSteps.value === 1 ? "" : "s"}`;
 });
 
-/** A past row is in the preview range when it is at or above the hovered one. */
+/** A past row is in the preview range when it is at or above the previewed one. */
 function willUndo(row) {
   if (row.kind !== "past") return false;
-  if (previewIndex.value == null) return false;
+  if (previewIndex.value < 0) return false;
   return row.index <= previewIndex.value;
+}
+
+/** How many steps activating this row would undo (for its accessible name). */
+function rowSteps(row) {
+  return row.kind === "past" ? row.index + 1 : 0;
+}
+
+function preview(row) {
+  previewId.value = row.kind === "past" ? row.op.id : null;
 }
 
 function rowIcon(op) {
@@ -121,9 +171,14 @@ function onRedo() {
 }
 
 async function onPick(row) {
-  if (row.kind !== "past") return;
+  if (row.kind !== "past" || store.busy) return;
   menuOpen.value = false;
-  previewIndex.value = null;
+  previewId.value = null;
+  // Vuetify restores focus to the activator on Esc and on Tab-past-the-last
+  // focusable, but not on a programmatic close: without this the row button is
+  // unmounted under the keyboard and focus lands on <body> (WCAG 2.4.3).
+  await nextTick();
+  focusChevron();
   await store.undoTo(row.op.id);
 }
 
@@ -134,7 +189,7 @@ async function onPick(row) {
  * like the first time it was opened.
  */
 watch(menuOpen, async (isOpen) => {
-  previewIndex.value = null;
+  previewId.value = null;
   if (!isOpen) return;
   store.refresh({ narrate: false });
   await nextTick();
@@ -152,7 +207,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="uc" role="group" aria-label="History">
+  <div ref="rootEl" class="uc" role="group" aria-label="Undo and redo">
     <div class="uc-group" :class="{ 'uc-group--open': menuOpen }">
       <button
         type="button"
@@ -160,6 +215,7 @@ defineExpose({
         :aria-disabled="!canUndo"
         :title="undoTitle"
         :aria-label="undoTitle"
+        :aria-keyshortcuts="undoKeyShortcut"
         @click="onUndo"
       >
         <v-icon size="19">mdi-undo-variant</v-icon>
@@ -170,6 +226,7 @@ defineExpose({
         :aria-disabled="!canRedo"
         :title="redoTitle"
         :aria-label="redoTitle"
+        :aria-keyshortcuts="redoKeyShortcut"
         @click="onRedo"
       >
         <v-icon size="19">mdi-redo-variant</v-icon>
@@ -181,6 +238,7 @@ defineExpose({
         origin="top start"
         :offset="8"
         transition="scale-transition"
+        :activator-props="{ 'aria-haspopup': 'dialog' }"
       >
         <template #activator="{ props: menuProps }">
           <button
@@ -189,13 +247,17 @@ defineExpose({
             class="uc-btn uc-btn--chevron"
             title="History"
             aria-label="History"
-            aria-haspopup="menu"
             :aria-expanded="menuOpen"
           >
             <v-icon size="18" class="uc-chevron">mdi-menu-down</v-icon>
           </button>
         </template>
-        <div class="tbm uc-panel">
+        <div
+          class="tbm uc-panel"
+          role="dialog"
+          aria-label="History"
+          @mouseleave="previewId = null"
+        >
           <span class="tbm-caret tbm-caret--start"></span>
           <div class="tbm-header">
             <v-icon size="18" class="tbm-header-icon">mdi-history</v-icon>
@@ -207,7 +269,7 @@ defineExpose({
               }}</span
             >
           </div>
-          <div ref="listEl" class="uc-list" @mouseleave="previewIndex = null">
+          <div ref="listEl" class="uc-list">
             <p v-if="!rows.length" class="uc-empty">
               Nothing recorded yet. Your next change lands here.
             </p>
@@ -224,12 +286,15 @@ defineExpose({
               :disabled="row.kind !== 'past'"
               :aria-label="
                 row.kind === 'past'
-                  ? `Undo back to: ${rowLabel(row.op)}`
+                  ? `Undo back to: ${rowLabel(row.op)} (${rowSteps(row)} step${
+                      rowSteps(row) === 1 ? '' : 's'
+                    })`
                   : `${rowLabel(row.op)} (undone)`
               "
-              @mouseenter="previewIndex = row.index >= 0 ? row.index : null"
-              @focus="previewIndex = row.index >= 0 ? row.index : null"
+              @mouseenter="preview(row)"
+              @focus="preview(row)"
               @click="onPick(row)"
+              @keydown.enter.stop.prevent="onPick(row)"
             >
               <v-icon size="18" class="uc-row-icon">{{
                 rowIcon(row.op)
@@ -238,8 +303,8 @@ defineExpose({
               <span class="uc-row-time">{{ rowTime(row.op) }}</span>
             </button>
           </div>
-          <div class="tbm-footer" aria-live="polite">
-            <v-icon size="16">mdi-cursor-default-click-outline</v-icon>
+          <div class="tbm-footer">
+            <v-icon size="16">mdi-gesture-tap</v-icon>
             <span>{{ footerText }}</span>
           </div>
         </div>

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -218,8 +218,8 @@
         </v-card-title>
         <v-card-text style="padding: 0 20px 4px">
           <div style="font-size: 0.875rem; opacity: 0.85; margin-bottom: 10px">
-            Leave the label empty for dense object detection, or type a phrase
-            to detect only that (e.g. "dog").
+            Leave the label empty for dense object detection, or type a phrase to
+            detect only that (e.g. "dog").
           </div>
           <v-text-field
             v-model="segmentPrompt"
@@ -231,9 +231,7 @@
           />
         </v-card-text>
         <v-card-actions style="padding: 8px 16px 16px">
-          <v-btn variant="text" @click="segmentDialogOpen = false"
-            >Cancel</v-btn
-          >
+          <v-btn variant="text" @click="segmentDialogOpen = false">Cancel</v-btn>
           <v-spacer />
           <v-btn color="primary" variant="tonal" @click="confirmSegment">
             Detect
@@ -268,9 +266,7 @@
       v-model="snapshotsWithDeletedOpen"
       :snapshots="snapshotsWithDeleted"
       :dont-show-again="userPrefsStore.hidePurgeSnapshotWarning"
-      @update:dont-show-again="
-        userPrefsStore.setHidePurgeSnapshotWarning($event)
-      "
+      @update:dont-show-again="userPrefsStore.setHidePurgeSnapshotWarning($event)"
     />
     <DeleteForeverDialog
       v-model:open="deleteForeverOpen"
@@ -1024,7 +1020,10 @@ import { useTasksStore } from "../../stores/useTasksStore";
 import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
 import { useLockedSetsStore } from "../../stores/useLockedSetsStore";
 import { useScrapheapRetentionStore } from "../../stores/useScrapheapRetentionStore";
-import { useNoticeStore, DEFAULT_TIMEOUTS } from "../../stores/useNoticeStore";
+import {
+  useNoticeStore,
+  DEFAULT_TIMEOUTS,
+} from "../../stores/useNoticeStore";
 import { useBreadcrumb } from "../../composables/useBreadcrumb";
 import {
   useAnchorHeight,
@@ -1094,11 +1093,7 @@ import {
   removeCharacterFaces,
   removeCharacterFacesByFaceId,
 } from "../../api/characters";
-import {
-  getPictureSet,
-  addPictureToSet,
-  removePictureFromSet,
-} from "../../api/pictureSets";
+import { getPictureSet, addPictureToSet, removePictureFromSet } from "../../api/pictureSets";
 import { getSharedPictureIds, revokeTokensByResource } from "../../api/users";
 import { listTaggers } from "../../api/taggers";
 import { runTextToImage } from "../../api/comfyui";
@@ -2427,7 +2422,9 @@ function getVideoThumbnailSrc(img) {
 // yet been populated falls back to cover centring until they arrive.
 function isSquareCropActive(img) {
   return (
-    !isJustifiedMode.value && !isVideo(img) && squareCropParams(img) !== null
+    !isJustifiedMode.value &&
+    !isVideo(img) &&
+    squareCropParams(img) !== null
   );
 }
 
@@ -2832,7 +2829,8 @@ const reviewOverlayOpen = computed(() => reviewSessionsStore.overlayOpen);
 // The trail logic lives in useBreadcrumb, shared with the desktop title bar.
 // In the desktop shell the breadcrumb renders in the title bar instead, so the
 // in-grid overlay below is gated on !isDesktop.
-const isDesktop = typeof window !== "undefined" && !!window.pixlstashDesktop;
+const isDesktop =
+  typeof window !== "undefined" && !!window.pixlstashDesktop;
 const { breadcrumb, navigateBreadcrumb } = useBreadcrumb();
 
 // Below 600px the centred notice card widens over the bottom-left breadcrumb, so
@@ -2844,7 +2842,7 @@ useBottomAnchor("grid-breadcrumb", breadcrumbEl, { narrowOnly: true });
 
 // The action receipt shares the selection pill's slot, so when the pill is up
 // the receipt sits above it. The lift is the pill's MEASURED height plus the
-// standard gap — never a constant, because the pill wraps and grows on coarse
+// standard gap, never a constant, because the pill wraps and grows on coarse
 // pointers (the 56px in floatingBottom.js is a first-frame fallback, not a
 // design token).
 const { height: selectionBarHeight } = useAnchorHeight("selection-bar");
@@ -3773,9 +3771,7 @@ const partialStackGroupingReason = computed(() => {
   const idSet = new Set(ids);
   const images = allGridImages.value || [];
   const byId = new Map(
-    images
-      .filter((img) => img && img.id != null)
-      .map((img) => [String(img.id), img]),
+    images.filter((img) => img && img.id != null).map((img) => [String(img.id), img]),
   );
 
   // Which stacks does the selection touch? (Members share stack_id even when
@@ -3795,9 +3791,7 @@ const partialStackGroupingReason = computed(() => {
     // An expanded stack is whole-stack only when every rendered member is
     // selected.
     const memberIds = images
-      .filter(
-        (img) => img && img.id != null && getPictureStackId(img) === stackId,
-      )
+      .filter((img) => img && img.id != null && getPictureStackId(img) === stackId)
       .map((img) => Number(img.id));
     const allSelected =
       memberIds.length > 0 && memberIds.every((mid) => idSet.has(mid));
@@ -4107,9 +4101,10 @@ async function runScrapheapSelectionPurge(idsToRemove, includeProtected) {
     );
   } catch (err) {
     console.error("Scrapheap purge failed", err);
-    noticeStore.error(`Couldn't delete those pictures. ${errorDetail(err)}`, {
-      key: "scrapheap-purge",
-    });
+    noticeStore.error(
+      `Couldn't delete those pictures. ${errorDetail(err)}`,
+      { key: "scrapheap-purge" },
+    );
   } finally {
     // The server spends the confirmation on the first attempt, so a retry must
     // go back through the preview rather than replaying a dead token.

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -218,8 +218,8 @@
         </v-card-title>
         <v-card-text style="padding: 0 20px 4px">
           <div style="font-size: 0.875rem; opacity: 0.85; margin-bottom: 10px">
-            Leave the label empty for dense object detection, or type a phrase to
-            detect only that (e.g. "dog").
+            Leave the label empty for dense object detection, or type a phrase
+            to detect only that (e.g. "dog").
           </div>
           <v-text-field
             v-model="segmentPrompt"
@@ -231,7 +231,9 @@
           />
         </v-card-text>
         <v-card-actions style="padding: 8px 16px 16px">
-          <v-btn variant="text" @click="segmentDialogOpen = false">Cancel</v-btn>
+          <v-btn variant="text" @click="segmentDialogOpen = false"
+            >Cancel</v-btn
+          >
           <v-spacer />
           <v-btn color="primary" variant="tonal" @click="confirmSegment">
             Detect
@@ -266,7 +268,9 @@
       v-model="snapshotsWithDeletedOpen"
       :snapshots="snapshotsWithDeleted"
       :dont-show-again="userPrefsStore.hidePurgeSnapshotWarning"
-      @update:dont-show-again="userPrefsStore.setHidePurgeSnapshotWarning($event)"
+      @update:dont-show-again="
+        userPrefsStore.setHidePurgeSnapshotWarning($event)
+      "
     />
     <DeleteForeverDialog
       v-model:open="deleteForeverOpen"
@@ -998,6 +1002,9 @@
       @reverse-image-search="handleReverseImageSearch"
       @selection-menu-open="toolbarSelectionMenuOpen = $event"
     />
+    <!-- The action receipt shares the selection pill's slot and lifts clear of
+         it when both are up. Owner-only, like the toolbar control. -->
+    <ActionReceipt v-if="!isReadOnly" :lift-px="actionReceiptLift" />
   </div>
 </template>
 
@@ -1017,12 +1024,13 @@ import { useTasksStore } from "../../stores/useTasksStore";
 import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
 import { useLockedSetsStore } from "../../stores/useLockedSetsStore";
 import { useScrapheapRetentionStore } from "../../stores/useScrapheapRetentionStore";
-import {
-  useNoticeStore,
-  DEFAULT_TIMEOUTS,
-} from "../../stores/useNoticeStore";
+import { useNoticeStore, DEFAULT_TIMEOUTS } from "../../stores/useNoticeStore";
 import { useBreadcrumb } from "../../composables/useBreadcrumb";
-import { useBottomAnchor } from "../../composables/useBottomAnchor";
+import {
+  useAnchorHeight,
+  useBottomAnchor,
+} from "../../composables/useBottomAnchor";
+import { FLOATING_BOTTOM_GAP_PX } from "../../utils/floatingBottom";
 import { useScopedNotice } from "../../composables/useScopedNotice";
 import { buildPurgeBadge } from "../../utils/retention.js";
 import { buildLockedDeleteMessage } from "../../utils/lockedDelete.js";
@@ -1044,6 +1052,7 @@ import ImageOverlay from "./ImageOverlay.vue";
 import EmptyScrapHeap from "../widgets/EmptyScrapHeap.vue";
 import Toolbar from "../panels/Toolbar.vue";
 import SelectionBar from "../panels/SelectionBar.vue";
+import ActionReceipt from "../widgets/ActionReceipt.vue";
 import ImageGridContextMenu from "../widgets/ImageGridContextMenu.vue";
 import SearchResultBar from "../widgets/SearchResultBar.vue";
 import StarRatingOverlay from "../widgets/StarRatingOverlay.vue";
@@ -1085,7 +1094,11 @@ import {
   removeCharacterFaces,
   removeCharacterFacesByFaceId,
 } from "../../api/characters";
-import { getPictureSet, addPictureToSet, removePictureFromSet } from "../../api/pictureSets";
+import {
+  getPictureSet,
+  addPictureToSet,
+  removePictureFromSet,
+} from "../../api/pictureSets";
 import { getSharedPictureIds, revokeTokensByResource } from "../../api/users";
 import { listTaggers } from "../../api/taggers";
 import { runTextToImage } from "../../api/comfyui";
@@ -2414,9 +2427,7 @@ function getVideoThumbnailSrc(img) {
 // yet been populated falls back to cover centring until they arrive.
 function isSquareCropActive(img) {
   return (
-    !isJustifiedMode.value &&
-    !isVideo(img) &&
-    squareCropParams(img) !== null
+    !isJustifiedMode.value && !isVideo(img) && squareCropParams(img) !== null
   );
 }
 
@@ -2821,8 +2832,7 @@ const reviewOverlayOpen = computed(() => reviewSessionsStore.overlayOpen);
 // The trail logic lives in useBreadcrumb, shared with the desktop title bar.
 // In the desktop shell the breadcrumb renders in the title bar instead, so the
 // in-grid overlay below is gated on !isDesktop.
-const isDesktop =
-  typeof window !== "undefined" && !!window.pixlstashDesktop;
+const isDesktop = typeof window !== "undefined" && !!window.pixlstashDesktop;
 const { breadcrumb, navigateBreadcrumb } = useBreadcrumb();
 
 // Below 600px the centred notice card widens over the bottom-left breadcrumb, so
@@ -2831,6 +2841,18 @@ const { breadcrumb, navigateBreadcrumb } = useBreadcrumb();
 // which is what `narrowOnly` encodes.
 const breadcrumbEl = ref(null);
 useBottomAnchor("grid-breadcrumb", breadcrumbEl, { narrowOnly: true });
+
+// The action receipt shares the selection pill's slot, so when the pill is up
+// the receipt sits above it. The lift is the pill's MEASURED height plus the
+// standard gap — never a constant, because the pill wraps and grows on coarse
+// pointers (the 56px in floatingBottom.js is a first-frame fallback, not a
+// design token).
+const { height: selectionBarHeight } = useAnchorHeight("selection-bar");
+const actionReceiptLift = computed(() =>
+  selectionBarHeight.value > 0
+    ? selectionBarHeight.value + FLOATING_BOTTOM_GAP_PX
+    : 0,
+);
 
 watch(
   visibleRangeLabel,
@@ -3751,7 +3773,9 @@ const partialStackGroupingReason = computed(() => {
   const idSet = new Set(ids);
   const images = allGridImages.value || [];
   const byId = new Map(
-    images.filter((img) => img && img.id != null).map((img) => [String(img.id), img]),
+    images
+      .filter((img) => img && img.id != null)
+      .map((img) => [String(img.id), img]),
   );
 
   // Which stacks does the selection touch? (Members share stack_id even when
@@ -3771,7 +3795,9 @@ const partialStackGroupingReason = computed(() => {
     // An expanded stack is whole-stack only when every rendered member is
     // selected.
     const memberIds = images
-      .filter((img) => img && img.id != null && getPictureStackId(img) === stackId)
+      .filter(
+        (img) => img && img.id != null && getPictureStackId(img) === stackId,
+      )
       .map((img) => Number(img.id));
     const allSelected =
       memberIds.length > 0 && memberIds.every((mid) => idSet.has(mid));
@@ -4081,10 +4107,9 @@ async function runScrapheapSelectionPurge(idsToRemove, includeProtected) {
     );
   } catch (err) {
     console.error("Scrapheap purge failed", err);
-    noticeStore.error(
-      `Couldn't delete those pictures. ${errorDetail(err)}`,
-      { key: "scrapheap-purge" },
-    );
+    noticeStore.error(`Couldn't delete those pictures. ${errorDetail(err)}`, {
+      key: "scrapheap-purge",
+    });
   } finally {
     // The server spends the confirmation on the first attempt, so a retry must
     // go back through the preview rather than replaying a dead token.

--- a/frontend/src/components/views/ImageOverlay.vue
+++ b/frontend/src/components/views/ImageOverlay.vue
@@ -786,7 +786,11 @@ import OverlayMetadataPanel from "./OverlayMetadataPanel.vue";
 import OverlayTagsPanel from "./OverlayTagsPanel.vue";
 import PluginParametersUI from "../widgets/PluginParametersUI.vue";
 import StarRatingOverlay from "../widgets/StarRatingOverlay.vue";
-import { faceBoxColor, getStackColor, toggleScore } from "../../utils/utils.js";
+import {
+  faceBoxColor,
+  getStackColor,
+  toggleScore,
+} from "../../utils/utils.js";
 import { dedupeTagList, getTagList } from "../../utils/tags.js";
 
 // Failures report through the notice surface instead of a blocking native
@@ -2152,7 +2156,7 @@ function handleKeydown(e) {
     showNextImage();
   } else if ((e.key === "z" || e.key === "Z") && !e.ctrlKey && !e.metaKey) {
     // Modifier-blind `z` would make Ctrl+Z and Ctrl+Shift+Z (which reports
-    // `e.key === "Z"`) zoom instead of undo — the worst kind of collision,
+    // `e.key === "Z"`) zoom instead of undo: the worst kind of collision,
     // because it does something visible and wrong.
     toggleZoom();
   } else if (e.key === " " || e.key === "Spacebar") {

--- a/frontend/src/components/views/ImageOverlay.vue
+++ b/frontend/src/components/views/ImageOverlay.vue
@@ -786,11 +786,7 @@ import OverlayMetadataPanel from "./OverlayMetadataPanel.vue";
 import OverlayTagsPanel from "./OverlayTagsPanel.vue";
 import PluginParametersUI from "../widgets/PluginParametersUI.vue";
 import StarRatingOverlay from "../widgets/StarRatingOverlay.vue";
-import {
-  faceBoxColor,
-  getStackColor,
-  toggleScore,
-} from "../../utils/utils.js";
+import { faceBoxColor, getStackColor, toggleScore } from "../../utils/utils.js";
 import { dedupeTagList, getTagList } from "../../utils/tags.js";
 
 // Failures report through the notice surface instead of a blocking native
@@ -2154,7 +2150,10 @@ function handleKeydown(e) {
     showPrevImage();
   } else if (["ArrowRight", "Right", "ArrowDown", "Down"].includes(e.key)) {
     showNextImage();
-  } else if (e.key === "z" || e.key === "Z") {
+  } else if ((e.key === "z" || e.key === "Z") && !e.ctrlKey && !e.metaKey) {
+    // Modifier-blind `z` would make Ctrl+Z and Ctrl+Shift+Z (which reports
+    // `e.key === "Z"`) zoom instead of undo — the worst kind of collision,
+    // because it does something visible and wrong.
     toggleZoom();
   } else if (e.key === " " || e.key === "Spacebar") {
     e.preventDefault();

--- a/frontend/src/components/widgets/ActionReceipt.test.js
+++ b/frontend/src/components/widgets/ActionReceipt.test.js
@@ -80,12 +80,40 @@ describe("ActionReceipt — states", () => {
     expect(wrapper.find(".kbdhint").attributes("aria-hidden")).toBe("true");
   });
 
-  it("is a polite live region so the outcome is announced, once", async () => {
+  it("announces through one persistent region, not the pill itself", async () => {
     const { wrapper } = mountWith(op());
     await wrapper.vm.$nextTick();
+
+    // The pill carries no live region: a region created at the same moment as
+    // its content announces unreliably, and a burst would create one region
+    // per action and queue a backlog of stale sentences.
     const pill = wrapper.find(".receipt");
-    expect(pill.attributes("role")).toBe("status");
-    expect(pill.attributes("aria-live")).toBe("polite");
+    expect(pill.attributes("role")).toBeUndefined();
+    expect(pill.attributes("aria-live")).toBeUndefined();
+
+    const region = wrapper.find('[data-testid="action-receipt-announcement"]');
+    expect(region.attributes("role")).toBe("status");
+    expect(region.attributes("aria-live")).toBe("polite");
+    expect(region.attributes("aria-atomic")).toBe("true");
+  });
+
+  it("speaks once for a burst rather than reading every step aloud", async () => {
+    const { store, wrapper } = mountWith(op({ summary: "First" }));
+    await wrapper.vm.$nextTick();
+    const region = () =>
+      wrapper.find('[data-testid="action-receipt-announcement"]').text();
+    expect(region()).toBe("");
+
+    store.showReceipt(store.buildReceipt(op({ summary: "Second" }), "did"));
+    await wrapper.vm.$nextTick();
+    vi.advanceTimersByTime(200);
+    store.showReceipt(store.buildReceipt(op({ summary: "Third" }), "did"));
+    await wrapper.vm.$nextTick();
+    expect(region()).toBe("");
+
+    vi.advanceTimersByTime(400);
+    await wrapper.vm.$nextTick();
+    expect(region()).toBe("Third \u00b7 12");
   });
 
   it("shows the coalesced +N when the step carries batch siblings", async () => {
@@ -115,7 +143,7 @@ describe("ActionReceipt — states", () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.find(".r-text").text()).toBe(
-      "Undone — Added tag 'portrait' · 12",
+      "Undone: Added tag 'portrait' · 12",
     );
     expect(wrapper.find(".r-btn").text()).toContain("Redo");
     // One pill, never a second stacked below it.
@@ -126,7 +154,7 @@ describe("ActionReceipt — states", () => {
     const { wrapper } = mountWith(op(), "undone", 3);
     await wrapper.vm.$nextTick();
     expect(wrapper.find(".r-text").text()).toBe(
-      "Undone 3 steps — Added tag 'portrait' · 12",
+      "Undone 3 steps: Added tag 'portrait' · 12",
     );
   });
 
@@ -186,6 +214,51 @@ describe("ActionReceipt — pause on hover and focus (WCAG 2.2.1)", () => {
 });
 
 describe("ActionReceipt — the action button", () => {
+  it("keeps the keyboard on the button when the pill flips to Redo", async () => {
+    // Attached to the document: `document.activeElement` only tracks a focus()
+    // call on an element that is actually in the page.
+    const store = useOperationStore();
+    const wrapper = mount(ActionReceipt, {
+      ...globalOpts,
+      attachTo: document.body,
+    });
+    store.showReceipt(store.buildReceipt(op(), "did"));
+    // The pill is REPLACED on flip; without focus restoration the user who
+    // reached Undo by keyboard is dropped to <body> (WCAG 2.4.3).
+    vi.spyOn(store, "undo").mockImplementation(async () => {
+      store.showReceipt(store.buildReceipt(op(), "undone"));
+      return {};
+    });
+    await wrapper.vm.$nextTick();
+
+    const button = wrapper.find(".r-btn");
+    button.element.focus();
+    await button.trigger("click");
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".r-btn").text()).toContain("Redo");
+    expect(document.activeElement).toBe(wrapper.find(".r-btn").element);
+  });
+
+  it("marks itself busy with aria-disabled, never the attribute", async () => {
+    const { store, wrapper } = mountWith(op());
+    store.busy = true;
+    await wrapper.vm.$nextTick();
+    const button = wrapper.find(".r-btn");
+    // A `disabled` button loses focus to <body> the instant it is disabled.
+    expect(button.attributes("disabled")).toBeUndefined();
+    expect(button.attributes("aria-disabled")).toBe("true");
+  });
+
+  it("advertises its shortcut in a way that survives the hidden keycaps", async () => {
+    const { wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".r-btn").attributes("aria-keyshortcuts")).toMatch(
+      /Control\+Z|Meta\+Z/,
+    );
+  });
+
   it("undoes from the default state", async () => {
     const { store, wrapper } = mountWith(op());
     const undo = vi.spyOn(store, "undo").mockResolvedValue(null);

--- a/frontend/src/components/widgets/ActionReceipt.test.js
+++ b/frontend/src/components/widgets/ActionReceipt.test.js
@@ -1,0 +1,232 @@
+// The action receipt pill — the transient half of undo/redo.
+//
+// The store owns the timers and the API (covered in useOperationStore.test.js);
+// these tests pin the contracts the PILL is responsible for: which state it
+// renders, that the drain window it hands CSS matches the store's own timer,
+// that hover and focus freeze that timer (WCAG 2.2.1), and that a receipt
+// replaced in place remounts rather than mutating a live region under the
+// screen reader.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount } from "@vue/test-utils";
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref } = await import("vue");
+  return {
+    apiClient: { get: vi.fn(), post: vi.fn() },
+    isReadOnly: ref(false),
+    setRequestClientId: vi.fn(),
+  };
+});
+
+vi.mock("../../api/operations", () => ({
+  listOperations: vi.fn().mockResolvedValue([]),
+  getUndoState: vi.fn().mockResolvedValue({ can_undo: false, can_redo: false }),
+  undoLastOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  redoOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  undoOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  undoBatch: vi.fn().mockResolvedValue({ operations: [] }),
+}));
+
+import ActionReceipt from "./ActionReceipt.vue";
+import { useOperationStore } from "../../stores/useOperationStore";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+function op(overrides = {}) {
+  return {
+    id: 10,
+    batch_id: null,
+    created_at: "2026-07-29T12:00:00",
+    op_type: "pictures.tags.add",
+    target_count: 12,
+    origin_client_id: "me",
+    undoable: true,
+    status: "applied",
+    summary: "Added tag 'portrait'",
+    ...overrides,
+  };
+}
+
+/** Mount the pill with one receipt already raised in the given mode. */
+function mountWith(operation, mode = "did", steps = 1) {
+  const store = useOperationStore();
+  const wrapper = mount(ActionReceipt, globalOpts);
+  store.showReceipt(store.buildReceipt(operation, mode, steps));
+  return { store, wrapper };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setActivePinia(createPinia());
+});
+
+describe("ActionReceipt — states", () => {
+  it("renders nothing while there is no receipt", () => {
+    mount(ActionReceipt, globalOpts);
+    expect(document.querySelector(".receipt")).toBeNull();
+  });
+
+  it("shows the summary, an Undo button and the shortcut hint by default", async () => {
+    const { wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".r-text").text()).toBe("Added tag 'portrait' · 12");
+    expect(wrapper.find(".r-btn").text()).toContain("Undo");
+    expect(wrapper.find(".kbdhint").exists()).toBe(true);
+    // The hint is decorative: announcing "Ctrl Z" on every action would make
+    // the live region unusable.
+    expect(wrapper.find(".kbdhint").attributes("aria-hidden")).toBe("true");
+  });
+
+  it("is a polite live region so the outcome is announced, once", async () => {
+    const { wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+    const pill = wrapper.find(".receipt");
+    expect(pill.attributes("role")).toBe("status");
+    expect(pill.attributes("aria-live")).toBe("polite");
+  });
+
+  it("shows the coalesced +N when the step carries batch siblings", async () => {
+    const store = useOperationStore();
+    store.operations = [
+      op({ id: 12, batch_id: "b1" }),
+      op({ id: 11, batch_id: "b1" }),
+      op({ id: 10, batch_id: "b1" }),
+    ];
+    const wrapper = mount(ActionReceipt, globalOpts);
+    store.showReceipt(
+      store.buildReceipt(op({ id: 12, batch_id: "b1" }), "did"),
+    );
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".r-more").text()).toBe("+2");
+  });
+
+  it("omits the +N for a lone step", async () => {
+    const { wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".r-more").exists()).toBe(false);
+  });
+
+  it("flips in place to the undone state and offers Redo", async () => {
+    const { wrapper } = mountWith(op(), "undone");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".r-text").text()).toBe(
+      "Undone — Added tag 'portrait' · 12",
+    );
+    expect(wrapper.find(".r-btn").text()).toContain("Redo");
+    // One pill, never a second stacked below it.
+    expect(wrapper.findAll(".receipt")).toHaveLength(1);
+  });
+
+  it("says how far a multi-step undo went", async () => {
+    const { wrapper } = mountWith(op(), "undone", 3);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".r-text").text()).toBe(
+      "Undone 3 steps — Added tag 'portrait' · 12",
+    );
+  });
+
+  it("states the limit instead of a dead button when the action is one-way", async () => {
+    const { wrapper } = mountWith(op({ undoable: false }), "blocked");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".r-limit").text()).toBe("Can't be undone");
+    expect(wrapper.find(".r-btn").exists()).toBe(false);
+  });
+});
+
+describe("ActionReceipt — the drain window", () => {
+  it("hands CSS the same window the store's timer uses", async () => {
+    const { wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".receipt").attributes("style")).toContain(
+      "--r-drain-dur: 5000ms",
+    );
+  });
+
+  it("uses the longer window for a destructive action", async () => {
+    const { wrapper } = mountWith(op({ op_type: "pictures.scrapheap.move" }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".receipt").attributes("style")).toContain(
+      "--r-drain-dur: 8000ms",
+    );
+  });
+});
+
+describe("ActionReceipt — pause on hover and focus (WCAG 2.2.1)", () => {
+  it("freezes the countdown while the pointer is on the pill", async () => {
+    const { store, wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find(".receipt").trigger("mouseenter");
+    vi.advanceTimersByTime(60000);
+    expect(store.receipt).not.toBeNull();
+
+    await wrapper.find(".receipt").trigger("mouseleave");
+    vi.advanceTimersByTime(5000);
+    expect(store.receipt).toBeNull();
+  });
+
+  it("freezes the countdown while focus is inside the pill", async () => {
+    const { store, wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find(".receipt").trigger("focusin");
+    vi.advanceTimersByTime(60000);
+    expect(store.receipt).not.toBeNull();
+
+    await wrapper.find(".receipt").trigger("focusout");
+    vi.advanceTimersByTime(5000);
+    expect(store.receipt).toBeNull();
+  });
+});
+
+describe("ActionReceipt — the action button", () => {
+  it("undoes from the default state", async () => {
+    const { store, wrapper } = mountWith(op());
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find(".r-btn").trigger("click");
+    expect(undo).toHaveBeenCalledTimes(1);
+  });
+
+  it("redoes from the undone state", async () => {
+    const { store, wrapper } = mountWith(op(), "undone");
+    const redo = vi.spyOn(store, "redo").mockResolvedValue(null);
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find(".r-btn").trigger("click");
+    expect(redo).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ActionReceipt — placement", () => {
+  it("lifts clear of the selection pill by the measured height it is given", async () => {
+    const store = useOperationStore();
+    const wrapper = mount(ActionReceipt, {
+      ...globalOpts,
+      props: { liftPx: 62 },
+    });
+    store.showReceipt(store.buildReceipt(op(), "did"));
+    await wrapper.vm.$nextTick();
+
+    // The lift is padding on the pointer-transparent wrapper, so the wrapper's
+    // measured box is the FULL height this component occupies on the bottom
+    // edge — which is what the anchor registry reports to the notice stack.
+    expect(
+      wrapper.find('[data-testid="action-receipt-slot"]').attributes("style"),
+    ).toContain("padding-bottom: 62px");
+  });
+
+  it("sits flush on the bottom edge when nothing else is parked there", () => {
+    const wrapper = mount(ActionReceipt, globalOpts);
+    expect(
+      wrapper.find('[data-testid="action-receipt-slot"]').attributes("style"),
+    ).toContain("padding-bottom: 0px");
+  });
+});

--- a/frontend/src/components/widgets/ActionReceipt.vue
+++ b/frontend/src/components/widgets/ActionReceipt.vue
@@ -27,11 +27,25 @@
  * measured border box is the FULL height this component occupies on the bottom
  * edge — which is exactly what the anchor registry needs to report.
  */
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+} from "vue";
 
 import { useBottomAnchor } from "../../composables/useBottomAnchor";
 import { useOperationStore } from "../../stores/useOperationStore";
-import { redoKeyHint, undoKeyHint } from "../../utils/shortcutHints";
+import {
+  isApplePlatform,
+  redoKeyHint,
+  undoKeyHint,
+} from "../../utils/shortcutHints";
+
+/** Settling window before the live region speaks, so a burst reads once. */
+const ANNOUNCE_THROTTLE_MS = 350;
 
 const props = defineProps({
   /**
@@ -70,11 +84,22 @@ const text = computed(() => {
   const entry = receipt.value;
   if (!entry) return "";
   if (undone.value && entry.steps > 1) {
-    return `Undone ${entry.steps} steps — ${entry.summary}`;
+    return `Undone ${entry.steps} steps: ${entry.summary}`;
   }
-  if (undone.value) return `Undone — ${entry.summary}`;
+  if (undone.value) return `Undone: ${entry.summary}`;
   return entry.summary;
 });
+
+/** The standard attribute for "this control has a keyboard shortcut". */
+const actionKeyShortcut = computed(() =>
+  undone.value
+    ? isApplePlatform()
+      ? "Shift+Meta+Z"
+      : "Control+Y"
+    : isApplePlatform()
+      ? "Meta+Z"
+      : "Control+Z",
+);
 
 // The drain's duration is a dismissal timeout, not a motion token: the motion
 // scale tops out at 420ms. It is handed to CSS as a custom property so the
@@ -92,9 +117,23 @@ const wrapperStyle = computed(() => ({
 const wrapperEl = ref(null);
 useBottomAnchor("action-receipt", wrapperEl);
 
-function onUndo() {
-  if (undone.value) store.redo();
-  else store.undo();
+/**
+ * Take the action and keep the keyboard where it was.
+ *
+ * The pill is REPLACED (a new node, keyed on the store's raise counter) when
+ * undo flips it to "Undone … Redo". Without this, a user who reached Undo with
+ * the keyboard has focus dropped to `<body>` and has to tab from the top of the
+ * document to reach the Redo the flip just produced — WCAG 2.4.3. The button is
+ * `aria-disabled` rather than `disabled` for the same reason: disabling a
+ * focused control moves focus off it.
+ */
+async function onUndo(event) {
+  if (store.busy) return;
+  const hadFocus = event?.currentTarget === document.activeElement;
+  await (undone.value ? store.redo() : store.undo());
+  if (!hadFocus) return;
+  await nextTick();
+  wrapperEl.value?.querySelector?.(".r-btn")?.focus?.();
 }
 
 // WCAG 2.2.1 — the countdown freezes on hover and on focus-within, and the CSS
@@ -124,13 +163,32 @@ onBeforeUnmount(() => {
   if (typeof document !== "undefined") {
     document.removeEventListener("visibilitychange", onVisibilityChange);
   }
+  if (announceTimer != null) clearTimeout(announceTimer);
 });
 
 // Keyed on the store's raise counter so a receipt REPLACED in place still
-// remounts: the drain has to restart, and a live region whose text is swapped
-// without a node change is announced unreliably. Nothing autofocuses, so the
-// remount cannot steal focus from the grid.
+// remounts and the drain restarts from full. The pill is deliberately NOT the
+// live region: a region created at the same moment as its content announces
+// unreliably, and a burst of actions would create one region per action and
+// queue a backlog of stale sentences. The announcement rides a single
+// persistent region instead (notice-surface.md §8).
 const pillKey = computed(() => receipt.value?.key ?? 0);
+
+// What the persistent region says. Throttled so a burst announces the outcome
+// once, rather than reading every intermediate step aloud.
+const announcement = ref("");
+let announceTimer = null;
+watch(text, (value) => {
+  if (announceTimer != null) clearTimeout(announceTimer);
+  if (!value) {
+    announcement.value = "";
+    return;
+  }
+  announceTimer = setTimeout(() => {
+    announceTimer = null;
+    announcement.value = value;
+  }, ANNOUNCE_THROTTLE_MS);
+});
 
 // A receipt raised while the tab is hidden starts with a running countdown
 // (the store arms it unconditionally). Re-apply the hidden-tab pause so it does
@@ -148,6 +206,16 @@ watch(pillKey, () => {
     :style="wrapperStyle"
     data-testid="action-receipt-slot"
   >
+    <!-- One persistent region, always mounted, so an announcement is never
+         raced by the node that carries it. -->
+    <span
+      class="visually-hidden"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="action-receipt-announcement"
+      >{{ announcement }}</span
+    >
     <transition name="receipt">
       <div
         v-if="receipt"
@@ -155,8 +223,6 @@ watch(pillKey, () => {
         class="receipt"
         :class="{ 'receipt--undone': undone, 'receipt--blocked': blocked }"
         :style="drainStyle"
-        role="status"
-        aria-live="polite"
         @mouseenter="pause"
         @mouseleave="resume"
         @focusin="pause"
@@ -172,7 +238,8 @@ watch(pillKey, () => {
           <button
             type="button"
             class="r-btn"
-            :disabled="store.busy"
+            :aria-disabled="store.busy"
+            :aria-keyshortcuts="actionKeyShortcut"
             @click="onUndo"
           >
             <v-icon size="16">{{ actionGlyph }}</v-icon>
@@ -201,6 +268,9 @@ watch(pillKey, () => {
   display: flex;
   justify-content: center;
   pointer-events: none;
+  /* The lift changes when the selection pill appears or leaves; without this
+     the receipt jumps instead of moving with it. */
+  transition: padding-bottom var(--dur-2) var(--ease-standard);
 }
 
 /* Visually identical to `.floating-selection-bar`, deliberately: the two share
@@ -284,14 +354,17 @@ watch(pillKey, () => {
   text-underline-offset: 2px;
   cursor: pointer;
 }
-.r-btn:hover:not(:disabled) {
+.r-btn:hover:not([aria-disabled="true"]) {
   background: var(--hover-wash);
 }
 .r-btn:focus-visible {
   box-shadow: var(--focus-ring);
   outline: none;
 }
-.r-btn:disabled {
+/* `aria-disabled`, never the attribute: disabling a control the keyboard is
+   currently ON moves focus to <body>, and this button flips to Redo the moment
+   the round trip lands. */
+.r-btn[aria-disabled="true"] {
   opacity: 0.35;
   cursor: default;
 }

--- a/frontend/src/components/widgets/ActionReceipt.vue
+++ b/frontend/src/components/widgets/ActionReceipt.vue
@@ -1,0 +1,392 @@
+<script setup>
+/**
+ * The action receipt — a transient pill that narrates what just happened and
+ * offers to take it back. One instance, rendered over the grid in the same slot
+ * as the floating selection bar.
+ *
+ * Built to the owner's "Undo / Redo System" design:
+ *
+ *   • Icon + human summary + Undo + the keyboard shortcut, so the shortcut is
+ *     taught at the moment it is useful.
+ *   • A hairline drains over the dwell window (5s, 8s for a destructive action).
+ *     Hover or focus pauses it — WCAG 2.2.1, and the pause is on the store's
+ *     dismissal timer too, so the pill cannot vanish out from under a cursor
+ *     that is on its way to Undo.
+ *   • Undoing flips the pill IN PLACE to "Undone — …" with Redo. Two receipts
+ *     are never stacked; the store holds exactly one and the newest replaces it.
+ *   • A one-way operation still gets a receipt, stating the limit. Never a dead
+ *     Undo button.
+ *
+ * The pill is not a notice (notice-surface.md governs those). It sits on
+ * `--z-floating` with the selection pill and the breadcrumb, and it registers
+ * with `useBottomAnchor` so the notice stack clears it by construction rather
+ * than by a hardcoded guess.
+ *
+ * Stacking: when the selection bar is up, the receipt sits above it. The lift is
+ * carried as padding on the (pointer-transparent) wrapper, so the wrapper's
+ * measured border box is the FULL height this component occupies on the bottom
+ * edge — which is exactly what the anchor registry needs to report.
+ */
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+
+import { useBottomAnchor } from "../../composables/useBottomAnchor";
+import { useOperationStore } from "../../stores/useOperationStore";
+import { redoKeyHint, undoKeyHint } from "../../utils/shortcutHints";
+
+const props = defineProps({
+  /**
+   * Lift the pill clear of another bottom-anchored element (the selection bar),
+   * in pixels. Measured by the caller — never assumed, because the pill wraps
+   * and grows on coarse pointers.
+   */
+  liftPx: { type: Number, default: 0 },
+});
+
+const store = useOperationStore();
+
+const receipt = computed(() => store.receipt);
+const undone = computed(() => receipt.value?.mode === "undone");
+const blocked = computed(() => receipt.value?.mode === "blocked");
+
+/** The glyph: the action's own icon, or the undo/limit glyph once it flips. */
+const glyph = computed(() => {
+  if (!receipt.value) return "";
+  if (undone.value) return "mdi-undo-variant";
+  if (blocked.value) return "mdi-information-outline";
+  return receipt.value.icon;
+});
+
+const actionLabel = computed(() => (undone.value ? "Redo" : "Undo"));
+const actionGlyph = computed(() =>
+  undone.value ? "mdi-redo-variant" : "mdi-undo-variant",
+);
+const keyHint = computed(() => (undone.value ? redoKeyHint() : undoKeyHint()));
+
+/**
+ * The sentence. A multi-step undo says how far it went instead of naming only
+ * the oldest step it reverted, which would understate what just happened.
+ */
+const text = computed(() => {
+  const entry = receipt.value;
+  if (!entry) return "";
+  if (undone.value && entry.steps > 1) {
+    return `Undone ${entry.steps} steps — ${entry.summary}`;
+  }
+  if (undone.value) return `Undone — ${entry.summary}`;
+  return entry.summary;
+});
+
+// The drain's duration is a dismissal timeout, not a motion token: the motion
+// scale tops out at 420ms. It is handed to CSS as a custom property so the
+// hairline and the store's timer always describe the same window.
+const drainStyle = computed(() => ({
+  "--r-drain-dur": `${receipt.value?.durationMs ?? 0}ms`,
+}));
+
+const wrapperStyle = computed(() => ({
+  paddingBottom: `${Math.max(0, props.liftPx)}px`,
+}));
+
+// Registered so the notice stack sits clear of whatever this occupies. The
+// wrapper (pill + lift) is the measured element, not the pill alone.
+const wrapperEl = ref(null);
+useBottomAnchor("action-receipt", wrapperEl);
+
+function onUndo() {
+  if (undone.value) store.redo();
+  else store.undo();
+}
+
+// WCAG 2.2.1 — the countdown freezes on hover and on focus-within, and the CSS
+// pauses the hairline on the same two conditions so the two never disagree.
+function pause() {
+  store.pauseReceipt();
+}
+function resume() {
+  store.resumeReceipt();
+}
+
+// …and while the tab is hidden, or a receipt raised just before a tab switch
+// expires unread. Mirrors NoticeHost's handling of the same hazard.
+function onVisibilityChange() {
+  if (typeof document === "undefined") return;
+  if (document.hidden) store.pauseReceipt();
+  else store.resumeReceipt();
+}
+
+onMounted(() => {
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibilityChange);
+  }
+});
+
+onBeforeUnmount(() => {
+  if (typeof document !== "undefined") {
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+  }
+});
+
+// Keyed on the store's raise counter so a receipt REPLACED in place still
+// remounts: the drain has to restart, and a live region whose text is swapped
+// without a node change is announced unreliably. Nothing autofocuses, so the
+// remount cannot steal focus from the grid.
+const pillKey = computed(() => receipt.value?.key ?? 0);
+
+// A receipt raised while the tab is hidden starts with a running countdown
+// (the store arms it unconditionally). Re-apply the hidden-tab pause so it does
+// not expire unseen — the same hazard `onVisibilityChange` covers for the pill
+// that was already up.
+watch(pillKey, () => {
+  if (typeof document !== "undefined" && document.hidden) store.pauseReceipt();
+});
+</script>
+
+<template>
+  <div
+    ref="wrapperEl"
+    class="receipt-slot"
+    :style="wrapperStyle"
+    data-testid="action-receipt-slot"
+  >
+    <transition name="receipt">
+      <div
+        v-if="receipt"
+        :key="pillKey"
+        class="receipt"
+        :class="{ 'receipt--undone': undone, 'receipt--blocked': blocked }"
+        :style="drainStyle"
+        role="status"
+        aria-live="polite"
+        @mouseenter="pause"
+        @mouseleave="resume"
+        @focusin="pause"
+        @focusout="resume"
+      >
+        <v-icon class="r-ico" size="18">{{ glyph }}</v-icon>
+        <span class="r-text">{{ text }}</span>
+        <span v-if="receipt.mergedCount > 0" class="r-more"
+          >+{{ receipt.mergedCount }}</span
+        >
+        <span v-if="blocked" class="r-limit">Can't be undone</span>
+        <template v-else>
+          <button
+            type="button"
+            class="r-btn"
+            :disabled="store.busy"
+            @click="onUndo"
+          >
+            <v-icon size="16">{{ actionGlyph }}</v-icon>
+            <span>{{ actionLabel }}</span>
+          </button>
+          <span class="kbdhint" aria-hidden="true">
+            <kbd v-for="key in keyHint" :key="key">{{ key }}</kbd>
+          </span>
+        </template>
+        <span class="r-progress run" aria-hidden="true"></span>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+/* The slot spans from the bottom edge up through the pill. Pointer-transparent
+   so it never eats a click aimed at the grid underneath; only the pill itself
+   takes pointer events. */
+.receipt-slot {
+  position: absolute;
+  bottom: var(--space-5);
+  left: 0;
+  right: 0;
+  z-index: var(--z-floating);
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+/* Visually identical to `.floating-selection-bar`, deliberately: the two share
+   one slot and are mutually exclusive in time, so two surfaces here would read
+   as two systems.
+   --elevation-3, not -4: -4 is reserved for dialogs and lightbox chrome, and
+   the pill this mirrors is -3 for exactly that reason. */
+.receipt {
+  position: relative;
+  width: max-content;
+  max-width: calc(100% - var(--space-6));
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  /* 6px block padding matches the selection pill's occupied height. Off-grid
+     and carried deliberately: that dimension belongs to the UI/UX-gated
+     action-bar reconciliation (visual-language.md §5/§13), not to this change. */
+  padding: 6px var(--space-4);
+  border-radius: var(--radius-pill);
+  background: rgba(var(--v-theme-surface), 0.86);
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.14);
+  box-shadow: var(--elevation-3);
+  backdrop-filter: blur(12px);
+  pointer-events: auto;
+  /* Deliberately NO overflow: hidden — it would clip both the drain's tail
+     inside the pill's cap radius and the focus ring on the inner controls. */
+}
+
+.r-ico {
+  color: rgb(var(--v-theme-on-surface));
+  flex-shrink: 0;
+}
+
+.r-text {
+  font-size: var(--text-base);
+  line-height: var(--leading-snug);
+  color: rgb(var(--v-theme-on-surface));
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The coalescing count. Not a badge: a badge overlays its host without shifting
+   layout, and this sits inline in the pill's flow. `+N` rather than `×N` —
+   "N more merged into this step", which is what coalescing actually did. */
+.r-more {
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  flex-shrink: 0;
+}
+
+/* The limit, stated up front on a one-way operation, in place of the button. */
+.r-limit {
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), 0.6);
+  padding-inline: var(--space-3);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Underlined semibold `on-surface`, not a `primary` label: an accent or primary
+   foreground is never small body text, and the underline makes the control
+   unambiguously actionable without relying on colour (WCAG 1.4.1). */
+.r-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: rgb(var(--v-theme-on-surface));
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.r-btn:hover:not(:disabled) {
+  background: var(--hover-wash);
+}
+.r-btn:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+.r-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.kbdhint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+/* ── Countdown drain ─────────────────────────────────────────────────────────
+   Inset to the pill's straight run. The cap radius is half the pill height
+   (~27px), so a full-bleed hairline would need `overflow: hidden` on the pill,
+   which clips the hairline's own tail AND the focus ring on the inner controls
+   (a WCAG 2.4.11 regression). --space-7 clears the cap; --space-1 is the
+   documented hairline inset. */
+.r-progress {
+  position: absolute;
+  inset-inline: var(--space-7);
+  bottom: var(--space-1);
+  height: var(--countdown-h);
+  border-radius: var(--radius-pill);
+  background: rgba(var(--v-theme-on-surface), 0.12);
+  overflow: hidden;
+  pointer-events: none;
+}
+
+/* scaleX, never an animated `width`: width relayouts the pill every frame. */
+.r-progress::after {
+  content: "";
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: rgba(var(--v-theme-on-surface), 0.45);
+  transform: scaleX(1);
+  transform-origin: left center;
+  will-change: transform;
+}
+
+.r-progress.run::after {
+  animation: r-drain var(--r-drain-dur, 5000ms) linear forwards;
+}
+
+@keyframes r-drain {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+/* WCAG 2.2.1. The store's dismissal timer pauses on the same two conditions, so
+   a frozen hairline never sits under a pill that vanishes anyway. */
+.receipt:hover .r-progress.run::after,
+.receipt:focus-within .r-progress.run::after {
+  animation-play-state: paused;
+}
+
+/* Enter is a 250ms rise with no bounce, exit is quicker — the design's timing.
+   It is slower than the selection pill's --dur-2/--dur-1 on purpose: the two
+   never co-occur, and a slightly slower arrival reads as "read me". */
+.receipt-enter-active {
+  transition:
+    transform var(--dur-3) var(--ease-decelerate),
+    opacity var(--dur-3) var(--ease-decelerate);
+}
+.receipt-leave-active {
+  transition:
+    transform var(--dur-2) var(--ease-accelerate),
+    opacity var(--dur-2) var(--ease-accelerate);
+}
+.receipt-enter-from,
+.receipt-leave-to {
+  transform: translateY(120%);
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* The travel goes; a zero-duration transition still snaps a translate into
+     place, so it has to be removed rather than shortened. */
+  .receipt-enter-from,
+  .receipt-leave-to {
+    transform: none;
+  }
+  /* The drain STAYS. It is essential animation (WCAG 2.3.3): the hairline is
+     the time-remaining readout, not decoration, and the global reduced-motion
+     collapse would run it to completion in 0.001ms and leave it frozen at
+     scaleX(0) — asserting "expired" about a live receipt. A 2px linear hairline
+     is at the bottom of the vestibular-risk scale. Defensible only because the
+     drain is never the deadline on the capability: undo survives the receipt in
+     the toolbar control, and hover/focus pauses the clock. */
+  .r-progress.run::after {
+    animation-duration: var(--r-drain-dur, 5000ms) !important;
+  }
+}
+</style>

--- a/frontend/src/composables/useBottomAnchor.js
+++ b/frontend/src/composables/useBottomAnchor.js
@@ -126,6 +126,28 @@ export function useBottomAnchor(name, elRef, { narrowOnly = false } = {}) {
 }
 
 /**
+ * The measured height of ONE registered anchor, or 0 when it is not visible.
+ *
+ * The notice stack only ever needs the tallest, but a second bottom-anchored
+ * element that stacks ON TOP of another (the action receipt above the selection
+ * pill) needs that one element's height to lift itself clear. Reading it from
+ * the registry keeps the height measured rather than guessed — the spec is
+ * explicit that the pill's 56px is a first-frame fallback and not a token.
+ *
+ * @param {string} name - the key the element registered under.
+ * @returns {{height: import('vue').ComputedRef<number>}} pixels, 0 when hidden.
+ */
+export function useAnchorHeight(name) {
+  const height = computed(() => {
+    const anchor = anchors.value[name];
+    if (!anchor?.visible) return 0;
+    const value = Number(anchor.height);
+    return Number.isFinite(value) && value > 0 ? value : 0;
+  });
+  return { height };
+}
+
+/**
  * The height bottom-anchored floating chrome currently occupies in the notice
  * column's footprint, including the gap that must sit above it.
  *

--- a/frontend/src/stores/useOperationStore.js
+++ b/frontend/src/stores/useOperationStore.js
@@ -44,6 +44,15 @@ export const HISTORY_LIMIT = 50;
 export const RECEIPT_MS = 5000;
 export const DESTRUCTIVE_RECEIPT_MS = 8000;
 
+/** Trailing-edge window for WS-driven re-reads. */
+export const WS_REFRESH_DEBOUNCE_MS = 400;
+
+/**
+ * How many Ctrl+Z presses may queue behind an in-flight undo. A cap, because a
+ * held key or a panicked burst should not walk the whole stack.
+ */
+export const MAX_QUEUED_STEPS = 5;
+
 /**
  * `op_type` → mdi glyph. Exact matches first; anything unknown falls through
  * `OP_ICON_RULES` and finally to `FALLBACK_ICON`.
@@ -139,7 +148,10 @@ export function summarizeOperation(operation) {
   const raw = String(operation.summary ?? "").trim();
   const base = raw || humanizeOpType(operation.op_type);
   const count = Number(operation.target_count);
-  if (Number.isFinite(count) && count > 1) return `${base} · ${count}`;
+  // Grouped, like every other count in the product: "2,700", not "2700".
+  if (Number.isFinite(count) && count > 1) {
+    return `${base} · ${count.toLocaleString()}`;
+  }
   return base;
 }
 
@@ -200,6 +212,14 @@ export const useOperationStore = defineStore("operation", () => {
   let inFlight = false;
   let refetchQueued = false;
 
+  // Trailing-edge debounce for WS-driven re-reads, and whether anything in the
+  // current window came from this client (and may therefore narrate itself).
+  let wsDebounceTimer = null;
+  let wsNarrate = false;
+
+  // Ctrl+Z presses waiting behind an in-flight undo.
+  let queuedUndos = 0;
+
   // ── Derived history ──────────────────────────────────────────────────────
   /**
    * The undo stack, newest first, capped at `HISTORY_LIMIT`. Only `applied`
@@ -228,6 +248,23 @@ export const useOperationStore = defineStore("operation", () => {
   const hasHistory = computed(
     () => past.value.length > 0 || future.value.length > 0,
   );
+
+  /**
+   * Was the step Ctrl+Z would take back done somewhere else?
+   *
+   * An external operation updates the stack silently (a pill offering to undo
+   * something the user did not just do is a trap), but the CONSEQUENCE is that
+   * the undo target quietly becomes another tab's action while the control
+   * looks unchanged. The affordance has to say so before it reverts something
+   * the user never did.
+   */
+  const nextUndoIsExternal = computed(() => {
+    if (!nextUndo.value) return false;
+    const origin = nextUndo.value.origin_client_id;
+    // No origin at all means a background job — also not this tab.
+    if (!origin) return true;
+    return origin !== myClientId();
+  });
 
   function myClientId() {
     try {
@@ -414,6 +451,11 @@ export const useOperationStore = defineStore("operation", () => {
    * Origin is read from the event `data` (never a contextvar, never a guess),
    * and only to decide whether the change may narrate itself.
    *
+   * Debounced on the trailing edge: a bulk action over thousands of pictures
+   * emits a continuous stream of these, and the stack does not need to be
+   * sub-second fresh. Without it the two reads would poll back to back at
+   * round-trip speed for the whole run.
+   *
    * @param {Object} payload - the parsed WS envelope.
    * @returns {Promise<void>} resolves once the re-read has landed.
    */
@@ -421,37 +463,96 @@ export const useOperationStore = defineStore("operation", () => {
     if (isReadOnly.value || !payload) return Promise.resolve();
     const mine =
       payload.origin_client_id && payload.origin_client_id === myClientId();
-    return refresh({ narrate: Boolean(mine) });
+    // Any own-origin event in the window makes the whole window narratable:
+    // dropping the flag because a background job's event arrived last would
+    // silently swallow the user's own receipt.
+    wsNarrate = wsNarrate || Boolean(mine);
+    if (wsDebounceTimer != null) clearTimeout(wsDebounceTimer);
+    return new Promise((resolve) => {
+      wsDebounceTimer = setTimeout(() => {
+        wsDebounceTimer = null;
+        const narrate = wsNarrate;
+        wsNarrate = false;
+        refresh({ narrate }).then(resolve, resolve);
+      }, WS_REFRESH_DEBOUNCE_MS);
+    });
   }
 
   // ── Mutations ────────────────────────────────────────────────────────────
+  /**
+   * Surface a failed undo/redo. Three shapes, because they mean three things:
+   *
+   *   409 — the stack moved under you (another tab got there first, or a new
+   *         action superseded the redo stack). Ordinary, not a defect.
+   *   423 — a locked picture set froze one of the targets. A state, not a
+   *         failure: the user has to unlock the set, and the server's detail
+   *         names it.
+   *   else — a real error, which stays until dismissed.
+   */
   function reportFailure(action, error) {
     const detail = error?.response?.data?.detail;
     const status = error?.response?.status;
-    // 409 is the ordinary "the stack moved under you" answer, not a defect:
-    // another tab undid it first, or a new action superseded the redo stack.
-    const text =
-      status === 409
-        ? (detail ?? `Nothing left to ${action}.`)
-        : (detail ?? `Could not ${action}. ${error?.message ?? ""}`.trim());
+    let level = "error";
+    let text;
+    if (status === 409) {
+      level = "warning";
+      text = detail ?? `Nothing left to ${action}.`;
+    } else if (status === 423) {
+      level = "warning";
+      text =
+        detail ??
+        `Could not ${action}: a locked picture set has frozen one of the pictures. Unlock the set to change it.`;
+    } else {
+      text = detail ?? `Could not ${action}. ${error?.message ?? ""}`.trim();
+    }
     console.warn(`useOperationStore: ${action} failed`, error);
+    // A receipt still offering the action that just failed is a lie; retire it
+    // before the notice explains what happened.
+    dismissReceipt();
     try {
-      useNoticeStore().push({
-        level: status === 409 ? "warning" : "error",
-        text,
-        key: `operation-${action}`,
-      });
+      useNoticeStore().push({ level, text, key: `operation-${action}` });
     } catch (e) {
       console.warn("useOperationStore: could not surface the failure", e);
     }
   }
 
   /**
+   * Tell the user that a shortcut they pressed had nothing to act on. A global
+   * key binding that silently does nothing is the one unacceptable answer:
+   * the user cannot tell it from a broken feature.
+   */
+  function reportNothingToDo(action) {
+    try {
+      useNoticeStore().push({
+        level: "info",
+        text: `Nothing to ${action}.`,
+        key: `operation-nothing-to-${action}`,
+      });
+    } catch (e) {
+      console.warn("useOperationStore: could not surface the empty stack", e);
+    }
+  }
+
+  /**
    * Undo the newest reversible operation (and its whole batch).
+   *
+   * Pressing Ctrl+Z repeatedly is the canonical undo idiom, and each press
+   * takes a round trip. A press that lands while one is in flight is QUEUED
+   * (up to `MAX_QUEUED_STEPS`) rather than dropped, or four of five presses
+   * would silently do nothing.
+   *
    * @returns {Promise<Object|null>} the API result, or null when it failed.
    */
   async function undo() {
-    if (isReadOnly.value || busy.value || !canUndo.value) return null;
+    if (isReadOnly.value) return null;
+    if (busy.value) {
+      if (queuedUndos < MAX_QUEUED_STEPS) queuedUndos += 1;
+      return null;
+    }
+    if (!canUndo.value) {
+      reportNothingToDo("undo");
+      return null;
+    }
     const target = nextUndo.value;
     busy.value = true;
     try {
@@ -461,11 +562,18 @@ export const useOperationStore = defineStore("operation", () => {
       if (reverted) showReceipt(buildReceipt(reverted, "undone"));
       return result;
     } catch (e) {
+      queuedUndos = 0;
       reportFailure("undo", e);
       await refresh({ narrate: false });
       return null;
     } finally {
       busy.value = false;
+      if (queuedUndos > 0 && canUndo.value) {
+        queuedUndos -= 1;
+        undo();
+      } else {
+        queuedUndos = 0;
+      }
     }
   }
 
@@ -474,7 +582,11 @@ export const useOperationStore = defineStore("operation", () => {
    * @returns {Promise<Object|null>} the API result, or null when it failed.
    */
   async function redo() {
-    if (isReadOnly.value || busy.value || !canRedo.value) return null;
+    if (isReadOnly.value || busy.value) return null;
+    if (!canRedo.value) {
+      reportNothingToDo("redo");
+      return null;
+    }
     const target = nextRedo.value;
     busy.value = true;
     try {
@@ -521,6 +633,22 @@ export const useOperationStore = defineStore("operation", () => {
 
     busy.value = true;
     let reverted = 0;
+    // One POST per step: a 20-step walk on a slow link would otherwise look
+    // like the app froze, with the popover shut and both buttons greyed until
+    // a receipt appeared from nowhere. Say what is happening while it happens.
+    const progressKey = steps > 1 ? "operation-undo-progress" : null;
+    if (progressKey) {
+      try {
+        useNoticeStore().push({
+          level: "info",
+          text: `Undoing ${steps} steps…`,
+          timeout: 0,
+          key: progressKey,
+        });
+      } catch (e) {
+        console.warn("useOperationStore: could not report undo progress", e);
+      }
+    }
     try {
       while (pending.length) {
         const id = pending.shift();
@@ -541,6 +669,16 @@ export const useOperationStore = defineStore("operation", () => {
       return reverted;
     } finally {
       busy.value = false;
+      if (progressKey) {
+        try {
+          useNoticeStore().dismissByKey(progressKey);
+        } catch (e) {
+          console.warn(
+            "useOperationStore: could not retire the progress notice",
+            e,
+          );
+        }
+      }
     }
   }
 
@@ -573,6 +711,10 @@ export const useOperationStore = defineStore("operation", () => {
   /** Drop every trace of the previous session (logout / vault switch). */
   function reset() {
     dismissReceipt();
+    if (wsDebounceTimer != null) clearTimeout(wsDebounceTimer);
+    wsDebounceTimer = null;
+    wsNarrate = false;
+    queuedUndos = 0;
     operations.value = [];
     canUndo.value = false;
     canRedo.value = false;
@@ -597,6 +739,7 @@ export const useOperationStore = defineStore("operation", () => {
     future,
     historyCount,
     hasHistory,
+    nextUndoIsExternal,
     // actions
     refresh,
     onPictureEvent,

--- a/frontend/src/stores/useOperationStore.js
+++ b/frontend/src/stores/useOperationStore.js
@@ -1,0 +1,614 @@
+// useOperationStore.js — the undo/redo stack, mirrored from the backend's
+// append-only operation log (backend_architecture.md §21).
+//
+// The server owns the history. This store is a read model over it plus the
+// transient "action receipt" state that narrates what just happened:
+//
+//   • `operations`  the newest 50 rows of GET /operations, newest FIRST.
+//   • `canUndo` / `canRedo` / `nextUndo` / `nextRedo` from GET /operations/undo-state,
+//     which is what enables and labels the toolbar control.
+//   • `receipt`     at most one live receipt. Never two — the newest replaces
+//     the current one in place (design rule), which is why this is a single ref
+//     and not a queue like `useNoticeStore`.
+//
+// Origin discipline (integration_architecture.md §8.1, pitfall 14). Every
+// operation row carries the `origin_client_id` of the tab that caused it. The
+// receipt narrates THIS client's actions only: an operation that arrives from
+// another tab or from a background job updates the stack silently, because a
+// pill offering "Undo" for something the user did not just do is a trap. The id
+// is used for echo-matching and nothing else — it is attacker-controllable and
+// never an access decision.
+//
+// Undo is OWNER_ONLY on the server, so a share/read-only session never calls
+// these endpoints and never renders the control.
+
+import { computed, ref } from "vue";
+import { defineStore } from "pinia";
+
+import { isReadOnly } from "../utils/apiClient";
+import {
+  getUndoState,
+  listOperations,
+  redoOperation,
+  undoBatch,
+  undoLastOperation,
+  undoOperation,
+} from "../api/operations";
+import { useNoticeStore } from "./useNoticeStore";
+import { useWsStore } from "./useWsStore";
+
+/** How many history steps the popover shows (design rule: capped at 50). */
+export const HISTORY_LIMIT = 50;
+
+/** Receipt dwell, in ms. Destructive actions get longer to catch the mistake. */
+export const RECEIPT_MS = 5000;
+export const DESTRUCTIVE_RECEIPT_MS = 8000;
+
+/**
+ * `op_type` → mdi glyph. Exact matches first; anything unknown falls through
+ * `OP_ICON_RULES` and finally to `FALLBACK_ICON`.
+ *
+ * Deliberately generic: op types are added by whichever backend lane needs
+ * them (the scrapheap-move lane lands its own alongside these), and a history
+ * row for an unrecognised type must still render as a sensible step rather
+ * than a blank or a crash.
+ */
+export const OP_ICONS = {
+  "pictures.tags.add": "mdi-tag-plus-outline",
+  "pictures.tags.remove": "mdi-tag-minus-outline",
+  "pictures.tags.remove_all": "mdi-tag-off-outline",
+  "pictures.tags.clear": "mdi-tag-off-outline",
+  "pictures.tags.replace": "mdi-tag-multiple-outline",
+  "pictures.score": "mdi-star-outline",
+  "pictures.fields": "mdi-pencil-outline",
+  "pictures.project": "mdi-folder-outline",
+  "characters.assign": "mdi-account-check-outline",
+  "characters.unassign": "mdi-account-off-outline",
+  "picture_sets.members.add": "mdi-playlist-plus",
+  "picture_sets.members.remove": "mdi-playlist-minus",
+  "picture_sets.members.replace": "mdi-playlist-edit-outline",
+  "stacks.create": "mdi-layers-outline",
+  "stacks.dissolve": "mdi-layers-off-outline",
+};
+
+/** Substring rules applied when `OP_ICONS` has no exact entry. Order matters. */
+const OP_ICON_RULES = [
+  [/scrapheap|trash|delete/, "mdi-trash-can-outline"],
+  [/restore|recover/, "mdi-backup-restore"],
+  [/tag/, "mdi-tag-outline"],
+  [/score|rating/, "mdi-star-outline"],
+  [/character|face/, "mdi-account-outline"],
+  [/set|collection/, "mdi-playlist-edit-outline"],
+  [/stack/, "mdi-layers-outline"],
+  [/project/, "mdi-folder-outline"],
+  [/description|caption/, "mdi-text-box-outline"],
+];
+
+const FALLBACK_ICON = "mdi-history";
+
+/**
+ * Op types whose receipt holds for 8s instead of 5s. Substring-matched for the
+ * same reason as the icons: a scrapheap op type this build has never seen must
+ * still get the longer window, because that is the one you most want to catch.
+ */
+const DESTRUCTIVE_RULES = [
+  /scrapheap/,
+  /delete/,
+  /remove_all/,
+  /\.clear$/,
+  /dissolve/,
+];
+
+/**
+ * The mdi glyph for an operation type.
+ * @param {string} opType - dotted verb, e.g. `"pictures.tags.add"`.
+ * @returns {string} an mdi class name, never empty.
+ */
+export function iconForOpType(opType) {
+  const key = String(opType ?? "");
+  if (OP_ICONS[key]) return OP_ICONS[key];
+  for (const [pattern, icon] of OP_ICON_RULES) {
+    if (pattern.test(key)) return icon;
+  }
+  return FALLBACK_ICON;
+}
+
+/**
+ * Is this operation destructive enough to earn the longer receipt window?
+ * @param {string} opType
+ * @returns {boolean}
+ */
+export function isDestructiveOpType(opType) {
+  const key = String(opType ?? "");
+  return DESTRUCTIVE_RULES.some((pattern) => pattern.test(key));
+}
+
+/**
+ * Human label for an operation. The server's `summary` is the single source of
+ * truth for the wording; the target count is appended so one glance answers
+ * "how much would this undo?" — the design's `Add tag "portrait" · 12` shape.
+ *
+ * Falls back to the dotted `op_type`, de-dotted, when a lane records a row
+ * without a summary: an unlabelled step is still better than a blank row.
+ *
+ * @param {Object} operation - an operation row from the API.
+ * @returns {string}
+ */
+export function summarizeOperation(operation) {
+  if (!operation) return "";
+  const raw = String(operation.summary ?? "").trim();
+  const base = raw || humanizeOpType(operation.op_type);
+  const count = Number(operation.target_count);
+  if (Number.isFinite(count) && count > 1) return `${base} · ${count}`;
+  return base;
+}
+
+function humanizeOpType(opType) {
+  const key = String(opType ?? "").trim();
+  if (!key) return "Change";
+  const words = key.replace(/[._]/g, " ").trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Local time-of-day label for a history row, matching the design's `14:02`.
+ * @param {string} createdAt - ISO timestamp from the API (UTC, naive).
+ * @returns {string} `HH:MM`, or `""` when unparseable.
+ */
+export function formatOperationTime(createdAt) {
+  if (!createdAt) return "";
+  // The API serialises naive UTC datetimes; without the marker the browser
+  // reads them as local and every row is off by the UTC offset.
+  const text = String(createdAt);
+  const iso = /(Z|[+-]\d{2}:?\d{2})$/.test(text) ? text : `${text}Z`;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export const useOperationStore = defineStore("operation", () => {
+  // ── Server state ─────────────────────────────────────────────────────────
+  /** The newest rows of the log, newest FIRST (the order the API returns). */
+  const operations = ref([]);
+  const canUndo = ref(false);
+  const canRedo = ref(false);
+  const nextUndo = ref(null);
+  const nextRedo = ref(null);
+  /** True while an undo/redo round-trip is in flight — the control disables. */
+  const busy = ref(false);
+  /** True once the first successful refresh has landed. */
+  const loaded = ref(false);
+
+  // ── Receipt state ────────────────────────────────────────────────────────
+  // At most one. `key` increments on every raise so the component can re-run
+  // its enter transition and restart the drain even when the pill is replaced
+  // in place rather than unmounted.
+  const receipt = ref(null);
+  let receiptKey = 0;
+  let receiptTimer = null;
+  let receiptRemaining = 0;
+  let receiptStartedAt = 0;
+  let receiptPaused = false;
+
+  // Highest operation id seen by a completed refresh. Used to tell a genuinely
+  // new operation from a re-read of the same history — an id we have already
+  // seen must never raise a second receipt.
+  let highWaterMark = null;
+
+  // Coalesce overlapping refreshes: WS bursts collapse into one in-flight
+  // request plus at most one trailing refetch.
+  let inFlight = false;
+  let refetchQueued = false;
+
+  // ── Derived history ──────────────────────────────────────────────────────
+  /**
+   * The undo stack, newest first, capped at `HISTORY_LIMIT`. Only `applied`
+   * rows: an `undone` row belongs to the redo side and a `superseded` one was
+   * cleared by a later action and can never come back.
+   */
+  const past = computed(() =>
+    operations.value
+      .filter((op) => op?.status === "applied")
+      .slice(0, HISTORY_LIMIT),
+  );
+
+  /**
+   * Steps that have been undone and can still be redone — the struck-through
+   * rows at the top of the History popover. `superseded` rows are excluded:
+   * a new action cleared them, which is exactly when the design says they go.
+   */
+  const future = computed(() =>
+    operations.value.filter((op) => op?.status === "undone"),
+  );
+
+  /** How many steps the footer reports. */
+  const historyCount = computed(() => past.value.length);
+
+  /** Nothing recorded yet → the toolbar control is disabled, not hidden. */
+  const hasHistory = computed(
+    () => past.value.length > 0 || future.value.length > 0,
+  );
+
+  function myClientId() {
+    try {
+      return useWsStore().clientId;
+    } catch (e) {
+      // Pinia not active (a bare unit test of a helper). Not fatal: without an
+      // id every operation reads as external, which is the safe direction.
+      console.warn("useOperationStore: no ws store for the client id", e);
+      return null;
+    }
+  }
+
+  // ── Receipt lifecycle ────────────────────────────────────────────────────
+  function clearReceiptTimer() {
+    if (receiptTimer != null) clearTimeout(receiptTimer);
+    receiptTimer = null;
+  }
+
+  function armReceiptTimer(ms) {
+    clearReceiptTimer();
+    receiptRemaining = ms;
+    receiptStartedAt = Date.now();
+    receiptPaused = false;
+    receiptTimer = setTimeout(dismissReceipt, ms);
+  }
+
+  /**
+   * Build the receipt payload for one operation.
+   *
+   * @param {Object} operation - the operation row being narrated.
+   * @param {'did'|'undone'|'blocked'} mode - `did` after the action, `undone`
+   *   after reverting it (the pill flips in place and offers Redo), `blocked`
+   *   when the operation was recorded for audit but cannot be reversed.
+   * @param {number} [steps=1] - how many history steps this receipt covers, so
+   *   a multi-step undo says so instead of naming only the newest one.
+   * @returns {Object} the receipt.
+   */
+  function buildReceipt(operation, mode, steps = 1) {
+    const opType = operation?.op_type ?? "";
+    const destructive = isDestructiveOpType(opType);
+    // "+N": how many sibling rows of the same bulk action this step carries.
+    // Grouped by batch id, which is the server's own definition of "one user
+    // action", rather than by a client-side time window.
+    const batchId = operation?.batch_id ?? null;
+    const merged = batchId
+      ? Math.max(
+          0,
+          operations.value.filter((op) => op?.batch_id === batchId).length - 1,
+        )
+      : 0;
+    receiptKey += 1;
+    return {
+      key: receiptKey,
+      mode,
+      operationId: operation?.id ?? null,
+      batchId,
+      opType,
+      icon: iconForOpType(opType),
+      summary: summarizeOperation(operation),
+      targetCount: Number(operation?.target_count) || 0,
+      mergedCount: merged,
+      steps,
+      destructive,
+      durationMs: destructive ? DESTRUCTIVE_RECEIPT_MS : RECEIPT_MS,
+    };
+  }
+
+  /**
+   * Raise a receipt, replacing any live one in place (never stacked).
+   * @param {Object} entry - a payload from {@link buildReceipt}.
+   */
+  function showReceipt(entry) {
+    if (!entry) return;
+    receipt.value = entry;
+    armReceiptTimer(entry.durationMs);
+  }
+
+  /** Retire the live receipt and its countdown. */
+  function dismissReceipt() {
+    clearReceiptTimer();
+    receipt.value = null;
+  }
+
+  /**
+   * Freeze the countdown (hover / focus-within). WCAG 2.2.1 — the user must be
+   * able to read and reach an Undo button without it disappearing.
+   */
+  function pauseReceipt() {
+    if (!receipt.value || receiptPaused || receiptTimer == null) return;
+    clearTimeout(receiptTimer);
+    receiptTimer = null;
+    receiptRemaining = Math.max(
+      0,
+      receiptRemaining - (Date.now() - receiptStartedAt),
+    );
+    receiptPaused = true;
+  }
+
+  /** Resume a frozen countdown from where it stopped. */
+  function resumeReceipt() {
+    if (!receipt.value || !receiptPaused) return;
+    receiptPaused = false;
+    if (receiptRemaining <= 0) {
+      dismissReceipt();
+      return;
+    }
+    receiptStartedAt = Date.now();
+    receiptTimer = setTimeout(dismissReceipt, receiptRemaining);
+  }
+
+  // ── Server reads ─────────────────────────────────────────────────────────
+  /**
+   * Re-read the log and the undo state.
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.narrate=true] - raise a receipt when the refresh
+   *   reveals a new operation from THIS client. Own undo/redo actions pass
+   *   `false` and raise their own receipt, so the two never race.
+   * @returns {Promise<void>}
+   */
+  async function refresh({ narrate = true } = {}) {
+    if (isReadOnly.value) return;
+    if (inFlight) {
+      refetchQueued = true;
+      return;
+    }
+    inFlight = true;
+    try {
+      const [rows, state] = await Promise.all([
+        listOperations({ limit: HISTORY_LIMIT }),
+        getUndoState(),
+      ]);
+      operations.value = Array.isArray(rows) ? rows : [];
+      canUndo.value = Boolean(state?.can_undo);
+      canRedo.value = Boolean(state?.can_redo);
+      nextUndo.value = state?.next_undo ?? null;
+      nextRedo.value = state?.next_redo ?? null;
+      const previous = highWaterMark;
+      const newest = operations.value[0];
+      if (newest?.id != null) {
+        highWaterMark =
+          previous == null ? newest.id : Math.max(previous, newest.id);
+      }
+      loaded.value = true;
+      if (narrate) narrateNewest(previous, newest);
+    } catch (e) {
+      // The stack is an affordance over a server that stays correct either
+      // way, so a failed read must never break the toolbar — log and keep the
+      // last known state rather than clearing it into a dead control.
+      console.warn(
+        "useOperationStore: failed to refresh the operation log; keeping last state",
+        e,
+      );
+    } finally {
+      inFlight = false;
+      if (refetchQueued) {
+        refetchQueued = false;
+        refresh({ narrate });
+      }
+    }
+  }
+
+  /**
+   * Raise a receipt for a newly-arrived operation, but only for this client's
+   * own actions. An operation from another tab or a background job updates the
+   * stack silently.
+   */
+  function narrateNewest(previousHighWaterMark, newest) {
+    if (!newest || newest.id == null) return;
+    // First load: the whole history is "new". Narrating it would pop a receipt
+    // for something that happened before the tab existed.
+    if (previousHighWaterMark == null) return;
+    if (newest.id <= previousHighWaterMark) return;
+    if (newest.status !== "applied") return;
+    const mine =
+      newest.origin_client_id && newest.origin_client_id === myClientId();
+    if (!mine) return;
+    showReceipt(buildReceipt(newest, newest.undoable ? "did" : "blocked"));
+  }
+
+  /**
+   * A WebSocket picture-change event landed. The log has no event of its own,
+   * so any picture mutation is the signal that the stack may have moved.
+   * Origin is read from the event `data` (never a contextvar, never a guess),
+   * and only to decide whether the change may narrate itself.
+   *
+   * @param {Object} payload - the parsed WS envelope.
+   * @returns {Promise<void>} resolves once the re-read has landed.
+   */
+  function onPictureEvent(payload) {
+    if (isReadOnly.value || !payload) return Promise.resolve();
+    const mine =
+      payload.origin_client_id && payload.origin_client_id === myClientId();
+    return refresh({ narrate: Boolean(mine) });
+  }
+
+  // ── Mutations ────────────────────────────────────────────────────────────
+  function reportFailure(action, error) {
+    const detail = error?.response?.data?.detail;
+    const status = error?.response?.status;
+    // 409 is the ordinary "the stack moved under you" answer, not a defect:
+    // another tab undid it first, or a new action superseded the redo stack.
+    const text =
+      status === 409
+        ? (detail ?? `Nothing left to ${action}.`)
+        : (detail ?? `Could not ${action}. ${error?.message ?? ""}`.trim());
+    console.warn(`useOperationStore: ${action} failed`, error);
+    try {
+      useNoticeStore().push({
+        level: status === 409 ? "warning" : "error",
+        text,
+        key: `operation-${action}`,
+      });
+    } catch (e) {
+      console.warn("useOperationStore: could not surface the failure", e);
+    }
+  }
+
+  /**
+   * Undo the newest reversible operation (and its whole batch).
+   * @returns {Promise<Object|null>} the API result, or null when it failed.
+   */
+  async function undo() {
+    if (isReadOnly.value || busy.value || !canUndo.value) return null;
+    const target = nextUndo.value;
+    busy.value = true;
+    try {
+      const result = await undoLastOperation();
+      await refresh({ narrate: false });
+      const reverted = target ?? result?.operations?.[0] ?? null;
+      if (reverted) showReceipt(buildReceipt(reverted, "undone"));
+      return result;
+    } catch (e) {
+      reportFailure("undo", e);
+      await refresh({ narrate: false });
+      return null;
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  /**
+   * Re-apply the most recently undone operation (and its whole batch).
+   * @returns {Promise<Object|null>} the API result, or null when it failed.
+   */
+  async function redo() {
+    if (isReadOnly.value || busy.value || !canRedo.value) return null;
+    const target = nextRedo.value;
+    busy.value = true;
+    try {
+      const result = await redoOperation();
+      await refresh({ narrate: false });
+      const replayed = target ?? result?.operations?.[0] ?? null;
+      if (replayed) showReceipt(buildReceipt(replayed, "did"));
+      return result;
+    } catch (e) {
+      reportFailure("redo", e);
+      await refresh({ narrate: false });
+      return null;
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  /**
+   * Undo every step from the newest down to, and including, `operationId` —
+   * the History popover's "click a step to undo back to it".
+   *
+   * The server has no multi-step call: `POST /operations/{id}/undo` reverts
+   * that operation and its batch, nothing newer. So the walk happens here,
+   * newest first, and each response tells us which ids it actually reverted
+   * (a batch takes its siblings with it), so a member already handled by an
+   * earlier iteration is dropped rather than re-requested into a 409. Nothing
+   * is swallowed: a real failure stops the walk and surfaces.
+   *
+   * @param {number} operationId - the step to stop at (it is undone too).
+   * @returns {Promise<number>} how many operations were reverted.
+   */
+  async function undoTo(operationId) {
+    if (isReadOnly.value || busy.value || operationId == null) return 0;
+    const stack = past.value;
+    const stopAt = stack.findIndex((op) => op?.id === operationId);
+    if (stopAt === -1) return 0;
+    const targets = stack.slice(0, stopAt + 1);
+    const oldest = targets[targets.length - 1];
+    const steps = targets.length;
+    const pending = targets
+      .map((op) => op?.id)
+      .filter((id) => id != null)
+      .sort((a, b) => b - a);
+
+    busy.value = true;
+    let reverted = 0;
+    try {
+      while (pending.length) {
+        const id = pending.shift();
+        const result = await undoOperation(id);
+        const done = new Set((result?.operations ?? []).map((op) => op?.id));
+        done.add(id);
+        reverted += done.size;
+        for (let i = pending.length - 1; i >= 0; i -= 1) {
+          if (done.has(pending[i])) pending.splice(i, 1);
+        }
+      }
+      await refresh({ narrate: false });
+      if (oldest) showReceipt(buildReceipt(oldest, "undone", steps));
+      return reverted;
+    } catch (e) {
+      reportFailure("undo", e);
+      await refresh({ narrate: false });
+      return reverted;
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  /**
+   * Undo one whole bulk action by its batch id — the single-call revert behind
+   * a bulk report ("Collapsed 2,700 groups — Undo").
+   * @param {string} batchId
+   * @returns {Promise<Object|null>} the API result, or null when it failed.
+   */
+  async function undoBatchById(batchId) {
+    if (isReadOnly.value || busy.value || !batchId) return null;
+    const target =
+      operations.value.find((op) => op?.batch_id === batchId) ?? null;
+    busy.value = true;
+    try {
+      const result = await undoBatch(batchId);
+      await refresh({ narrate: false });
+      const reverted = target ?? result?.operations?.[0] ?? null;
+      if (reverted) showReceipt(buildReceipt(reverted, "undone"));
+      return result;
+    } catch (e) {
+      reportFailure("undo", e);
+      await refresh({ narrate: false });
+      return null;
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  /** Drop every trace of the previous session (logout / vault switch). */
+  function reset() {
+    dismissReceipt();
+    operations.value = [];
+    canUndo.value = false;
+    canRedo.value = false;
+    nextUndo.value = null;
+    nextRedo.value = null;
+    loaded.value = false;
+    highWaterMark = null;
+  }
+
+  return {
+    // state
+    operations,
+    canUndo,
+    canRedo,
+    nextUndo,
+    nextRedo,
+    busy,
+    loaded,
+    receipt,
+    // computed
+    past,
+    future,
+    historyCount,
+    hasHistory,
+    // actions
+    refresh,
+    onPictureEvent,
+    undo,
+    redo,
+    undoTo,
+    undoBatchById,
+    showReceipt,
+    buildReceipt,
+    dismissReceipt,
+    pauseReceipt,
+    resumeReceipt,
+    reset,
+  };
+});

--- a/frontend/src/stores/useOperationStore.test.js
+++ b/frontend/src/stores/useOperationStore.test.js
@@ -1,0 +1,496 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+
+// The store reads `isReadOnly` off the apiClient singleton and talks to the
+// backend only through `api/operations`. Both are mocked so no HTTP happens and
+// every branch (read-only, 409, batch coalescing) can be driven directly.
+vi.mock("../utils/apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn() },
+  isReadOnly: { value: false },
+  // useWsStore mirrors its client id into the client's module scope on setup.
+  setRequestClientId: vi.fn(),
+}));
+
+vi.mock("../api/operations", () => ({
+  listOperations: vi.fn(),
+  getUndoState: vi.fn(),
+  undoLastOperation: vi.fn(),
+  redoOperation: vi.fn(),
+  undoOperation: vi.fn(),
+  undoBatch: vi.fn(),
+}));
+
+import { isReadOnly as readOnly } from "../utils/apiClient";
+import {
+  getUndoState,
+  listOperations,
+  redoOperation,
+  undoBatch,
+  undoLastOperation,
+  undoOperation,
+} from "../api/operations";
+import {
+  DESTRUCTIVE_RECEIPT_MS,
+  RECEIPT_MS,
+  formatOperationTime,
+  iconForOpType,
+  isDestructiveOpType,
+  summarizeOperation,
+  useOperationStore,
+} from "./useOperationStore";
+import { useWsStore } from "./useWsStore";
+
+const MY_CLIENT = "client-me";
+const OTHER_CLIENT = "client-them";
+
+function op(overrides = {}) {
+  return {
+    id: 1,
+    batch_id: null,
+    created_at: "2026-07-29T12:00:00",
+    op_type: "pictures.tags.add",
+    target_type: "picture",
+    target_ids: [1, 2],
+    target_count: 2,
+    source: "ui",
+    origin_client_id: MY_CLIENT,
+    undoable: true,
+    status: "applied",
+    summary: "Added tag 'portrait'",
+    ...overrides,
+  };
+}
+
+/** Seed the mocked API with a history and an undo-state derived from it. */
+function serve(rows, state = {}) {
+  listOperations.mockResolvedValue(rows);
+  getUndoState.mockResolvedValue({
+    can_undo: rows.some((r) => r.status === "applied" && r.undoable),
+    can_redo: rows.some((r) => r.status === "undone"),
+    next_undo: rows.find((r) => r.status === "applied" && r.undoable) ?? null,
+    next_redo: rows.find((r) => r.status === "undone") ?? null,
+    ...state,
+  });
+}
+
+/** Bring the store to a settled state so the NEXT refresh can narrate. */
+async function primed(rows) {
+  const store = useOperationStore();
+  serve(rows);
+  await store.refresh();
+  return store;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setActivePinia(createPinia());
+  readOnly.value = false;
+  for (const fn of [
+    listOperations,
+    getUndoState,
+    undoLastOperation,
+    redoOperation,
+    undoOperation,
+    undoBatch,
+  ]) {
+    fn.mockReset();
+  }
+  // A stable per-tab client id so "mine" vs "external" is decidable.
+  useWsStore().clientId = MY_CLIENT;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("iconForOpType", () => {
+  it("maps a known op type to its glyph", () => {
+    expect(iconForOpType("pictures.tags.add")).toBe("mdi-tag-plus-outline");
+    expect(iconForOpType("stacks.dissolve")).toBe("mdi-layers-off-outline");
+  });
+
+  it("falls through to a substring rule for a type this build has not seen", () => {
+    // The scrapheap lane lands its own op types alongside these.
+    expect(iconForOpType("pictures.scrapheap.move")).toBe(
+      "mdi-trash-can-outline",
+    );
+    expect(iconForOpType("pictures.tags.something_new")).toBe(
+      "mdi-tag-outline",
+    );
+  });
+
+  it("falls back to a neutral glyph for anything unrecognised", () => {
+    expect(iconForOpType("plugins.frobnicate")).toBe("mdi-history");
+    expect(iconForOpType(undefined)).toBe("mdi-history");
+  });
+});
+
+describe("isDestructiveOpType", () => {
+  it("flags scrapheap and clearing operations", () => {
+    expect(isDestructiveOpType("pictures.scrapheap.move")).toBe(true);
+    expect(isDestructiveOpType("pictures.tags.clear")).toBe(true);
+    expect(isDestructiveOpType("stacks.dissolve")).toBe(true);
+  });
+
+  it("leaves ordinary edits alone", () => {
+    expect(isDestructiveOpType("pictures.tags.add")).toBe(false);
+    expect(isDestructiveOpType("pictures.score")).toBe(false);
+  });
+});
+
+describe("summarizeOperation", () => {
+  it("appends the target count when more than one picture is touched", () => {
+    expect(summarizeOperation(op({ target_count: 12 }))).toBe(
+      "Added tag 'portrait' · 12",
+    );
+  });
+
+  it("omits the count for a single picture", () => {
+    expect(summarizeOperation(op({ target_count: 1 }))).toBe(
+      "Added tag 'portrait'",
+    );
+  });
+
+  it("humanises the op type when the server recorded no summary", () => {
+    expect(summarizeOperation(op({ summary: null, target_count: 1 }))).toBe(
+      "Pictures tags add",
+    );
+  });
+});
+
+describe("formatOperationTime", () => {
+  it("returns an empty string for a missing or unparseable timestamp", () => {
+    expect(formatOperationTime(null)).toBe("");
+    expect(formatOperationTime("not a date")).toBe("");
+  });
+
+  it("parses the API's naive UTC timestamp as UTC, not as local time", () => {
+    // Without the Z the browser would read this as local and shift the row.
+    const withMarker = formatOperationTime("2026-07-29T12:00:00Z");
+    const naive = formatOperationTime("2026-07-29T12:00:00");
+    expect(naive).toBe(withMarker);
+    expect(naive).toMatch(/\d{2}[:.]\d{2}/);
+  });
+});
+
+describe("useOperationStore — refresh and the history split", () => {
+  it("splits applied rows into past and undone rows into future", async () => {
+    const store = useOperationStore();
+    serve([
+      op({ id: 5, status: "undone" }),
+      op({ id: 4 }),
+      op({ id: 3 }),
+      op({ id: 2, status: "superseded" }),
+    ]);
+    await store.refresh();
+
+    expect(store.past.map((o) => o.id)).toEqual([4, 3]);
+    expect(store.future.map((o) => o.id)).toEqual([5]);
+    // A superseded row was cleared by a later action; it is in neither list.
+    expect(store.historyCount).toBe(2);
+    expect(store.hasHistory).toBe(true);
+  });
+
+  it("skips the server entirely in a read-only session", async () => {
+    readOnly.value = true;
+    const store = useOperationStore();
+    await store.refresh();
+    expect(listOperations).not.toHaveBeenCalled();
+    expect(getUndoState).not.toHaveBeenCalled();
+  });
+
+  it("keeps the last known state when the read fails", async () => {
+    const store = await primed([op({ id: 4 })]);
+    listOperations.mockRejectedValue(new Error("boom"));
+    await store.refresh();
+    expect(store.past.map((o) => o.id)).toEqual([4]);
+  });
+});
+
+describe("useOperationStore — receipts narrate this client only", () => {
+  it("raises no receipt on the first load", async () => {
+    const store = useOperationStore();
+    serve([op({ id: 9 })]);
+    await store.refresh();
+    expect(store.receipt).toBeNull();
+  });
+
+  it("raises a receipt for a new operation from this client", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10, summary: "Scored ★★★★" }), op({ id: 9 })]);
+    await store.refresh();
+
+    expect(store.receipt).toMatchObject({
+      mode: "did",
+      operationId: 10,
+      summary: "Scored ★★★★ · 2",
+      icon: "mdi-tag-plus-outline",
+    });
+  });
+
+  it("stays silent for an operation from another client", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10, origin_client_id: OTHER_CLIENT }), op({ id: 9 })]);
+    await store.refresh();
+
+    expect(store.receipt).toBeNull();
+    // The stack still moved — silently is not the same as not at all.
+    expect(store.past.map((o) => o.id)).toEqual([10, 9]);
+  });
+
+  it("marks an operation recorded for audit as not undoable", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10, undoable: false }), op({ id: 9 })]);
+    await store.refresh();
+    expect(store.receipt.mode).toBe("blocked");
+  });
+
+  it("counts the batch siblings as the coalesced +N", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([
+      op({ id: 12, batch_id: "b1" }),
+      op({ id: 11, batch_id: "b1" }),
+      op({ id: 10, batch_id: "b1" }),
+      op({ id: 9 }),
+    ]);
+    await store.refresh();
+    expect(store.receipt.mergedCount).toBe(2);
+  });
+
+  it("reports no +N for a lone operation", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10 }), op({ id: 9 })]);
+    await store.refresh();
+    expect(store.receipt.mergedCount).toBe(0);
+  });
+
+  it("never stacks two receipts — the newest replaces the current one", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10 }), op({ id: 9 })]);
+    await store.refresh();
+    const first = store.receipt.key;
+    serve([op({ id: 11, summary: "Second" }), op({ id: 10 }), op({ id: 9 })]);
+    await store.refresh();
+
+    expect(store.receipt.key).toBeGreaterThan(first);
+    expect(store.receipt.operationId).toBe(11);
+  });
+
+  it("holds a destructive receipt for 8s and an ordinary one for 5s", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10 }), op({ id: 9 })]);
+    await store.refresh();
+    expect(store.receipt.durationMs).toBe(RECEIPT_MS);
+
+    serve([
+      op({ id: 11, op_type: "pictures.scrapheap.move" }),
+      op({ id: 10 }),
+      op({ id: 9 }),
+    ]);
+    await store.refresh();
+    expect(store.receipt.durationMs).toBe(DESTRUCTIVE_RECEIPT_MS);
+    expect(store.receipt.icon).toBe("mdi-trash-can-outline");
+  });
+});
+
+describe("useOperationStore — the receipt countdown", () => {
+  async function withLiveReceipt() {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10 }), op({ id: 9 })]);
+    await store.refresh();
+    return store;
+  }
+
+  it("dismisses itself when the window elapses", async () => {
+    const store = await withLiveReceipt();
+    vi.advanceTimersByTime(RECEIPT_MS - 1);
+    expect(store.receipt).not.toBeNull();
+    vi.advanceTimersByTime(1);
+    expect(store.receipt).toBeNull();
+  });
+
+  it("pauses on hover and resumes from where it stopped (WCAG 2.2.1)", async () => {
+    const store = await withLiveReceipt();
+    vi.advanceTimersByTime(2000);
+    store.pauseReceipt();
+    vi.advanceTimersByTime(60000);
+    expect(store.receipt).not.toBeNull();
+
+    store.resumeReceipt();
+    vi.advanceTimersByTime(2999);
+    expect(store.receipt).not.toBeNull();
+    vi.advanceTimersByTime(1);
+    expect(store.receipt).toBeNull();
+  });
+
+  it("dismisses on demand", async () => {
+    const store = await withLiveReceipt();
+    store.dismissReceipt();
+    expect(store.receipt).toBeNull();
+  });
+});
+
+describe("useOperationStore — undo and redo", () => {
+  it("undoes, then flips the receipt to the undone state with Redo offered", async () => {
+    const store = await primed([op({ id: 10, summary: "Moved to Scrapheap" })]);
+    undoLastOperation.mockResolvedValue({ operations: [op({ id: 10 })] });
+    serve([op({ id: 10, status: "undone" })]);
+
+    await store.undo();
+
+    expect(undoLastOperation).toHaveBeenCalledTimes(1);
+    expect(store.receipt).toMatchObject({ mode: "undone", operationId: 10 });
+    expect(store.canRedo).toBe(true);
+  });
+
+  it("refuses to undo when there is nothing to undo", async () => {
+    const store = useOperationStore();
+    serve([]);
+    await store.refresh();
+    await store.undo();
+    expect(undoLastOperation).not.toHaveBeenCalled();
+  });
+
+  it("refuses to undo in a read-only session", async () => {
+    const store = await primed([op({ id: 10 })]);
+    readOnly.value = true;
+    await store.undo();
+    expect(undoLastOperation).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 409 as a warning and re-reads the stack", async () => {
+    const store = await primed([op({ id: 10 })]);
+    undoLastOperation.mockRejectedValue({
+      response: { status: 409, data: { detail: "Nothing to undo" } },
+    });
+    serve([op({ id: 10, status: "undone" })]);
+
+    await store.undo();
+
+    expect(store.receipt).toBeNull();
+    // The stack was re-read rather than left showing a step that is gone.
+    expect(store.past).toHaveLength(0);
+  });
+
+  it("redoes and narrates the replayed step", async () => {
+    const store = useOperationStore();
+    serve([op({ id: 10, status: "undone" })]);
+    await store.refresh();
+    redoOperation.mockResolvedValue({ operations: [op({ id: 10 })] });
+    serve([op({ id: 10 })]);
+
+    await store.redo();
+
+    expect(redoOperation).toHaveBeenCalledTimes(1);
+    expect(store.receipt).toMatchObject({ mode: "did", operationId: 10 });
+  });
+
+  it("undoes one whole bulk action by batch id", async () => {
+    const store = await primed([
+      op({ id: 11, batch_id: "b1" }),
+      op({ id: 10, batch_id: "b1" }),
+    ]);
+    undoBatch.mockResolvedValue({ operations: [] });
+    serve([
+      op({ id: 11, batch_id: "b1", status: "undone" }),
+      op({ id: 10, batch_id: "b1", status: "undone" }),
+    ]);
+
+    await store.undoBatchById("b1");
+
+    expect(undoBatch).toHaveBeenCalledWith("b1");
+    expect(store.receipt).toMatchObject({ mode: "undone" });
+  });
+});
+
+describe("useOperationStore — undoTo walks the stack", () => {
+  it("undoes every step from the newest down to the clicked one", async () => {
+    const store = await primed([
+      op({ id: 13 }),
+      op({ id: 12 }),
+      op({ id: 11 }),
+    ]);
+    undoOperation.mockImplementation(async (id) => ({
+      operations: [op({ id })],
+    }));
+    serve([
+      op({ id: 13, status: "undone" }),
+      op({ id: 12, status: "undone" }),
+      op({ id: 11 }),
+    ]);
+
+    const reverted = await store.undoTo(12);
+
+    expect(undoOperation.mock.calls.map(([id]) => id)).toEqual([13, 12]);
+    expect(reverted).toBe(2);
+    expect(store.receipt).toMatchObject({ mode: "undone", steps: 2 });
+  });
+
+  it("does not re-request a batch sibling the server already reverted", async () => {
+    const store = await primed([
+      op({ id: 13, batch_id: "b1" }),
+      op({ id: 12, batch_id: "b1" }),
+      op({ id: 11 }),
+    ]);
+    // Undoing 13 takes its whole batch (12) with it.
+    undoOperation.mockResolvedValue({
+      operations: [op({ id: 13 }), op({ id: 12 })],
+    });
+    serve([op({ id: 11 })]);
+
+    await store.undoTo(12);
+
+    expect(undoOperation).toHaveBeenCalledTimes(1);
+    expect(undoOperation).toHaveBeenCalledWith(13);
+  });
+
+  it("ignores a step that is not on the stack", async () => {
+    const store = await primed([op({ id: 13 })]);
+    expect(await store.undoTo(999)).toBe(0);
+    expect(undoOperation).not.toHaveBeenCalled();
+  });
+});
+
+describe("useOperationStore — WebSocket reconciliation", () => {
+  it("narrates an own-origin picture event", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10 }), op({ id: 9 })]);
+    await store.onPictureEvent({
+      type: "pictures_changed",
+      origin_client_id: MY_CLIENT,
+    });
+    expect(store.receipt).not.toBeNull();
+  });
+
+  it("updates the stack silently for an external picture event", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10, origin_client_id: OTHER_CLIENT }), op({ id: 9 })]);
+    await store.onPictureEvent({
+      type: "pictures_changed",
+      origin_client_id: OTHER_CLIENT,
+    });
+    expect(store.receipt).toBeNull();
+    expect(store.past.map((o) => o.id)).toEqual([10, 9]);
+  });
+
+  it("stays off the wire in a read-only session", async () => {
+    readOnly.value = true;
+    const store = useOperationStore();
+    await store.onPictureEvent({ type: "pictures_changed" });
+    expect(listOperations).not.toHaveBeenCalled();
+  });
+});
+
+describe("useOperationStore — reset", () => {
+  it("drops the history, the receipt and the enablement flags", async () => {
+    const store = await primed([op({ id: 10 })]);
+    store.showReceipt(store.buildReceipt(op({ id: 10 }), "did"));
+    store.reset();
+
+    expect(store.operations).toEqual([]);
+    expect(store.receipt).toBeNull();
+    expect(store.canUndo).toBe(false);
+    expect(store.canRedo).toBe(false);
+    expect(store.loaded).toBe(false);
+  });
+});

--- a/frontend/src/stores/useOperationStore.test.js
+++ b/frontend/src/stores/useOperationStore.test.js
@@ -32,12 +32,14 @@ import {
 import {
   DESTRUCTIVE_RECEIPT_MS,
   RECEIPT_MS,
+  WS_REFRESH_DEBOUNCE_MS,
   formatOperationTime,
   iconForOpType,
   isDestructiveOpType,
   summarizeOperation,
   useOperationStore,
 } from "./useOperationStore";
+import { useNoticeStore } from "./useNoticeStore";
 import { useWsStore } from "./useWsStore";
 
 const MY_CLIENT = "client-me";
@@ -142,6 +144,12 @@ describe("summarizeOperation", () => {
   it("appends the target count when more than one picture is touched", () => {
     expect(summarizeOperation(op({ target_count: 12 }))).toBe(
       "Added tag 'portrait' · 12",
+    );
+  });
+
+  it("groups a bulk count the way the rest of the product does", () => {
+    expect(summarizeOperation(op({ target_count: 2700 }))).toBe(
+      `Added tag 'portrait' · ${(2700).toLocaleString()}`,
     );
   });
 
@@ -452,10 +460,17 @@ describe("useOperationStore — undoTo walks the stack", () => {
 });
 
 describe("useOperationStore — WebSocket reconciliation", () => {
+  /** Fire an event and let the trailing-edge debounce elapse. */
+  async function fire(store, payload) {
+    const settled = store.onPictureEvent(payload);
+    await vi.advanceTimersByTimeAsync(WS_REFRESH_DEBOUNCE_MS);
+    await settled;
+  }
+
   it("narrates an own-origin picture event", async () => {
     const store = await primed([op({ id: 9 })]);
     serve([op({ id: 10 }), op({ id: 9 })]);
-    await store.onPictureEvent({
+    await fire(store, {
       type: "pictures_changed",
       origin_client_id: MY_CLIENT,
     });
@@ -465,7 +480,7 @@ describe("useOperationStore — WebSocket reconciliation", () => {
   it("updates the stack silently for an external picture event", async () => {
     const store = await primed([op({ id: 9 })]);
     serve([op({ id: 10, origin_client_id: OTHER_CLIENT }), op({ id: 9 })]);
-    await store.onPictureEvent({
+    await fire(store, {
       type: "pictures_changed",
       origin_client_id: OTHER_CLIENT,
     });
@@ -473,11 +488,143 @@ describe("useOperationStore — WebSocket reconciliation", () => {
     expect(store.past.map((o) => o.id)).toEqual([10, 9]);
   });
 
+  it("collapses a burst into one re-read", async () => {
+    const store = await primed([op({ id: 9 })]);
+    listOperations.mockClear();
+    serve([op({ id: 10 }), op({ id: 9 })]);
+
+    // A bulk action emits a continuous stream of these; without the debounce
+    // the two reads would poll back to back for the whole run.
+    for (let i = 0; i < 20; i += 1) {
+      store.onPictureEvent({
+        type: "pictures_changed",
+        origin_client_id: MY_CLIENT,
+      });
+      await vi.advanceTimersByTimeAsync(50);
+    }
+    await vi.advanceTimersByTimeAsync(WS_REFRESH_DEBOUNCE_MS);
+    expect(listOperations).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the window narratable when a background event lands last", async () => {
+    const store = await primed([op({ id: 9 })]);
+    serve([op({ id: 10 }), op({ id: 9 })]);
+
+    // The user's own change, then a background job's echo inside the same
+    // window. Dropping the flag would silently swallow the user's receipt.
+    store.onPictureEvent({
+      type: "tags_changed",
+      origin_client_id: MY_CLIENT,
+    });
+    const settled = store.onPictureEvent({ type: "pictures_changed" });
+    await vi.advanceTimersByTimeAsync(WS_REFRESH_DEBOUNCE_MS);
+    await settled;
+
+    expect(store.receipt).not.toBeNull();
+  });
+
   it("stays off the wire in a read-only session", async () => {
     readOnly.value = true;
     const store = useOperationStore();
     await store.onPictureEvent({ type: "pictures_changed" });
+    await vi.advanceTimersByTimeAsync(WS_REFRESH_DEBOUNCE_MS);
     expect(listOperations).not.toHaveBeenCalled();
+  });
+});
+
+describe("useOperationStore — a shortcut never does nothing silently", () => {
+  it("says so when there is nothing to undo", async () => {
+    const store = useOperationStore();
+    serve([]);
+    await store.refresh();
+    await store.undo();
+
+    expect(undoLastOperation).not.toHaveBeenCalled();
+    expect(useNoticeStore().notices.map((n) => n.text)).toContain(
+      "Nothing to undo.",
+    );
+  });
+
+  it("says so when there is nothing to redo", async () => {
+    const store = useOperationStore();
+    serve([]);
+    await store.refresh();
+    await store.redo();
+    expect(useNoticeStore().notices.map((n) => n.text)).toContain(
+      "Nothing to redo.",
+    );
+  });
+
+  it("queues repeated presses instead of dropping them", async () => {
+    const store = await primed([op({ id: 12 }), op({ id: 11 })]);
+    let resolveFirst;
+    undoLastOperation
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (resolveFirst = resolve)),
+      )
+      .mockResolvedValue({ operations: [] });
+
+    const first = store.undo();
+    // Hammering Ctrl+Z is the canonical idiom; a press landing mid-flight
+    // must not be swallowed.
+    store.undo();
+    resolveFirst({ operations: [op({ id: 12 })] });
+    await first;
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(undoLastOperation).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("useOperationStore — failure shapes", () => {
+  it("reports a locked picture set as a state, not as an error", async () => {
+    const store = await primed([op({ id: 10 })]);
+    undoLastOperation.mockRejectedValue({
+      response: { status: 423, data: { detail: "Set 'Eval slice' is locked" } },
+    });
+    serve([op({ id: 10 })]);
+
+    await store.undo();
+
+    const notice = useNoticeStore().notices.at(-1);
+    expect(notice.level).toBe("warning");
+    expect(notice.text).toContain("locked");
+  });
+
+  it("retires a receipt that would still offer the action that failed", async () => {
+    const store = await primed([op({ id: 10 })]);
+    store.showReceipt(store.buildReceipt(op({ id: 10 }), "did"));
+    undoLastOperation.mockRejectedValue({
+      response: { status: 409, data: { detail: "Nothing to undo" } },
+    });
+    serve([op({ id: 10 })]);
+
+    await store.undo();
+    expect(store.receipt).toBeNull();
+  });
+});
+
+describe("useOperationStore — nextUndoIsExternal", () => {
+  it("is false for this client's own step", async () => {
+    const store = await primed([op({ id: 10 })]);
+    expect(store.nextUndoIsExternal).toBe(false);
+  });
+
+  it("is true for another tab's step and for a background job", async () => {
+    const store = await primed([
+      op({ id: 10, origin_client_id: OTHER_CLIENT }),
+    ]);
+    expect(store.nextUndoIsExternal).toBe(true);
+
+    const other = await primed([op({ id: 11, origin_client_id: null })]);
+    expect(other.nextUndoIsExternal).toBe(true);
+  });
+
+  it("is false when there is nothing to undo at all", async () => {
+    const store = useOperationStore();
+    serve([]);
+    await store.refresh();
+    expect(store.nextUndoIsExternal).toBe(false);
   });
 });
 

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -116,6 +116,11 @@
      --------------------------------------------------------------------------- */
   --badge-size: 16px; /* min height/width of a count pill (was an ad-hoc 15px) */
   --badge-size-dot: 8px; /* the no-count activity dot (was an ad-hoc 7px) */
+  /* The countdown drain hairline on a self-dismissing transient surface (the
+     action receipt today; the notice card is the obvious second consumer, and
+     naming it now is what stops that surface picking 3px). It is a rendered
+     height, not padding, so it cannot borrow from the spacing scale. */
+  --countdown-h: 2px;
   --bar-height: 48px; /* contextual action-bar / toolbar band height */
   /* The right-hand stats rail's fixed column width. Not invented: it is already
      the de-facto constant in `.stats-sidebar` (width/min-width/max-width) and in

--- a/frontend/src/utils/shortcutHints.js
+++ b/frontend/src/utils/shortcutHints.js
@@ -1,0 +1,58 @@
+// Platform-correct keycap labels for the undo/redo affordances.
+//
+// The binding itself is the same everywhere — the global handler accepts either
+// Ctrl or Meta — but the HINT has to match the keyboard in front of the user.
+// A macOS user shown "Ctrl+Z" learns the wrong habit, and the toolbar tooltip
+// is where the shortcut is taught once the receipt is gone.
+//
+// Detection prefers `navigator.userAgentData.platform` (the modern, non-frozen
+// source) and falls back to the user-agent string, which is the only signal
+// available in Safari and in jsdom.
+
+/**
+ * Is this an Apple platform (macOS, iPadOS, iOS)?
+ *
+ * @param {Object} [nav=navigator] - injectable for tests.
+ * @returns {boolean} true when the ⌘ key is the modifier the user expects.
+ */
+export function isApplePlatform(
+  nav = typeof navigator !== "undefined" ? navigator : null,
+) {
+  if (!nav) return false;
+  const modern = nav.userAgentData?.platform;
+  if (typeof modern === "string" && modern) return /mac|ios/i.test(modern);
+  const agent = nav.userAgent ?? "";
+  return /Mac|iPhone|iPad|iPod/i.test(agent);
+}
+
+/**
+ * Keycap labels for "undo", in press order.
+ * @param {Object} [nav] - injectable navigator.
+ * @returns {Array<string>} e.g. `["Ctrl", "Z"]` or `["⌘", "Z"]`.
+ */
+export function undoKeyHint(nav) {
+  return isApplePlatform(nav) ? ["⌘", "Z"] : ["Ctrl", "Z"];
+}
+
+/**
+ * Keycap labels for "redo", in press order.
+ *
+ * macOS has no Ctrl+Y convention: the system redo is ⇧⌘Z, so that is what the
+ * hint shows even though the handler also accepts Y.
+ *
+ * @param {Object} [nav] - injectable navigator.
+ * @returns {Array<string>} e.g. `["Ctrl", "Y"]` or `["⇧", "⌘", "Z"]`.
+ */
+export function redoKeyHint(nav) {
+  return isApplePlatform(nav) ? ["⇧", "⌘", "Z"] : ["Ctrl", "Y"];
+}
+
+/**
+ * The same hint as one flat string, for a `title` attribute or an aria-label
+ * where separate keycap elements are not available.
+ * @param {Array<string>} keys - a hint from {@link undoKeyHint}.
+ * @returns {string} e.g. `"Ctrl+Z"`.
+ */
+export function formatKeyHint(keys) {
+  return (Array.isArray(keys) ? keys : []).join("+");
+}

--- a/frontend/src/utils/shortcutHints.test.js
+++ b/frontend/src/utils/shortcutHints.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatKeyHint,
+  isApplePlatform,
+  redoKeyHint,
+  undoKeyHint,
+} from "./shortcutHints";
+
+const MAC_UA = { userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" };
+const WIN_UA = { userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" };
+const LINUX_UA = { userAgent: "Mozilla/5.0 (X11; Linux x86_64)" };
+
+describe("isApplePlatform", () => {
+  it("prefers userAgentData over the user-agent string", () => {
+    // A Chromium browser reporting macOS through the modern API while its
+    // frozen UA string still says Windows must resolve to macOS.
+    expect(
+      isApplePlatform({ userAgentData: { platform: "macOS" }, ...WIN_UA }),
+    ).toBe(true);
+    expect(
+      isApplePlatform({ userAgentData: { platform: "Windows" }, ...MAC_UA }),
+    ).toBe(false);
+  });
+
+  it("falls back to the user-agent string", () => {
+    expect(isApplePlatform(MAC_UA)).toBe(true);
+    expect(isApplePlatform({ userAgent: "iPhone" })).toBe(true);
+    expect(isApplePlatform(WIN_UA)).toBe(false);
+    expect(isApplePlatform(LINUX_UA)).toBe(false);
+  });
+
+  it("is false when there is no navigator at all", () => {
+    expect(isApplePlatform(null)).toBe(false);
+  });
+});
+
+describe("undoKeyHint / redoKeyHint", () => {
+  it("shows Ctrl keycaps off Apple platforms", () => {
+    expect(undoKeyHint(WIN_UA)).toEqual(["Ctrl", "Z"]);
+    expect(redoKeyHint(WIN_UA)).toEqual(["Ctrl", "Y"]);
+  });
+
+  it("shows the command keycaps on Apple platforms", () => {
+    expect(undoKeyHint(MAC_UA)).toEqual(["⌘", "Z"]);
+    // macOS has no Ctrl+Y convention; the system redo is shift-command-Z.
+    expect(redoKeyHint(MAC_UA)).toEqual(["⇧", "⌘", "Z"]);
+  });
+});
+
+describe("formatKeyHint", () => {
+  it("joins keycaps for a title attribute", () => {
+    expect(formatKeyHint(["Ctrl", "Z"])).toBe("Ctrl+Z");
+    expect(formatKeyHint(["⇧", "⌘", "Z"])).toBe("⇧+⌘+Z");
+  });
+
+  it("tolerates a missing hint", () => {
+    expect(formatKeyHint(null)).toBe("");
+  });
+});


### PR DESCRIPTION
Implements the owner's "Undo / Redo System" design from the design system (stacked on #626). Action receipt over the grid (default / coalesced / undone / not-undoable states, 5s drain, 8s destructive, hover pauses, reduced-motion-safe), toolbar undo/redo pair with history popover (hover preview, undo-to-step, struck-through redo rows), operations store fed by the API + WS events (origin-aware: external clients update the stack silently), global Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z.

Owner rulings honored: scrapheap ops in (generic op_type mapping; pairs with #631), imports out, filter/sort out. Coalescing groups by batch_id, not the mock's 4s window.

Deliberate deviations from the mock, each with rationale in the PR thread: elevation-3 (lead-designer ruling; -4 is reserved for dialogs), 32px chevron (WCAG 2.5.8), aria-disabled over disabled (focus + tooltip survival), no em-dash copy. Mount points kept additive: Toolbar +6, ImageGrid +22, App.vue +107 (mostly comments/wiring).

ui-ux pass fixed 10 real issues, including Ctrl+Z toggling lightbox zoom (modifier-blind `z` binding in ImageOverlay), undo firing invisibly behind modals (now declined), two focus-loss holes, Enter dead on history rows, and chatty live regions.

987 frontend tests (87 new), eslint + build clean.

Known follow-ups needing owner rulings: receipt visibility above modals vs the design's slot; Ctrl+Z inside review sessions (two undo stacks, one keystroke); ghosted scrapheap cells + touched-picture pulse (need ImageGrid work, deferred per brief).

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U