### PR TITLE
Record migration 0087 in the migration table

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -963,7 +963,9 @@ Selected milestones:
 
 | 0086 | Append-only `operation` table — the operation log / undo-redo substrate (§21), carrying `batch_id` from day one |
 
-Current head: `0086_add_operation_log`.
+| 0087 | `characterprojectmember` / `picturesetprojectmember` join tables — many-to-many characters and picture sets across projects (#125). Additive: the scalar `project_id` FKs stay and stay populated as the primary project, and the migration backfills one join row per existing assignment |
+
+Current head: `0087_add_entity_project_membership`.
 
 ---
 


### PR DESCRIPTION
The v1.9 merge train renumbered `0086_add_entity_project_membership` to `0087` (it collided with the operation log's 0086). The migration table in `docs/backend_architecture.md` §12 never gained a row for it and still named 0086 as the current head.

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U