### PR TITLE
Undo in the lightbox and consistent Ctrl+Z in review sessions

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -70,6 +70,7 @@ frontend/src/
 │   ├── useGridRealtimeSync.js   # WebSocket picture-event decision table for ImageGrid (see §9)
 │   ├── useBreadcrumb.js         # Current-view breadcrumb trail from route + id→name maps; shared by in-grid nav and TitleBar
 │   ├── useReviewRoute.js        # URL ⇄ tag-review overlay (`?review=…`); mirrors ImageGrid's `?overlay=` mechanics (+ *.test.js)
+│   ├── useActionReceipt.js      # The receipt contract (wording, keycaps, drain, pause, focus) shared by the grid pill and the lightbox's own narration
 │   ├── useVersionCheck.js       # "New version available" check (pixlstash.dev poll); single owner gated by `enabled`
 │   └── useSidebarExpansion.js   # Which sidebar sections / projects / folders are open; localStorage-backed (+ *.test.js)
 │
@@ -131,7 +132,7 @@ frontend/src/
     ├── editors/     # Entity create / edit / delete dialogs
     ├── settings/    # UserSettingsDialog, its section sub-components (Appearance, Behaviour, SmartScore, Workflows, Account, Snapshots, Compute), and the Settings* layout primitives (SettingsRow, SettingsSection, SettingsChip/ChipGrid, SettingsFieldBlock, SettingsSliderRow, SettingsTwoCol, SettingsInfoCard, SettingsAddTagRow)
     ├── io/          # Import / export / external-service connection
-    └── widgets/     # Reusable primitives, including the App* design-system layer (AppButton/AppDialog/AppInput/AppSelect/AppStepper/AppTextarea + FieldLabel) and ActionReceipt (the transient undo pill)
+    └── widgets/     # Reusable primitives, including the App* design-system layer (AppButton/AppDialog/AppInput/AppSelect/AppStepper/AppTextarea + FieldLabel) and the two undo receipts (ActionReceipt over the grid, OverlayActionReceipt inside the lightbox)
 ```
 
 ---
@@ -186,7 +187,7 @@ The application shell. Responsibilities:
 - Renders the three-panel layout: `SideBar` | `ImageGrid` (+ `Toolbar`) | `StatsSidebar`.
 - Manages the `PhotosImportDialog`.
 - Owns the **WebSocket lifecycle only** (connect / reconnect / close / `set_filters`); the picture-event decision table is delegated to `useGridRealtimeSync` (see §9).
-- Handles global keyboard shortcuts, window drag/drop, paste events. Undo/redo (`Ctrl+Z` / `Ctrl+Y` / `Ctrl+Shift+Z`, Meta accepted everywhere) lives in `handleGlobalKeydown` and declines in four cases, each for its own reason: while typing (a text field keeps its native undo stack), in a read-only session, on key auto-repeat (a held `Ctrl+Z` must not walk the stack), and while a modal overlay owns the screen — the receipt sits on `--z-floating`, under the lightbox and under every dialog, so an undo fired from there would mutate the library with no visible narration. Promoting the receipt above those layers is the recorded follow-up that would lift the last guard.
+- Handles global keyboard shortcuts, window drag/drop, paste events. Undo/redo (`Ctrl+Z` / `Ctrl+Y` / `Ctrl+Shift+Z`, Meta accepted everywhere) lives in `handleGlobalKeydown` and declines in four cases, each for its own reason: while typing (a text field keeps its native undo stack), in a read-only session, on key auto-repeat (a held `Ctrl+Z` must not walk the stack), and while a modal **dialog** owns the screen — the receipt sits on `--z-floating`, under every dialog scrim, so an undo fired from there would mutate the library with no visible narration. See "Undo has three keyboard owners" below for the two surfaces that own the chord themselves.
 - Fetches user config on startup (`GET /users/me/config`) and applies persisted preferences via the relevant stores.
 - Persists sidebar/stats open state to `localStorage`.
 
@@ -489,6 +490,22 @@ The transient undo pill, built to the owner's "Undo / Redo System" design. One i
 
 #### `UndoControl.vue` (511 lines, `panels/`)
 The toolbar undo/redo pair plus a chevron opening the History popover. Mounted by `Toolbar` next to the sort split-button — the same position in the Electron shell and in the browser, which is why it is not in the breadcrumb. Buttons use `aria-disabled` + a guarded handler rather than the native `disabled`, so they stay tabbable and keep naming the step ("Nothing to undo"), and carry `aria-keyshortcuts`. The popover reuses the shared `.tbm*` menu chrome and is labelled `role="dialog"` (not `menu`): it is a list of ordinary tab-order buttons with no roving arrow-key navigation, so claiming a menu would promise a contract it does not honour. Rows are newest-first, undone steps struck through and inert; hovering **or focusing** a row previews how far back you would go (`--active-wash` + an `--active-bar` inset rail across the whole range), and activating it walks the stack via `undoTo`. Enter is handled explicitly because Vuetify's menu `preventDefault`s it. Focus returns to the chevron on a programmatic close. Exposes `openHistory()`.
+
+#### `OverlayActionReceipt.vue` (`widgets/`)
+The lightbox's own narration of the same single receipt, mounted by `ImageOverlay` as the last child of `.overlay-main`. The owner ruled that undo must work in the lightbox and that the affordance may be fitted differently there, because the lightbox has its own GUI — so this is not the grid pill promoted above the modal layer. Everything the receipt *means* comes from the shared `useActionReceipt` composable, so the two surfaces cannot drift; only the chrome differs: `dark-surface`/`on-dark-surface` at 0.9 (the exact fill `.overlay-topbar` and `.overlay-rail` carry), `--elevation-4` (the rung `visual-language.md` §7 names for lightbox chrome, and the reason the grid pill takes -3), a `0.2` border matching `.overlay-nav`, and its own 64px transient-status lane inset by `--filmstrip-rail-width` / `--sidebar-width` so it centres on the visible image. Three deliberate differences beyond the material: **no live region** (the grid's still speaks from underneath, so a second one would double-speak); **no History popover** (choosing a step is a browsing task whose preview has no referent on a surface showing one picture); and a **scope clause** above one target ("Across 2,700 pictures, not just this one"), derived from the count alone so navigating to the next picture cannot falsify it. Nothing on this surface ever says "this picture". Exposes `containsFocus()` / `dismiss()` for the overlay's Escape guard.
+
+#### Undo has three keyboard owners
+`Ctrl+Z` is one vocabulary with three implementations, because three surfaces own the keyboard:
+
+| Surface | Owner | What the chord does |
+|---|---|---|
+| The grid and the app shell | `App.vue` `handleGlobalKeydown` | `useOperationStore.undo()`, narrated by the grid `ActionReceipt`. |
+| The lightbox | `ImageOverlay.handleKeydown` | The same store, narrated by `OverlayActionReceipt`. |
+| A review session | `ReviewSessionsOverlay.handleKeyDown` → `ReviewSessionView.attemptUndo` | The **review's own** single-step undo (`POST /tag_suggestions/{id}/reopen`), never the operation stack. |
+
+The lightbox and the review overlay both register a `window` keydown listener in their own `onMounted` and stop propagation while open, and a child mounts before its parent — so **App's binding is unreachable from either**, whatever its own guards say. (`isModalOverlayOpen()` never fired for the lightbox in the first place: it looks for a Vuetify scrim, and `.image-overlay` renders its own.) That is why the binding is re-implemented per surface rather than centralised.
+
+The review's stack is separate **on purpose**: a review decision also flips its `tag_suggestion` row's status and writes the human-label ledger, and `operation_log_service.capture_state_in_session` captures neither, so putting them on one stack would undo half of each decision. The boundary is stated rather than crossed — the cheat-sheet row reads "Undo the last decision in this review", and an empty review stack answers with a notice naming the toolbar rather than silently reaching past the overlay. `U` remains an alias for the identical request. Merging the two stacks needs three new capture facets (ledger, suggestion status, `anomaly_tag_uncertainty`) and a policy decision about `/tag_suggestions` being `PICTURE_SCOPED` while `/operations` is `OWNER_ONLY`; recorded as follow-up, not done here.
 
 #### `AddToEntityControl.vue` (966 lines)
 Reusable control for assigning images to/from characters and sets. Props: `type` (`'character'`|`'set'`), `imageIds`, `selectedCharacter`, `selectedSet`. Emits: `added`, `removed`, `selected`. Used in `Toolbar`, `ImageOverlay`, `ImageGridContextMenu`.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1690,12 +1690,19 @@ function handleGlobalKeydown(e) {
   //   * typing: a text field keeps its own native undo stack;
   //   * read-only: the endpoints are owner-only anyway;
   //   * auto-repeat: a HELD Ctrl+Z must not walk the whole stack;
-  //   * a modal overlay owns the screen: the receipt lives on --z-floating,
-  //     under the lightbox and under any dialog, so an undo fired from there
-  //     would mutate the library with no visible narration. That breaks the
-  //     design's own "every undo raises a receipt" invariant, so the shortcut
-  //     declines rather than acting blind. Promoting the receipt above those
-  //     layers is the recorded follow-up.
+  //   * a modal DIALOG owns the screen: the receipt lives on --z-floating,
+  //     under any dialog scrim, so an undo fired from there would mutate the
+  //     library with no visible narration. That breaks the design's own "every
+  //     undo raises a receipt" invariant, so the shortcut declines rather than
+  //     acting blind.
+  //
+  // The lightbox is NOT covered by that last guard and never was:
+  // `isModalOverlayOpen()` looks for a Vuetify scrim, and `.image-overlay`
+  // renders its own. What actually stops this handler there is ImageOverlay's
+  // `stopImmediatePropagation()` on a listener registered before this one (a
+  // child mounts first). Undo works in the lightbox, and it is the lightbox's
+  // own key handler plus `OverlayActionReceipt` that do it, fitted to that
+  // surface's GUI per the owner's ruling.
   if (
     (e.ctrlKey || e.metaKey) &&
     !e.altKey &&

--- a/frontend/src/components/reviews/ReviewDecisionBar.vue
+++ b/frontend/src/components/reviews/ReviewDecisionBar.vue
@@ -116,11 +116,8 @@
       class="rs-decide-btn"
       type="button"
       :disabled="!canUndo"
-      :title="
-        undoBlocked
-          ? undefined
-          : 'Undo the last decision — reopens it and reverses the tag change.'
-      "
+      :title="undoBlocked ? undefined : undoTitle"
+      :aria-keyshortcuts="undoKeyShortcuts"
       v-bind="lockAttrs('undo')"
       @click="emit('undo')"
     >
@@ -148,6 +145,12 @@
 
 <script setup>
 import { computed, onUnmounted, ref, useId, watch } from "vue";
+
+import {
+  formatKeyHint,
+  isApplePlatform,
+  undoKeyHint,
+} from "../../utils/shortcutHints";
 
 const props = defineProps({
   kind: { type: String, required: true }, // 'binary' | 'pair'
@@ -181,6 +184,18 @@ const chipId = useId();
 
 const undoBlocked = computed(() =>
   props.canUndo ? props.blocked?.undo || "" : "",
+);
+
+// The control teaches BOTH keys, and says which stack it undoes. Ctrl+Z is the
+// app-wide vocabulary and now works here too, but it is the review's own
+// single-step undo that it runs, not the app-wide history behind the overlay.
+const undoTitle = computed(
+  () =>
+    `Undo the last decision in this review (U or ${formatKeyHint(undoKeyHint())}). Reopens it and reverses the tag change.`,
+);
+// A space-separated list of alternatives, which is what the attribute takes.
+const undoKeyShortcuts = computed(() =>
+  isApplePlatform() ? "Meta+Z U" : "Control+Z U",
 );
 
 // aria-disabled (NOT disabled) + the reason, co-located via aria-describedby so

--- a/frontend/src/components/reviews/ReviewSessionView.vue
+++ b/frontend/src/components/reviews/ReviewSessionView.vue
@@ -246,6 +246,7 @@ import {
   pairAction,
 } from "../../stores/useReviewSessionsStore";
 import { useLockedSetsStore } from "../../stores/useLockedSetsStore";
+import { useNoticeStore } from "../../stores/useNoticeStore";
 import {
   LOCKED_UNDO_CHIP_LABEL,
   blockedDecisionMessage,
@@ -265,6 +266,10 @@ const props = defineProps({
 
 const store = useReviewSessionsStore();
 const lockedSetsStore = useLockedSetsStore();
+// "Nothing to undo" is reported on the notice surface rather than the card's
+// live region: the region is assertive and cleared on every card change, and
+// this message has to be visible to a sighted user who pressed a shortcut.
+const noticeStore = useNoticeStore();
 
 const current = computed(() => store.current);
 
@@ -550,13 +555,46 @@ function attemptPair(corner) {
   store.answerPair(corner);
 }
 
+/**
+ * The one gate every undo goes through: the bar's button, `U`, and Ctrl+Z.
+ *
+ * Three outcomes, all of them answered. A locked picture set makes the decision
+ * final (announced and flashed on the chip). An empty stack says so, and says
+ * where the other stack is: the app-wide Ctrl+Z history is deliberately NOT
+ * this one, and a user who made forty edits before opening the review would
+ * otherwise conclude it had been thrown away. Otherwise the decision is
+ * reopened and the card comes back.
+ */
 function attemptUndo() {
   if (undoBlockedReason.value) {
     announceBlocked(undoBlockedReason.value);
     return;
   }
+  if (!store.canUndo) {
+    announcement.value = "";
+    noticeStore.push({
+      level: "info",
+      text: "Nothing to undo in this review. Earlier changes are still undoable from the toolbar after you close it.",
+      key: "review-nothing-to-undo",
+    });
+    return;
+  }
   announcement.value = "";
-  store.undo();
+  undoAndAnnounce();
+}
+
+/**
+ * Undo, then say so — in that order, and after the card has landed.
+ *
+ * The `current` watcher clears `announcement` on every card change, and a
+ * successful undo IS a card change (the reopened card returns to the head of
+ * the queue). Announcing before that lands means the watcher wipes it and the
+ * success is silent, which looks exactly like a working feature.
+ */
+async function undoAndAnnounce() {
+  await store.undo();
+  await nextTick();
+  announcement.value = "Undone. The last decision is back in the queue.";
 }
 
 function confirmPending() {
@@ -601,7 +639,8 @@ const pendingMessage = computed(() => {
 //
 // Returns true when the key was consumed. Y/N/S/U on binary; B/N/L/R/S/U on
 // pair; Enter/Escape resolve a pending consistency confirm; H toggles the
-// evidence region.
+// evidence region. `"undo"` is the same request as `U`, sent by the overlay
+// when the user presses Ctrl+Z: one undo vocabulary, two ways to say it.
 function handleKey(key) {
   if (pendingDecision.value) {
     if (key === "enter") {
@@ -613,16 +652,22 @@ function handleKey(key) {
       return true;
     }
     // Swallow decision keys while a confirm is staged.
-    return ["y", "n", "b", "l", "r", "s", "u"].includes(key);
+    return ["y", "n", "b", "l", "r", "s", "u", "undo"].includes(key);
+  }
+  // Undo sits ABOVE the `current` guard on purpose: it does not act on the card
+  // in front of you, it puts the LAST one back — which is exactly what you want
+  // when the queue has just run dry and there is no current card at all.
+  // It always consumes the key: `attemptUndo` answers all three outcomes
+  // (blocked, nothing to undo, done), so the press was answered rather than
+  // swallowed.
+  if (key === "u" || key === "undo") {
+    attemptUndo();
+    return true;
   }
   const item = current.value;
   if (!item) return false;
   if (key === "s") {
     doSkip();
-    return true;
-  }
-  if (key === "u") {
-    attemptUndo();
     return true;
   }
   if (key === "h") {

--- a/frontend/src/components/reviews/reviewUndoConsistency.test.js
+++ b/frontend/src/components/reviews/reviewUndoConsistency.test.js
@@ -1,0 +1,335 @@
+// One undo vocabulary inside a review session (owner ruling, 2026-07-29).
+//
+// Ctrl+Z used to be dead here: the review overlay's capture-phase handler bailed
+// on any ctrl/meta/alt, and App's global handler skips the whole overlay, so the
+// chord reached nothing at all while `U` quietly did the work. These tests pin
+// the three claims that fix makes:
+//
+//   • Ctrl+Z and `U` are the SAME request, through one gate.
+//   • That gate answers all three outcomes — done, blocked by a locked set, and
+//     nothing to undo — because a shortcut that silently does nothing is
+//     indistinguishable from a broken one.
+//   • It is the REVIEW's undo, never the app-wide operation stack. A review
+//     decision also flips its suggestion row's status and writes the human-label
+//     ledger, neither of which the operation log captures, so the two stacks
+//     stay separate and the boundary is stated rather than crossed.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount, flushPromises } from "@vue/test-utils";
+import { nextTick, h } from "vue";
+
+vi.mock("../../utils/apiClient", () => ({
+  apiClient: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    delete: vi.fn().mockResolvedValue({ data: {} }),
+  },
+  isReadOnly: { value: false },
+}));
+
+import ReviewSessionView from "./ReviewSessionView.vue";
+import ReviewSessionsOverlay from "../views/ReviewSessionsOverlay.vue";
+import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
+import { useLockedSetsStore } from "../../stores/useLockedSetsStore";
+import { useNoticeStore } from "../../stores/useNoticeStore";
+
+globalThis.ResizeObserver = class {
+  constructor(_callback) {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const VIcon = {
+  name: "v-icon",
+  setup:
+    (_props, { slots }) =>
+    () =>
+      h("i", { class: "v-icon" }, slots.default?.()),
+};
+
+const globalOpts = {
+  stubs: { "v-icon": VIcon },
+  provide: {
+    "rs-backend-url": "http://backend.test",
+    "rs-open-zoom": () => {},
+    "rs-open-tag-apply": () => {},
+  },
+};
+
+const session = {
+  id: "sess1",
+  tag: "shirt",
+  stats: { found: 3, scanned: 100, prev_reviewed: 0 },
+  progress: { done: 1, pending: 2, skipped: 0 },
+  created_at: null,
+  stale: false,
+};
+
+function binaryItem(overrides = {}) {
+  return {
+    id: 1,
+    kind: "binary",
+    direction: "remove",
+    tag: "shirt",
+    picture_id: 10,
+    picture_ext: "jpg",
+    confidence: 0.82,
+    neighbors: [],
+    ...overrides,
+  };
+}
+
+/** Seed an open session whose undo stack already carries one decision. */
+function seedWithHistory(store, { pictureId = 10 } = {}) {
+  store.sessions = [session];
+  store.view = { type: "session", id: "sess1" };
+  store.queues = {
+    sess1: { items: [binaryItem({ id: 2 })], loading: false, error: null },
+  };
+  store.undoStacks = {
+    sess1: [
+      {
+        item: binaryItem({ id: 1, picture_id: pictureId }),
+        action: "remove_tag",
+        delta: { removed: 1 },
+        votes: [],
+      },
+    ],
+  };
+  return store;
+}
+
+function seedEmpty(store) {
+  store.sessions = [session];
+  store.view = { type: "session", id: "sess1" };
+  store.queues = {
+    sess1: { items: [binaryItem({ id: 2 })], loading: false, error: null },
+  };
+  store.undoStacks = { sess1: [] };
+  return store;
+}
+
+function mountSession() {
+  return mount(ReviewSessionView, { props: { session }, global: globalOpts });
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe("review undo — one gate for `U` and Ctrl+Z", () => {
+  it("runs the review's own undo for both keys", async () => {
+    const store = seedWithHistory(useReviewSessionsStore());
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(undefined);
+    const w = mountSession();
+    await nextTick();
+
+    expect(w.vm.handleKey("u")).toBe(true);
+    expect(w.vm.handleKey("undo")).toBe(true);
+    expect(undo).toHaveBeenCalledTimes(2);
+  });
+
+  it("undoes even with no card in front of you", async () => {
+    // The queue has run dry (`current` is null). Undo does not act on the card
+    // on screen, it puts the LAST one back, which is exactly when you want it.
+    const store = seedWithHistory(useReviewSessionsStore());
+    store.queues = { sess1: { items: [], loading: false, error: null } };
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(undefined);
+    const w = mountSession();
+    await nextTick();
+
+    expect(w.vm.handleKey("undo")).toBe(true);
+    expect(undo).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces the success after the card has landed, not before", async () => {
+    // The `current` watcher clears the live region on every card change, and a
+    // successful undo IS a card change. Announcing first means the watcher wipes
+    // it and the success is silent.
+    const store = seedWithHistory(useReviewSessionsStore());
+    vi.spyOn(store, "undo").mockImplementation(async () => {
+      store.queues = {
+        sess1: {
+          items: [binaryItem({ id: 1 }), binaryItem({ id: 2 })],
+          loading: false,
+          error: null,
+        },
+      };
+    });
+    const w = mountSession();
+    await nextTick();
+
+    w.vm.handleKey("undo");
+    await flushPromises();
+    await nextTick();
+
+    expect(w.find('[aria-live="assertive"]').text()).toBe(
+      "Undone. The last decision is back in the queue.",
+    );
+  });
+});
+
+describe("review undo — the three outcomes are all answered", () => {
+  it("says so, and never touches the app-wide stack, when there is nothing to undo", async () => {
+    const store = seedEmpty(useReviewSessionsStore());
+    const notices = useNoticeStore();
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(undefined);
+    const w = mountSession();
+    await nextTick();
+
+    // Consumed: the press was ANSWERED, not swallowed.
+    expect(w.vm.handleKey("undo")).toBe(true);
+    expect(undo).not.toHaveBeenCalled();
+    const text = notices.notices.map((n) => n.text).join(" ");
+    expect(text).toContain("Nothing to undo in this review");
+    // The boundary is stated rather than crossed: the app-wide history is still
+    // there, it is just not what this key reaches.
+    expect(text).toContain("toolbar");
+  });
+
+  it("announces the locked-set reason and issues no request", async () => {
+    const store = seedWithHistory(useReviewSessionsStore(), { pictureId: 77 });
+    useLockedSetsStore().sets = [
+      { id: 99, name: "Holiday 2019", picture_ids: [77] },
+    ];
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(undefined);
+    const w = mountSession();
+    await nextTick();
+
+    expect(w.vm.handleKey("undo")).toBe(true);
+    expect(undo).not.toHaveBeenCalled();
+    await nextTick();
+    expect(w.find('[aria-live="assertive"]').text()).toContain("Holiday 2019");
+  });
+});
+
+// ── The overlay's keyboard routing ──────────────────────────────────────────
+// The chord has to be caught BEFORE the modifier bail that made it dead, and
+// the bail has to survive for everything else.
+
+const SessionStub = {
+  name: "ReviewSessionView",
+  props: { session: { type: Object, required: true } },
+  setup(_props, { expose }) {
+    const handleKey = vi.fn(() => true);
+    expose({ handleKey });
+    SessionStub.lastHandleKey = handleKey;
+    return () => h("div", { class: "session-stub" });
+  },
+};
+
+const Blank = { name: "Blank", render: () => h("div") };
+
+const overlayOpts = {
+  global: {
+    stubs: {
+      "v-icon": VIcon,
+      ReviewSessionView: SessionStub,
+      ReviewRail: Blank,
+      TagHealthBoard: Blank,
+      ReviewArchivedReceipt: Blank,
+      NewReviewDialog: Blank,
+      TbTagPanel: Blank,
+    },
+  },
+  attachTo: document.body,
+};
+
+async function mountOverlayWithSession() {
+  const store = useReviewSessionsStore();
+  const w = mount(ReviewSessionsOverlay, overlayOpts);
+  await flushPromises();
+  // `load()` resets the view to the board on mount, so the session is seeded
+  // afterwards rather than before.
+  seedWithHistory(store);
+  await nextTick();
+  return { store, w };
+}
+
+function press(key, init = {}) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("ReviewSessionsOverlay — Ctrl+Z is no longer dead", () => {
+  it("routes the chord to the review's own undo and consumes it", async () => {
+    const { w } = await mountOverlayWithSession();
+
+    const event = press("z", { ctrlKey: true });
+    expect(SessionStub.lastHandleKey).toHaveBeenCalledWith("undo");
+    expect(event.defaultPrevented).toBe(true);
+    w.unmount();
+  });
+
+  it("accepts Meta+Z too, so the binding is not platform-specific", async () => {
+    const { w } = await mountOverlayWithSession();
+
+    press("z", { metaKey: true });
+    expect(SessionStub.lastHandleKey).toHaveBeenCalledWith("undo");
+    w.unmount();
+  });
+
+  it("does not walk the stack on a held key", async () => {
+    const { w } = await mountOverlayWithSession();
+
+    press("z", { ctrlKey: true, repeat: true });
+    expect(SessionStub.lastHandleKey).not.toHaveBeenCalled();
+    w.unmount();
+  });
+
+  it("leaves the other chords alone", async () => {
+    const { w } = await mountOverlayWithSession();
+
+    for (const key of ["f", "a", "c", "r"]) {
+      const event = press(key, { ctrlKey: true });
+      expect(event.defaultPrevented).toBe(false);
+    }
+    expect(SessionStub.lastHandleKey).not.toHaveBeenCalled();
+    w.unmount();
+  });
+
+  it("answers redo instead of leaving it dead or reaching the app-wide stack", async () => {
+    const notices = useNoticeStore();
+    const { w } = await mountOverlayWithSession();
+
+    const event = press("y", { ctrlKey: true });
+    expect(event.defaultPrevented).toBe(true);
+    expect(SessionStub.lastHandleKey).not.toHaveBeenCalled();
+    expect(notices.notices.map((n) => n.text).join(" ")).toContain(
+      "Nothing to redo in this review",
+    );
+    w.unmount();
+  });
+
+  it("answers the chord on the board, where there is no review to undo in", async () => {
+    const notices = useNoticeStore();
+    const w = mount(ReviewSessionsOverlay, overlayOpts);
+    await flushPromises();
+
+    press("z", { ctrlKey: true });
+    expect(notices.notices.map((n) => n.text).join(" ")).toContain(
+      "Nothing to undo here",
+    );
+    w.unmount();
+  });
+
+  it("teaches both keys, and the scope, in the cheat-sheet", async () => {
+    const { w } = await mountOverlayWithSession();
+
+    press("?");
+    await nextTick();
+    const sheet = w.find(".rs-keys");
+    expect(sheet.exists()).toBe(true);
+    expect(sheet.text()).toMatch(/U \/ (Ctrl\+Z|⌘\+Z)/);
+    expect(sheet.text()).toContain("Undo the last decision in this review");
+    w.unmount();
+  });
+});

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -999,8 +999,20 @@
       @selection-menu-open="toolbarSelectionMenuOpen = $event"
     />
     <!-- The action receipt shares the selection pill's slot and lifts clear of
-         it when both are up. Owner-only, like the toolbar control. -->
-    <ActionReceipt v-if="!isReadOnly" :lift-px="actionReceiptLift" />
+         it when both are up. Owner-only, like the toolbar control.
+
+         `pill-hidden` while the lightbox is open, NOT `v-if`: the lightbox has
+         its own narration of the same single receipt, so two pills would render
+         it at two positions and the grid one would show through the backdrop.
+         The component stays mounted because it carries the one app-wide
+         `role="status"` region, which the lightbox deliberately does not
+         duplicate (the lightbox does not `inert` the grid, so that region still
+         speaks and a second one would double-speak). -->
+    <ActionReceipt
+      v-if="!isReadOnly"
+      :lift-px="actionReceiptLift"
+      :pill-hidden="overlayOpen"
+    />
   </div>
 </template>
 

--- a/frontend/src/components/views/ImageOverlay.vue
+++ b/frontend/src/components/views/ImageOverlay.vue
@@ -606,11 +606,19 @@
             {{ zoomHudLabel }}
           </div>
 
-          <div v-if="swipeHintVisible" class="overlay-swipe-hint">
+          <!-- Both hints stand down while a receipt is up: they are ambient
+               teaching with no deadline, the receipt is feedback on a committed
+               action that expires. "Click or Space to show controls" under an
+               Undo button is worse than redundant, because that click is not
+               the click the user wants. They return when the receipt retires. -->
+          <div
+            v-if="swipeHintVisible && !hasReceipt"
+            class="overlay-swipe-hint"
+          >
             <v-icon size="18">mdi-swap-horizontal</v-icon>
             <span>Swipe to navigate</span>
           </div>
-          <div v-if="chromeHidden" class="overlay-chrome-hint">
+          <div v-if="chromeHidden && !hasReceipt" class="overlay-chrome-hint">
             <span>Click or <kbd>Space</kbd> to show controls</span>
           </div>
         </div>
@@ -731,6 +739,17 @@
             :video-duration="videoMeta.duration"
           />
         </aside>
+
+        <!-- The lightbox's own narration of an undoable action. Last child of
+             `.overlay-main` on purpose: this is where `--filmstrip-rail-width`
+             is declared, last-in-DOM is last-in-tab-order, and it escapes
+             `.overlay-canvas`'s `overflow: hidden`, which would clip the focus
+             ring on the Undo button. -->
+        <OverlayActionReceipt
+          v-if="!isReadOnly"
+          ref="receiptRef"
+          :chrome-hidden="chromeHidden"
+        />
       </div>
     </div>
   </div>
@@ -778,12 +797,14 @@ import {
 import { useGenStackPrefsStore } from "../../stores/useGenStackPrefsStore";
 import { useLockedSetsStore } from "../../stores/useLockedSetsStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
+import { useOperationStore } from "../../stores/useOperationStore";
 import { copyText } from "../../utils/clipboard";
 import AddToEntityControl from "../widgets/AddToEntityControl.vue";
 import OverlayDescriptionPanel from "./OverlayDescriptionPanel.vue";
 import OverlayFilmstrip from "./OverlayFilmstrip.vue";
 import OverlayMetadataPanel from "./OverlayMetadataPanel.vue";
 import OverlayTagsPanel from "./OverlayTagsPanel.vue";
+import OverlayActionReceipt from "../widgets/OverlayActionReceipt.vue";
 import PluginParametersUI from "../widgets/PluginParametersUI.vue";
 import StarRatingOverlay from "../widgets/StarRatingOverlay.vue";
 import {
@@ -796,6 +817,12 @@ import { dedupeTagList, getTagList } from "../../utils/tags.js";
 // Failures report through the notice surface instead of a blocking native
 // alert() (docs/design/notice-surface.md §1).
 const noticeStore = useNoticeStore();
+// Undo/redo is the same stack the grid uses; only the narration differs here
+// (OverlayActionReceipt, in the lightbox's own dark chrome).
+const operationStore = useOperationStore();
+const receiptRef = ref(null);
+/** A receipt is on screen: the two bottom-centre hints stand down while it is. */
+const hasReceipt = computed(() => Boolean(operationStore.receipt));
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -2005,6 +2032,29 @@ function showNextImage() {
   return navigateOverlayImage(1);
 }
 
+/**
+ * Is the keystroke landing in a text-entry surface?
+ *
+ * A text field keeps its own native undo stack, and the lightbox has several
+ * (the tag field, the description editor, the plugin parameter inputs). Both
+ * the event target and `document.activeElement` count, matching the strictness
+ * App's global handler uses: a Vuetify combobox moves focus around, so the two
+ * do not always agree.
+ *
+ * @param {EventTarget|null} target - the keydown target.
+ * @returns {boolean}
+ */
+function isTypingTarget(target) {
+  const active = typeof document === "undefined" ? null : document.activeElement;
+  return [target, active].some(
+    (el) =>
+      el instanceof HTMLElement &&
+      (el.isContentEditable ||
+        ["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName) ||
+        el.getAttribute("role") === "textbox"),
+  );
+}
+
 function handleKeydown(e) {
   if (!open.value) return;
   // Prevent other window keydown listeners (e.g. ImageGrid) from seeing this
@@ -2028,6 +2078,39 @@ function handleKeydown(e) {
       e.preventDefault();
       handleUserActivity();
       openContextMenuFromKeyboard();
+      return;
+    }
+  }
+
+  // Undo / redo, handled HERE rather than by App's global binding.
+  //
+  // This handler is registered in ImageOverlay's own `onMounted`, and a child
+  // mounts before its parent, so it runs before App's window listener — and it
+  // calls `stopImmediatePropagation()` above. App's `Ctrl+Z` therefore never
+  // sees a keystroke while the lightbox is open, no matter what its own guards
+  // say. The owner ruled that undo must work here anyway, fitted to the
+  // lightbox's own GUI: `OverlayActionReceipt` narrates the result inside the
+  // overlay chrome, so the action is never taken blind.
+  //
+  // Above the `chromeHidden` bail on purpose. The narration is a transient HUD
+  // like the progress cards and the swipe hint, none of which hide with the
+  // chrome, so undo stays reachable on a bare image and still reports itself.
+  if (
+    (e.ctrlKey || e.metaKey) &&
+    !e.altKey &&
+    !e.repeat &&
+    !isReadOnly.value &&
+    !isTypingTarget(e.target)
+  ) {
+    const undoKey = e.key?.toLowerCase();
+    if (undoKey === "z" && !e.shiftKey) {
+      e.preventDefault();
+      operationStore.undo();
+      return;
+    }
+    if (undoKey === "y" || (undoKey === "z" && e.shiftKey)) {
+      e.preventDefault();
+      operationStore.redo();
       return;
     }
   }
@@ -2141,6 +2224,17 @@ function handleKeydown(e) {
   }
 
   if (e.key === "Escape") {
+    // Focus is inside the receipt: retire it and hand the keyboard back to the
+    // canvas, without closing the lightbox. A keyboard user who tabbed into the
+    // pill needs an exit that is not "leave the whole surface". Escape is NOT a
+    // general receipt dismissal — the pill blocks nothing and expires on its
+    // own, and making Escape-to-close depend on an invisible countdown would be
+    // a worse failure than a pill that outlived its welcome.
+    if (receiptRef.value?.containsFocus?.()) {
+      receiptRef.value.dismiss();
+      overlayCanvasRef.value?.focus?.();
+      return;
+    }
     if (drawMode.value) {
       clearDrawMode();
     } else if (pluginMenuOpen.value) {

--- a/frontend/src/components/views/ImageOverlayUndo.test.js
+++ b/frontend/src/components/views/ImageOverlayUndo.test.js
@@ -1,0 +1,287 @@
+// Ctrl+Z inside the lightbox.
+//
+// This was dead, and not for the reason the code claimed. App's guard checks
+// for a Vuetify scrim, which `.image-overlay` does not render; what actually
+// stopped it is ImageOverlay's own `stopImmediatePropagation()` on a listener
+// registered BEFORE App's (a child mounts first). So the binding has to live in
+// the overlay's own handler, which is what these tests drive: they dispatch on
+// `window`, exactly as a real keypress arrives.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+
+const getMock = vi.fn(async (url) => {
+  if (typeof url === "string" && url.includes("/workflow")) {
+    const e = new Error("no workflow");
+    e.response = { status: 404 };
+    throw e;
+  }
+  return { data: [] };
+});
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref } = await import("vue");
+  return {
+    apiClient: { get: (...a) => getMock(...a), post: vi.fn(), delete: vi.fn() },
+    appendShareToken: (u) => u,
+    isReadOnly: ref(false),
+    setRequestClientId: vi.fn(),
+  };
+});
+
+vi.mock("../../api/operations", () => ({
+  listOperations: vi.fn().mockResolvedValue([]),
+  getUndoState: vi.fn().mockResolvedValue({ can_undo: true, can_redo: true }),
+  undoLastOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  redoOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  undoOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  undoBatch: vi.fn().mockResolvedValue({ operations: [] }),
+}));
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+import { useOperationStore } from "../../stores/useOperationStore";
+
+// The receipt is deliberately NOT stubbed: the Escape guard and the hint
+// suppression are contracts between the two components.
+const STUBS = {
+  OverlayTagsPanel: true,
+  OverlayFilmstrip: true,
+  OverlayDescriptionPanel: true,
+  OverlayMetadataPanel: true,
+  AddToEntityControl: true,
+  StarRatingOverlay: true,
+  PluginParametersUI: true,
+  "v-icon": true,
+  "v-menu": true,
+  "v-tooltip": true,
+};
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+async function openOverlay() {
+  const { default: ImageOverlay } = await import("./ImageOverlay.vue");
+  const wrapper = mount(ImageOverlay, {
+    props: {
+      open: false,
+      initialImageId: 7,
+      allImages: [{ id: 7, tags: [] }],
+      backendUrl: "http://test",
+      tagUpdate: { key: 0, pictureIds: [] },
+      descriptionUpdate: { key: 0, pictureIds: [] },
+      smartScoreUpdate: { key: 0, pictureIds: [] },
+    },
+    global: { stubs: STUBS },
+    attachTo: document.body,
+  });
+  await wrapper.setProps({ open: true });
+  await flush();
+  await flush();
+  return wrapper;
+}
+
+function press(key, init = {}) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  (init.target ?? window).dispatchEvent(event);
+  return event;
+}
+
+function op(overrides = {}) {
+  return {
+    id: 10,
+    batch_id: null,
+    created_at: "2026-07-29T12:00:00",
+    op_type: "pictures.tags.add",
+    target_count: 1,
+    origin_client_id: "me",
+    undoable: true,
+    status: "applied",
+    summary: "Added tag 'portrait'",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe("ImageOverlay — the undo binding", () => {
+  it("undoes on Ctrl+Z while the lightbox is open", async () => {
+    const store = useOperationStore();
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    const wrapper = await openOverlay();
+
+    const event = press("z", { ctrlKey: true });
+    expect(undo).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("accepts Meta+Z, so the binding is not platform-specific", async () => {
+    const store = useOperationStore();
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    const wrapper = await openOverlay();
+
+    press("z", { metaKey: true });
+    expect(undo).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
+  });
+
+  it("redoes on Ctrl+Y and on Ctrl+Shift+Z", async () => {
+    const store = useOperationStore();
+    const redo = vi.spyOn(store, "redo").mockResolvedValue(null);
+    const wrapper = await openOverlay();
+
+    press("y", { ctrlKey: true });
+    press("Z", { ctrlKey: true, shiftKey: true });
+    expect(redo).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
+
+  it("does not walk the stack on a held key", async () => {
+    const store = useOperationStore();
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    const wrapper = await openOverlay();
+
+    press("z", { ctrlKey: true, repeat: true });
+    expect(undo).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it("leaves a text field its own native undo", async () => {
+    const store = useOperationStore();
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    const wrapper = await openOverlay();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    press("z", { ctrlKey: true, target: input });
+    expect(undo).not.toHaveBeenCalled();
+
+    input.remove();
+    wrapper.unmount();
+  });
+
+  it("still zooms on a bare z", async () => {
+    // The regression the base lane fixed: a modifier-blind `z` made Ctrl+Z zoom
+    // instead of undo. Both halves have to keep working.
+    const store = useOperationStore();
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    const wrapper = await openOverlay();
+
+    expect(wrapper.find(".zoom-hud").classes()).toContain("hidden");
+    press("z");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".zoom-hud").classes()).not.toContain("hidden");
+    expect(undo).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it("still undoes with the chrome hidden", async () => {
+    // The narration is a transient HUD like the progress cards and the swipe
+    // hint, none of which hide with the chrome, so undo stays reachable on a
+    // bare image and still reports itself.
+    const store = useOperationStore();
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    const wrapper = await openOverlay();
+
+    press(" ");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".overlay-shell").classes()).toContain("chrome-hidden");
+
+    press("z", { ctrlKey: true });
+    expect(undo).toHaveBeenCalledTimes(1);
+    // …and the keystroke did not drag the chrome back.
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".overlay-shell").classes()).toContain("chrome-hidden");
+    wrapper.unmount();
+  });
+});
+
+describe("ImageOverlay — the narration on this surface", () => {
+  it("renders the receipt in the lightbox's own chrome", async () => {
+    const store = useOperationStore();
+    const wrapper = await openOverlay();
+    store.showReceipt(store.buildReceipt(op(), "did"));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".overlay-receipt").exists()).toBe(true);
+    expect(wrapper.find(".overlay-receipt .r-text").text()).toBe(
+      "Added tag 'portrait'",
+    );
+    wrapper.unmount();
+  });
+
+  it("stands the chrome hint down while a receipt is up, and back after", async () => {
+    const store = useOperationStore();
+    const wrapper = await openOverlay();
+    press(" ");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".overlay-chrome-hint").exists()).toBe(true);
+
+    store.showReceipt(store.buildReceipt(op(), "did"));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".overlay-chrome-hint").exists()).toBe(false);
+
+    store.dismissReceipt();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".overlay-chrome-hint").exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("keeps the receipt through arrow navigation", async () => {
+    // The receipt narrates an OPERATION, not a picture. Dismissing it on
+    // navigation would remove the undo affordance exactly as the user walks
+    // away from the mistake.
+    const store = useOperationStore();
+    const wrapper = await openOverlay();
+    store.showReceipt(store.buildReceipt(op(), "did"));
+    await wrapper.vm.$nextTick();
+
+    press("ArrowRight");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".overlay-receipt").exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("gives a keyboard user inside the pill an exit that is not closing the lightbox", async () => {
+    const store = useOperationStore();
+    const wrapper = await openOverlay();
+    store.showReceipt(store.buildReceipt(op(), "did"));
+    await wrapper.vm.$nextTick();
+
+    wrapper.find(".overlay-receipt .r-btn").element.focus();
+    press("Escape");
+    await wrapper.vm.$nextTick();
+
+    expect(store.receipt).toBeNull();
+    expect(wrapper.emitted("close")).toBeFalsy();
+    wrapper.unmount();
+  });
+
+  it("closes the lightbox on Escape from anywhere else, receipt or not", async () => {
+    const store = useOperationStore();
+    const wrapper = await openOverlay();
+    store.showReceipt(store.buildReceipt(op(), "did"));
+    await wrapper.vm.$nextTick();
+
+    press("Escape");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("close")).toBeTruthy();
+    // The receipt is NOT dismissed on close: the same one, with its remaining
+    // dwell, is handed back to the grid pill already mounted underneath.
+    expect(store.receipt).not.toBeNull();
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/views/ReviewSessionsOverlay.vue
+++ b/frontend/src/components/views/ReviewSessionsOverlay.vue
@@ -131,9 +131,11 @@ import ReviewSessionView from "../reviews/ReviewSessionView.vue";
 import ReviewArchivedReceipt from "../reviews/ReviewArchivedReceipt.vue";
 import NewReviewDialog from "../reviews/NewReviewDialog.vue";
 import TbTagPanel from "../panels/TbTagPanel.vue";
+import { useNoticeStore } from "../../stores/useNoticeStore";
 import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
 import { useSelectionStore } from "../../stores/useSelectionStore";
 import { useProjectStore } from "../../stores/useProjectStore";
+import { formatKeyHint, undoKeyHint } from "../../utils/shortcutHints";
 
 // Sidebar selection sentinels (mirrors useSelectionStore.js / App.vue).
 const ALL_PICTURES_ID = "ALL";
@@ -148,6 +150,7 @@ const emit = defineEmits(["close", "tags-applied"]);
 const store = useReviewSessionsStore();
 const selectionStore = useSelectionStore();
 const projectStore = useProjectStore();
+const noticeStore = useNoticeStore();
 
 const sessionRef = ref(null);
 const boardRef = ref(null);
@@ -166,17 +169,25 @@ const archivedReview = computed(() =>
     : null,
 );
 
-const SHORTCUTS = [
+// The undo row names both keys because they are the same action: Ctrl+Z (⌘Z on
+// a Mac) is the app-wide undo vocabulary and must mean something everywhere,
+// and `U` is the reviewer muscle memory that keeps working. "in this review" is
+// the whole point of the row: it is the only place the scope boundary between
+// the review's undo and the app-wide one is taught before the user hits it.
+const SHORTCUTS = computed(() => [
   ["Y / N", "Answer a binary card (yes / no)"],
   ["B / N / L / R", "Answer a pair card (both / neither / left / right)"],
   ["S", "Skip — leaves the queue undecided, no change made"],
-  ["U", "Undo the last decision"],
+  [
+    `U / ${formatKeyHint(undoKeyHint())}`,
+    "Undo the last decision in this review",
+  ],
   ["H", "Show / hide the evidence region"],
   ["T", "Apply tags to the pictured image(s)"],
   ["/", "Filter the tag health board"],
   ["?", "This cheat-sheet"],
   ["Esc", "Close the topmost layer"],
-];
+]);
 
 // Translate the app's current selection into the dialog's scope prefill, so a
 // review created from a filtered view lands pre-scoped to it (old overlay
@@ -372,8 +383,101 @@ function isEditable(el) {
   return tag === "INPUT" || tag === "TEXTAREA";
 }
 
+/**
+ * Ctrl+Z / ⌘Z, and only that.
+ *
+ * Ctrl+Shift+Z and Ctrl+Y are REDO, which a review has no meaning for: undo
+ * puts the card back at the head of the queue, so "redo" would be deciding it
+ * again, and that is a decision rather than a replay. They are left alone.
+ *
+ * @param {KeyboardEvent} event
+ * @returns {boolean}
+ */
+function isUndoChord(event) {
+  return (
+    (event.ctrlKey || event.metaKey) &&
+    !event.altKey &&
+    !event.shiftKey &&
+    !event.repeat &&
+    event.key?.toLowerCase() === "z"
+  );
+}
+
+/** Ctrl+Y or Ctrl+Shift+Z: redo, everywhere else in the app. */
+function isRedoChord(event) {
+  const key = event.key?.toLowerCase();
+  return (
+    (event.ctrlKey || event.metaKey) &&
+    !event.altKey &&
+    !event.repeat &&
+    (key === "y" || (key === "z" && event.shiftKey))
+  );
+}
+
+/**
+ * One undo request, however it was typed: `U`, Ctrl+Z, or the bar's button all
+ * land here.
+ *
+ * The session view owns every guard and every message once a review is open — a
+ * locked picture set makes a decision final, an empty stack has to say so — and
+ * it consumes the key in all of those cases. This function only covers the case
+ * it can see and the session view cannot: no review open at all.
+ *
+ * The review's undo is deliberately a SEPARATE stack from the app-wide one
+ * behind the overlay. A review decision also flips its suggestion row's status
+ * and writes the human-label ledger, and the operation log captures neither, so
+ * one shared stack would undo half of each decision. Ctrl+Z therefore always
+ * means "my last action HERE" and never quietly reaches past the overlay; the
+ * message says where the other stack lives instead.
+ */
+function handleUndoRequest() {
+  if (sessionRef.value) {
+    sessionRef.value.handleKey("undo");
+    closeZoom();
+    return;
+  }
+  noticeStore.push({
+    level: "info",
+    text: "Nothing to undo here. Close the review sessions to undo earlier changes from the toolbar.",
+    key: "review-nothing-to-undo",
+  });
+}
+
+/**
+ * Redo has no meaning in a review: undo puts the card back at the head of the
+ * queue, so re-applying the decision means answering the card again. Say that
+ * rather than leaving the chord dead, and never let it fall through to the
+ * app-wide redo behind the overlay.
+ */
+function reportNoRedo() {
+  noticeStore.push({
+    level: "info",
+    text: "Nothing to redo in this review. Answer the card again to reapply a decision you undid.",
+    key: "review-nothing-to-redo",
+  });
+}
+
 function handleKeyDown(event) {
   if (isEditable(event.target) || isEditable(document.activeElement)) return;
+
+  // Undo/redo are checked BEFORE the modifier bail below — that bail is what
+  // made Ctrl+Z dead in a review session, while App's global handler skips the
+  // whole overlay. The owner ruled the chord must be consistent, so it lands
+  // here on the review's own undo, exactly like `U`. The bail itself stays for
+  // everything else: Ctrl+F, Ctrl+A, Ctrl+C and Ctrl+R must keep working.
+  //
+  // Skipped while the cheat-sheet or the new-review dialog owns the screen, on
+  // the same rule the letter keys follow below: a modal layer is up, so nothing
+  // behind it acts.
+  const modalLayerUp = shortcutsOpen.value || Boolean(dialog.value);
+  if (!modalLayerUp && (isUndoChord(event) || isRedoChord(event))) {
+    if (isUndoChord(event)) handleUndoRequest();
+    else reportNoRedo();
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    return;
+  }
+
   if (event.metaKey || event.ctrlKey || event.altKey) return;
 
   const key = event.key.toLowerCase();
@@ -403,6 +507,10 @@ function handleKeyDown(event) {
     boardRef.value?.focusFilter?.();
   } else if (key === "t" && store.current) {
     tagApplyOpen.value = !tagApplyOpen.value;
+  } else if (key === "u") {
+    // Same request as Ctrl+Z, so the two cannot drift: `U` on the board (no
+    // review open) now gets the same answer instead of doing nothing.
+    handleUndoRequest();
   } else if (key === "enter" && sessionRef.value) {
     handled = !!sessionRef.value.handleKey("enter");
   } else if (sessionRef.value) {

--- a/frontend/src/components/widgets/ActionReceipt.vue
+++ b/frontend/src/components/widgets/ActionReceipt.vue
@@ -39,6 +39,13 @@ const props = defineProps({
    * and grows on coarse pointers.
    */
   liftPx: { type: Number, default: 0 },
+  /**
+   * Hide the PILL while another surface renders the same receipt (the lightbox
+   * has its own narration in its own chrome). The component stays mounted: it
+   * carries the one app-wide live region, and the lightbox deliberately has
+   * none, so unmounting this would silence every undo announcement made there.
+   */
+  pillHidden: { type: Boolean, default: false },
 });
 
 // The receipt contract — wording, glyphs, keycaps, the drain window, the
@@ -63,6 +70,11 @@ const {
   resume,
   takeAction,
 } = useActionReceipt();
+
+/** The button's accessible name: the verb alone does not say what it undoes. */
+const actionAccessibleName = computed(
+  () => `${actionLabel.value}: ${text.value}`,
+);
 
 const wrapperStyle = computed(() => ({
   paddingBottom: `${Math.max(0, props.liftPx)}px`,
@@ -93,7 +105,16 @@ function onUndo(event) {
     data-testid="action-receipt-slot"
   >
     <!-- One persistent region, always mounted, so an announcement is never
-         raced by the node that carries it. -->
+         raced by the node that carries it. It is also the ONLY one in the app:
+         the lightbox's narration deliberately has none, because the lightbox
+         does not `inert` or `aria-hidden` the grid, so this region still speaks
+         from underneath it. Do not gate it on the lightbox being closed, and do
+         not add a second one there.
+
+         If the lightbox is ever made a proper modal (`aria-modal` + `inert`),
+         this region goes inert with the rest of the grid and undo announcements
+         go silent everywhere. The fix then is to MOVE this one region up beside
+         NoticeHost, not to duplicate it. -->
     <span
       class="visually-hidden"
       role="status"
@@ -104,7 +125,7 @@ function onUndo(event) {
     >
     <transition name="receipt">
       <div
-        v-if="receipt"
+        v-if="receipt && !pillHidden"
         :key="pillKey"
         class="receipt"
         :class="{ 'receipt--undone': undone, 'receipt--blocked': blocked }"
@@ -125,6 +146,7 @@ function onUndo(event) {
             type="button"
             class="r-btn"
             :aria-disabled="store.busy"
+            :aria-label="actionAccessibleName"
             :aria-keyshortcuts="actionKeyShortcut"
             @click="onUndo"
           >

--- a/frontend/src/components/widgets/ActionReceipt.vue
+++ b/frontend/src/components/widgets/ActionReceipt.vue
@@ -27,25 +27,10 @@
  * measured border box is the FULL height this component occupies on the bottom
  * edge — which is exactly what the anchor registry needs to report.
  */
-import {
-  computed,
-  nextTick,
-  onBeforeUnmount,
-  onMounted,
-  ref,
-  watch,
-} from "vue";
+import { computed, ref } from "vue";
 
+import { useActionReceipt } from "../../composables/useActionReceipt";
 import { useBottomAnchor } from "../../composables/useBottomAnchor";
-import { useOperationStore } from "../../stores/useOperationStore";
-import {
-  isApplePlatform,
-  redoKeyHint,
-  undoKeyHint,
-} from "../../utils/shortcutHints";
-
-/** Settling window before the live region speaks, so a burst reads once. */
-const ANNOUNCE_THROTTLE_MS = 350;
 
 const props = defineProps({
   /**
@@ -56,57 +41,28 @@ const props = defineProps({
   liftPx: { type: Number, default: 0 },
 });
 
-const store = useOperationStore();
-
-const receipt = computed(() => store.receipt);
-const undone = computed(() => receipt.value?.mode === "undone");
-const blocked = computed(() => receipt.value?.mode === "blocked");
-
-/** The glyph: the action's own icon, or the undo/limit glyph once it flips. */
-const glyph = computed(() => {
-  if (!receipt.value) return "";
-  if (undone.value) return "mdi-undo-variant";
-  if (blocked.value) return "mdi-information-outline";
-  return receipt.value.icon;
-});
-
-const actionLabel = computed(() => (undone.value ? "Redo" : "Undo"));
-const actionGlyph = computed(() =>
-  undone.value ? "mdi-redo-variant" : "mdi-undo-variant",
-);
-const keyHint = computed(() => (undone.value ? redoKeyHint() : undoKeyHint()));
-
-/**
- * The sentence. A multi-step undo says how far it went instead of naming only
- * the oldest step it reverted, which would understate what just happened.
- */
-const text = computed(() => {
-  const entry = receipt.value;
-  if (!entry) return "";
-  if (undone.value && entry.steps > 1) {
-    return `Undone ${entry.steps} steps: ${entry.summary}`;
-  }
-  if (undone.value) return `Undone: ${entry.summary}`;
-  return entry.summary;
-});
-
-/** The standard attribute for "this control has a keyboard shortcut". */
-const actionKeyShortcut = computed(() =>
-  undone.value
-    ? isApplePlatform()
-      ? "Shift+Meta+Z"
-      : "Control+Y"
-    : isApplePlatform()
-      ? "Meta+Z"
-      : "Control+Z",
-);
-
-// The drain's duration is a dismissal timeout, not a motion token: the motion
-// scale tops out at 420ms. It is handed to CSS as a custom property so the
-// hairline and the store's timer always describe the same window.
-const drainStyle = computed(() => ({
-  "--r-drain-dur": `${receipt.value?.durationMs ?? 0}ms`,
-}));
+// The receipt contract — wording, glyphs, keycaps, the drain window, the
+// hover/focus/hidden-tab pause and the focus-preserving action — is shared with
+// the lightbox's own narration (`OverlayActionReceipt.vue`). This surface owns
+// the single app-wide live region; the lightbox's does not announce.
+const {
+  store,
+  receipt,
+  undone,
+  blocked,
+  glyph,
+  actionLabel,
+  actionGlyph,
+  keyHint,
+  text,
+  actionKeyShortcut,
+  drainStyle,
+  pillKey,
+  announcement,
+  pause,
+  resume,
+  takeAction,
+} = useActionReceipt();
 
 const wrapperStyle = computed(() => ({
   paddingBottom: `${Math.max(0, props.liftPx)}px`,
@@ -117,86 +73,16 @@ const wrapperStyle = computed(() => ({
 const wrapperEl = ref(null);
 useBottomAnchor("action-receipt", wrapperEl);
 
-/**
- * Take the action and keep the keyboard where it was.
- *
- * The pill is REPLACED (a new node, keyed on the store's raise counter) when
- * undo flips it to "Undone … Redo". Without this, a user who reached Undo with
- * the keyboard has focus dropped to `<body>` and has to tab from the top of the
- * document to reach the Redo the flip just produced — WCAG 2.4.3. The button is
- * `aria-disabled` rather than `disabled` for the same reason: disabling a
- * focused control moves focus off it.
- */
-async function onUndo(event) {
-  if (store.busy) return;
-  const hadFocus = event?.currentTarget === document.activeElement;
-  await (undone.value ? store.redo() : store.undo());
-  if (!hadFocus) return;
-  await nextTick();
-  wrapperEl.value?.querySelector?.(".r-btn")?.focus?.();
+// The pill is REPLACED (a new node, keyed on the store's raise counter) when
+// undo flips it to "Undone … Redo", so the keyboard has to be put back on the
+// button the flip produced (WCAG 2.4.3). The button is `aria-disabled` rather
+// than `disabled` for the same reason: disabling a focused control moves focus
+// off it.
+function onUndo(event) {
+  return takeAction(event, () =>
+    wrapperEl.value?.querySelector?.(".r-btn")?.focus?.(),
+  );
 }
-
-// WCAG 2.2.1 — the countdown freezes on hover and on focus-within, and the CSS
-// pauses the hairline on the same two conditions so the two never disagree.
-function pause() {
-  store.pauseReceipt();
-}
-function resume() {
-  store.resumeReceipt();
-}
-
-// …and while the tab is hidden, or a receipt raised just before a tab switch
-// expires unread. Mirrors NoticeHost's handling of the same hazard.
-function onVisibilityChange() {
-  if (typeof document === "undefined") return;
-  if (document.hidden) store.pauseReceipt();
-  else store.resumeReceipt();
-}
-
-onMounted(() => {
-  if (typeof document !== "undefined") {
-    document.addEventListener("visibilitychange", onVisibilityChange);
-  }
-});
-
-onBeforeUnmount(() => {
-  if (typeof document !== "undefined") {
-    document.removeEventListener("visibilitychange", onVisibilityChange);
-  }
-  if (announceTimer != null) clearTimeout(announceTimer);
-});
-
-// Keyed on the store's raise counter so a receipt REPLACED in place still
-// remounts and the drain restarts from full. The pill is deliberately NOT the
-// live region: a region created at the same moment as its content announces
-// unreliably, and a burst of actions would create one region per action and
-// queue a backlog of stale sentences. The announcement rides a single
-// persistent region instead (notice-surface.md §8).
-const pillKey = computed(() => receipt.value?.key ?? 0);
-
-// What the persistent region says. Throttled so a burst announces the outcome
-// once, rather than reading every intermediate step aloud.
-const announcement = ref("");
-let announceTimer = null;
-watch(text, (value) => {
-  if (announceTimer != null) clearTimeout(announceTimer);
-  if (!value) {
-    announcement.value = "";
-    return;
-  }
-  announceTimer = setTimeout(() => {
-    announceTimer = null;
-    announcement.value = value;
-  }, ANNOUNCE_THROTTLE_MS);
-});
-
-// A receipt raised while the tab is hidden starts with a running countdown
-// (the store arms it unconditionally). Re-apply the hidden-tab pause so it does
-// not expire unseen — the same hazard `onVisibilityChange` covers for the pill
-// that was already up.
-watch(pillKey, () => {
-  if (typeof document !== "undefined" && document.hidden) store.pauseReceipt();
-});
 </script>
 
 <template>

--- a/frontend/src/components/widgets/OverlayActionReceipt.test.js
+++ b/frontend/src/components/widgets/OverlayActionReceipt.test.js
@@ -1,0 +1,245 @@
+// Undo inside the lightbox (owner ruling, 2026-07-29).
+//
+// The lightbox has its own GUI, so it gets its own narration rather than the
+// grid pill promoted above the modal layer. Two things had to be true for that
+// to be honest, and these tests pin both:
+//
+//   1. Ctrl+Z actually reaches the operation stack while the lightbox is open.
+//      It did not before: ImageOverlay registers its window listener in its own
+//      `onMounted` and calls `stopImmediatePropagation()`, and a child mounts
+//      before its parent, so App's global binding never saw the keystroke.
+//   2. The result is narrated ON the lightbox, honouring the receipt contract
+//      (timings, pause, one at a time, reduced motion) while adding the one
+//      thing the grid does not need: how far past the visible picture the step
+//      reached.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount } from "@vue/test-utils";
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref } = await import("vue");
+  return {
+    apiClient: { get: vi.fn(), post: vi.fn() },
+    appendShareToken: (u) => u,
+    isReadOnly: ref(false),
+    setRequestClientId: vi.fn(),
+  };
+});
+
+vi.mock("../../api/operations", () => ({
+  listOperations: vi.fn().mockResolvedValue([]),
+  getUndoState: vi.fn().mockResolvedValue({ can_undo: false, can_redo: false }),
+  undoLastOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  redoOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  undoOperation: vi.fn().mockResolvedValue({ operations: [] }),
+  undoBatch: vi.fn().mockResolvedValue({ operations: [] }),
+}));
+
+import OverlayActionReceipt from "./OverlayActionReceipt.vue";
+import ActionReceipt from "./ActionReceipt.vue";
+import { useOperationStore } from "../../stores/useOperationStore";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+function op(overrides = {}) {
+  return {
+    id: 10,
+    batch_id: null,
+    created_at: "2026-07-29T12:00:00",
+    op_type: "pictures.tags.add",
+    target_count: 1,
+    origin_client_id: "me",
+    undoable: true,
+    status: "applied",
+    summary: "Added tag 'portrait'",
+    ...overrides,
+  };
+}
+
+function mountWith(operation, mode = "did", steps = 1, props = {}) {
+  const store = useOperationStore();
+  const wrapper = mount(OverlayActionReceipt, { ...globalOpts, props });
+  store.showReceipt(store.buildReceipt(operation, mode, steps));
+  return { store, wrapper };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setActivePinia(createPinia());
+});
+
+describe("OverlayActionReceipt — states", () => {
+  it("renders nothing while there is no receipt", () => {
+    const wrapper = mount(OverlayActionReceipt, globalOpts);
+    expect(wrapper.find(".overlay-receipt").exists()).toBe(false);
+  });
+
+  it("shows the summary, an Undo button and the shortcut hint", async () => {
+    const { wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".r-text").text()).toBe("Added tag 'portrait'");
+    expect(wrapper.find(".r-btn").text()).toContain("Undo");
+    expect(wrapper.find(".kbdhint").attributes("aria-hidden")).toBe("true");
+  });
+
+  it("flips in place to the undone state and offers Redo", async () => {
+    const { wrapper } = mountWith(op(), "undone");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".r-text").text()).toBe("Undone: Added tag 'portrait'");
+    expect(wrapper.find(".r-btn").text()).toContain("Redo");
+    // One pill, never a second stacked beside it.
+    expect(wrapper.findAll(".overlay-receipt")).toHaveLength(1);
+  });
+
+  it("states the limit instead of a dead button when the action is one-way", async () => {
+    const { wrapper } = mountWith(op({ undoable: false }), "blocked");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".r-limit").text()).toBe("Can't be undone");
+    expect(wrapper.find(".r-btn").exists()).toBe(false);
+  });
+
+  it("names what the button will undo, not just the verb", async () => {
+    const { wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".r-btn").attributes("aria-label")).toBe(
+      "Undo: Added tag 'portrait'",
+    );
+  });
+});
+
+describe("OverlayActionReceipt — the scope clause", () => {
+  // The lightbox shows one picture while Ctrl+Z can revert an action across
+  // thousands. The clause is derived from the COUNT only, so navigating to the
+  // next picture cannot falsify it.
+  it("says how far past the visible picture a bulk step reached", async () => {
+    const { wrapper } = mountWith(op({ target_count: 2700 }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".r-scope").text()).toBe(
+      "Across 2,700 pictures, not just this one",
+    );
+  });
+
+  it("says so in the past tense once the step has been reverted", async () => {
+    const { wrapper } = mountWith(op({ target_count: 2700 }), "undone");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".r-scope").text()).toBe(
+      "Reverted across 2,700 pictures, not just this one",
+    );
+  });
+
+  it("stays silent on a single-picture step", async () => {
+    const { wrapper } = mountWith(op({ target_count: 1 }));
+    await wrapper.vm.$nextTick();
+    // "Just this picture" would be noise on the common case, and false the
+    // moment the user navigates away.
+    expect(wrapper.find(".r-scope").exists()).toBe(false);
+  });
+
+  it("never claims to be about the picture on screen", async () => {
+    const { wrapper } = mountWith(op({ target_count: 2700 }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).not.toMatch(/this picture\b/);
+    expect(wrapper.text()).not.toMatch(/this image\b/);
+  });
+});
+
+describe("OverlayActionReceipt — the receipt contract", () => {
+  it("hands CSS the same window the store's timer uses", async () => {
+    const { wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".overlay-receipt").attributes("style")).toContain(
+      "--r-drain-dur: 5000ms",
+    );
+  });
+
+  it("uses the longer window for a destructive action", async () => {
+    const { wrapper } = mountWith(op({ op_type: "pictures.scrapheap.move" }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".overlay-receipt").attributes("style")).toContain(
+      "--r-drain-dur: 8000ms",
+    );
+  });
+
+  it("freezes the countdown on hover and on focus (WCAG 2.2.1)", async () => {
+    const { store, wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find(".overlay-receipt").trigger("mouseenter");
+    vi.advanceTimersByTime(60000);
+    expect(store.receipt).not.toBeNull();
+
+    await wrapper.find(".overlay-receipt").trigger("mouseleave");
+    vi.advanceTimersByTime(5000);
+    expect(store.receipt).toBeNull();
+  });
+
+  it("marks itself busy with aria-disabled, never the attribute", async () => {
+    const { store, wrapper } = mountWith(op());
+    store.busy = true;
+    await wrapper.vm.$nextTick();
+    const button = wrapper.find(".r-btn");
+    expect(button.attributes("disabled")).toBeUndefined();
+    expect(button.attributes("aria-disabled")).toBe("true");
+  });
+
+  it("undoes and redoes through the same store the grid uses", async () => {
+    const { store, wrapper } = mountWith(op());
+    const undo = vi.spyOn(store, "undo").mockResolvedValue(null);
+    await wrapper.vm.$nextTick();
+    await wrapper.find(".r-btn").trigger("click");
+    expect(undo).toHaveBeenCalledTimes(1);
+
+    const { store: s2, wrapper: w2 } = mountWith(op(), "undone");
+    const redo = vi.spyOn(s2, "redo").mockResolvedValue(null);
+    await w2.vm.$nextTick();
+    await w2.find(".r-btn").trigger("click");
+    expect(redo).toHaveBeenCalledTimes(1);
+  });
+
+  it("widens its band to the whole canvas while the chrome is hidden", async () => {
+    const { wrapper } = mountWith(op(), "did", 1, { chromeHidden: true });
+    await wrapper.vm.$nextTick();
+    // The rail and the sidebar keep their width while hidden, so the band has
+    // to collapse or the pill sits off-centre against a rail nobody can see.
+    expect(
+      wrapper
+        .find('[data-testid="overlay-action-receipt-slot"]')
+        .classes("chrome-hidden"),
+    ).toBe(true);
+  });
+});
+
+describe("the single live region", () => {
+  it("is the grid's, and the lightbox adds no second one", async () => {
+    // The lightbox does not `inert` or `aria-hidden` the grid, so the grid's
+    // persistent region still speaks from underneath. A second one here would
+    // be guaranteed double-speak.
+    const store = useOperationStore();
+    const grid = mount(ActionReceipt, {
+      ...globalOpts,
+      props: { pillHidden: true },
+    });
+    const lightbox = mount(OverlayActionReceipt, globalOpts);
+    store.showReceipt(store.buildReceipt(op(), "did"));
+    await grid.vm.$nextTick();
+    await lightbox.vm.$nextTick();
+
+    expect(lightbox.findAll('[role="status"]')).toHaveLength(0);
+    expect(grid.findAll('[role="status"]')).toHaveLength(1);
+
+    // …and the grid's PILL is out of the way, so the same receipt is not drawn
+    // at two positions with the lightbox's backdrop between them.
+    expect(grid.find(".receipt").exists()).toBe(false);
+    expect(lightbox.find(".overlay-receipt").exists()).toBe(true);
+
+    vi.advanceTimersByTime(400);
+    await grid.vm.$nextTick();
+    expect(
+      grid.find('[data-testid="action-receipt-announcement"]').text(),
+    ).toBe("Added tag 'portrait'");
+  });
+});

--- a/frontend/src/components/widgets/OverlayActionReceipt.vue
+++ b/frontend/src/components/widgets/OverlayActionReceipt.vue
@@ -1,0 +1,426 @@
+<script setup>
+/**
+ * The lightbox's own narration of an undoable action.
+ *
+ * The owner ruled that undo must work inside the lightbox, and that the
+ * affordance may be fitted differently there because the lightbox has its own
+ * GUI. So this is not the grid pill promoted above the modal layer — it is the
+ * same receipt, rendered in the overlay's own material.
+ *
+ * What is identical (all of it from `useActionReceipt`, so the two surfaces
+ * cannot drift): the wording, the glyphs, the keycaps, the dwell window and its
+ * hairline drain, the hover/focus/hidden-tab pause, the in-place flip to
+ * "Undone … Redo", the "Can't be undone" limit instead of a dead button, and the
+ * store's one-receipt-at-a-time rule.
+ *
+ * What is different, and why:
+ *
+ *   • Material. `dark-surface` / `on-dark-surface` at 0.9, the exact fill
+ *     `.overlay-topbar` and `.overlay-rail` already carry, so it reads as this
+ *     surface's chrome rather than as an imported card. `--elevation-4` is the
+ *     rung visual-language.md §7 names for lightbox chrome; the grid pill takes
+ *     -3 precisely because -4 was reserved for here.
+ *   • NO live region. The grid's `ActionReceipt` stays mounted underneath and
+ *     the lightbox does not `inert` or `aria-hidden` it, so its persistent
+ *     `role="status"` region still speaks. A second region here would be
+ *     guaranteed double-speak, not a risk of it.
+ *   • A scope clause. In the grid you made the selection and can watch the
+ *     tiles change; here you can see exactly one picture while Ctrl+Z reverts
+ *     an action across thousands. Above one target the pill says how wide the
+ *     step was, derived from the count alone so it stays true no matter which
+ *     picture is on screen. Nothing here ever says "this picture" — that would
+ *     become a lie the instant the user presses the right arrow.
+ *   • No History popover. Choosing a step is a browsing task whose preview has
+ *     no visible referent on a surface showing one picture. Repeated Ctrl+Z
+ *     still walks the stack, and the toolbar control is one Escape away.
+ */
+import { computed, ref } from "vue";
+
+import { useActionReceipt } from "../../composables/useActionReceipt";
+
+defineProps({
+  /**
+   * The overlay's chrome-hidden state. The rail and the sidebar are only
+   * opacity-hidden and keep their width, so the band has to collapse to the
+   * whole canvas or the pill sits off-centre against a rail nobody can see.
+   */
+  chromeHidden: { type: Boolean, default: false },
+});
+
+// `announce: false`: the grid's receipt owns the single app-wide live region.
+const {
+  store,
+  receipt,
+  undone,
+  blocked,
+  glyph,
+  actionLabel,
+  actionGlyph,
+  keyHint,
+  text,
+  actionKeyShortcut,
+  drainStyle,
+  pillKey,
+  pause,
+  resume,
+  takeAction,
+} = useActionReceipt({ announce: false });
+
+const rootEl = ref(null);
+
+/**
+ * How wide the step was, when it was wider than the picture on screen.
+ *
+ * Derived from `targetCount` only, never from the displayed picture, so
+ * navigating away cannot falsify it. Absent at one target: "Just this picture"
+ * would be noise on the common case and false the moment the user moves on.
+ */
+const scopeNote = computed(() => {
+  const count = Number(receipt.value?.targetCount);
+  if (!Number.isFinite(count) || count <= 1) return "";
+  const pictures = `${count.toLocaleString()} pictures`;
+  return undone.value
+    ? `Reverted across ${pictures}, not just this one`
+    : `Across ${pictures}, not just this one`;
+});
+
+/** The button's accessible name: the verb alone does not say what it undoes. */
+const actionAccessibleName = computed(
+  () => `${actionLabel.value}: ${text.value}`,
+);
+
+function onAction(event) {
+  return takeAction(event, () =>
+    rootEl.value?.querySelector?.(".r-btn")?.focus?.(),
+  );
+}
+
+/** Does the keyboard currently sit inside the pill? Drives the Escape guard. */
+function containsFocus() {
+  if (typeof document === "undefined" || !rootEl.value) return false;
+  return rootEl.value.contains(document.activeElement);
+}
+
+defineExpose({
+  containsFocus,
+  /** Escape pressed with focus in the pill: retire it, keep the lightbox. */
+  dismiss() {
+    store.dismissReceipt();
+  },
+});
+</script>
+
+<template>
+  <!-- Pointer-transparent band; only the pill takes pointer events, so a click
+       aimed at the image behind it is never eaten. `@click.stop` on the pill
+       keeps the overlay's "any click reveals the chrome" handler from dragging
+       the whole chrome back when the user just wanted Undo. -->
+  <div
+    ref="rootEl"
+    class="overlay-receipt-slot"
+    :class="{ 'chrome-hidden': chromeHidden }"
+    data-testid="overlay-action-receipt-slot"
+  >
+    <transition name="receipt">
+      <div
+        v-if="receipt"
+        :key="pillKey"
+        class="overlay-receipt"
+        :class="{
+          'overlay-receipt--undone': undone,
+          'overlay-receipt--blocked': blocked,
+        }"
+        :style="drainStyle"
+        data-testid="overlay-action-receipt"
+        @click.stop
+        @mouseenter="pause"
+        @mouseleave="resume"
+        @focusin="pause"
+        @focusout="resume"
+      >
+        <v-icon class="r-ico" size="18">{{ glyph }}</v-icon>
+        <span class="r-body">
+          <span class="r-text">{{ text }}</span>
+          <span v-if="scopeNote" class="r-scope">{{ scopeNote }}</span>
+        </span>
+        <span v-if="receipt.mergedCount > 0" class="r-more"
+          >+{{ receipt.mergedCount }}</span
+        >
+        <span v-if="blocked" class="r-limit">Can't be undone</span>
+        <template v-else>
+          <button
+            type="button"
+            class="r-btn"
+            :aria-disabled="store.busy"
+            :aria-label="actionAccessibleName"
+            :aria-keyshortcuts="actionKeyShortcut"
+            @click="onAction"
+          >
+            <v-icon size="16">{{ actionGlyph }}</v-icon>
+            <span>{{ actionLabel }}</span>
+          </button>
+          <span class="kbdhint" aria-hidden="true">
+            <kbd v-for="key in keyHint" :key="key">{{ key }}</kbd>
+          </span>
+        </template>
+        <span class="r-progress run" aria-hidden="true"></span>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+/* The lightbox's transient-status lane. Centred on the VISIBLE image, not on
+   the viewport, so the pill never drifts under the filmstrip rail or the
+   sidebar. `--filmstrip-rail-width` is declared on `.overlay-main`
+   (filmstripStyleVars), `--sidebar-width` on `.overlay-shell`.
+
+   64px: the line `.overlay-progress--comfyui` already establishes, and one
+   --space-8 of clearance above the 16px hint lane whose tallest occupant is
+   ~30px. The 16px lane was rejected because `.zoom-hud` lives there and is
+   PERSISTENT at any zoom other than fit; trading a common collision for the
+   rare one with a running job is the whole argument.
+
+   z-index 6 is the overlay's own trapped local scale (visual-language.md §14
+   sanctions it): the same rung as `.overlay-progress`, which is the same class
+   of object. */
+.overlay-receipt-slot {
+  position: absolute;
+  bottom: calc(var(--space-5) + var(--space-8));
+  left: var(--filmstrip-rail-width, 0px);
+  right: var(--sidebar-width, 0px);
+  z-index: 6;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  /* `--sidebar-width` flips instantly (0 to 320px) while `.overlay-sidebar`
+     slides its width over 200ms. Without this the pill jumps mid-glide. */
+  transition:
+    left var(--dur-2) var(--ease-standard),
+    right var(--dur-2) var(--ease-standard);
+}
+
+/* Chrome hidden: the rail and the sidebar are opacity-hidden but keep their
+   width, so the band has to collapse to the whole canvas or the pill sits
+   visibly off-centre against a rail nobody can see. */
+.overlay-receipt-slot.chrome-hidden {
+  left: 0;
+  right: 0;
+}
+
+/* The grid pill's recipe in this surface's material. Capped, unlike the grid
+   pill: the cap is what keeps it clear of the progress cards on a narrow
+   window. Deliberately NO overflow: hidden — it would clip both the drain's
+   tail inside the cap radius and the focus ring on the Undo button. */
+.overlay-receipt {
+  position: relative;
+  width: max-content;
+  max-width: min(var(--notice-max-w), calc(100% - var(--space-6)));
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  /* 6px block padding: the carried off-grid value the grid pill documents, and
+     independently `.overlay-swipe-hint`'s own padding on this surface. */
+  padding: 6px var(--space-4);
+  border-radius: var(--radius-pill);
+  background: rgba(var(--v-theme-dark-surface), 0.9);
+  /* 0.2, not the grid pill's 0.14: `.overlay-nav` already solves this exact
+     problem (a bordered floating control over an arbitrary photo) at 0.2, and
+     a 0.14 hairline over a bright photo is not an edge. */
+  border: 1px solid rgba(var(--v-theme-on-dark-surface), 0.2);
+  /* -4, not the grid pill's -3. §7 assigns -4 to lightbox chrome, and the grid
+     pill takes -3 precisely because -4 was reserved for here. */
+  box-shadow: var(--elevation-4);
+  backdrop-filter: blur(12px);
+  pointer-events: auto;
+}
+
+.r-ico {
+  color: rgb(var(--v-theme-on-dark-surface));
+  flex-shrink: 0;
+}
+
+.r-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.r-text {
+  font-size: var(--text-base);
+  line-height: var(--leading-snug);
+  color: rgb(var(--v-theme-on-dark-surface));
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* How wide the step was. Secondary weight, at the same treatment as the limit
+   note, because it qualifies the sentence above rather than competing with it. */
+.r-scope {
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+  color: rgba(var(--v-theme-on-dark-surface), 0.6);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.r-more {
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--v-theme-on-dark-surface), 0.7);
+  flex-shrink: 0;
+}
+
+.r-limit {
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-dark-surface), 0.6);
+  padding-inline: var(--space-3);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.r-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+  padding: var(--space-2) var(--space-3);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: rgb(var(--v-theme-on-dark-surface));
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+/* `--hover-wash` is `rgba(accent, 0.14)` in BOTH themes, so it composites to a
+   visible warm lift on this dark fill without a variant. */
+.r-btn:hover:not([aria-disabled="true"]) {
+  background: var(--hover-wash);
+}
+.r-btn:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+/* `aria-disabled`, never the attribute: disabling a control the keyboard is on
+   moves focus to <body>, and this button flips to Redo when the trip lands. */
+.r-btn[aria-disabled="true"] {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.kbdhint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+/* The global App.css `kbd` rule with `on-background` swapped for
+   `on-dark-surface`. The global rule is right in geometry and wrong in colour
+   here: light-theme `on-background` is near-black, i.e. a dark fill and a dark
+   border on a dark pill. */
+.overlay-receipt kbd {
+  display: inline-block;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-2xs);
+  font-family: var(--font-mono);
+  background: rgba(var(--v-theme-on-dark-surface), 0.08);
+  border: 1px solid rgba(var(--v-theme-on-dark-surface), 0.2);
+  border-radius: var(--radius-sm);
+  line-height: 1.5;
+}
+
+/* ── Countdown drain ──────────────────────────────────────────────────────── */
+.r-progress {
+  position: absolute;
+  inset-inline: var(--space-7);
+  bottom: var(--space-1);
+  height: var(--countdown-h);
+  border-radius: var(--radius-pill);
+  background: rgba(var(--v-theme-on-dark-surface), 0.12);
+  overflow: hidden;
+  pointer-events: none;
+}
+
+/* scaleX, never an animated `width`: width relayouts the pill every frame. */
+.r-progress::after {
+  content: "";
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: rgba(var(--v-theme-on-dark-surface), 0.45);
+  transform: scaleX(1);
+  transform-origin: left center;
+  will-change: transform;
+}
+
+.r-progress.run::after {
+  animation: r-drain var(--r-drain-dur, 5000ms) linear forwards;
+}
+
+@keyframes r-drain {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+/* WCAG 2.2.1. The store's dismissal timer pauses on the same two conditions. */
+.overlay-receipt:hover .r-progress.run::after,
+.overlay-receipt:focus-within .r-progress.run::after {
+  animation-play-state: paused;
+}
+
+/* The grid pill's timing, deliberately identical: the receipt's arrival should
+   read the same on both surfaces. The 120% rise starts inside the canvas and
+   nothing clips it, which is one reason this mounts outside `.overlay-canvas`
+   and its `overflow: hidden`. */
+.receipt-enter-active {
+  transition:
+    transform var(--dur-3) var(--ease-decelerate),
+    opacity var(--dur-3) var(--ease-decelerate);
+}
+.receipt-leave-active {
+  transition:
+    transform var(--dur-2) var(--ease-accelerate),
+    opacity var(--dur-2) var(--ease-accelerate);
+}
+.receipt-enter-from,
+.receipt-leave-to {
+  transform: translateY(120%);
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* The travel goes; a zero-duration transition still snaps a translate into
+     place, so it has to be removed rather than shortened. */
+  .receipt-enter-from,
+  .receipt-leave-to {
+    transform: none;
+  }
+  /* The drain STAYS. It is essential animation (WCAG 2.3.3): the hairline is
+     the time-remaining readout, and the global reduced-motion collapse would
+     run it to completion in 0.001ms and leave it frozen at scaleX(0),
+     asserting "expired" about a live receipt.
+
+     The grid pill justifies this by pointing at the toolbar control surviving
+     the receipt. That fallback is FALSE here — `UndoControl` is occluded by the
+     lightbox. What survives instead is the Ctrl+Z binding this overlay's own
+     key handler keeps live, plus the hover/focus pause. Same conclusion, and a
+     2px linear hairline is at the bottom of the vestibular-risk scale, but the
+     reasoning had to be re-made rather than copied. */
+  .r-progress.run::after {
+    animation-duration: var(--r-drain-dur, 5000ms) !important;
+  }
+}
+</style>

--- a/frontend/src/composables/useActionReceipt.js
+++ b/frontend/src/composables/useActionReceipt.js
@@ -1,0 +1,207 @@
+// useActionReceipt.js — the receipt contract, once, for every surface that
+// narrates it.
+//
+// The store (`useOperationStore`) holds at most ONE live receipt and owns its
+// dwell timer. What a receipt *reads as* — which glyph, which sentence, which
+// verb on the button, which keycaps, how long the hairline drains, when the
+// countdown freezes — is the same on every surface that shows it. Only the
+// chrome differs: the grid gets a light pill in the selection bar's slot
+// (`ActionReceipt.vue`), the lightbox gets a dark HUD in its own vocabulary
+// (`OverlayActionReceipt.vue`).
+//
+// So the contract lives here and the components are left with markup and
+// styles. That is also what keeps the two honest: a change to the wording, the
+// pause rule or the announcement cannot land on one surface and miss the other.
+//
+// The one thing that is NOT shared is the live region. Exactly one region may
+// announce the receipt app-wide, or a screen reader hears every action twice
+// (the grid stays mounted underneath the lightbox). Pass `announce: false` on
+// the secondary surface; the primary one keeps speaking.
+
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+} from "vue";
+
+import { useOperationStore } from "../stores/useOperationStore";
+import {
+  isApplePlatform,
+  redoKeyHint,
+  undoKeyHint,
+} from "../utils/shortcutHints";
+
+/** Settling window before the live region speaks, so a burst reads once. */
+export const ANNOUNCE_THROTTLE_MS = 350;
+
+/**
+ * Everything a receipt surface needs except its markup.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.announce=true] - own the single app-wide live
+ *   region. Only one surface may; a second one double-speaks.
+ * @returns {Object} the receipt view model plus its lifecycle handlers.
+ */
+export function useActionReceipt({ announce = true } = {}) {
+  const store = useOperationStore();
+
+  const receipt = computed(() => store.receipt);
+  const undone = computed(() => receipt.value?.mode === "undone");
+  const blocked = computed(() => receipt.value?.mode === "blocked");
+
+  /** The glyph: the action's own icon, or the undo/limit glyph once it flips. */
+  const glyph = computed(() => {
+    if (!receipt.value) return "";
+    if (undone.value) return "mdi-undo-variant";
+    if (blocked.value) return "mdi-information-outline";
+    return receipt.value.icon;
+  });
+
+  const actionLabel = computed(() => (undone.value ? "Redo" : "Undo"));
+  const actionGlyph = computed(() =>
+    undone.value ? "mdi-redo-variant" : "mdi-undo-variant",
+  );
+  const keyHint = computed(() =>
+    undone.value ? redoKeyHint() : undoKeyHint(),
+  );
+
+  /**
+   * The sentence. A multi-step undo says how far it went instead of naming only
+   * the oldest step it reverted, which would understate what just happened.
+   */
+  const text = computed(() => {
+    const entry = receipt.value;
+    if (!entry) return "";
+    if (undone.value && entry.steps > 1) {
+      return `Undone ${entry.steps} steps: ${entry.summary}`;
+    }
+    if (undone.value) return `Undone: ${entry.summary}`;
+    return entry.summary;
+  });
+
+  /** The standard attribute for "this control has a keyboard shortcut". */
+  const actionKeyShortcut = computed(() =>
+    undone.value
+      ? isApplePlatform()
+        ? "Shift+Meta+Z"
+        : "Control+Y"
+      : isApplePlatform()
+        ? "Meta+Z"
+        : "Control+Z",
+  );
+
+  // The drain's duration is a dismissal timeout, not a motion token: the motion
+  // scale tops out at 420ms. It is handed to CSS as a custom property so the
+  // hairline and the store's timer always describe the same window.
+  const drainStyle = computed(() => ({
+    "--r-drain-dur": `${receipt.value?.durationMs ?? 0}ms`,
+  }));
+
+  // Keyed on the store's raise counter so a receipt REPLACED in place still
+  // remounts and the drain restarts from full.
+  const pillKey = computed(() => receipt.value?.key ?? 0);
+
+  // WCAG 2.2.1 — the countdown freezes on hover and on focus-within, and each
+  // surface's CSS pauses its hairline on the same two conditions so the two
+  // never disagree.
+  function pause() {
+    store.pauseReceipt();
+  }
+  function resume() {
+    store.resumeReceipt();
+  }
+
+  // …and while the tab is hidden, or a receipt raised just before a tab switch
+  // expires unread. Mirrors NoticeHost's handling of the same hazard.
+  function onVisibilityChange() {
+    if (typeof document === "undefined") return;
+    if (document.hidden) store.pauseReceipt();
+    else store.resumeReceipt();
+  }
+
+  // What the persistent region says. Throttled so a burst announces the outcome
+  // once, rather than reading every intermediate step aloud.
+  const announcement = ref("");
+  let announceTimer = null;
+
+  if (announce) {
+    watch(text, (value) => {
+      if (announceTimer != null) clearTimeout(announceTimer);
+      if (!value) {
+        announcement.value = "";
+        return;
+      }
+      announceTimer = setTimeout(() => {
+        announceTimer = null;
+        announcement.value = value;
+      }, ANNOUNCE_THROTTLE_MS);
+    });
+  }
+
+  onMounted(() => {
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibilityChange);
+    }
+  });
+
+  onBeforeUnmount(() => {
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    }
+    if (announceTimer != null) clearTimeout(announceTimer);
+  });
+
+  // A receipt raised while the tab is hidden starts with a running countdown
+  // (the store arms it unconditionally). Re-apply the hidden-tab pause so it
+  // does not expire unseen — the same hazard `onVisibilityChange` covers for a
+  // receipt that was already up.
+  watch(pillKey, () => {
+    if (typeof document !== "undefined" && document.hidden) {
+      store.pauseReceipt();
+    }
+  });
+
+  /**
+   * Take the action and keep the keyboard where it was.
+   *
+   * The surface's button is REPLACED (a new node, keyed on the store's raise
+   * counter) when undo flips it to "Undone … Redo". Without this, a user who
+   * reached Undo with the keyboard has focus dropped to `<body>` and has to tab
+   * from the top of the document to reach the Redo the flip just produced —
+   * WCAG 2.4.3.
+   *
+   * @param {Event} event - the click, so the caller need not track focus.
+   * @param {Function} refocus - called after the flip to restore the keyboard.
+   * @returns {Promise<void>}
+   */
+  async function takeAction(event, refocus) {
+    if (store.busy) return;
+    const hadFocus = event?.currentTarget === document.activeElement;
+    await (undone.value ? store.redo() : store.undo());
+    if (!hadFocus) return;
+    await nextTick();
+    refocus?.();
+  }
+
+  return {
+    store,
+    receipt,
+    undone,
+    blocked,
+    glyph,
+    actionLabel,
+    actionGlyph,
+    keyHint,
+    text,
+    actionKeyShortcut,
+    drainStyle,
+    pillKey,
+    announcement,
+    pause,
+    resume,
+    takeAction,
+  };
+}


### PR DESCRIPTION
Implements the owner's two rulings on top of #632 (stacked).

**Lightbox:** new `OverlayActionReceipt` fitted to the overlay's own chrome — its own 64px transient-status lane centered on the visible image, inset for filmstrip/sidebar, elevation-4 per the lightbox rung, all four receipt states plus a lightbox-only scope clause ("Across 2,700 pictures, not just this one") so a vault-wide undo is never mistaken for a single-image action. Ctrl+Z/Ctrl+Y active in the lightbox, including with chrome hidden. Shared contract extracted to a `useActionReceipt` composable so the two surfaces can't drift; the grid pill hides (not unmounts — it carries the app's one live region) while the overlay is open.

Root-cause note: the old suppression premise was wrong — `isModalOverlayOpen()` never matched the lightbox; `ImageOverlay`'s own `stopImmediatePropagation` was eating the chord. Fixed at the source, stale comment corrected, and the regression test dispatches on `window` against the real component to prove it.

**Review sessions:** Ctrl+Z now means "undo my last decision here" — one `handleUndoRequest` shared by `U` and Ctrl+Z, working even when the queue ran dry, with honest copy for empty-stack/redo/locked outcomes and a platform-aware cheat-sheet row. The unified-stack path (review decisions riding the op-log) was investigated and rejected on correctness: the op-log's tag facet captures only 1 of the 4 things a review decision writes, so Ctrl+Z would restore a partial inverse; the full merge needs three new capture facets + an authz-asymmetry decision, recorded as a follow-up in `frontend_architecture.md`.

1027 frontend tests (+40 new), lint + build clean. No Python touched.

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U