### PR TITLE
Dedup → Stacks backend: tiered detection, verdicts, queue APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,9 @@ jobs:
           tests/test_comfyui_workflow_extraction.py
           tests/test_dedup_sweep_api.py
           tests/test_dedup_sweep_service.py
+          tests/test_dedup_tier_service.py
+          tests/test_dedup_tiers_api.py
+          tests/test_dedup_verdict_service.py
           tests/test_detections_scope.py
           tests/test_facial_features_worker.py
           tests/test_find_orphaned_files.py

--- a/design/1.9-dedup/CONTRACT.md
+++ b/design/1.9-dedup/CONTRACT.md
@@ -26,9 +26,11 @@ with a one-time notice pointing at the new sidebar entry.
 ## Design-over-shipped-backend deltas (backend adapts)
 
 1. **Cover selection formula** replaces the shipped planner's keeper order
-   (score → smart score → recency): `pixels×4 + tags×3 + userScore×2 + RAW
-   bonus`, ties break to **oldest capture time**. Always a visible
-   preselection the user can override (1–9); never silent.
+   (score → smart score → recency): `megapixels×4 + tags×3 + userScore×2 +
+   RAW bonus`, ties break to **oldest capture time**. Always a visible
+   preselection the user can override (1–9); never silent. (The pixel term is
+   **megapixels**, not raw pixel count: at raw counts it would dwarf every
+   other term and the formula would be "biggest file wins" with decoration.)
 2. **Policy model** replaces `SweepPolicy`'s auto/review split semantics with
    tier gating: Tier 1 exact is always included and cannot be switched off;
    each looser tier is a separate opt-in with its own live count and enabling
@@ -49,6 +51,14 @@ with a one-time notice pointing at the new sidebar entry.
    membership onto the stack and takes the highest score. Nothing is
    overwritten or lost. (Reconcile with existing stack semantics; if current
    "Stack groups" behaviour differs, the design's union wins.)
+   **Characters carry one carve-out.** A face carries a bbox and an embedding
+   that belong to one specific picture, so a true face-to-character union
+   would mean fabricating `Face` rows. When the group's members between them
+   reference exactly **one** character, members that lack it get
+   `pending_character_id` (the shipped deferred-assignment path). A group
+   spanning **several** characters is left alone and logged — inventing
+   detection data is worse than not unioning. Tags, sets, projects and score
+   union unconditionally.
 
 ## Performance rules (design §1, binding)
 
@@ -56,7 +66,11 @@ with a one-time notice pointing at the new sidebar entry.
   with a "scanned N% of M" banner streaming.
 - Queue is virtual: one group in the DOM, prefetch next group's thumbnails
   only; group list paged from the DB by confidence descending, never loaded
-  whole. 10 groups and 10,000 must perform identically.
+  whole. 10 groups and 10,000 must perform identically. Paging is by
+  **keyset cursor**, not offset: the queue is a live list (a verdict removes
+  the row the user just decided, a tier-2 scan commits new groups after every
+  bucket), and an offset re-read skips exactly as many groups as changed
+  underneath it.
 - Scoped scans (project/set/character/folder context menu "Find duplicates
   in…" with live count) reuse cached hashes and return instantly; queue opens
   with a dismissible scope pill.

--- a/design/1.9-dedup/CONTRACT.md
+++ b/design/1.9-dedup/CONTRACT.md
@@ -1,0 +1,93 @@
+# Dedup → Stacks — implementation contract (v1.9, routed 2026-07-29)
+
+Authority: the owner's "Deduplication → Stacks" card in the PixlStash Design
+System (`ui_kits/app/dedup-stacks.html` + `dedup-stacks.babel.js`; exact copies
+sit next to this file). This lifts the master plan's Loop 1 design gate. Where
+the design and previously shipped backend disagree, **the design wins**; the
+deltas are listed explicitly below. The design's own §7 "Rules" block is the
+handoff checklist — implement it verbatim unless a line below overrides it.
+
+## The feature in one paragraph
+
+Duplicate detection becomes a sidebar **Duplicates** destination with a live
+to-do count. Detection is tiered: exact matches from an indexed hash query
+(~ms, always on), near-dupes from perceptual hashes compared **only within
+candidate buckets** (same dimensions / capture minute / import batch / folder,
+streamed as buckets finish), and embedding similarity as an opt-in background
+tier reusing the existing likeness data. The queue shows group rows (one
+focused, keyboard-driven: Enter stack · S keep separate · C compare · 1–9 set
+cover · X exclude candidate · Ctrl+Z undo, auto-advance). The only verdicts
+are **stack** or **keep separate** — no deletion anywhere in 1.9. Exact
+matches go through a bulk auto-stack dialog (one batch op, one Ctrl+Z).
+Verdicts persist keyed on group signature so rescans never re-ask. The
+"Similarity to …" / Likeness-Groups sort order is removed from the sort menu,
+with a one-time notice pointing at the new sidebar entry.
+
+## Design-over-shipped-backend deltas (backend adapts)
+
+1. **Cover selection formula** replaces the shipped planner's keeper order
+   (score → smart score → recency): `pixels×4 + tags×3 + userScore×2 + RAW
+   bonus`, ties break to **oldest capture time**. Always a visible
+   preselection the user can override (1–9); never silent.
+2. **Policy model** replaces `SweepPolicy`'s auto/review split semantics with
+   tier gating: Tier 1 exact is always included and cannot be switched off;
+   each looser tier is a separate opt-in with its own live count and enabling
+   one requires the tier above it; near-dupe threshold default **0.90**;
+   below **0.65 nothing is suggested at all** (hard floor). The shipped
+   dry-run/report API and non-destructive planner remain the foundation —
+   rework, don't discard.
+3. **Tier 1 (exact hash) and Tier 2 (bucketed perceptual hash) are new.**
+   The shipped planner covers only the embedding tier. Investigate what hash
+   columns exist (e.g. metadata/content hashes) and document which one Tier 1
+   uses; if a new column is needed it follows the conditional-migration rules
+   and backfills via the finder/task system, incrementally on import.
+4. **Verdict memory is a new table**: verdict keyed on a group signature
+   (sorted member content hashes). "Keep separate" is permanent until the
+   user reopens it from the Stacks view. Re-imports and rescans never re-ask.
+   This is what makes the sidebar count trustworthy.
+5. **Metadata union on stacking**: stacking unions tags, characters and set
+   membership onto the stack and takes the highest score. Nothing is
+   overwritten or lost. (Reconcile with existing stack semantics; if current
+   "Stack groups" behaviour differs, the design's union wins.)
+
+## Performance rules (design §1, binding)
+
+- Never block on a full pass: the queue opens with whatever has been found,
+  with a "scanned N% of M" banner streaming.
+- Queue is virtual: one group in the DOM, prefetch next group's thumbnails
+  only; group list paged from the DB by confidence descending, never loaded
+  whole. 10 groups and 10,000 must perform identically.
+- Scoped scans (project/set/character/folder context menu "Find duplicates
+  in…" with live count) reuse cached hashes and return instantly; queue opens
+  with a dismissible scope pill.
+
+## Undo integration (binding)
+
+Every verdict raises the standard action receipt and lands in the operation
+log (stacking is already a recorded facet). Bulk auto-stack coalesces into a
+single batch id, so N stacks reverse with one Ctrl+Z. The frontend consumes
+the shipped `useOperationStore` / `ActionReceipt` from the undo lane.
+
+## UI inventory (frontend lane)
+
+Sidebar Duplicates row (live count badge, spinner while scanning); scan
+banner; queue rows (focused row = accent bar + caret + tinted bg + filled
+Stack button + "keyboard acts here" label; thumbnails at grid scale carrying
+NO metadata; why-pills: olive check = matching evidence, red × = evidence
+against, e.g. "different resolution", "subject moved"); Compare view (= issue
+#156: every candidate field-by-field, best value highlighted per column, full
+paths, Stack / Keep separate in its footer); auto-stack dialog (dry-run counts,
+the single consent); stacks in the grid (count badge, edge ticks, expansion
+strip with cover marker, grid-view expand-stacks toggle); Filters popover
+gains a Stacks segment row (Any / Stacked / Unstacked / Unresolved
+duplicates) with the choice spelled out and live match count; context-menu
+scoped entry + scope pill; done-state; one-time sort-menu migration notice.
+File paths shown ONLY for reference-folder pictures. Confidence pill per
+group (`exact` styled distinctly). No em-dashes in shipped copy; design
+tokens only; the design's mock CSS maps onto repo tokens.
+
+## Explicitly out of scope for 1.9
+
+Deletion / dehydration (v1.11), auto-at-import policy setting (plan item 6 —
+only if trivially cheap once the finder exists), Immich-style per-group
+mandatory adjudication of exact matches.

--- a/design/1.9-dedup/README.md
+++ b/design/1.9-dedup/README.md
@@ -1,0 +1,11 @@
+Handoff bundle for the v1.9 Dedup → Stacks feature (master plan Loop 1 exit).
+Source of truth: the "Deduplication → Stacks" card in the claude.ai Design
+System project "PixlStash Design System" (ui_kits/app/dedup-stacks.html +
+dedup-stacks.babel.js), fetched 2026-07-29.
+
+- CONTRACT.md — distilled spec + the reconciliation deltas vs the shipped
+  sweep planner (read FIRST; it is the implementation authority ordering).
+- dedup-stacks.babel.js — the exact interaction/visual reference: group data
+  shapes, queue states, keyboard model, dialog, grid-stack treatments, §7
+  rules list. The card's HTML shell only carries mock CSS; the repo's design
+  tokens are the styling authority.

--- a/design/1.9-dedup/dedup-stacks.babel.js
+++ b/design/1.9-dedup/dedup-stacks.babel.js
@@ -1,0 +1,835 @@
+const DS = window.PixlStashDesignSystem_ac544c || {};
+const { Button, Kbd, SectionLabel, Badge, Tag, ScoreStars } = DS;
+const { useState, useEffect, useCallback, useMemo } = React;
+
+const KH = ({ keys }) => <span className="kbdhint">{keys.map((k, i) => <Kbd key={i}>{k}</Kbd>)}</span>;
+
+const GROUPS = [
+  { id:'g1', kind:'exact', conf:1, why:[['Identical file hash'],['Same dimensions'],['Imported 4 min apart']],
+    cands:[
+      { src:'scene-01', res:'6016×4016', px:24.2, size:14.8, date:'12 May 14:22', score:4, tags:2, fmt:'JPEG', path:'/shoots/may/DSC_4417.jpg' },
+      { src:'scene-01', res:'6016×4016', px:24.2, size:14.8, date:'12 May 14:22', score:0, tags:0, fmt:'JPEG', path:'/backup/2024/DSC_4417 (1).jpg', ref:true },
+    ] },
+  { id:'g2', kind:'near', conf:0.96, why:[['96% visual match'],['Same capture second'],['Different resolution', true],['One is a re-export', true]],
+    cands:[
+      { src:'tile-03', res:'4032×3024', px:12.2, size:8.4, date:'03 Jun 09:11', score:3, tags:4, fmt:'JPEG', path:'/shoots/jun/IMG_2201.jpg' },
+      { src:'tile-03', res:'1920×1440', px:2.8, size:1.1, date:'03 Jun 09:11', score:0, tags:0, fmt:'WEBP', path:'/export/web/IMG_2201.webp', ref:true },
+      { src:'tile-03', res:'2048×1536', px:3.1, size:1.6, date:'11 Jun 18:40', score:0, tags:1, fmt:'JPEG', path:'/tmp/upscale/IMG_2201_x2.jpg', ref:true },
+    ] },
+  { id:'g3', kind:'near', conf:0.81, why:[['81% visual match'],['Burst — 0.6s apart'],['Same folder'],['Subject moved between frames', true]],
+    cands:[
+      { src:'tile-08', res:'4032×3024', px:12.2, size:7.9, date:'21 Jun 16:04', score:5, tags:3, fmt:'JPEG', path:'/shoots/jun/burst_0071.jpg' },
+      { src:'tile-08', res:'4032×3024', px:12.2, size:8.1, date:'21 Jun 16:04', score:2, tags:0, fmt:'JPEG', path:'/shoots/jun/burst_0072.jpg' },
+      { src:'tile-08', res:'4032×3024', px:12.2, size:7.6, date:'21 Jun 16:04', score:0, tags:0, fmt:'JPEG', path:'/shoots/jun/burst_0073.jpg' },
+      { src:'tile-08', res:'4032×3024', px:12.2, size:8.3, date:'21 Jun 16:04', score:0, tags:0, fmt:'JPEG', path:'/shoots/jun/burst_0074.jpg' },
+    ] },
+  { id:'g4', kind:'near', conf:0.68, why:[['68% visual match'],['Same scene, different framing', true],['Different subject position', true]],
+    cands:[
+      { src:'scene-03', res:'5472×3648', px:20.0, size:11.2, date:'02 Jul 11:58', score:4, tags:5, fmt:'RAW', path:'/shoots/jul/A7R0912.arw' },
+      { src:'scene-04', res:'5472×3648', px:20.0, size:10.7, date:'02 Jul 11:59', score:3, tags:2, fmt:'RAW', path:'/shoots/jul/A7R0913.arw' },
+    ] },
+  { id:'g5', kind:'exact', conf:1, why:[['Identical file hash'],['Same folder twice']],
+    cands:[
+      { src:'tile-11', res:'3000×2000', px:6.0, size:4.2, date:'18 Apr 08:30', score:3, tags:2, fmt:'JPEG', path:'/shoots/apr/set_a/0031.jpg' },
+      { src:'tile-11', res:'3000×2000', px:6.0, size:4.2, date:'18 Apr 08:30', score:0, tags:0, fmt:'JPEG', path:'/shoots/apr/set_a copy/0031.jpg', ref:true },
+    ] },
+  { id:'g6', kind:'near', conf:0.93, why:[['93% visual match'],['Crop of the same frame'],['Different aspect ratio', true],['Different resolution', true]],
+    cands:[
+      { src:'tile-14', res:'6000×4000', px:24.0, size:13.4, date:'27 Apr 19:02', score:5, tags:6, fmt:'JPEG', path:'/shoots/apr/hero_full.jpg' },
+      { src:'tile-14', res:'2400×2400', px:5.8, size:3.1, date:'27 Apr 19:44', score:2, tags:1, fmt:'JPEG', path:'/shoots/apr/hero_square.jpg' },
+      { src:'tile-14', res:'1080×1080', px:1.2, size:0.6, date:'27 Apr 19:45', score:0, tags:0, fmt:'JPEG', path:'/export/social/hero_ig.jpg', ref:true },
+    ] },
+  { id:'g7', kind:'near', conf:0.87, why:[['87% visual match'],['Burst — 1.1s apart'],['Same folder'],['Eyes closed in one', true]],
+    cands:[
+      { src:'scene-05', res:'4032×3024', px:12.2, size:8.8, date:'09 Jul 07:15', score:4, tags:2, fmt:'JPEG', path:'/shoots/jul/dawn_014.jpg' },
+      { src:'scene-05', res:'4032×3024', px:12.2, size:8.6, date:'09 Jul 07:15', score:0, tags:0, fmt:'JPEG', path:'/shoots/jul/dawn_015.jpg' },
+      { src:'scene-05', res:'4032×3024', px:12.2, size:9.0, date:'09 Jul 07:15', score:0, tags:0, fmt:'JPEG', path:'/shoots/jul/dawn_016.jpg' },
+    ] },
+];
+
+// keeper score — largest pixel count, then metadata richness, then user score
+function pickCover(cands) {
+  let best = 0;
+  cands.forEach((c, i) => {
+    const s = c.px * 4 + c.tags * 3 + c.score * 2 + (c.fmt === 'RAW' ? 8 : 0);
+    const bs = cands[best].px * 4 + cands[best].tags * 3 + cands[best].score * 2 + (cands[best].fmt === 'RAW' ? 8 : 0);
+    if (s > bs) best = i;
+  });
+  return best;
+}
+const bestOf = (cands, key) => Math.max(...cands.map(c => c[key]));
+// keep the filename visible without bidi reordering — truncate the head in JS, not with direction:rtl
+const shortPath = (p) => { const s = p.split('/').filter(Boolean); return s.length > 2 ? '…/' + s.slice(-2).join('/') : p; };
+
+function Shell({ children, active, crumb }) {
+  return (
+    <React.Fragment>
+      <div className="titlebar">
+        <div className="tb-brand"><img src="../../assets/Logo.png" alt="" /><span className="wordmark">Pixl<span className="s">Stash</span></span></div>
+        <nav className="breadcrumb"><span className="sep">›</span><span className="crumb link">Global</span><span className="sep">›</span><span className="crumb">{crumb}</span></nav>
+        <span className="tb-spacer"></span><span className="tb-version">v1.9.0-dev.3</span>
+        <div className="tb-win">
+          <button><span className="mdi mdi-window-minimize"></span></button>
+          <button><span className="mdi mdi-window-maximize"></span></button>
+          <button className="close"><span className="mdi mdi-window-close"></span></button>
+        </div>
+      </div>
+      <div className="fm">
+        <aside className="sidebar">
+          <div className="side-tabs">
+            <button className="side-tab active"><span className="mdi mdi-web"></span> Global</button>
+            <button className="side-tab"><span className="mdi mdi-folder-outline"></span> Projects</button>
+            <button className="side-tab"><span className="mdi mdi-monitor"></span> Folders</button>
+          </div>
+          <div className="side-scroll">
+            <div className={`row ${active === 'all' ? 'active' : ''}`}><span className="lead mdi mdi-image-multiple"></span><span className="label">All Pictures</span><span className="count">128,412</span></div>
+            <div className={`row ${active === 'dupes' ? 'active' : ''}`}><span className="lead mdi mdi-content-duplicate"></span><span className="label">Duplicates</span>{active === 'dupes' ? children.badge : <span className="count">4</span>}</div>
+            <div className="row"><span className="lead mdi mdi-trash-can-outline"></span><span className="label">Scrapheap</span><span className="count">2</span></div>
+            <div className="sec">People<span className="sp"></span><span className="mdi mdi-plus"></span></div>
+            <div className="row"><img className="avatar" src="../../assets/samples/tile-01.webp" alt="" /><span className="label">Angela Merkel</span><span className="count">8</span></div>
+            <div className="row"><img className="avatar" src="../../assets/samples/tile-05.webp" alt="" /><span className="label">Walter</span><span className="count">4</span></div>
+            <div className="sec">Sets<span className="sp"></span><span className="mdi mdi-plus"></span></div>
+            <div className="row"><span className="set-ico mdi mdi-crown" style={{ color:'#00acc1' }}></span><span className="label">Celebrities</span><span className="count">20</span></div>
+          </div>
+        </aside>
+        <main className="main">{children.main}</main>
+      </div>
+    </React.Fragment>
+  );
+}
+
+function Cand({ c, i, cands, isCover, isOut, onCover, onToggle }) {
+  return (
+    <div className={`cand ${isCover ? 'cover' : ''} ${isOut ? 'out' : ''}`}
+      onClick={() => onCover(i)}
+      onContextMenu={(e) => { e.preventDefault(); onToggle(i); }}
+      title={isOut ? 'Right-click to include in the stack' : 'Click to make cover · right-click to leave out of the stack'}>
+      <div className="cthumb">
+        <img src={`../../assets/samples/${c.src}.webp`} alt="" />
+        {isCover && !isOut && <span className="cflag"><span className="mdi mdi-star" style={{ fontSize:12 }}></span>Cover</span>}
+        {isOut && <span className="cflag outf">Not in stack</span>}
+        <span className="cnum">{i + 1}</span>
+      </div>
+      <div className="cmeta">
+        <div className="mline"><span className="mk">Resolution</span><span className={`mv ${c.px === bestOf(cands,'px') ? 'best' : 'dim'}`}>{c.res}</span></div>
+        <div className="mline"><span className="mk">File</span><span className={`mv ${c.size === bestOf(cands,'size') ? 'best' : 'dim'}`}>{c.size} MB · {c.fmt}</span></div>
+        <div className="mline"><span className="mk">Captured</span><span className="mv dim">{c.date}</span></div>
+        <div className="mline"><span className="mk">Score</span><span className={`mv ${c.score && c.score === bestOf(cands,'score') ? 'best' : 'dim'}`}>{c.score ? '★'.repeat(c.score) : '—'}</span></div>
+        <div className="mline"><span className="mk">Metadata</span><span className={`mv ${c.tags && c.tags === bestOf(cands,'tags') ? 'best' : 'dim'}`}>{c.tags ? `${c.tags} tags` : 'none'}</span></div>
+        <div className="mline"><span className="mk">In stack</span>
+          <span className="mv" style={{ display:'flex', alignItems:'center', gap:4 }}>
+            <button className="bbtn bbtn--icon" style={{ height:18, width:18 }} title={isOut ? 'Include in stack' : 'Leave out of stack'}
+              onClick={(e) => { e.stopPropagation(); onToggle(i); }}>
+              <span className={`mdi mdi-${isOut ? 'plus-circle-outline' : 'minus-circle-outline'}`} style={{ fontSize:15 }}></span>
+            </button>
+            <span style={{ color:'var(--text-muted)' }}>{isOut ? 'No' : 'Yes'}</span>
+          </span>
+        </div>
+      </div>
+      {c.ref && (
+        <div className="cfoot">
+          <span className="mdi mdi-folder-eye-outline" title="Reference folder — not managed by PixlStash"></span>
+          <span style={{ flex:1, minWidth:0, whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis' }} title={c.path}>{shortPath(c.path)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GroupRow({ g, n, focused, cover, out, onFocus, onCover, onToggle, onStack, onSeparate, onCompare }) {
+  const inStack = g.cands.length - out.length;
+  return (
+    <div className={`grow ${focused ? 'focus' : ''}`} onClick={onFocus}>
+      <div className="ginfo">
+        {focused && <span className="gcaret mdi mdi-menu-right"></span>}
+        <div className="gn"><b>Group {n}</b><span>{g.cands.length} pictures</span></div>
+        <span className={`conf ${g.kind === 'exact' ? 'exact' : ''}`} style={{ alignSelf:'flex-start' }}>
+          <span className={`mdi mdi-${g.kind === 'exact' ? 'approximately-equal' : 'blur'}`} style={{ fontSize:14 }}></span>
+          {g.kind === 'exact' ? <b>Exact</b> : <React.Fragment><b>{Math.round(g.conf * 100)}%</b> similar</React.Fragment>}
+        </span>
+        {focused
+          ? <span className="gfocusnote"><span className="mdi mdi-keyboard-outline" style={{ fontSize:13 }}></span>Keyboard acts here</span>
+          : <div className="greasons">{[...g.why.filter(w => w[1]), ...g.why.filter(w => !w[1])].slice(0, 2).map(([w, neg], i) => <i key={i} className={neg ? 'neg' : ''}><span className={`mdi mdi-${neg ? 'close' : 'check'}`}></span>{w}</i>)}</div>}
+      </div>
+      <div className="gstrip">
+        {g.cands.map((c, i) => {
+          const isOut = out.includes(i);
+          return (
+            <div key={i} className={`gthumb ${i === cover ? 'iscover' : ''} ${isOut ? 'out' : ''}`}
+              onClick={(e) => { e.stopPropagation(); onFocus(); onCover(i); }}
+              onContextMenu={(e) => { e.preventDefault(); onFocus(); onToggle(i); }}
+              title={isOut ? 'Right-click to include' : 'Click to make cover · right-click to exclude'}>
+              <div className="gt">
+                <img src={`../../assets/samples/${c.src}.webp`} alt="" />
+                <span className="gnum">{i + 1}</span>
+                {i === cover && !isOut && <span className="gcv">COVER</span>}
+                {isOut && <span className="gx mdi mdi-minus-circle-outline"></span>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="gact">
+        <Button variant={focused ? 'accent' : 'secondary'} size="sm" iconLeft="layers-plus" onClick={(e) => { e.stopPropagation(); onStack(); }}>Stack {inStack}{focused && <span className="kin"><Kbd>Enter</Kbd></span>}</Button>
+        <Button variant="ghost" size="sm" iconLeft="call-split" onClick={(e) => { e.stopPropagation(); onSeparate(); }}>Keep separate{focused && <span className="kin"><Kbd>S</Kbd></span>}</Button>
+        <button className="gcompare" onClick={(e) => { e.stopPropagation(); onFocus(); onCompare(); }}>
+          <span className="mdi mdi-compare-horizontal" style={{ fontSize:15 }}></span>Compare all {g.cands.length}{focused && <Kbd>C</Kbd>}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Queue() {
+  const [focus, setFocus] = useState(0);
+  const [covers, setCovers] = useState(() => GROUPS.map(g => pickCover(g.cands)));
+  const [outs, setOuts] = useState(() => GROUPS.map(() => []));
+  const [resolved, setResolved] = useState([]);
+  const [receipt, setReceipt] = useState(null);
+  const [compare, setCompare] = useState(null);
+  const listRef = React.useRef(null);
+  const [scan, setScan] = useState(62);
+  const [tiersOpen, setTiersOpen] = useState(false);
+  const [tiers, setTiers] = useState({ high:true, medium:true, loose:false });
+  const tierLabel = !tiers.high ? 'Exact only' : tiers.loose ? 'Exact + all near' : tiers.medium ? 'Exact + near ≥75%' : 'Exact + near ≥90%';
+  const inTier = (g) => g.kind === 'exact' || (g.conf >= 0.90 ? tiers.high : g.conf >= 0.75 ? tiers.medium : tiers.loose);
+  const open = GROUPS.map((g, i) => i).filter(i => !resolved.some(r => r.i === i) && inTier(GROUPS[i]));
+  const focusIdx = open.includes(focus) ? focus : (open[0] ?? -1);
+
+  useEffect(() => {
+    const t = setInterval(() => setScan(s => (s >= 100 ? 100 : s + 1)), 900);
+    return () => clearInterval(t);
+  }, []);
+
+  const resolve = useCallback((i, verdict) => {
+    const g = GROUPS[i];
+    if (!g) return;
+    const n = g.cands.length - outs[i].length;
+    setResolved(r => [...r, { i, verdict }]);
+    setReceipt({ verdict, n, at: Date.now() });
+    setFocus(f => {
+      const rest = GROUPS.map((_, j) => j).filter(j => j !== i && !resolved.some(r => r.i === j));
+      return rest.find(j => j > i) ?? rest[rest.length - 1] ?? 0;
+    });
+  }, [outs, resolved]);
+
+  useEffect(() => { if (!receipt) return; const t = setTimeout(() => setReceipt(null), 5000); return () => clearTimeout(t); }, [receipt]);
+
+  const undo = useCallback(() => {
+    setResolved(r => {
+      if (!r.length) return r;
+      setFocus(r[r.length - 1].i);
+      setReceipt(null);
+      return r.slice(0, -1);
+    });
+  }, []);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list || focusIdx < 0) return;
+    const row = list.querySelector('.grow.focus');
+    if (!row) return;
+    const top = row.offsetTop, bottom = top + row.offsetHeight;
+    if (top < list.scrollTop) list.scrollTop = top;
+    else if (bottom > list.scrollTop + list.clientHeight) list.scrollTop = bottom - list.clientHeight;
+  }, [focusIdx, resolved.length]);
+
+  const setCover = (i, v) => setCovers(c => c.map((x, j) => j === i ? v : x));
+  const toggleOut = (i, v) => setOuts(o => o.map((x, j) => j === i ? (x.includes(v) ? x.filter(y => y !== v) : [...x, v]) : x));
+
+  useEffect(() => {
+    const h = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') { e.preventDefault(); undo(); return; }
+      if (e.key === 'Escape' && compare !== null) { setCompare(null); return; }
+      if (e.ctrlKey || e.metaKey || focusIdx < 0) return;
+      const k = e.key.toLowerCase();
+      if (compare !== null) {
+        if (k === 'enter') { e.preventDefault(); resolve(compare, 'stacked'); setCompare(null); }
+        else if (k === 's') { e.preventDefault(); resolve(compare, 'separate'); setCompare(null); }
+        return;
+      }
+      if (k === 'enter') { e.preventDefault(); resolve(focusIdx, 'stacked'); }
+      else if (k === 's') { e.preventDefault(); resolve(focusIdx, 'separate'); }
+      else if (k === 'arrowdown' || k === 'j') { e.preventDefault(); const p = open.indexOf(focusIdx); setFocus(open[Math.min(open.length - 1, p + 1)]); }
+      else if (k === 'arrowup' || k === 'k') { e.preventDefault(); const p = open.indexOf(focusIdx); setFocus(open[Math.max(0, p - 1)]); }
+      else if (k === 'c') { e.preventDefault(); setCompare(focusIdx); }
+      else if (/^[1-9]$/.test(k)) { const n = +k - 1; if (n < GROUPS[focusIdx].cands.length) setCover(focusIdx, n); }
+      else if (k === 'x') { toggleOut(focusIdx, covers[focusIdx]); }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [focusIdx, open, covers, compare, resolve, undo]);
+
+  return (
+    <div className="frame">
+      <div className="app" style={{ height:700 }}>
+        <Shell crumb="Duplicates" active="dupes" children={{
+          badge: <span className="badge">{open.length}</span>,
+          main: <React.Fragment>
+            <div className="toolbar">
+              <div className="tb-left">
+                <div className="split">
+                  <button className="bbtn bbtn--icon"><span className="mdi mdi-sort-ascending"></span></button>
+                  <button className="bbtn"><span className="prefix">Sort:</span><span className="mdi mdi-star"></span><span>Confidence</span><span className="mdi mdi-menu-down chev"></span></button>
+                </div>
+                <button className={`bbtn ${tiersOpen ? 'bbtn--open' : ''}`} onClick={() => setTiersOpen(t => !t)}><span className="mdi mdi-filter-outline"></span><span>{tierLabel}</span><span className="mdi mdi-menu-down chev"></span></button>
+                <button className="bbtn"><span className="prefix">Scope:</span><span>Whole library</span><span className="mdi mdi-menu-down chev"></span></button>
+                <div className="sep"></div>
+                <div className="grp">
+                  <button className="bbtn bbtn--icon" onClick={undo} title="Undo" style={{ opacity: resolved.length ? 1 : .35 }}><span className="mdi mdi-undo-variant"></span></button>
+                  <button className="bbtn bbtn--icon" title="Redo" style={{ opacity:.35 }}><span className="mdi mdi-redo-variant"></span></button>
+                </div>
+              </div>
+              <div className="tb-right">
+                <button className="bbtn bbtn--accent"><span className="mdi mdi-flash-outline"></span>Auto-stack 1,204 exact matches</button>
+                <div className="sep"></div>
+                <button className="bbtn bbtn--icon" title="Duplicate detection settings"><span className="mdi mdi-cog-outline"></span></button>
+              </div>
+            </div>
+            {tiersOpen && (
+              <div className="tbm" style={{ width:340, top:42, left:150 }}>
+                <span className="tbm-caret"></span>
+                <div className="tbm-head"><span className="ic mdi mdi-filter"></span><span className="tbm-title">Include</span><span className="tbm-sp" style={{ flex:1 }}></span>
+                  <span className="tbm-count">{open.length} groups</span></div>
+                <div className="tbm-sec">
+                  <div className="tierrow locked">
+                    <span className="cbox"><span className="mdi mdi-check"></span></span>
+                    <span className="tname">Exact matches <span className="trange">hash</span></span>
+                    <span className="tcount">1,204</span>
+                  </div>
+                  <div className={`tierrow ${tiers.high ? 'on' : ''}`} onClick={() => setTiers(t => ({ ...t, high:!t.high, medium:t.high ? false : t.medium, loose:t.high ? false : t.loose }))}>
+                    <span className="cbox">{tiers.high && <span className="mdi mdi-check"></span>}</span>
+                    <span className="tname">Near-identical <span className="trange">≥90%</span></span>
+                    <span className="tcount">96</span>
+                  </div>
+                  <div className={`tierrow ${tiers.medium ? 'on' : ''}`} style={{ opacity: tiers.high ? 1 : .4, pointerEvents: tiers.high ? 'auto' : 'none' }}
+                    onClick={() => setTiers(t => ({ ...t, medium:!t.medium, loose:t.medium ? false : t.loose }))}>
+                    <span className="cbox">{tiers.medium && <span className="mdi mdi-check"></span>}</span>
+                    <span className="tname">Bursts &amp; re-exports <span className="trange">75–90%</span></span>
+                    <span className="tcount">38</span>
+                  </div>
+                  <div className={`tierrow ${tiers.loose ? 'on' : ''}`} style={{ opacity: tiers.medium ? 1 : .4, pointerEvents: tiers.medium ? 'auto' : 'none' }}
+                    onClick={() => setTiers(t => ({ ...t, loose:!t.loose }))}>
+                    <span className="cbox">{tiers.loose && <span className="mdi mdi-check"></span>}</span>
+                    <span className="tname">Same scene <span className="trange">65–75%</span></span>
+                    <span className="tcount">9</span>
+                  </div>
+                  {tiers.loose && (
+                    <div className="tierwarn"><span className="mdi mdi-alert-outline"></span>
+                      Same-scene groups are often genuinely different pictures. Compare before stacking — these are the ones people get wrong.</div>
+                  )}
+                </div>
+              </div>
+            )}
+            {scan < 100 && (
+              <div className="scanbar">
+                <span className="sb-ico mdi mdi-radar"></span>
+                <span className="sb-txt">Still scanning — <b>{(scan * 1284).toLocaleString()}</b> of <b>128,412</b> pictures compared. Groups appear as they're found.</span>
+                <span className="sb-sub">{scan}% · ~{Math.max(1, Math.round((100 - scan) / 7))} min left</span>
+                <div className="sb-track"><div className="sb-fill" style={{ width:`${scan}%` }}></div></div>
+              </div>
+            )}
+            {focusIdx >= 0 ? (
+              <div className="queue">
+                <div className="qhead">
+                  <span className="qtitle">{open.length} groups to review</span>
+                  <span className="qsub">{resolved.length} done</span>
+                  <span className="sp"></span>
+                  <span className="khint" style={{ color:'var(--text)' }}><KH keys={['↑','↓']} /> choose group</span>
+                  <span className="khint"><KH keys={['Enter']} /> stack it</span>
+                  <span className="khint"><KH keys={['S']} /> keep separate</span>
+                  <span className="khint"><KH keys={['C']} /> compare</span>
+                  <span className="khint"><KH keys={['Ctrl','Z']} /> undo</span>
+                </div>
+                <div className="qlist" ref={listRef}>
+                  {open.map(i => (
+                    <GroupRow key={GROUPS[i].id} g={GROUPS[i]} n={i + 1} focused={i === focusIdx}
+                      cover={covers[i]} out={outs[i]} onFocus={() => setFocus(i)}
+                      onCover={(v) => setCover(i, v)} onToggle={(v) => toggleOut(i, v)}
+                      onStack={() => resolve(i, 'stacked')} onSeparate={() => resolve(i, 'separate')}
+                      onCompare={() => setCompare(i)} />
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="qdone">
+                <span className="mdi mdi-check-circle-outline"></span>
+                <h3>Queue clear</h3>
+                <p>{resolved.filter(r => r.verdict === 'stacked').length} groups stacked, {resolved.filter(r => r.verdict === 'separate').length} kept separate. Scanning continues in the background — new groups will appear here as they're found.</p>
+                <Button variant="secondary" size="sm" iconLeft="undo-variant" onClick={undo}>Undo last</Button>
+              </div>
+            )}
+            {compare !== null && GROUPS[compare] && (
+              <div className="scrim" onClick={() => setCompare(null)}>
+                <div className="dlg" style={{ width:'auto', maxWidth:1180 }} onClick={(e) => e.stopPropagation()}>
+                  <div className="dlg-head"><span className="mdi mdi-compare-horizontal"></span><b>Compare group {compare + 1}</b>
+                    <span style={{ flex:1 }}></span>
+                    <span className={`conf ${GROUPS[compare].kind === 'exact' ? 'exact' : ''}`}>
+                      {GROUPS[compare].kind === 'exact' ? <b>Exact match</b> : <React.Fragment><b>{Math.round(GROUPS[compare].conf * 100)}%</b> similar</React.Fragment>}
+                    </span>
+                  </div>
+                  <div className="dlg-body">
+                    <div className="cands" style={{ padding:0 }}>
+                      {GROUPS[compare].cands.map((c, i) => (
+                        <Cand key={i} c={c} i={i} cands={GROUPS[compare].cands} isCover={i === covers[compare]}
+                          isOut={outs[compare].includes(i)} onCover={(v) => setCover(compare, v)} onToggle={(v) => toggleOut(compare, v)} />
+                      ))}
+                    </div>
+                    <div className="why" style={{ padding:0 }}>
+                      {GROUPS[compare].why.map(([w, neg], i) => (
+                        <span key={i} className={`wtag ${neg ? 'wtag--neg' : ''}`}><span className={`mdi mdi-${neg ? 'close' : 'check'}`}></span>{w}</span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="dlg-foot">
+                    <span className="khint" style={{ marginRight:'auto' }}>Click a picture to make it cover · right-click to leave it out</span>
+                    <Button variant="ghost" size="md" onClick={() => setCompare(null)}>Close<span className="kin"><Kbd>Esc</Kbd></span></Button>
+                    <Button variant="secondary" size="md" iconLeft="call-split" onClick={() => { resolve(compare, 'separate'); setCompare(null); }}>Keep separate<span className="kin"><Kbd>S</Kbd></span></Button>
+                    <Button variant="accent" size="md" iconLeft="layers-plus" onClick={() => { resolve(compare, 'stacked'); setCompare(null); }}>Stack {GROUPS[compare].cands.length - outs[compare].length}<span className="kin"><Kbd>Enter</Kbd></span></Button>
+                  </div>
+                </div>
+              </div>
+            )}
+            {receipt && (
+              <div className="receipt">
+                <span className={`r-ico mdi mdi-${receipt.verdict === 'stacked' ? 'layers-plus' : 'call-split'}`}></span>
+                <span className="r-text">{receipt.verdict === 'stacked'
+                  ? <React.Fragment>Stacked <b>{receipt.n} pictures</b> — cover kept, nothing deleted</React.Fragment>
+                  : <React.Fragment>Kept <b>{receipt.n} pictures</b> separate — won't be suggested again</React.Fragment>}</span>
+                <Button variant="ghost" size="sm" iconLeft="undo-variant" onClick={undo}>Undo<span className="kin"><Kbd>Ctrl</Kbd><Kbd>Z</Kbd></span></Button>
+                <span className="r-progress"></span>
+              </div>
+            )}
+          </React.Fragment>
+        }} />
+      </div>
+    </div>
+  );
+}
+
+const GRID = ['tile-06','tile-04','tile-07','tile-09','tile-10','tile-11','tile-12','tile-13','tile-14','tile-15','tile-16','tile-01'];
+const STACK_AT = 2;
+const STACK_MEMBERS = ['tile-08','tile-08','tile-08','tile-08'];
+
+function GridStacks() {
+  const [expanded, setExpanded] = useState(false);
+  const [menu, setMenu] = useState('filter');
+  const [stackFilter, setStackFilter] = useState('all');
+  return (
+    <div className="frame">
+      <div className="app" style={{ height:660 }}>
+        <Shell crumb="All Pictures" active="all" children={{ main: <React.Fragment>
+          <div className="toolbar">
+            <div className="tb-left">
+              <div className="split">
+                <button className="bbtn bbtn--icon"><span className="mdi mdi-sort-ascending"></span></button>
+                <button className="bbtn"><span className="prefix">Sort:</span><span className="mdi mdi-calendar"></span><span>Date Created</span><span className="mdi mdi-menu-down chev"></span></button>
+              </div>
+              <button className={`bbtn ${menu === 'filter' ? 'bbtn--open' : ''}`} onClick={() => setMenu(m => m === 'filter' ? null : 'filter')}><span className="mdi mdi-filter-outline"></span><span className="mdi mdi-menu-down chev"></span></button>
+              <button className={`bbtn ${menu === 'view' ? 'bbtn--open' : ''}`} onClick={() => setMenu(m => m === 'view' ? null : 'view')} title="Grid view"><span className="mdi mdi-view-grid"></span><span className="mdi mdi-menu-down chev"></span></button>
+              <div className="sep"></div>
+              <button className="bbtn bbtn--icon" title="Search (F)"><span className="mdi mdi-magnify"></span></button>
+              <button className="bbtn bbtn--icon" title="Export current grid to zip"><span className="mdi mdi-tray-arrow-down"></span></button>
+              <button className="bbtn bbtn--icon" title="Import photos"><span className="mdi mdi-cloud-upload-outline"></span></button>
+            </div>
+            <div className="tb-right">
+              <button className="bbtn bbtn--icon" title="Review and fix tags"><span className="mdi mdi-tag-check-outline"></span></button>
+              <button className="bbtn bbtn--icon" title="Settings"><span className="mdi mdi-cog-outline"></span></button>
+              <button className="bbtn bbtn--icon" title="Show/Hide stats sidebar"><span className="mdi mdi-chart-bar"></span></button>
+            </div>
+          </div>
+        <div className="grid-scroll">
+          {menu === 'filter' && (
+            <div className="tbm" style={{ width:376, top:6, left:104 }}>
+              <span className="tbm-caret"></span>
+              <div className="rfhead"><span className="ic mdi mdi-filter"></span><span className="t">Filters</span><span className="sp"></span>
+                <span className="cnt">{stackFilter === 'dupes' ? '9' : stackFilter === 'only' ? '61' : '128'} matches</span>
+                <button className="clear"><span className="mdi mdi-close-circle-outline" style={{ fontSize:16 }}></span> Clear</button></div>
+              <div className="rfsec">
+                <div className="rfcheckrow">
+                  <label className="rfcheck"><span className="box"></span>Shared pictures only</label>
+                  <label className="rfcheck"><span className="box"></span>Unassigned only</label>
+                </div>
+              </div>
+              <div className="rfsec">
+                <div style={{ display:'flex', gap:'var(--space-4)' }}>
+                  <div style={{ flex:1 }}>
+                    <span className="rflabel">Media</span>
+                    <div className="bigseg" style={{ marginTop:'var(--space-2)' }}>
+                      <button className="bigbtn bigbtn--on" title="All media"><span className="mdi mdi-image-multiple-outline"></span></button>
+                      <button className="bigbtn" title="Images"><span className="mdi mdi-image-outline"></span></button>
+                      <button className="bigbtn" title="Video"><span className="mdi mdi-video-outline"></span></button>
+                    </div>
+                  </div>
+                  <div style={{ flex:1, display:'flex', flexDirection:'column', alignItems:'flex-end' }}>
+                    <span className="rflabel">Faces</span>
+                    <div className="bigseg" style={{ marginTop:'var(--space-2)' }}>
+                      <button className="bigbtn bigbtn--on" title="Any"><span className="mdi mdi-infinity"></span></button>
+                      <button className="bigbtn" title="Has face"><span className="mdi mdi-face-recognition"></span></button>
+                      <button className="bigbtn" title="No face"><span className="mdi mdi-account-off-outline"></span></button>
+                    </div>
+                  </div>
+                </div>
+                <div style={{ marginTop:'var(--space-3)' }}>
+                  <span className="rflabel">Stacks</span>
+                  <div className="bigseg" style={{ marginTop:'var(--space-2)', alignSelf:'flex-start', width:'fit-content' }}>
+                    {[['all','Any stack state','infinity'],['only','Stacked only','image-multiple'],['unstacked','Unstacked only','image-outline'],['dupes','Unresolved duplicates','content-duplicate']].map(([v, label, ic]) => (
+                      <button key={v} className={`bigbtn ${stackFilter === v ? 'bigbtn--on' : ''}`} title={label} onClick={() => setStackFilter(v)}>
+                        <span className={`mdi mdi-${ic}`}></span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="rfsec">
+                <div style={{ display:'flex', justifyContent:'space-between' }}><span className="rflabel">Min score</span><span className="rflabel">Max score</span></div>
+                <div style={{ display:'flex', justifyContent:'space-between' }}>
+                  <div className="rfstars">{[0,1,2,3,4].map(i => <span key={i} className="mdi mdi-star-outline"></span>)}</div>
+                  <div className="rfstars">{[0,1,2,3,4].map(i => <span key={i} className="mdi mdi-star-outline"></span>)}</div>
+                </div>
+              </div>
+              <div className="rfsec"><div className="rfcollapse"><span className="rflabel">Impossible tags</span><span className="mdi mdi-chevron-down"></span></div></div>
+              <div className="rfsec">
+                <div className="rfcollapse" style={{ cursor:'default' }}><span className="rflabel">Tags</span><span style={{ fontSize:'var(--text-sm)', color:'var(--text-muted)' }}>Clear</span></div>
+                <div className="rfinput"><span className="mdi mdi-magnify" style={{ fontSize:16 }}></span> Filter by tag…</div>
+              </div>
+              <div className="rfsec"><div className="rfcollapse"><span className="rflabel">Tag confidence</span><span className="mdi mdi-chevron-down"></span></div></div>
+              <div className="rfsec"><div className="rfcollapse"><span className="rflabel">ComfyUI</span><span className="mdi mdi-chevron-down"></span></div></div>
+            </div>
+          )}
+          {menu === 'view' && (
+            <div className="tbm" style={{ width:264, top:6, left:150 }}>
+              <span className="tbm-caret"></span>
+              <div className="tbm-head"><span className="ic mdi mdi-view-grid"></span><span className="tbm-title">Grid view</span><span className="tbm-sp"></span>
+                <button className="tbm-ghost"><span className="mdi mdi-view-compact-outline"></span> Compact</button></div>
+              <div className="tbm-sec">
+                <div className="row-between"><span>Size</span><div className="slider"><span className="fill"></span><span className="knob"></span></div><span className="mono">Medium</span></div>
+              </div>
+              <div className="tbm-sec">
+                <span className="tbm-label">Stacks</span>
+                <div className="btngroup">
+                  <button className={`gbtn ${expanded ? 'gbtn--on' : ''}`} onClick={() => setExpanded(true)}><span className="mdi mdi-arrow-expand-vertical"></span>Expand all</button>
+                  <button className={`gbtn ${!expanded ? 'gbtn--on' : ''}`} onClick={() => setExpanded(false)}><span className="mdi mdi-arrow-collapse-vertical"></span>Collapse</button>
+                </div>
+              </div>
+              <div className="tbm-sec">
+                <span className="tbm-label">Overlays</span>
+                <div className="grid3">
+                  <button className="toggle toggle--vert"><span className="mdi mdi-face-recognition"></span>Face boxes</button>
+                  <button className="toggle toggle--vert on"><span className="mdi mdi-shape-outline"></span>Object boxes</button>
+                  <button className="toggle toggle--vert on"><span className="mdi mdi-alert-outline"></span>Problems</button>
+                </div>
+              </div>
+            </div>
+          )}
+          <div className="cgrid">
+            {GRID.slice(0, STACK_AT).map((t, i) => (
+              <div key={i} className="cell"><img src={`../../assets/samples/${t}.webp`} alt="" /></div>
+            ))}
+            <div className="cell stack">
+              <img src="../../assets/samples/tile-08.webp" alt="" />
+              <span className="stackbadge"><span className="mdi mdi-image-multiple"></span>4</span>
+              <span className="score-dot"></span>
+            </div>
+            {expanded && (
+              <div className="exp">
+                <div className="ehead">
+                  <b><span className="mdi mdi-image-multiple"></span>Stack of 4</b>
+                  <span>Burst · 81% similar</span>
+                  <span>21 Jun 16:04</span>
+                </div>
+                <div className="estrip">
+                  {STACK_MEMBERS.map((m, i) => (
+                    <div key={i} className={`eth ${i === 0 ? 'iscover' : ''}`}>
+                      <img src={`../../assets/samples/${m}.webp`} alt="" />
+                      {i === 0 && <span className="cv">Cover</span>}
+                    </div>
+                  ))}
+                  <div style={{ display:'flex', alignItems:'center', paddingLeft:'var(--space-2)', gap:'var(--space-2)' }}>
+                    <Button variant="ghost" size="sm" iconLeft="call-split">Unstack</Button>
+                    <Button variant="ghost" size="sm" iconLeft="star-outline">Set cover</Button>
+                  </div>
+                </div>
+              </div>
+            )}
+            {GRID.slice(STACK_AT).map((t, i) => (
+              <div key={i} className="cell"><img src={`../../assets/samples/${t}.webp`} alt="" /></div>
+            ))}
+          </div>
+        </div>
+        </React.Fragment> }} />
+      </div>
+    </div>
+  );
+}
+
+function AutoStackDialog() {
+  return (
+    <div className="frame" style={{ position:'relative' }}>
+      <div className="app" style={{ height:420 }}>
+        <div className="grid-scroll" style={{ filter:'blur(1px)', opacity:.5 }}>
+          <div className="cgrid">
+            {GRID.map((t, i) => <div key={i} className="cell"><img src={`../../assets/samples/${t}.webp`} alt="" /></div>)}
+          </div>
+        </div>
+        <div className="scrim">
+          <div className="dlg">
+            <div className="dlg-head"><span className="mdi mdi-flash-outline"></span><b>Auto-stack exact matches</b></div>
+            <div className="dlg-body">
+              <p>Byte-identical files need no judgment. This stacks every exact-match group and picks the copy with the richest metadata as cover. Near-duplicates are left for the queue.</p>
+              <div className="dryrun">
+                <div className="dr pos"><span className="mdi mdi-layers-plus"></span><span className="sp">Stacks to create</span><b>1,204</b></div>
+                <div className="dr pos"><span className="mdi mdi-image-multiple-outline"></span><span className="sp">Pictures collapsed into a cover</span><b>2,861</b></div>
+                <div className="dr"><span className="mdi mdi-tag-multiple-outline"></span><span className="sp">Covers gaining metadata from copies</span><b>318</b></div>
+                <div className="dr"><span className="mdi mdi-blur"></span><span className="sp">Near-duplicate groups left in queue</span><b>143</b></div>
+                <div className="dr"><span className="mdi mdi-delete-off-outline"></span><span className="sp">Files deleted</span><b>0</b></div>
+              </div>
+              <p style={{ display:'flex', alignItems:'center', gap:'var(--space-2)' }}><span className="mdi mdi-information-outline" style={{ fontSize:16, color:'var(--accent)' }}></span>Reversible as one step with <Kbd>Ctrl</Kbd><Kbd>Z</Kbd> for the rest of the session.</p>
+            </div>
+            <div className="dlg-foot">
+              <span className="sp"></span>
+              <Button variant="ghost" size="md">Cancel</Button>
+              <Button variant="accent" size="md" iconLeft="layers-plus">Create 1,204 stacks<span className="kin"><Kbd>Enter</Kbd></span></Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ContextEntry() {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="frame">
+      <div className="app" style={{ height:420 }}>
+        <div className="fm">
+          <aside className="sidebar" style={{ position:'relative' }}>
+            <div className="side-tabs">
+              <button className="side-tab active"><span className="mdi mdi-web"></span> Global</button>
+              <button className="side-tab"><span className="mdi mdi-folder-outline"></span> Projects</button>
+              <button className="side-tab"><span className="mdi mdi-monitor"></span> Folders</button>
+            </div>
+            <div className="side-scroll">
+              <div className="row"><span className="lead mdi mdi-image-multiple"></span><span className="label">All Pictures</span><span className="count">128,412</span></div>
+              <div className="row"><span className="lead mdi mdi-content-duplicate"></span><span className="label">Duplicates</span><span className="count">143</span></div>
+              <div className="sec">Sets<span className="sp"></span><span className="mdi mdi-plus"></span></div>              <div className="row"><span className="set-ico mdi mdi-crown" style={{ color:'#00acc1' }}></span><span className="label">Celebrities</span><span className="count">20</span></div>
+              <div className={`row ${open ? 'active' : ''}`} onClick={() => setOpen(o => !o)} style={{ cursor:'context-menu' }}>
+                <span className="set-ico mdi mdi-folder-multiple-image" style={{ color:'#26a69a' }}></span><span className="label">Release Set B</span><span className="count">1,482</span>
+              </div>
+              <div className="row"><span className="set-ico mdi mdi-code-braces" style={{ color:'#e53935' }}></span><span className="label">AI Characters</span><span className="count">101</span></div>
+            </div>
+          </aside>
+          <main className="main" style={{ position:'relative' }}>
+            <div className="toolbar">
+              <div className="tb-left">
+                <div className="split">
+                  <button className="bbtn bbtn--icon"><span className="mdi mdi-sort-ascending"></span></button>
+                  <button className="bbtn"><span className="prefix">Sort:</span><span className="mdi mdi-calendar"></span><span>Date Created</span><span className="mdi mdi-menu-down chev"></span></button>
+                </div>
+                <button className="bbtn"><span className="mdi mdi-filter-outline"></span><span className="mdi mdi-menu-down chev"></span></button>
+                <button className="bbtn"><span className="mdi mdi-view-grid"></span><span className="mdi mdi-menu-down chev"></span></button>
+              </div>
+              <div className="tb-right">
+                <button className="bbtn bbtn--icon" title="Settings"><span className="mdi mdi-cog-outline"></span></button>
+              </div>
+            </div>
+            <div className="grid-scroll">
+              <div className="cgrid">
+                {GRID.slice(0, 12).map((t, i) => <div key={i} className="cell"><img src={`../../assets/samples/${t}.webp`} alt="" /></div>)}
+              </div>
+            </div>
+            {open && (
+              <div className="ctx" style={{ left:-64, top:132 }}>
+                <div className="ctx-label">Release Set B</div>
+                <div className="ctx-item"><span className="mdi mdi-pencil-outline"></span>Edit set…</div>
+                <div className="ctx-item"><span className="mdi mdi-tray-arrow-down"></span>Export to zip</div>
+                <div className="ctx-div"></div>
+                <div className="ctx-item hi"><span className="mdi mdi-content-duplicate"></span><span className="sp">Find duplicates in this set</span><span className="cnt">18</span></div>
+                <div className="ctx-item"><span className="mdi mdi-image-multiple"></span><span className="sp">Filter to stacks in this set</span><span className="cnt">7</span></div>
+                <div className="ctx-div"></div>
+                <div className="ctx-item"><span className="mdi mdi-lock-outline"></span>Lock set</div>
+                <div className="ctx-item danger"><span className="mdi mdi-trash-can-outline"></span>Delete set…</div>
+              </div>
+            )}
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Spec({ title, note, children, wide }) {
+  return (
+    <div className="spec" style={wide ? { gridColumn:'span 2' } : null}>
+      <div className="stage">{children}</div>
+      <div className="cap"><b>{title}</b><span>{note}</span></div>
+    </div>
+  );
+}
+
+function Page() {
+  return (
+    <div className="page">
+      <div className="lede">
+        <div>
+          <h1>Dedup <span className="s">→</span> Stacks</h1>
+          <p>1.9.0. Duplicate detection becomes a destination with a count, and its only verdict is <b>stack</b> or <b>keep separate</b>. Nothing is deleted — that's a later release.</p>
+        </div>
+        <div className="note-card warn">
+          <h3>Why the sort order has to go</h3>
+          <p>“Similarity to …” is a <b>lens</b>, not a task. It never tells you how many duplicates you have, offers no verdict, has no bulk action, and forgets everything the moment you change sort. Users don't discover it, and when they do they can't finish anything with it.</p>
+          <p>It also implies a full-library comparison every time you use it — the thing that makes Immich's dedup unusable at scale.</p>
+        </div>
+        <div className="note-card good">
+          <h3>What replaces it</h3>
+          <p><b>Tiered detection</b> — exact matches come from an indexed hash query in milliseconds; near-dupes are found inside candidate buckets, streamed in, and cached forever.</p>
+          <p><b>A triage queue</b> — one group on screen, cover preselected with reasons shown, one keystroke, auto-advance. Designed for groups-per-minute, not groups-displayed.</p>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>1 · Detection strategy</h2><span>The part that keeps it fast on 128k pictures — and the reason it isn't Immich's model</span></div>
+        <div className="tiers">
+          <div className="tier">
+            <div className="th"><span className="mdi mdi-approximately-equal"></span><b>Tier 1 · Exact</b><span className="cost">~200 ms</span></div>
+            <p>A hash column with an index. <code>GROUP BY hash HAVING count(*) &gt; 1</code>. No ML, no image decode, no GPU.</p>
+            <ul>
+              <li>Typically 60–80% of a real backlog</li>
+              <li>Zero human judgment needed → bulk auto-stack</li>
+              <li>Runs on import, incrementally</li>
+            </ul>
+          </div>
+          <div className="tier">
+            <div className="th"><span className="mdi mdi-view-grid-outline"></span><b>Tier 2 · Bucketed near</b><span className="cost">seconds/bucket</span></div>
+            <p>Perceptual hash compared <b>only within candidate buckets</b> — same dimensions, same capture minute, same import batch, same folder. Never library-wide.</p>
+            <ul>
+              <li>Turns O(n²) into many tiny problems</li>
+              <li>Catches bursts, re-exports, resizes</li>
+              <li>Streams groups as buckets finish</li>
+            </ul>
+          </div>
+          <div className="tier">
+            <div className="th"><span className="mdi mdi-brain"></span><b>Tier 3 · Embedding</b><span className="cost">background, opt-in</span></div>
+            <p>Full ML similarity for cross-folder, differently-framed near-dupes. Expensive, so it's a background job the user opts into — never a prerequisite for seeing results.</p>
+            <ul>
+              <li>Reuses embeddings the app already computes</li>
+              <li>Results append to the same queue</li>
+              <li>Cached; only new assets rescan</li>
+            </ul>
+          </div>
+        </div>
+        <div className="note-card">
+          <h3>Three rules that keep it usable at any size</h3>
+          <p><b>Never block on a full pass.</b> The queue opens with whatever's been found so far and a “scanned 62% of 128,412” banner. Immich's review page waits for everything, then tries to render it all.</p>
+          <p><b>Virtualize the queue, don't paginate a page.</b> One group is in the DOM at a time. 10 groups and 10,000 groups perform identically.</p>
+          <p><b>Persist verdicts.</b> “Keep separate” is remembered per group signature, so a rescan never re-asks. This is what makes the count trustworthy — and what the sort order could never do.</p>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>2 · The review queue, live</h2><span>↑↓ chooses the group the keyboard acts on — the accent bar and caret mark it. Enter stacks it, S keeps it separate, C compares.</span></div>
+        <Queue />
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>3 · Stacks in the grid</h2><span>The result — All Pictures keeps its normal toolbar; the grid-view button expands stacks</span></div>
+        <GridStacks />
+        <div className="board">
+          <Spec title="Collapsed stack" note="Matches the grid's existing badge vocabulary — the same translucent chip and mdi-image-multiple icon the selection bar already uses — plus the count. No new chrome: a stack is a picture first.">
+            <div className="demo-cell">
+              <img src="../../assets/samples/tile-08.webp" alt="" />
+              <span className="stackbadge"><span className="mdi mdi-image-multiple"></span>4</span>
+            </div>
+          </Spec>
+          <Spec title="Suggested, not yet stacked" note="Groups still waiting in the queue use the duplicate icon and a ? in place of a count — never a fake state change. Clicking it jumps to that group in the queue.">
+            <div className="demo-cell">
+              <img src="../../assets/samples/tile-03.webp" alt="" />
+              <span className="stackbadge" style={{ color:'var(--text-muted)' }}><span className="mdi mdi-content-duplicate"></span>3?</span>
+            </div>
+          </Spec>
+          <Spec title="Kept separate" note="No marker at all. The group is remembered as resolved so no rescan re-suggests it, but the grid shows nothing — the user's decision is that these are simply different pictures.">
+            <div className="demo-cell"><img src="../../assets/samples/scene-03.webp" alt="" /></div>
+          </Spec>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>4 · Duplicates in context</h2><span>Right-click any project, set, character or folder — dedup scoped to that data set</span></div>
+        <ContextEntry />
+        <div className="board">
+          <Spec title="Scoped queue header" note="Choosing the context item opens the same queue with a scope pill in place of the whole-library scope. Dismissing the pill widens back to the full library without losing your position.">
+            <div style={{ display:'flex', alignItems:'center', gap:'var(--space-3)', flexWrap:'wrap', justifyContent:'center' }}>
+              <span className="qtitle" style={{ fontSize:'var(--text-md)', fontWeight:'var(--weight-semibold)' }}>Group 1</span>
+              <span className="qsub" style={{ fontSize:'var(--text-sm)', color:'var(--text-muted)' }}>of 18</span>
+              <span className="scopepill"><span className="mdi mdi-folder-multiple-image"></span>Release Set B<button className="mdi mdi-close"></button></span>
+            </div>
+          </Spec>
+          <Spec title="Why it belongs on the row" note="A scoped scan is a fraction of the work of a library scan — usually instant. Putting it on the object the user is already looking at is the difference between “dedup this shoot” being a two-second job and a global chore.">
+            <div style={{ display:'flex', flexDirection:'column', gap:'var(--space-2)', width:'100%', maxWidth:300 }}>
+              <div className="ctx-item hi" style={{ borderRadius:'var(--radius-sm)' }}><span className="mdi mdi-folder-outline"></span><span className="sp">Find duplicates in this folder</span><span className="cnt">4</span></div>
+              <div className="ctx-item hi" style={{ borderRadius:'var(--radius-sm)' }}><span className="mdi mdi-account-box-outline"></span><span className="sp">Find duplicates for Walter</span><span className="cnt">2</span></div>
+              <div className="ctx-item hi" style={{ borderRadius:'var(--radius-sm)' }}><span className="mdi mdi-briefcase-outline"></span><span className="sp">Find duplicates in this project</span><span className="cnt">61</span></div>
+            </div>
+          </Spec>
+          <Spec title="Zero-state" note="When a scoped scan finds nothing, the menu item still appears but reads as resolved rather than vanishing — an absent item reads as a missing feature, a zero reads as an answer.">
+            <div className="ctx-item" style={{ borderRadius:'var(--radius-sm)', opacity:.55 }}><span className="mdi mdi-check"></span><span className="sp">No duplicates in this set</span></div>
+          </Spec>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>5 · Bulk: the fast lane</h2><span>Exact matches never deserve a human</span></div>
+        <AutoStackDialog />
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>6 · Migrating off Similarity Groups</h2><span>What happens to the existing sort order</span></div>
+        <div className="migrate">
+          <div className="mcol old">
+            <h4>1.8 — Sort order</h4>
+            <div style={{ display:'flex', gap:'var(--space-2)', marginBottom:'var(--space-3)' }}>
+              <span className="togglebtn gone"><span className="mdi mdi-account-search-outline"></span>Similarity to …</span>
+            </div>
+            <p>Reorders the grid so lookalikes sit next to each other. No count, no verdict, no memory. Discoverable only by opening the sort menu and reading every option.</p>
+            <p>Removed from the sort menu in 1.9.0.</p>
+          </div>
+          <div className="marrow"><span className="mdi mdi-arrow-right"></span></div>
+          <div className="mcol">
+            <h4>1.9 — Destination + queue</h4>
+            <div style={{ display:'flex', gap:'var(--space-2)', marginBottom:'var(--space-3)', flexWrap:'wrap' }}>
+              <span className="togglebtn on"><span className="mdi mdi-content-duplicate"></span>Duplicates <span style={{ background:'rgba(0,0,0,.25)', borderRadius:99, padding:'0 6px', fontSize:11 }}>143</span></span>
+              <span className="togglebtn"><span className="mdi mdi-filter-outline"></span>Filter › Stacked only</span>
+            </div>
+            <p>A sidebar entry with a live count that goes down as you work, and a queue that produces stacks. Stacked / unstacked becomes a <b>filter</b> rather than a second destination — only the thing with a to-do count earns a sidebar row. The similarity <i>signal</i> survives: it now builds groups instead of shuffling the grid.</p>
+            <p>On first launch after upgrade: a one-line notice in the sort menu's place pointing at the new sidebar entry, shown once.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>7 · Rules</h2><span>Handoff</span></div>
+        <div className="rulelist">
+          <div className="rule"><span className="rn mdi mdi-star-outline"></span><p><b>Cover selection</b>Score = <code>pixels×4 + tags×3 + userScore×2 + RAW bonus</code>. Highest wins, ties break to oldest capture time. Always shown as a preselection the user can override with 1–9; never silent.</p></div>
+          <div className="rule"><span className="rn mdi mdi-shield-check-outline"></span><p><b>No deletion in 1.9</b>Every member file stays on disk and in the database. A stack is a grouping row plus a cover pointer — dropping it restores the flat grid exactly. This is what makes the whole feature safe to ship without confirmation dialogs.</p></div>
+          <div className="rule"><span className="rn mdi mdi-tag-multiple-outline"></span><p><b>Metadata union</b>Stacking unions tags, characters and Set membership onto the stack, and takes the highest score. Nothing is overwritten or lost — the reason Immich users get burned is albums silently breaking, and a union can't break anything.</p></div>
+          <div className="rule"><span className="rn mdi mdi-view-sequential-outline"></span><p><b>Rows, not one-at-a-time</b>The queue shows as many groups as fit. Exactly one row is focused — accent left bar, caret, tinted background, filled Stack button and a “keyboard acts here” label — so <code>↑↓</code> then <code>Enter</code>/<code>S</code> can never be ambiguous about which group it hits.</p></div>
+          <div className="rule"><span className="rn mdi mdi-image-size-select-actual"></span><p><b>Thumbnails carry no metadata</b>Queue rows show pictures at grid scale, edge to edge, with only the cover label and the index while focused. Resolution, size, date and tag counts live in Compare, in two columns with de-emphasised labels so the values read first and the metadata never squeezes the image.</p></div>
+          <div className="rule"><span className="rn mdi mdi-close-circle-outline"></span><p><b>Signals cut both ways</b>Matching evidence is an olive check pill; anything arguing against a stack — different resolution, different aspect ratio, subject moved, eyes closed — is a red × pill. A group carrying red pills is exactly the one that needs Compare, so the pills do the warning rather than generic "review carefully" copy.</p></div>
+          <div className="rule"><span className="rn mdi mdi-folder-eye-outline"></span><p><b>Paths only where they matter</b>File location shows only for pictures in reference folders, where the user manages the files themselves and needs to know which copy is which. Managed library pictures hide it — there, the path is an implementation detail.</p></div>
+          <div className="rule"><span className="rn mdi mdi-compare-horizontal"></span><p><b>Compare is a button, not a secret</b>Every row carries a <b>Compare all N</b> button showing <code>C</code> on the focused row. It opens the full field-by-field view — every candidate, best value highlighted per column, full paths — with Stack and Keep separate in its footer so the decision is made without a second trip.</p></div>
+          <div className="rule"><span className="rn mdi mdi-filter-outline"></span><p><b>Stacks is a filter, not a place</b>A second row of the same large icon segments, directly under the media-type row — Any / Stacked / Unstacked / Unresolved duplicates — with the current choice spelled out beside it and the header's match count updating live. Only <b>Duplicates</b>, which has a to-do count, earns a sidebar entry.</p></div>
+          <div className="rule"><span className="rn mdi mdi-shield-half-full"></span><p><b>Confidence tiers gate the queue</b>Exact matches are always included and can't be switched off. Each looser tier is a separate opt-in with its own count, and enabling one requires the tier above it — so a user can't land on “same scene” suggestions without having deliberately walked down to them. Turning on the loosest tier states the risk in place.</p></div>
+          <div className="rule"><span className="rn mdi mdi-memory"></span><p><b>Queue is virtual</b>One group in the DOM. Prefetch the next group's thumbnails only. Group list is paged from the database by confidence descending; never loaded whole.</p></div>
+          <div className="rule"><span className="rn mdi mdi-keyboard-outline"></span><p><b>Keyboard</b><code>Enter</code> stack · <code>S</code> keep separate · <code>1–9</code> set cover · <code>X</code> exclude the focused candidate · <code>Ctrl+Z</code> undo. Auto-advance after every verdict; the queue is designed to be worked without a mouse.</p></div>
+          <div className="rule"><span className="rn mdi mdi-undo-variant"></span><p><b>Undo integration</b>Every verdict raises the standard action receipt and lands in the history stack. Bulk auto-stack coalesces into a single step, so 1,204 stacks reverse with one <code>Ctrl+Z</code>.</p></div>
+          <div className="rule"><span className="rn mdi mdi-bookmark-check-outline"></span><p><b>Resolved memory</b>Verdicts are keyed on a group signature (sorted member hashes), so re-imports and rescans never re-ask. “Keep separate” is permanent until the user reopens it from the Stacks view.</p></div>
+          <div className="rule"><span className="rn mdi mdi-crosshairs-gps"></span><p><b>Scoped entry points</b>Every collection object — project, set, character, folder — carries <b>Find duplicates in…</b> in its context menu with a live count. A scoped scan reuses cached hashes, so it returns instantly; the queue opens with a dismissible scope pill.</p></div>
+          <div className="rule"><span className="rn mdi mdi-tune-variant"></span><p><b>Threshold</b>Default 0.90. Exact matches are always shown. Below 0.65 nothing is suggested at all — a low threshold produces confident-looking garbage and destroys trust in the count.</p></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+if (window.__DEDUP_HOST) ReactDOM.createRoot(document.getElementById('root')).render(<Page />);

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1660,6 +1660,50 @@ Both sites pass `expand_stacks=True, expand_stacks_include_deleted=True`. `norma
 
 No new routes and no migration: the existing undo/redo endpoints carry all of it, and `operation` is generic over `op_type`.
 
+### 21.2 Post-restore hooks — reopening what an operation also decided
+
+The recorded before/after state covers the reversible **picture** facets. An
+operation can additionally have decided something that is *not* a picture facet,
+and restoring the pictures without reopening that decision leaves the two halves
+disagreeing. The v1.9 duplicate verdict is the first such case, and QA
+caught it half-working: undoing a stack verdict unstacked the pictures but left the
+`DedupVerdict` decided and the `DedupGroup` resolved, so the group never returned
+to the queue, was not counted, and **survived a rescan** (the signature still
+carried a live verdict). The only way back was a `POST /dedup/verdicts/reopen`
+no user could find.
+
+`register_post_restore_hook(op_type, hook)` is the generic seam. `_restore` — the
+one place both undo and redo write state — dispatches the registered hooks after
+every state has been applied and **before the commit**, so the decision and the
+pictures land in one transaction or not at all; a hook that raises aborts the
+whole restore and the operation stays `applied`.
+
+- The hook is called **once per restore** with *every* operation of its own
+  `op_type` in that restore (`(session, operations, direction)`), so a 2 700-row
+  batch undo is one call, not 2 700.
+- `direction` is `RESTORE_UNDO` / `RESTORE_REDO`.
+- **The op-log core imports no feature module.** Registration lives in the
+  feature that owns the `op_type` — `dedup_verdict_service` registers at import
+  time and is imported by `routes/dedup.py`, which `Server` mounts at startup.
+  An `op_type` with no hook simply has none.
+
+Pinned by `tests/test_operation_log.py::test_a_post_restore_hook_runs_once_per_restore_with_its_whole_batch`
+and `::test_a_failing_post_restore_hook_aborts_the_whole_undo`.
+
+### 21.3 `batch_id` is namespaced
+
+`new_batch_id()` mints `srv-<uuid4hex>` (`SERVER_BATCH_ID_PREFIX`). A batch id can
+also come from a client, and the two must be distinguishable: an un-namespaced id
+makes a client-supplied grouping key indistinguishable from a server-minted one,
+so a client could submit an id that reads as a server batch — or graft its rows
+into an existing batch, where one Ctrl+Z then reverses more than the user did.
+Client-supplied ids are the `cli-` shape, validated at the request boundary
+(`^cli-[A-Za-z0-9_-]{4,76}$`, ≤80 chars) and refused with a **400** when they do
+not match. Note the deliberate asymmetry with the header form: an unusable
+*header* is dropped and ignored because a header is ambient; an unusable *body*
+field is a refusal, because the client named it on purpose and silently ignoring
+it would mis-group its undo.
+
 ---
 
 ## 22. Tiered Duplicate Detection (v1.9 Dedup → Stacks)
@@ -1740,12 +1784,20 @@ Two further caps, both logged when they bite (never silent):
 | `MAX_PAIRS_PER_BUCKET` | 50 000 (~4 MB) | pairs materialised for one bucket |
 | `MAX_TRACKED_PAIRS` | 400 000 (~32 MB) | pairs a whole streaming scan retains across buckets |
 
-Hitting the per-bucket cap keeps every matching member connected (the retained
-pairs are the lowest-offset ones), so group *membership* is unaffected; what is
-lost is confidence *resolution*, since the weakest-link value is measured over
-fewer edges. Hitting the scan-wide cap stops cross-bucket chaining growing, so a
-chain spanning two buckets can be reported as two groups. Both log a warning
-naming the bucket or scan and what was given up.
+**The per-bucket cap can lose membership, and the log says so.** Pairs are
+emitted in increasing member-offset order, so the cap keeps the nearest-offset
+edges and drops every wider one. In a *uniformly* near-identical bucket that is
+harmless — the offset-1 edges alone span the block — and the only loss is
+confidence *resolution*. In a **dense but non-uniform** block it is not: ~700
+mutually matching members exhaust 50 000 pairs well inside the low offsets, so a
+member whose only match sits at a wider offset gets no edge at all and is split
+into its own group or drops out of the queue entirely. An earlier version of this
+paragraph claimed membership was never lost; that was wrong. The warning now
+names the bucket, the offset it stopped at, and that consequence, and states the
+mitigations (resolve the dense block and rescan, narrow the bucket, or raise
+`MAX_PAIRS_PER_BUCKET` for the memory it costs). Hitting the scan-wide cap stops
+cross-bucket chaining growing, so a chain spanning two buckets can be reported as
+two groups. Both log a warning naming the bucket or scan and what was given up.
 
 ### 22.3 Tier 3 — embedding
 
@@ -1762,10 +1814,16 @@ the dry-run planner, unchanged).
 - Tier 1 is always included and **has no switch**.
 - Each looser tier is a separate opt-in, and `embedding_enabled` **requires**
   `near_enabled`.
-- `threshold` defaults to `0.90`; `MIN_THRESHOLD = 0.65` is a hard floor. A
-  request below it raises `ValueError` → HTTP 400. It is never silently clamped:
-  a low threshold produces confident-looking garbage and destroys trust in the
-  sidebar count.
+- `threshold` defaults to `0.90`; `MIN_THRESHOLD = 0.65` is a hard floor. It is
+  never silently clamped: a low threshold produces confident-looking garbage and
+  destroys trust in the sidebar count. **The refusal is a 422, not a 400.** The
+  floor is a pydantic `ge=MIN_THRESHOLD` bound on the query parameter and on
+  `TierPolicyModel.threshold`, so FastAPI rejects a low value before any handler
+  runs, on every route. `TierPolicy.__post_init__` keeps its own `ValueError`
+  check because it is the *service-level* invariant — reachable from a task or a
+  test that never went through a request — and the tier-dependency rule it also
+  enforces (`embedding_enabled` requires `near_enabled`) is not expressible as a
+  field bound, so **that** one is the 400 the handlers translate.
 
 ### 22.5 Cover selection and evidence
 
@@ -1789,6 +1847,19 @@ The server reports reasons. The user concludes.
   *upserts on `signature`*, so a rescan refreshes rows instead of duplicating
   them, and the queue is paged from `(resolved, confidence DESC)` and never
   materialised whole. This is what makes 10 groups and 10,000 cost the same.
+
+  **The upsert honours tier precedence** (`TIER_STRENGTH`: exact > near >
+  embedding). Two tiers routinely find the *same* group — a byte-identical pair
+  is also perceptually identical, so every near-enabled scan rediscovers every
+  exact pair under the same signature — and the upsert originally wrote
+  `row.tier` unconditionally. An exact pair silently demoted to `near`
+  disappeared from the exact-only default view **and** from
+  `POST /dedup/auto-stack`, which only ever acts on `exact`. Tier, confidence,
+  evidence and cover move together (they describe one finding); membership is
+  refreshed either way, because the signature pins the member *content keys* and
+  a re-import can give the same content new picture ids. Pinned by
+  `test_a_near_scan_does_not_downgrade_an_exact_group` and
+  `test_the_upsert_takes_the_stronger_tier_in_either_arrival_order`.
 - **`dedupverdict`** — verdict memory keyed on the group **signature**: `sha256`
   of the sorted member content keys, where a content key is
   **`<pixel_sha>:<size_bytes>`** (or `id:<n>` for a picture not yet hashed).
@@ -1812,7 +1883,44 @@ The server reports reasons. The user concludes.
 dropped below two, so the sidebar badge cannot be inflated by scrapheaped
 pictures.
 
-### 22.7 Streaming and the background path
+**Scope ids are normalised and validated at construction** (`DedupScope.__post_init__`),
+not at query time. Project / set / character ids must parse as integers. A
+**folder** `scope_id` is stripped of trailing separators and **refused when that
+leaves it empty**: `/`, `\`, `///` all rstripped to `""`, which became a `LIKE`
+pattern of `%` — a "Find duplicates in this folder" request that silently meant
+the whole vault, plus a persisted `dedupscan` row whose `scope_key` claimed
+otherwise. Normalising at construction also collapses `/photos` and `/photos/`
+onto one scope key instead of two scans.
+
+### 22.7 Paging the queue: a keyset cursor, not an offset
+
+`GET /dedup/groups` pages by an **opaque keyset cursor**. The queue is a live
+list: a verdict removes the row the user just decided from `resolved=False`, and
+a tier-2 scan commits new groups after every bucket. Both shift every later row's
+offset, so `offset=limit` on the next request skips exactly as many groups as the
+page's decisions removed — a deterministic, silent skip reproduced with a single
+verdict between two pages.
+
+- **Order is `(confidence DESC, id ASC)`**, and the cursor encodes that pair for
+  the last delivered row. Wire form: unpadded base64url over
+  `"1|<confidence at %.17g>|<group id>"` (`CURSOR_VERSION` is the leading `1`).
+  17 significant digits make the float round-trip exactly, which the tie-break
+  branch depends on.
+- **The tie-break half is load-bearing.** Every exact group sits at the same
+  confidence, so `confidence < c` alone would drop the rest of the tied run and
+  `confidence <= c` would repeat it forever. The predicate is
+  `confidence < c OR (confidence = c AND id > i)`.
+- `next_cursor` is `null` once the page is not full — end-of-found. A full last
+  page hands back a cursor that yields one empty page, which is cheaper than the
+  extra `COUNT` needed to know for certain.
+- **Opaque by intent.** Clients pass it back verbatim. A cursor this server did
+  not mint is a **400**, never a silent restart from the top — silently paging
+  from offset 0 would hand the client page 1 forever.
+- `offset` still works and is **deprecated**; sending both is a **400** rather
+  than a silent preference, because a client that sends both has two different
+  ideas of where it is.
+
+### 22.8 Streaming and the background path
 
 `DedupScanFinder` / `DedupScanTask` (`TaskType.DEDUP_SCAN`) turn a `pending`
 `dedupscan` row into work. Tier 1 runs first and in one shot so the queue is never
@@ -1836,7 +1944,7 @@ rows. It is *not* a statement about the scan: a scan is inherently proportional 
 the library, it holds the single DB writer while it runs, and its memory is bounded
 by the caps in §22.2 rather than being free.
 
-### 22.8 Verdicts and the metadata union
+### 22.9 Verdicts and the metadata union
 
 The only two verdicts are **stack** and **keep separate**. Neither deletes
 anything; there is no destructive route on this surface in 1.9.
@@ -1898,7 +2006,7 @@ live share token for that set immediately reaches it — the picture, its tags, 
 - **Recommended, not implemented:** a `shared_sets_affected` count in the dry-run
   summary so the consent dialog can say so out loud.
 
-### 22.9 Operation-log integration (§21)
+### 22.10 Operation-log integration (§21)
 
 Every stack verdict records **exactly one** `Operation` row.
 
@@ -1919,6 +2027,27 @@ Every stack verdict records **exactly one** `Operation` row.
   picture facet, so `record_operation_in_session` would return `None` anyway;
   writing a no-op row would still consume a Ctrl+Z. The way back from
   keep-separate is the explicit reopen action.
+- **A stack verdict is always recorded under a `batch_id`**, minted server-side
+  (`srv-…`, §21.3) when the caller supplies none. The batch id is what ties the
+  `Operation` row back to its `DedupVerdict` row, and that correlation is what
+  makes the undo complete — see below.
+- **Undo reopens the verdict, not only the pictures.** `restore_verdicts_in_session`
+  is registered as the §21.2 post-restore hook for `dedup.stack`. On **undo** it
+  stamps `reopened_at` on every verdict in the restored batches (the row is kept
+  — the decision history is worth keeping) and sets its group `resolved=False`;
+  on **redo** it clears `reopened_at` and re-resolves the group. `decided_at` is
+  never re-stamped: it records when the user decided, and "live" is exactly
+  `reopened_at IS NULL`. One query covers a 2 700-group batch undo. Without this
+  the undo was half an undo: the pictures came back unstacked while the group
+  stayed decided, invisible in the queue and in the counts, and it **survived a
+  rescan** because `verdict_signatures_in_session` still saw a live verdict.
+  Pinned at the HTTP level by `test_undo_returns_the_stacked_group_to_the_queue`,
+  `test_batch_undo_after_auto_stack_returns_every_group` (QA's exact repro) and
+  `test_an_undo_does_not_reopen_a_group_it_never_touched`.
+- **A pre-existing row without a batch id cannot be correlated**, and the hook
+  says so with a warning naming the operation ids rather than half-restoring in
+  silence: the pictures are back, the group stays decided until the user reopens
+  it explicitly.
 - **Origin discipline.** `actor` / `source` / `origin_client_id` come from
   `operation_log_service.request_context(request)`, read in the handler on the
   request's own task and passed down explicitly — never from the contextvar, which

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1728,6 +1728,25 @@ is dominated by the top bit and says nothing about Hamming proximity.
 `LikenessUtils.PHASH_PREFIX_LEN = 3` is dead code with no reader. The reusable
 precomputed bucket key is `size_bin_index`, and that is what tier 2 uses.
 
+**Memory is bounded separately from CPU.** `MAX_BUCKET_MEMBERS` caps the
+comparison *work*; it does not cap the *result*. A bucket whose members are
+mutually near-identical (a burst of near-black frames, a folder of solid-colour
+placeholders, one image copied 4000 times) yields `k*(k-1)/2` pairs — ~8M tuples,
+roughly 580 MB, for a component the union-find only needs a spanning subset of.
+Two further caps, both logged when they bite (never silent):
+
+| Constant | Value | Bounds |
+|---|---|---|
+| `MAX_PAIRS_PER_BUCKET` | 50 000 (~4 MB) | pairs materialised for one bucket |
+| `MAX_TRACKED_PAIRS` | 400 000 (~32 MB) | pairs a whole streaming scan retains across buckets |
+
+Hitting the per-bucket cap keeps every matching member connected (the retained
+pairs are the lowest-offset ones), so group *membership* is unaffected; what is
+lost is confidence *resolution*, since the weakest-link value is measured over
+fewer edges. Hitting the scan-wide cap stops cross-bucket chaining growing, so a
+chain spanning two buckets can be reported as two groups. Both log a warning
+naming the bucket or scan and what was given up.
+
 ### 22.3 Tier 3 — embedding
 
 Opt-in, and recomputes nothing: it folds the existing `PictureLikeness` edge table
@@ -1762,7 +1781,7 @@ as a *preselection* the user overrides, together with:
 
 The server reports reasons. The user concludes.
 
-### 22.6 Persistence: three tables
+### 22.6 Persistence: four tables
 
 `pixlstash/db_models/dedup.py`, migration `0088_add_dedup_tier_tables`:
 
@@ -1770,11 +1789,22 @@ The server reports reasons. The user concludes.
   *upserts on `signature`*, so a rescan refreshes rows instead of duplicating
   them, and the queue is paged from `(resolved, confidence DESC)` and never
   materialised whole. This is what makes 10 groups and 10,000 cost the same.
-- **`dedupverdict`** — verdict memory keyed on the group **signature**
-  (`sha256` of the sorted member content keys, `pixel_sha` where available and
-  `id:<n>` where not). Because the key is content and not ids, a rescan or a
-  re-import never re-asks. `reopened_at` marks a verdict as no longer live; the
-  row is kept so the decision history survives.
+- **`dedupverdict`** — verdict memory keyed on the group **signature**: `sha256`
+  of the sorted member content keys, where a content key is
+  **`<pixel_sha>:<size_bytes>`** (or `id:<n>` for a picture not yet hashed).
+  Because the key is content and not ids, a rescan or a re-import never re-asks.
+  `reopened_at` marks a verdict as no longer live; the row is kept so the
+  decision history survives.
+
+  **The size co-key is not optional.** Identity has to match detection: tier 1
+  groups on `(pixel_sha, size_bytes)` precisely because the digest is sampled
+  above 128 KiB. A signature over the digest alone was not injective over groups
+  — two distinct exact groups differing only in size collapsed onto one
+  signature, and all three consequences were silent: the upsert-on-signature
+  dropped one group from the queue, a `keep_separate` on the survivor resolved
+  both file sets, and a stack verdict's write target depended on scan order
+  rather than on what the user saw. Pinned by
+  `test_two_groups_sharing_a_digest_but_not_a_size_stay_distinct`.
 - **`dedupscan`** — one row per scope key, both the scan *request* (status
   `pending`) and the "scanned N of M" progress readout.
 
@@ -1791,6 +1821,20 @@ the queue the moment that bucket finishes and `scanned_buckets` advances with it
 tier 3 appends last. Restarting a scan is safe because persistence is an upsert.
 The finder `depends_on` `PIXEL_SHA` and `IMAGE_EMBEDDING` so a scan reports honest
 counts rather than a partially hashed library.
+
+**Only the groups a bucket could have changed are re-persisted.** Pairs are
+retained across buckets so a chain spanning two of them folds into one group, but
+each bucket tracks the picture ids its *new* pairs touched and rewrites only the
+groups containing one of them. The earlier version re-derived and re-wrote **every
+group after every bucket** — `O(buckets × groups)` DELETE+INSERT on the single DB
+writer thread, which every import, tag edit, scrapheap move and verdict then
+queues behind.
+
+**Honest scope of the performance claim.** §22.6's "10 groups and 10,000 perform
+identically" is a statement about the **queue page**, which reads exactly `limit`
+rows. It is *not* a statement about the scan: a scan is inherently proportional to
+the library, it holds the single DB writer while it runs, and its memory is bounded
+by the caps in §22.2 rather than being free.
 
 ### 22.8 Verdicts and the metadata union
 
@@ -1818,17 +1862,77 @@ The union writes tags and scores, which are curation state, so it calls
 `enforce_pictures_not_locked` first: a locked-set member makes the whole verdict a
 423 rather than a half-applied union.
 
-### 22.9 Operation-log seam
+**Guard ordering is load-bearing.** `_stack_members` calls
+`enforce_stack_membership_not_locked` **before** it folds any other stack in, and
+that guard expands through `expand_picture_ids_to_stacks` — which is why a locked
+co-member dragged in by the fold is caught even though
+`apply_metadata_union_in_session` only checks the group's own members. Moving the
+lock check after the fold would open that hole. Pinned by
+`test_a_locked_co_member_of_a_folded_stack_is_refused`.
 
-Every verdict raises an action receipt and lands in the operation log (§21),
-with bulk auto-stack coalescing into one `batch_id` so N stacks reverse with one
-undo. The two features were developed on separate lanes, so
-`dedup_verdict_service._record_operation` imports the operation log lazily and,
-should the module ever be absent, logs a warning naming it and the consequence
-(the verdict still applies but is not reversible in one keystroke) rather than
-failing the verdict. With both lanes merged the import resolves and the seam is
-live: it passes `batch_id`, `op_type` and the before/after picture state to
-`record_operation_in_session`, so verdicts are recorded with no further wiring.
+#### Accepted risk A1 — the union widens live share tokens
+
+**This is a change to who can see what, not only to metadata.** Unioning set and
+project membership adds an out-of-scope duplicate to a *shared* set, and every
+live share token for that set immediately reaches it — the picture, its tags, its
+`pixel_sha`, its file. The authz gate is behaving correctly (the picture genuinely
+*is* a set member after the union); the widening is the membership change itself.
+
+- **Not new.** An ordinary `POST /stacks` does exactly the same thing; this is the
+  shipped stack-atomic membership model, not a dedup regression.
+- **What is new is the amplification.** `POST /dedup/auto-stack` with
+  `dry_run=false` applies it to **every exact group in the vault** behind one
+  consent dialog. The dry run reports `groups` / `pictures` and a
+  `dry_run_summary`, but **not** how many shared sets or live tokens would gain
+  members.
+- **Blast radius.** Bounded to the owner's own sharing decisions: only sets and
+  projects that already have an outstanding token, and only pictures the owner has
+  just declared duplicates of something already in that set.
+- **Compensating controls.** `dry_run=true` is the default; the union is additive
+  and reversible through the operation log; tokens are owner-minted and READ-only;
+  a locked set refuses the union outright.
+- **Ruling: accepted** for the single-owner product. **Revisit** at the start of
+  any multi-user work, and immediately if bulk auto-stack is ever wired to run
+  unattended (at import or on a schedule) — unattended bulk membership widening is
+  a different risk and this acceptance does not cover it.
+- **Recommended, not implemented:** a `shared_sets_affected` count in the dry-run
+  summary so the consent dialog can say so out loud.
+
+### 22.9 Operation-log integration (§21)
+
+Every stack verdict records **exactly one** `Operation` row.
+
+- **One verdict, one row.** The verdict path deliberately does *not* call
+  `routes/stacks.py`, whose handlers already wrap themselves in
+  `run_recorded_metadata_task`; going through them would write a second row and
+  "one verdict, one undo" would stop being true. `_stack_members` stacks
+  in-session and `_record_operation` records once around the whole verdict.
+- **Bulk auto-stack shares one `batch_id`** across every group in the run, so
+  `POST /operations/batches/{batch_id}/undo` reverses the lot in one step. The
+  response carries the `batch_id` **even when the run only partially applied**
+  (see below), so work that happened is never left without a way to reverse it.
+- **The snapshot is stack-expanded**, taken over `expand_picture_ids_to_stacks`
+  with `include_deleted=True`: folding a stack reparents co-members the group
+  never named, and `normalize_stack_positions` renumbers soft-deleted members too
+  (§21.1). Both are pinned by non-vacuous tests.
+- **Keep-separate and reopen record nothing.** Neither changes a reversible
+  picture facet, so `record_operation_in_session` would return `None` anyway;
+  writing a no-op row would still consume a Ctrl+Z. The way back from
+  keep-separate is the explicit reopen action.
+- **Origin discipline.** `actor` / `source` / `origin_client_id` come from
+  `operation_log_service.request_context(request)`, read in the handler on the
+  request's own task and passed down explicitly — never from the contextvar, which
+  is dead on the DB worker thread. Only the two recording handlers take a
+  `Request`; keep-separate and reopen deliberately do not, since the values would
+  be dead arguments.
+
+**A bulk run is never aborted by one bad group.** The locked-set guards raise
+`HTTPException(423)`, so the loop catches that alongside `DedupVerdictError`,
+rolls back just that iteration, and records the group under an explicit outcome:
+`applied`, `blocked` (a guard refused it) or `failed` (it could not be resolved).
+Catching only `DedupVerdictError` meant a locked group mid-run propagated out
+after earlier groups had already committed — a partially applied mutation whose
+server-minted batch id the caller never saw.
 
 ---
 

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -977,7 +977,9 @@ Selected milestones:
 
 | 0087 | `characterprojectmember` / `picturesetprojectmember` join tables — many-to-many characters and picture sets across projects (#125). Additive: the scalar `project_id` FKs stay and stay populated as the primary project, and the migration backfills one join row per existing assignment |
 
-Current head: `0087_add_entity_project_membership`.
+| 0088 | `dedupgroup` / `dedupgroupmember` / `dedupverdict` / `dedupscan` — the tiered Duplicates queue cache, verdict memory and scan progress (§22.6). Additive, and deliberately no `NULL` reset: tier 1 reuses the existing `pixel_sha` column and the runtime `MissingPixelShaFinder` backfills rows where it is `NULL` (§22.1) |
+
+Current head: `0088_add_dedup_tier_tables`.
 
 ---
 

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -91,7 +91,7 @@ pixlstash/
 │   ├── projects.py                   # Projects
 │   ├── picture_sets.py               # Picture sets + membership
 │   ├── stacks.py                     # Stacks
-│   ├── dedup.py                      # Near-duplicate sweep policy + dry run
+│   ├── dedup.py                      # Duplicate queue, counts, scan, verdicts + sweep dry run
 │   ├── config.py                     # User/server config + progress
 │   ├── reference_folders.py          # Reference folders
 │   ├── import_folders.py             # Watch folders
@@ -149,6 +149,8 @@ pixlstash/
 ├── services/                         # Business-logic extracted from route handlers
 │   ├── config_service.py             # Hardware monitoring + import folder utilities
 │   ├── dedup_sweep_service.py        # Vault-wide near-duplicate sweep planner (read-only)
+│   ├── dedup_tier_service.py         # Tiered detection, tier policy, cover + evidence (§22)
+│   ├── dedup_verdict_service.py      # Stack / keep-separate verdicts + metadata union (§22)
 │   ├── plugin_service.py             # Image plugin orchestration + progress tracking
 │   ├── share_service.py              # Share-token validation + watermark resolution
 │   └── tag_prediction_service.py     # Confirm / reject / reset tag predictions
@@ -354,7 +356,9 @@ Add/remove user tags; bulk clear; confirm or reject model-predicted tags (`TagPr
 Standard CRUD; set/stack membership management; stack reordering.
 
 ### `dedup.py`
-The vault-wide near-duplicate sweep, **dry run only** (v1.9 Lane E). `GET /dedup/sweep/policy` returns the server's default confidence policy plus the bounds and closed vocabularies a client should build its controls from; `POST /dedup/sweep/dry-run` resolves every near-duplicate group in the vault under a supplied policy and returns the plan behind "N groups auto-collapse, M need review". Both are `owner_only` (a vault-wide aggregate cannot be narrowed to a share token's scope without leaking out-of-scope counts — the same reasoning as `tag_health`), and neither writes anything. All logic lives in [services/dedup_sweep_service.py](../pixlstash/services/dedup_sweep_service.py); the handlers only translate the request body into a `SweepPolicy` and serialise the `SweepReport`. Execution (applying a plan), the review queue, and the auto-at-import policy are later work; the dry-run planner already accepts an optional `operation_batch_id` so a future apply step can correlate a plan with the operation-log batch that undoes it.
+The vault-wide near-duplicate sweep, **dry run only** (v1.9 Lane E). `GET /dedup/sweep/policy` returns the server's default confidence policy plus the bounds and closed vocabularies a client should build its controls from; `POST /dedup/sweep/dry-run` resolves every near-duplicate group in the vault under a supplied policy and returns the plan behind "N groups auto-collapse, M need review". Both are `owner_only` (a vault-wide aggregate cannot be narrowed to a share token's scope without leaking out-of-scope counts — the same reasoning as `tag_health`), and neither writes anything. All logic lives in [services/dedup_sweep_service.py](../pixlstash/services/dedup_sweep_service.py); the handlers only translate the request body into a `SweepPolicy` and serialise the `SweepReport`. Execution (applying a plan) and the auto-at-import policy are later work; the dry-run planner already accepts an optional `operation_batch_id` so a future apply step can correlate a plan with the operation-log batch that undoes it.
+
+The same module also serves the **v1.9 tiered Duplicates queue** — `GET /dedup/policy`, `GET /dedup/groups`, `POST /dedup/counts`, `POST /dedup/scan`, `POST /dedup/verdicts/{stack,keep-separate,reopen}` and `POST /dedup/auto-stack`. Every one of them is `owner_only` for the same reasoning plus, for the verdict routes, the fact that they mutate stacks across arbitrary pictures. Detection lives in [services/dedup_tier_service.py](../pixlstash/services/dedup_tier_service.py) and verdicts in [services/dedup_verdict_service.py](../pixlstash/services/dedup_verdict_service.py); the handlers only build a `TierPolicy` / `DedupScope` (a bad one is a 400, never a silent retune) and call a service wrapper. See §22 for the tiers, the hash decision, the bucket design, the cover formula and the verdict memory, and `docs/integration_architecture.md` §19 for the request/response contract.
 
 ### `config.py`
 | Method | Path | Purpose |
@@ -430,8 +434,16 @@ Public guest scoring and shared-link endpoints.
 | GET    | /api/v1/characters/{id}/summary                                               | characters      | Get character category summary                             |
 | GET    | /api/v1/characters/{id}/{field}                                               | characters      | Get character field                                        |
 | GET    | /api/v1/check-session                                                         | auth            | Check Session                                              |
+| POST   | /api/v1/dedup/auto-stack                                                      | dedup           | Bulk auto-stack the exact tier                             |
+| POST   | /api/v1/dedup/counts                                                          | dedup           | Live duplicate counts, global and scoped                   |
+| GET    | /api/v1/dedup/groups                                                          | dedup           | One page of the duplicate queue                            |
+| GET    | /api/v1/dedup/policy                                                          | dedup           | Duplicate detection tier defaults                          |
+| POST   | /api/v1/dedup/scan                                                            | dedup           | Queue a duplicate scan                                     |
 | POST   | /api/v1/dedup/sweep/dry-run                                                   | dedup           | Plan a vault-wide near-duplicate sweep                     |
 | GET    | /api/v1/dedup/sweep/policy                                                    | dedup           | Near-duplicate sweep policy defaults                       |
+| POST   | /api/v1/dedup/verdicts/keep-separate                                          | dedup           | Record that a group is not duplicates                      |
+| POST   | /api/v1/dedup/verdicts/reopen                                                 | dedup           | Return a decided group to the queue                        |
+| POST   | /api/v1/dedup/verdicts/stack                                                  | dedup           | Stack a duplicate group                                    |
 | GET    | /api/v1/login                                                                 | auth            | Check Registration                                         |
 | POST   | /api/v1/login                                                                 | auth            | Login                                                      |
 | POST   | /api/v1/logout                                                                | auth            | Logout                                                     |
@@ -984,7 +996,7 @@ Current head: `0087_add_entity_project_membership`.
 └── reference-folders/         # If configured
 ```
 
-- `pixel_sha` (SHA-256 of decoded pixels) is used for import deduplication.
+- `pixel_sha` (indexed) is used for import deduplication and for §22's tier-1 exact-duplicate detection. It is a **SHA-256 over the file's bytes** (not over decoded pixels, despite the name), and it is **sampled** above 128 KiB: `ImageUtils._calculate_sha256_digest` digests 8 chunks of 8 KiB spread across the file rather than every byte. Anything comparing on it should pair it with `size_bytes` — see §22.1.
 - Watermarks are rendered on demand and cached in memory.
 
 ### Database
@@ -1648,6 +1660,176 @@ No new routes and no migration: the existing undo/redo endpoints carry all of it
 
 ---
 
-*Last updated: 2026-07-28. Update this document whenever architectural patterns, module boundaries, or integration contracts change.*
+## 22. Tiered Duplicate Detection (v1.9 Dedup → Stacks)
+
+The Duplicates queue is filled by three tiers of increasing cost and decreasing
+certainty. Detection lives in `pixlstash/services/dedup_tier_service.py`; what
+happens when the user decides lives in `pixlstash/services/dedup_verdict_service.py`.
+The shipped `dedup_sweep_service.py` dry-run planner is unchanged and remains the
+non-destructive foundation the whole feature is built on.
+
+### 22.1 Tier 1 — exact, and the hash decision
+
+Tier 1 is `GROUP BY pixel_sha, size_bytes HAVING count(*) > 1` on the **existing
+indexed `picture.pixel_sha` column**. No new hash column was added.
+
+Be honest about what `pixel_sha` is. `ImageUtils._calculate_sha256_digest` hashes
+the whole file only up to 128 KiB; above that it samples 8 chunks of 8 KiB spread
+across the file. So it is a *sampled* content digest, not a full-file SHA-256, and
+two files could in principle share one while differing in an unsampled region.
+
+Two consequences, both deliberate:
+
+- **`size_bytes` is a co-key, not decoration.** The sample offsets are derived from
+  the file size, so equal size plus equal sampled digest is a far stronger claim
+  than the digest alone. It costs nothing — the `pixel_sha` index already narrows
+  the group.
+- **Exact matches still go through a consent dialog.** `POST /dedup/auto-stack`
+  defaults to `dry_run=true`; the design deliberately does not stack exact matches
+  at import without the user seeing the count first. The worst case of a false
+  exact match is two different pictures in one *stack*, which is reversible with
+  one keystroke and destroys nothing.
+
+A new full-file hash column was considered and rejected: it would mean re-reading
+every byte of every file in the library on upgrade to buy a guarantee this feature
+does not need. `pixel_sha` is already computed incrementally on every import path;
+`MissingPixelShaFinder` / `PixelShaTask` (`TaskType.PIXEL_SHA`) backfill the rows
+that predate it, selecting on `pixel_sha IS NULL` — which is why migration
+`0088` contains no `NULL` reset.
+
+### 22.2 Tier 2 — bucketed near, and what "bucket" reuses
+
+Perceptual hashes are compared **only within candidate buckets**, never
+library-wide. `build_near_buckets()` emits four bucket kinds from columns the
+library already maintains:
+
+| Bucket kind | Column | Catches |
+|---|---|---|
+| `size_bin` | `picture.size_bin_index` (indexed `(w << 32) + h`) | re-saves, re-encodes, burst frames |
+| `capture_minute` | `created_at` truncated to the minute | bursts, re-exports that changed size |
+| `import_folder` | `picture.import_source_folder` (indexed) | one import run |
+| `folder` | parent directory of `file_path` | a duplicated folder |
+
+A picture belongs to several buckets; that is the point. Buckets over
+`MAX_BUCKET_MEMBERS` (4000) are **split into shards**, never dropped, so no
+candidate is silently skipped.
+
+Inside a bucket the comparison is a numpy XOR plus a SWAR popcount over the 64-bit
+dHash in `picture.perceptual_hash`, with
+`similarity = 1 - hamming / 64`. A 4000-member bucket is ~8M popcounts, which is
+milliseconds.
+
+**`LikenessParameter.PHASH_PREFIX` is deliberately not used as a bucket key.**
+Despite the name it stores the *entire* 64-bit dHash linearly normalised into
+`[0, 1]` (`int(phash[:16], 16) / (2**64 - 1)`), so numeric proximity in that slot
+is dominated by the top bit and says nothing about Hamming proximity.
+`LikenessUtils.PHASH_PREFIX_LEN = 3` is dead code with no reader. The reusable
+precomputed bucket key is `size_bin_index`, and that is what tier 2 uses.
+
+### 22.3 Tier 3 — embedding
+
+Opt-in, and recomputes nothing: it folds the existing `PictureLikeness` edge table
+into components through the shipped `dedup_sweep_service.stream_likeness_edges` /
+`_LikenessForest`. Its groups append to the same queue.
+
+### 22.4 Policy: tier gating replaces the auto/review split
+
+`TierPolicy` is the queue's policy surface and supersedes `SweepPolicy`'s
+auto/review split *for the queue* (`SweepPolicy` remains the parameter object for
+the dry-run planner, unchanged).
+
+- Tier 1 is always included and **has no switch**.
+- Each looser tier is a separate opt-in, and `embedding_enabled` **requires**
+  `near_enabled`.
+- `threshold` defaults to `0.90`; `MIN_THRESHOLD = 0.65` is a hard floor. A
+  request below it raises `ValueError` → HTTP 400. It is never silently clamped:
+  a low threshold produces confident-looking garbage and destroys trust in the
+  sidebar count.
+
+### 22.5 Cover selection and evidence
+
+Cover score is `megapixels*4 + tags*3 + score*2 + 8 if RAW`; highest wins, ties
+break to the **oldest capture time**, then to the lowest id. It is always exposed
+as a *preselection* the user overrides, together with:
+
+- **group evidence** — matching pills and evidence-against pills (different
+  resolution / aspect ratio / file format), so a group carrying red pills is
+  visibly the one that needs Compare;
+- **per-candidate evidence** — what each candidate is best at and where it loses,
+  plus its numeric `cover_score`.
+
+The server reports reasons. The user concludes.
+
+### 22.6 Persistence: three tables
+
+`pixlstash/db_models/dedup.py`, migration `0088_add_dedup_tier_tables`:
+
+- **`dedupgroup` / `dedupgroupmember`** — the found-groups cache. Detection
+  *upserts on `signature`*, so a rescan refreshes rows instead of duplicating
+  them, and the queue is paged from `(resolved, confidence DESC)` and never
+  materialised whole. This is what makes 10 groups and 10,000 cost the same.
+- **`dedupverdict`** — verdict memory keyed on the group **signature**
+  (`sha256` of the sorted member content keys, `pixel_sha` where available and
+  `id:<n>` where not). Because the key is content and not ids, a rescan or a
+  re-import never re-asks. `reopened_at` marks a verdict as no longer live; the
+  row is kept so the decision history survives.
+- **`dedupscan`** — one row per scope key, both the scan *request* (status
+  `pending`) and the "scanned N of M" progress readout.
+
+`prune_stale_groups_in_session()` removes groups whose live membership has
+dropped below two, so the sidebar badge cannot be inflated by scrapheaped
+pictures.
+
+### 22.7 Streaming and the background path
+
+`DedupScanFinder` / `DedupScanTask` (`TaskType.DEDUP_SCAN`) turn a `pending`
+`dedupscan` row into work. Tier 1 runs first and in one shot so the queue is never
+empty; tier 2 then commits **after each bucket**, so a bucket's groups appear in
+the queue the moment that bucket finishes and `scanned_buckets` advances with it;
+tier 3 appends last. Restarting a scan is safe because persistence is an upsert.
+The finder `depends_on` `PIXEL_SHA` and `IMAGE_EMBEDDING` so a scan reports honest
+counts rather than a partially hashed library.
+
+### 22.8 Verdicts and the metadata union
+
+The only two verdicts are **stack** and **keep separate**. Neither deletes
+anything; there is no destructive route on this surface in 1.9.
+
+Stacking applies the metadata union onto every member:
+
+| What | Behaviour |
+|---|---|
+| project + set membership | union, via the existing `reconcile_stack_membership` |
+| tags | union of every non-sentinel tag; `__tag` / `__tag:<engine>` markers are excluded so an already-tagged picture is not re-queued |
+| score | every member lifted to `max(score)`; never lowered |
+| characters | see below |
+
+**Characters are the one honest limitation.** A face carries a bbox and an
+embedding that belong to one specific picture, so a true face-to-character union
+would mean fabricating `Face` rows. Instead, when the group's members between them
+reference exactly **one** character, members that do not already carry it get
+`Picture.pending_character_id` (the shipped deferred-assignment mechanism the face
+extraction task consumes). A group spanning several characters is left alone and
+logged.
+
+The union writes tags and scores, which are curation state, so it calls
+`enforce_pictures_not_locked` first: a locked-set member makes the whole verdict a
+423 rather than a half-applied union.
+
+### 22.9 Operation-log seam
+
+Every verdict raises an action receipt and lands in the operation log (§21),
+with bulk auto-stack coalescing into one `batch_id` so N stacks reverse with one
+undo. The two features were developed on separate lanes, so
+`dedup_verdict_service._record_operation` imports the operation log lazily and,
+should the module ever be absent, logs a warning naming it and the consequence
+(the verdict still applies but is not reversible in one keystroke) rather than
+failing the verdict. With both lanes merged the import resolves and the seam is
+live: it passes `batch_id`, `op_type` and the before/after picture state to
+`record_operation_in_session`, so verdicts are recorded with no further wiring.
+
+---
+
+*Last updated: 2026-07-29. Update this document whenever architectural patterns, module boundaries, or integration contracts change.*
 
 ### Known drift / cleanup notes

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -26,6 +26,7 @@
 16. [Versioning](#16-versioning)
 17. [Integration Pitfalls](#17-integration-pitfalls)
 18. [Integration Diagrams](#18-integration-diagrams)
+19. [Duplicates Queue API (v1.9)](#19-duplicates-queue-api-v19)
 
 ---
 
@@ -564,4 +565,172 @@ flowchart TB
 
 ---
 
-*Last updated: 2026-07-19. Update this document whenever any integration contract (URL prefix, event names, auth mode, build output path, CORS policy, share-token mechanism, settings field names) changes.*
+## 19. Duplicates Queue API (v1.9)
+
+The contract behind the sidebar **Duplicates** destination. Every route is
+`owner_only`; a share token gets 403 on all of them. Backend design is
+`docs/backend_architecture.md` §22.
+
+**Two rules the client must hold to.** The queue is *paged*, never fetched whole
+(`GET /dedup/groups` returns `total` so a scrollbar can be sized without a second
+request), and a group is addressed by its **`signature`**, never by an id. The
+signature is a hash of the group's member content hashes, so it survives a rescan
+and a re-import; a numeric id would not.
+
+### `GET /dedup/policy`
+
+No parameters. Renders the tier switches and the threshold slider so 0.90 and the
+0.65 floor are never hardcoded twice.
+
+```jsonc
+{
+  "defaults": { "near_enabled": false, "embedding_enabled": false,
+                "threshold": 0.9, "min_group_size": 2, "max_group_size": 24 },
+  "bounds": {
+    "min_threshold": 0.65, "max_threshold": 0.99999,
+    "tiers": ["exact", "near", "embedding"],
+    "always_on_tiers": ["exact"],
+    "tier_requires": { "exact": null, "near": "exact", "embedding": "near" },
+    "scope_types": ["global", "project", "set", "character", "folder"],
+    "verdicts": ["stacked", "keep_separate"],
+    "max_page_size": 200
+  }
+}
+```
+
+`always_on_tiers` is why the exact switch renders disabled; `tier_requires` is why
+enabling *embedding* must first enable *near*. Sending `embedding_enabled=true`
+without `near_enabled` is a **400**, and a `threshold` below `min_threshold` is a
+**422** — neither is silently corrected.
+
+### `GET /dedup/groups`
+
+Query: `near_enabled`, `embedding_enabled`, `threshold`, `scope_type`,
+`scope_id`, `offset`, `limit` (≤ 200).
+
+```jsonc
+{
+  "groups": [{
+    "signature": "9f2c…",           // the id every verdict route takes
+    "tier": "exact",                 // exact | near | embedding
+    "confidence": 1.0,               // 1.0 for exact; else the WEAKEST pairwise link
+    "member_count": 2,
+    "cover_picture_id": 41,          // a preselection, never a silent decision
+    "why": [                         // group evidence, BOTH directions
+      { "text": "Identical file hash", "against": false },
+      { "text": "Different resolution", "against": true }
+    ],
+    "created_at": "2026-07-29T09:00:00",
+    "candidates": [{
+      "picture_id": 41, "width": 6016, "height": 4016, "megapixels": 24.16,
+      "size_bytes": 14800000, "format": "jpeg", "is_raw": false,
+      "score": 4, "tag_count": 2,
+      "created_at": "2026-05-12T14:22:00", "imported_at": "2026-05-13T08:00:00",
+      "stack_id": null, "reference_folder_id": null,
+      "file_path": null,             // non-null ONLY for reference-folder pictures
+      "cover_score": 108.64,         // megapixels*4 + tags*3 + score*2 + 8 if RAW
+      "why": [{ "text": "Highest resolution", "against": false }]
+    }]
+  }],
+  "total": 128, "offset": 0, "limit": 20,
+  "policy": { … }, "scope": { "scope_type": "global", "scope_id": null, "key": "global" },
+  "scan": { "status": "running", "scanned_pictures": 79412, "total_pictures": 128412,
+            "scanned_buckets": 210, "total_buckets": 940, "groups_found": 128,
+            "error": null }
+}
+```
+
+`scan` is the banner. `status` is `idle` when the scope has never been scanned —
+that is not an error, the queue still shows what an earlier global scan found.
+`file_path` is populated **only** for reference-folder pictures, where the user
+manages the files; for a managed-library picture the path is an implementation
+detail and the API returns `null`.
+
+Render the `why` pills as reasons, not conclusions: `against: false` is the olive
+check, `against: true` the red x. A group carrying red pills is the one that needs
+Compare.
+
+### `POST /dedup/counts`
+
+Read-only despite the verb (a scope list does not fit a URL). Body:
+`{ "policy": {…}, "scopes": [{ "scope_type": "set", "scope_id": "9" }] }`.
+
+```jsonc
+{
+  "unresolved_groups": 128,                              // the sidebar badge
+  "by_tier": { "exact": 96, "near": 30, "embedding": 2 },// INCLUDING disabled tiers
+  "scopes": [{ "scope_type": "set", "scope_id": "9", "key": "set:9",
+               "unresolved_groups": 4 }],
+  "policy": { … }, "scan": { … }
+}
+```
+
+`by_tier` deliberately reports tiers that are switched off, so a tier switch can
+be labelled with what enabling it would add. A non-global scope without a
+`scope_id` is a **400**.
+
+### `POST /dedup/scan`
+
+Body: `{ "policy": {…}, "scope": { "scope_type": "project", "scope_id": "3" } }`.
+Returns the scan progress row **immediately** — the queue is opened while the
+scan runs. Hashes are cached (computed on import), so a scoped scan only reads and
+compares them. Tier 1 lands in milliseconds; tier 2 groups appear as each
+candidate bucket finishes, so poll `GET /dedup/groups` and watch
+`scan.scanned_buckets` rather than waiting for `status: "complete"`.
+
+### Verdict routes
+
+All three take `{ "signature": "9f2c…", "batch_id": "…" }`; `POST
+/dedup/verdicts/stack` additionally takes `cover_picture_id` and
+`excluded_picture_ids`. An unknown signature, a cover outside the group, or
+excluding down to fewer than two members is a **400**. A member frozen by a locked
+picture set is a **423** with the usual `pictures_locked` detail.
+
+| Route | Effect |
+|---|---|
+| `POST /dedup/verdicts/stack` | Stacks the included members behind the cover and applies the metadata union. |
+| `POST /dedup/verdicts/keep-separate` | Records that the group is not duplicates. Changes **no** picture row. |
+| `POST /dedup/verdicts/reopen` | Returns a decided group to the queue. Does **not** unstack anything. |
+
+`stack` and `keep-separate` return:
+
+```jsonc
+{ "signature": "9f2c…", "verdict": "stacked", "stack_id": 77,
+  "cover_picture_id": 41, "picture_ids": [41, 42], "excluded_picture_ids": [],
+  "batch_id": "a1b2…",
+  "metadata_union": { "tags_added": 3, "scores_lifted": 1,
+                      "characters_pending": 0, "membership_changed": true,
+                      "best_score": 5 } }
+```
+
+`metadata_union` is what the action receipt should say. Stacking **unions** tags,
+project membership and set membership onto every member and lifts every member to
+the highest score; nothing is overwritten and nothing is deleted.
+
+### `POST /dedup/auto-stack`
+
+Body: `{ "scope": {…}, "dry_run": true, "batch_id": null, "limit": null }`.
+**Defaults to `dry_run: true`**, which returns the counts the consent dialog shows
+and writes nothing. Send `dry_run: false` to apply.
+
+```jsonc
+{ "batch_id": "a1b2…", "dry_run": false, "groups": 1204, "pictures": 2611,
+  "scope": { … }, "results": [ /* one verdict object per group */ ],
+  "failures": [ { "signature": "…", "error": "…" } ] }
+```
+
+Only the **exact** tier is eligible; near and embedding groups always go through
+the queue no matter how confident they look. Every group in the run shares one
+`batch_id`, so N stacks reverse with a single undo. `failures` is non-empty when a
+group could not be stacked — one bad group never aborts the run, and the response
+reports the partial result honestly rather than hiding it.
+
+### Not in this API
+
+There is **no deletion route** anywhere in v1.9. A stack is a grouping row plus a
+cover pointer; dropping it restores the flat grid exactly. Any UI copy implying
+files are removed would be wrong.
+
+---
+
+*Last updated: 2026-07-29. Update this document whenever any integration contract (URL prefix, event names, auth mode, build output path, CORS policy, share-token mechanism, settings field names) changes.*

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -628,6 +628,7 @@ Query: `near_enabled`, `embedding_enabled`, `threshold`, `scope_type`,
       "created_at": "2026-05-12T14:22:00", "imported_at": "2026-05-13T08:00:00",
       "stack_id": null, "reference_folder_id": null,
       "file_path": null,             // non-null ONLY for reference-folder pictures
+      "thumbnail_version": "320x240",// append as ?v= — same token the grid uses
       "cover_score": 108.64,         // megapixels*4 + tags*3 + score*2 + 8 if RAW
       "why": [{ "text": "Highest resolution", "against": false }]
     }]
@@ -650,6 +651,19 @@ Render the `why` pills as reasons, not conclusions: `against: false` is the oliv
 check, `against: true` the red x. A group carrying red pills is the one that needs
 Compare.
 
+**`thumbnail_version` must be appended as `?v=`** to every thumbnail URL the queue
+builds — `/api/v1/pictures/thumbnails/{picture_id}.webp?v={thumbnail_version}` —
+exactly as the batch-thumbnail endpoint does (both come from the same server-side
+helper, so they cannot drift). Without it a thumbnail regenerated mid-triage keeps
+painting the stale cached bitmap, because the queue's URL never changes. The value
+is `"0"` until the picture has been processed.
+
+**Scope validation.** `scope_id` must be an integer for `project` / `set` /
+`character`; anything else is a **400** at the boundary on every route that takes a
+scope, including `POST /dedup/scan` (which writes nothing on a rejected scope). For
+`folder`, `%` and `_` are escaped rather than treated as wildcards, so a folder
+scope always means the folder it names.
+
 ### `POST /dedup/counts`
 
 Read-only despite the verb (a scope list does not fit a URL). Body:
@@ -667,7 +681,8 @@ Read-only despite the verb (a scope list does not fit a URL). Body:
 
 `by_tier` deliberately reports tiers that are switched off, so a tier switch can
 be labelled with what enabling it would add. A non-global scope without a
-`scope_id` is a **400**.
+`scope_id` is a **400**, and the `scopes` list is capped at **200** entries (each
+is a separate correlated `COUNT`) — over that is a **422**.
 
 ### `POST /dedup/scan`
 
@@ -707,23 +722,60 @@ picture set is a **423** with the usual `pictures_locked` detail.
 project membership and set membership onto every member and lifts every member to
 the highest score; nothing is overwritten and nothing is deleted.
 
+> **The union is also a visibility change.** Adding an out-of-scope duplicate to a
+> *shared* set means every live share token for that set now reaches it. That is
+> the shipped stack-atomic membership model (ordinary `POST /stacks` does the
+> same), but auto-stack applies it in bulk — worth saying out loud in the consent
+> copy. See backend §22.8 accepted risk A1.
+
 ### `POST /dedup/auto-stack`
 
 Body: `{ "scope": {…}, "dry_run": true, "batch_id": null, "limit": null }`.
 **Defaults to `dry_run: true`**, which returns the counts the consent dialog shows
 and writes nothing. Send `dry_run: false` to apply.
 
+Dry run:
+
 ```jsonc
-{ "batch_id": "a1b2…", "dry_run": false, "groups": 1204, "pictures": 2611,
-  "scope": { … }, "results": [ /* one verdict object per group */ ],
-  "failures": [ { "signature": "…", "error": "…" } ] }
+{ "batch_id": null, "dry_run": true, "groups": 1204, "pictures": 2611,
+  "scope": { … }, "results": [],
+  "dry_run_summary": {
+    "groups": 1204,
+    "groups_by_tier": { "exact": 1204, "near": 0, "embedding": 0 },
+    "pictures": 2611,
+    "covers_gaining_tags": 310,
+    "covers_gaining_score": 88,
+    "covers_gaining_metadata": 361   // the dialog's "covers gaining metadata" row
+  } }
+```
+
+`dry_run_summary` is derived from the **same** snapshot as the top-level counts in
+a single read, so the dialog's figures can never disagree with each other. The
+union is not executed to produce them and nothing is written; a cover "gains" a
+facet when some other member of its group carries something it does not.
+
+Applied (including a partially applied run):
+
+```jsonc
+{ "batch_id": "a1b2…", "dry_run": false, "groups": 1203, "pictures": 2609,
+  "scope": { … },
+  "results":  [ { …verdict…, "outcome": "applied" } ],
+  "failures": [ { "signature": "…", "outcome": "blocked", "status_code": 423,
+                  "error": { "code": "set_locked", … } } ],
+  "blocked": 1, "failed": 0 }
 ```
 
 Only the **exact** tier is eligible; near and embedding groups always go through
 the queue no matter how confident they look. Every group in the run shares one
-`batch_id`, so N stacks reverse with a single undo. `failures` is non-empty when a
-group could not be stacked — one bad group never aborts the run, and the response
-reports the partial result honestly rather than hiding it.
+`batch_id`, so N stacks reverse with a single `POST
+/operations/batches/{batch_id}/undo`.
+
+**Every group is accounted for under exactly one `outcome`** — `applied`,
+`blocked` (a guard refused it, in practice a locked picture set at 423) or
+`failed` (it could not be resolved at all). One bad group never aborts the run,
+and **the `batch_id` is returned even on a partially applied run**, so work that
+did happen always comes back with its undo handle. Show `blocked` groups to the
+user: they are still in the queue awaiting an individual decision.
 
 ### Not in this API
 

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -606,7 +606,7 @@ without `near_enabled` is a **400**, and a `threshold` below `min_threshold` is 
 ### `GET /dedup/groups`
 
 Query: `near_enabled`, `embedding_enabled`, `threshold`, `scope_type`,
-`scope_id`, `offset`, `limit` (≤ 200).
+`scope_id`, `cursor`, `limit` (≤ 200), and the deprecated `offset`.
 
 ```jsonc
 {
@@ -634,12 +634,23 @@ Query: `near_enabled`, `embedding_enabled`, `threshold`, `scope_type`,
     }]
   }],
   "total": 128, "offset": 0, "limit": 20,
+  "cursor": null,                    // echo of the cursor this page was read from
+  "next_cursor": "MXwxfDQy",         // pass back as ?cursor=; null at end-of-found
   "policy": { … }, "scope": { "scope_type": "global", "scope_id": null, "key": "global" },
   "scan": { "status": "running", "scanned_pictures": 79412, "total_pictures": 128412,
             "scanned_buckets": 210, "total_buckets": 940, "groups_found": 128,
             "error": null }
 }
 ```
+
+**Page with `cursor`, not `offset`.** Send the previous page's `next_cursor`
+back verbatim and stop when it is `null`. The queue is a live list: deciding a
+verdict removes the group the user just decided, and a tier-2 scan commits new
+groups after every bucket, so an `offset` re-read skips exactly as many groups as
+changed underneath it — reproducibly, with a single verdict between two pages.
+The cursor is **opaque**: never construct, parse or edit one. A cursor the server
+did not mint is a **400** (not a silent restart from page 1), `offset` is
+deprecated but still works, and sending **both** is a **400**.
 
 `scan` is the banner. `status` is `idle` when the scope has never been scanned —
 that is not an error, the queue still shows what an earlier global scan found.
@@ -701,11 +712,24 @@ All three take `{ "signature": "9f2c…", "batch_id": "…" }`; `POST
 excluding down to fewer than two members is a **400**. A member frozen by a locked
 picture set is a **423** with the usual `pictures_locked` detail.
 
+**`batch_id` is namespaced.** Omit it and the server mints its own `srv-…`;
+supply one only to make several calls reverse as one undo, and then it must match
+`cli-<4–76 chars of A-Z a-z 0-9 _ ->` (≤ 80). Any other shape — including a
+`srv-…` id — is a **400**, so a client cannot mint what reads as a server batch
+or graft its rows into an existing one.
+
 | Route | Effect |
 |---|---|
 | `POST /dedup/verdicts/stack` | Stacks the included members behind the cover and applies the metadata union. |
 | `POST /dedup/verdicts/keep-separate` | Records that the group is not duplicates. Changes **no** picture row. |
 | `POST /dedup/verdicts/reopen` | Returns a decided group to the queue. Does **not** unstack anything. |
+
+**Undoing a stack verdict also returns its group to the queue.** `POST
+/operations/undo` and `POST /operations/batches/{batch_id}/undo` unstack the
+pictures *and* reopen the verdict, so after an undo the group is back in `GET
+/dedup/groups` and back in the sidebar count with no extra call — do not follow an
+undo with a `reopen`. Redo re-decides it. `reopen` stays the explicit way back
+from a **keep-separate**, which records no operation and therefore has no undo.
 
 `stack` and `keep-separate` return:
 
@@ -726,7 +750,7 @@ the highest score; nothing is overwritten and nothing is deleted.
 > *shared* set means every live share token for that set now reaches it. That is
 > the shipped stack-atomic membership model (ordinary `POST /stacks` does the
 > same), but auto-stack applies it in bulk — worth saying out loud in the consent
-> copy. See backend §22.8 accepted risk A1.
+> copy. See backend §22.9 accepted risk A1.
 
 ### `POST /dedup/auto-stack`
 

--- a/docs/reviews/authz-coverage-matrix.md
+++ b/docs/reviews/authz-coverage-matrix.md
@@ -258,6 +258,35 @@ covered in both directions by `tests/test_dedup_sweep_api.py`
 | GET | `/api/v1/dedup/sweep/policy` | owner_only |  | Sweep policy defaults/bounds; operator surface, returns no per-object data |
 | POST | `/api/v1/dedup/sweep/dry-run` | owner_only |  | Vault-wide near-duplicate plan (counts + picture ids across the whole library); cannot be narrowed to a share token's scope without leaking out-of-scope counts, same reasoning as tag_health. POST also blocked for READ tokens |
 
+The eight routes below were added 2026-07-29 with the v1.9 tiered Duplicates queue
+(Lane 1A). All are new, none carries inline authz code (the gate is the sole
+enforcement, §16.1), and all eight are covered **in both directions** by
+`tests/test_dedup_tiers_api.py` — negative via `Authorization: Bearer` *and* via
+the `?token=` query-parameter path
+(`test_scoped_read_token_is_denied_on_every_route`), plus
+`test_a_denied_verdict_route_changed_nothing` (the 403 is fail-closed: no write
+happened) and `test_unauthenticated_is_denied`; positive on every route via the
+owner cookie session across the policy, queue, counts, scan, verdict and
+auto-stack tests.
+
+Two rationales apply. **Read routes:** a duplicate group is defined by *content
+identity*, not by collection membership, so it routinely spans a share token's
+scope boundary; narrowing it would leak that out-of-scope copies exist, which is
+the tag_health reasoning. **Write routes:** a verdict is addressed by a content
+signature that can name any picture in the vault and mutates stack membership,
+tags, project/set membership and scores, so there is no coherent scoped form of it.
+
+| Method | Effective path | Policy | id_param / body_ids | Rationale (current enforcement) |
+|---|---|---|---|---|
+| GET | `/api/v1/dedup/policy` | owner_only |  | Tier defaults/bounds; operator surface, returns no per-object data |
+| GET | `/api/v1/dedup/groups` | owner_only |  | Returns duplicate groups with picture ids, dimensions and (for reference-folder pictures) file paths from anywhere in the vault; content-identity grouping crosses any token scope |
+| POST | `/api/v1/dedup/counts` | owner_only |  | Vault-wide and per-scope duplicate counts. Read-only but POST because the scope list does not fit a URL; POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/scan` | owner_only |  | Queues a background scan over the vault or a chosen scope; owner-only maintenance trigger. POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/verdicts/stack` | owner_only |  | Mutates stack membership, tags, project/set membership and scores across pictures named only by a content signature. POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/verdicts/keep-separate` | owner_only |  | Writes a permanent verdict about an arbitrary set of vault pictures. POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/verdicts/reopen` | owner_only |  | Reverses a stored verdict about an arbitrary set of vault pictures. POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/auto-stack` | owner_only |  | Bulk stacking across the whole vault under one undo batch; the most far-reaching mutation on this surface. POST also blocked for READ tokens |
+
 ### characters.py
 
 | Method | Effective path | Policy | id_param / body_ids | Rationale (current enforcement) |

--- a/pixlstash/authz/registry.py
+++ b/pixlstash/authz/registry.py
@@ -469,6 +469,77 @@ ROUTE_POLICIES: dict[tuple[str, str], RoutePolicy] = {
             "as tag_health). POST is also blocked for READ tokens"
         ),
     ),
+    # ── dedup.py (v1.9 tiered duplicate queue) ──────────────────────────────
+    # Every route on this surface is OWNER_ONLY for one of two reasons, both of
+    # which are the tag-health reasoning: a vault-wide aggregate cannot be
+    # narrowed to a share token's scope without leaking the existence and count
+    # of out-of-scope pictures, and a verdict mutates stacks across arbitrary
+    # pictures that a scoped token has no business touching.
+    ("GET", "/api/v1/dedup/policy"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Tier defaults/bounds for the duplicate queue; an owner-only "
+            "operator surface returning no per-object data"
+        ),
+    ),
+    ("GET", "/api/v1/dedup/groups"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Returns duplicate groups with picture ids, dimensions and (for "
+            "reference-folder pictures) file paths from anywhere in the vault. "
+            "A group is defined by content identity, not by collection "
+            "membership, so it routinely spans a share token's scope boundary "
+            "and cannot be narrowed without leaking that out-of-scope copies "
+            "exist"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/counts"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Vault-wide and per-scope duplicate counts. Read-only but POST "
+            "because the scope list does not fit a URL; POST is also blocked "
+            "for READ tokens. Counts describe pictures outside any token's "
+            "scope (same reasoning as tag_health)"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/scan"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Queues a background scan over the whole vault or a chosen scope; "
+            "an owner-only maintenance trigger. POST is also blocked for READ "
+            "tokens"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/verdicts/stack"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Mutates stack membership, tags, project/set membership and scores "
+            "across pictures identified only by a content signature, which can "
+            "name any picture in the vault. POST is also blocked for READ tokens"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/verdicts/keep-separate"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Writes a permanent verdict about an arbitrary set of vault "
+            "pictures. POST is also blocked for READ tokens"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/verdicts/reopen"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Reverses a stored verdict about an arbitrary set of vault "
+            "pictures. POST is also blocked for READ tokens"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/auto-stack"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Bulk stacking across the whole vault under one undo batch; the "
+            "most far-reaching mutation on this surface. POST is also blocked "
+            "for READ tokens"
+        ),
+    ),
     # ── characters.py ───────────────────────────────────────────────────────
     ("GET", "/api/v1/characters"): _LIST_AWARE,
     ("GET", "/api/v1/characters/{id}"): RoutePolicy(_CHAR, id_param="id"),

--- a/pixlstash/db_models/__init__.py
+++ b/pixlstash/db_models/__init__.py
@@ -1,4 +1,10 @@
 from .character import Character  # noqa: F401
+from .dedup import (  # noqa: F401
+    DedupGroup,
+    DedupGroupMember,
+    DedupScan,
+    DedupVerdict,
+)
 from .deleted_file_log import DeletedFileLog  # noqa: F401
 from .entity_project import (  # noqa: F401
     CharacterProjectMember,

--- a/pixlstash/db_models/dedup.py
+++ b/pixlstash/db_models/dedup.py
@@ -1,0 +1,253 @@
+"""Persistent state for the tiered duplicate detection queue (v1.9).
+
+Three concerns, three tables:
+
+* :class:`DedupGroup` / :class:`DedupGroupMember` — the **found groups cache**.
+  Detection writes groups here as it finds them, so the queue is paged from the
+  database by confidence descending and never materialised whole in memory (the
+  design's "10 groups and 10,000 perform identically" rule). Without this cache a
+  "page 40 of the queue" request would have to redo the whole scan.
+* :class:`DedupVerdict` — the **verdict memory**. Keyed on a group *signature*
+  (see :func:`pixlstash.services.dedup_tier_service.group_signature`), not on
+  group or picture ids, so a rescan or a re-import that produces the same set of
+  files finds the same signature and never re-asks. "Keep separate" is permanent
+  until the user reopens it.
+* :class:`DedupScan` — the **scan progress** behind the "scanned N of M" banner
+  and the scoped-scan entry points, one row per scope key.
+
+Nothing here stores pixels, and no row in this module ever causes a delete: a
+verdict is either a stack (additive) or a "keep separate" note.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String
+from sqlmodel import Field, SQLModel
+
+# ``DedupGroup.tier`` / scan tier values. Ordered loosest-last: tier 1 is exact
+# and always on, each looser tier is an opt-in that requires the tier above it.
+TIER_EXACT = "exact"
+TIER_NEAR = "near"
+TIER_EMBEDDING = "embedding"
+
+# ``DedupVerdict.verdict`` values. The only two verdicts in 1.9 — there is no
+# deletion verdict anywhere in this release.
+VERDICT_STACKED = "stacked"
+VERDICT_KEEP_SEPARATE = "keep_separate"
+
+# ``DedupScan.status`` values.
+SCAN_PENDING = "pending"
+SCAN_RUNNING = "running"
+SCAN_COMPLETE = "complete"
+SCAN_FAILED = "failed"
+
+
+class DedupGroup(SQLModel, table=True):
+    """One detected duplicate group awaiting (or carrying) a verdict.
+
+    A group is identified by its :attr:`signature` rather than its id, so the
+    same set of files always maps to the same row across rescans. Detection
+    upserts on the signature; the queue pages on ``(resolved, confidence DESC)``.
+
+    Attributes:
+        signature: Stable hash of the sorted member content keys. Unique.
+        tier: Which tier found it (:data:`TIER_EXACT` / :data:`TIER_NEAR` /
+            :data:`TIER_EMBEDDING`). Exact is always shown; the looser tiers are
+            filtered by the caller's :class:`~pixlstash.services.dedup_tier_service.TierPolicy`.
+        confidence: 1.0 for an exact match, otherwise the group's weakest
+            pairwise similarity — the value the queue sorts by, descending.
+        member_count: Number of members, denormalised so the queue page does not
+            need a join to render "Stack 3".
+        cover_picture_id: The server's cover preselection (never silent — the
+            client shows it and the user may override with 1-9).
+        evidence: JSON ``[[text, against_bool], ...]`` — the why-pills. Stored
+            with the group because it describes *this* grouping, and recomputing
+            it would need the member metadata the queue page is trying to avoid
+            loading for every group.
+        resolved: True once a verdict covers this signature. The sidebar badge
+            counts ``resolved IS FALSE``.
+        scan_id: The :class:`DedupScan` that produced it, or NULL for a group
+            found outside a tracked scan.
+    """
+
+    __tablename__ = "dedupgroup"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    signature: str = Field(
+        sa_column=Column("signature", String, nullable=False, unique=True, index=True)
+    )
+    tier: str = Field(sa_column=Column("tier", String, nullable=False, index=True))
+    confidence: float = Field(default=0.0, index=True)
+    member_count: int = Field(default=0)
+    cover_picture_id: Optional[int] = Field(default=None)
+    evidence: Optional[str] = Field(
+        default=None, sa_column=Column("evidence", String, nullable=True)
+    )
+    resolved: bool = Field(default=False, index=True)
+    scan_id: Optional[int] = Field(default=None, index=True)
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column("created_at", DateTime, nullable=False),
+    )
+
+    __table_args__ = (
+        # The queue's only hot query: unresolved groups, confidence descending.
+        Index("ix_dedupgroup_queue", "resolved", "confidence"),
+    )
+
+
+class DedupGroupMember(SQLModel, table=True):
+    """Membership of a picture in a :class:`DedupGroup`.
+
+    ``picture_id`` is indexed because the scoped counts (project / set /
+    character / folder context menus) and the invalidation path both start from
+    a picture id set and ask which groups it touches.
+    """
+
+    __tablename__ = "dedupgroupmember"
+
+    group_id: int = Field(
+        sa_column=Column(
+            "group_id",
+            Integer,
+            ForeignKey("dedupgroup.id", ondelete="CASCADE"),
+            primary_key=True,
+            index=True,
+        )
+    )
+    picture_id: int = Field(
+        sa_column=Column(
+            "picture_id",
+            Integer,
+            ForeignKey("picture.id", ondelete="CASCADE"),
+            primary_key=True,
+            index=True,
+        )
+    )
+    position: int = Field(default=0)
+
+
+class DedupVerdict(SQLModel, table=True):
+    """A remembered decision about one group signature.
+
+    This is what makes the sidebar count trustworthy: a rescan re-derives the
+    same signature and resolves the group immediately instead of asking again.
+    A "keep separate" verdict is permanent until :attr:`reopened_at` is stamped
+    from the Stacks view.
+
+    Attributes:
+        signature: The group signature this verdict covers. Unique.
+        verdict: :data:`VERDICT_STACKED` or :data:`VERDICT_KEEP_SEPARATE`.
+        picture_ids: JSON list of the member ids the verdict was made on, for
+            the audit trail and for the reopen path.
+        excluded_picture_ids: JSON list of members the user left out of the
+            stack (the design's X key). Empty for keep-separate.
+        cover_picture_id: The cover the user confirmed or chose.
+        stack_id: The stack the members landed in, for a ``stacked`` verdict.
+        batch_id: The operation-log batch this verdict was recorded under; bulk
+            auto-stack shares one batch id across every group so N stacks
+            reverse with a single undo.
+        reopened_at: When the user reopened the decision. A reopened verdict no
+            longer resolves its group, so the group returns to the queue.
+    """
+
+    __tablename__ = "dedupverdict"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    signature: str = Field(
+        sa_column=Column("signature", String, nullable=False, unique=True, index=True)
+    )
+    verdict: str = Field(
+        sa_column=Column("verdict", String, nullable=False, index=True)
+    )
+    picture_ids: str = Field(
+        default="[]", sa_column=Column("picture_ids", String, nullable=False)
+    )
+    excluded_picture_ids: str = Field(
+        default="[]", sa_column=Column("excluded_picture_ids", String, nullable=False)
+    )
+    cover_picture_id: Optional[int] = Field(default=None)
+    stack_id: Optional[int] = Field(default=None, index=True)
+    batch_id: Optional[str] = Field(
+        default=None, sa_column=Column("batch_id", String, nullable=True, index=True)
+    )
+    decided_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column("decided_at", DateTime, nullable=False),
+    )
+    reopened_at: Optional[datetime] = Field(
+        default=None, sa_column=Column("reopened_at", DateTime, nullable=True)
+    )
+
+
+class DedupScan(SQLModel, table=True):
+    """Progress of one scan, keyed on its scope.
+
+    One row per scope key ("global", "project:3", "set:9", ...), reused across
+    rescans of that scope so the banner has a stable place to read from and a
+    scoped scan can report "reused cached hashes" without inventing a new row
+    every time.
+
+    Attributes:
+        scope_key: Canonical scope identifier. Unique.
+        scanned_pictures / total_pictures: The "scanned N of M" banner.
+        scanned_buckets / total_buckets: Tier-2 bucket progress; a bucket's
+            groups become visible in the queue the moment its bucket finishes.
+        tiers: JSON list of the tiers this scan was asked to run.
+    """
+
+    __tablename__ = "dedupscan"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    scope_key: str = Field(
+        sa_column=Column("scope_key", String, nullable=False, unique=True, index=True)
+    )
+    scope_type: str = Field(
+        default="global", sa_column=Column("scope_type", String, nullable=False)
+    )
+    scope_id: Optional[str] = Field(
+        default=None, sa_column=Column("scope_id", String, nullable=True)
+    )
+    tiers: str = Field(default="[]", sa_column=Column("tiers", String, nullable=False))
+    threshold: float = Field(default=0.9)
+    status: str = Field(
+        default=SCAN_PENDING,
+        sa_column=Column("status", String, nullable=False, index=True),
+    )
+    total_pictures: int = Field(default=0)
+    scanned_pictures: int = Field(default=0)
+    total_buckets: int = Field(default=0)
+    scanned_buckets: int = Field(default=0)
+    groups_found: int = Field(default=0)
+    error: Optional[str] = Field(
+        default=None, sa_column=Column("error", String, nullable=True)
+    )
+    started_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column("started_at", DateTime, nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column("updated_at", DateTime, nullable=False),
+    )
+    finished_at: Optional[datetime] = Field(
+        default=None, sa_column=Column("finished_at", DateTime, nullable=True)
+    )
+
+
+__all__ = [
+    "DedupGroup",
+    "DedupGroupMember",
+    "DedupScan",
+    "DedupVerdict",
+    "SCAN_COMPLETE",
+    "SCAN_FAILED",
+    "SCAN_PENDING",
+    "SCAN_RUNNING",
+    "TIER_EMBEDDING",
+    "TIER_EXACT",
+    "TIER_NEAR",
+    "VERDICT_KEEP_SEPARATE",
+    "VERDICT_STACKED",
+]

--- a/pixlstash/migrations/versions/0087_add_dedup_tier_tables.py
+++ b/pixlstash/migrations/versions/0087_add_dedup_tier_tables.py
@@ -1,0 +1,142 @@
+"""Add the tiered duplicate-detection tables (v1.9 Dedup -> Stacks).
+
+Four tables backing the Duplicates queue:
+
+* ``dedupgroup`` / ``dedupgroupmember`` — the found-groups cache. Detection
+  writes groups as it finds them so the queue can be paged from the database by
+  confidence descending instead of being materialised whole.
+* ``dedupverdict`` — verdict memory keyed on a group signature (the sorted
+  member content hashes), so rescans and re-imports never re-ask.
+* ``dedupscan`` — per-scope scan progress for the "scanned N of M" banner.
+
+**No reprocessing reset is needed.** Tier 1 reuses the existing indexed
+``picture.pixel_sha`` column and tier 2 the existing ``picture.perceptual_hash``
+/ ``picture.size_bin_index`` columns; nothing computed by an earlier release
+becomes invalid, so no column is NULLed here. Pictures whose ``pixel_sha`` was
+never computed are backfilled by ``MissingPixelShaFinder`` at runtime, which
+already selects on ``pixel_sha IS NULL`` — a reset would be a no-op.
+
+Revision ID: 0087_add_dedup_tier_tables
+Revises: 0085_recompute_smart_score_restored_builtin_anchors
+Create Date: 2026-07-29 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0087_add_dedup_tier_tables"
+down_revision: Union[str, None] = "0085_recompute_smart_score_restored_builtin_anchors"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "dedupgroup" not in existing_tables:
+        op.create_table(
+            "dedupgroup",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("signature", sa.String(), nullable=False),
+            sa.Column("tier", sa.String(), nullable=False),
+            sa.Column("confidence", sa.Float(), nullable=True),
+            sa.Column("member_count", sa.Integer(), nullable=True),
+            sa.Column("cover_picture_id", sa.Integer(), nullable=True),
+            sa.Column("evidence", sa.String(), nullable=True),
+            sa.Column("resolved", sa.Boolean(), nullable=True),
+            sa.Column("scan_id", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_dedupgroup_signature", "dedupgroup", ["signature"], unique=True
+        )
+        op.create_index("ix_dedupgroup_tier", "dedupgroup", ["tier"])
+        op.create_index("ix_dedupgroup_confidence", "dedupgroup", ["confidence"])
+        op.create_index("ix_dedupgroup_resolved", "dedupgroup", ["resolved"])
+        op.create_index("ix_dedupgroup_scan_id", "dedupgroup", ["scan_id"])
+        op.create_index("ix_dedupgroup_queue", "dedupgroup", ["resolved", "confidence"])
+
+    if "dedupgroupmember" not in existing_tables:
+        op.create_table(
+            "dedupgroupmember",
+            sa.Column("group_id", sa.Integer(), nullable=False),
+            sa.Column("picture_id", sa.Integer(), nullable=False),
+            sa.Column("position", sa.Integer(), nullable=True),
+            sa.ForeignKeyConstraint(
+                ["group_id"], ["dedupgroup.id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(["picture_id"], ["picture.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("group_id", "picture_id"),
+        )
+        op.create_index(
+            "ix_dedupgroupmember_group_id", "dedupgroupmember", ["group_id"]
+        )
+        op.create_index(
+            "ix_dedupgroupmember_picture_id", "dedupgroupmember", ["picture_id"]
+        )
+
+    if "dedupverdict" not in existing_tables:
+        op.create_table(
+            "dedupverdict",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("signature", sa.String(), nullable=False),
+            sa.Column("verdict", sa.String(), nullable=False),
+            sa.Column("picture_ids", sa.String(), nullable=False),
+            sa.Column("excluded_picture_ids", sa.String(), nullable=False),
+            sa.Column("cover_picture_id", sa.Integer(), nullable=True),
+            sa.Column("stack_id", sa.Integer(), nullable=True),
+            sa.Column("batch_id", sa.String(), nullable=True),
+            sa.Column("decided_at", sa.DateTime(), nullable=False),
+            sa.Column("reopened_at", sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_dedupverdict_signature", "dedupverdict", ["signature"], unique=True
+        )
+        op.create_index("ix_dedupverdict_verdict", "dedupverdict", ["verdict"])
+        op.create_index("ix_dedupverdict_stack_id", "dedupverdict", ["stack_id"])
+        op.create_index("ix_dedupverdict_batch_id", "dedupverdict", ["batch_id"])
+
+    if "dedupscan" not in existing_tables:
+        op.create_table(
+            "dedupscan",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("scope_key", sa.String(), nullable=False),
+            sa.Column("scope_type", sa.String(), nullable=False),
+            sa.Column("scope_id", sa.String(), nullable=True),
+            sa.Column("tiers", sa.String(), nullable=False),
+            sa.Column("threshold", sa.Float(), nullable=True),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("total_pictures", sa.Integer(), nullable=True),
+            sa.Column("scanned_pictures", sa.Integer(), nullable=True),
+            sa.Column("total_buckets", sa.Integer(), nullable=True),
+            sa.Column("scanned_buckets", sa.Integer(), nullable=True),
+            sa.Column("groups_found", sa.Integer(), nullable=True),
+            sa.Column("error", sa.String(), nullable=True),
+            sa.Column("started_at", sa.DateTime(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), nullable=False),
+            sa.Column("finished_at", sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_dedupscan_scope_key", "dedupscan", ["scope_key"], unique=True
+        )
+        op.create_index("ix_dedupscan_status", "dedupscan", ["status"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    for table in ("dedupscan", "dedupverdict", "dedupgroupmember", "dedupgroup"):
+        if table in existing_tables:
+            op.drop_table(table)

--- a/pixlstash/migrations/versions/0088_add_dedup_tier_tables.py
+++ b/pixlstash/migrations/versions/0088_add_dedup_tier_tables.py
@@ -9,12 +9,26 @@ Four tables backing the Duplicates queue:
   member content hashes), so rescans and re-imports never re-ask.
 * ``dedupscan`` — per-scope scan progress for the "scanned N of M" banner.
 
-**No reprocessing reset is needed.** Tier 1 reuses the existing indexed
-``picture.pixel_sha`` column and tier 2 the existing ``picture.perceptual_hash``
-/ ``picture.size_bin_index`` columns; nothing computed by an earlier release
-becomes invalid, so no column is NULLed here. Pictures whose ``pixel_sha`` was
-never computed are backfilled by ``MissingPixelShaFinder`` at runtime, which
-already selects on ``pixel_sha IS NULL`` — a reset would be a no-op.
+**No reprocessing reset is needed on `picture`.** Tier 1 reuses the existing
+indexed ``picture.pixel_sha`` column and tier 2 the existing
+``picture.perceptual_hash`` / ``picture.size_bin_index`` columns; nothing
+computed by an earlier release becomes invalid, so no column is NULLed here.
+Pictures whose ``pixel_sha`` was never computed are backfilled by
+``MissingPixelShaFinder`` at runtime, which already selects on
+``pixel_sha IS NULL`` — a reset would be a no-op.
+
+**Stale signatures are purged.** The group signature was changed during review to
+include the ``size_bytes`` co-key (``<pixel_sha>:<size_bytes>``), because the
+digest alone is sampled above 128 KiB and did not identify a file — two distinct
+exact groups could collide on one signature. Rows written before that change are
+keyed on the old format: a stale ``dedupverdict`` would silently never match
+again (a remembered decision quietly forgotten) and a stale ``dedupgroup`` would
+linger forever, matching no future detection while still inflating the sidebar
+badge. Neither self-heals, so this migration empties the four tables when they
+already exist. That can only affect a developer machine that ran this feature
+branch before the fix — the tables ship for the first time here — and rebuilding
+them costs one rescan. Amending the migration rather than stacking a second one
+follows the feature-branch rule in CLAUDE.md.
 
 Revision ID: 0088_add_dedup_tier_tables
 Revises: 0087_add_entity_project_membership
@@ -131,6 +145,14 @@ def upgrade() -> None:
             "ix_dedupscan_scope_key", "dedupscan", ["scope_key"], unique=True
         )
         op.create_index("ix_dedupscan_status", "dedupscan", ["status"])
+
+    # Purge rows written under the pre-review signature format (see the module
+    # docstring). Only a table that already existed can hold them; a table just
+    # created above is empty, so the DELETE is a no-op there. Children first so
+    # the foreign key holds on databases that enforce it.
+    for table in ("dedupgroupmember", "dedupgroup", "dedupverdict", "dedupscan"):
+        if table in existing_tables:
+            op.execute(sa.text(f"DELETE FROM {table}"))  # noqa: S608 - fixed literals
 
 
 def downgrade() -> None:

--- a/pixlstash/migrations/versions/0088_add_dedup_tier_tables.py
+++ b/pixlstash/migrations/versions/0088_add_dedup_tier_tables.py
@@ -16,8 +16,8 @@ becomes invalid, so no column is NULLed here. Pictures whose ``pixel_sha`` was
 never computed are backfilled by ``MissingPixelShaFinder`` at runtime, which
 already selects on ``pixel_sha IS NULL`` — a reset would be a no-op.
 
-Revision ID: 0087_add_dedup_tier_tables
-Revises: 0085_recompute_smart_score_restored_builtin_anchors
+Revision ID: 0088_add_dedup_tier_tables
+Revises: 0087_add_entity_project_membership
 Create Date: 2026-07-29 00:00:00.000000
 
 """
@@ -28,8 +28,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "0087_add_dedup_tier_tables"
-down_revision: Union[str, None] = "0085_recompute_smart_score_restored_builtin_anchors"
+revision: str = "0088_add_dedup_tier_tables"
+down_revision: Union[str, None] = "0087_add_entity_project_membership"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/pixlstash/routes/dedup.py
+++ b/pixlstash/routes/dedup.py
@@ -1,34 +1,66 @@
-"""HTTP routes for the vault-wide near-duplicate sweep (dry run only).
+"""HTTP routes for duplicate detection: the tiered queue plus the sweep dry run.
 
-Two endpoints, both owner-only:
+Two surfaces live here, and every route is owner-only.
 
-* ``GET  /dedup/sweep/policy``  — the default confidence policy plus the bounds
-  every knob is validated against, so a client renders its controls from the
-  server's values instead of re-hardcoding thresholds.
-* ``POST /dedup/sweep/dry-run`` — resolve every near-duplicate group in the vault
-  under a supplied policy and return the plan: how many groups auto-collapse, how
-  many need review, why each review group needs review, what each group would do
-  to existing stacks, and how many bytes the non-keeper members hold.
+**The v1.9 Duplicates queue** (:mod:`pixlstash.services.dedup_tier_service` and
+:mod:`pixlstash.services.dedup_verdict_service`):
 
-**Nothing here mutates anything.** The sweep's execution step is a later lane;
-this surface is the policy-level consent screen's data source. Resolution means
-stacking, never deleting — see :mod:`pixlstash.services.dedup_sweep_service`.
+* ``GET  /dedup/policy``            — tier defaults + bounds; the client renders
+  its tier switches and threshold slider from these values rather than
+  re-hardcoding 0.90 and 0.65.
+* ``GET  /dedup/groups``            — one page of the queue, confidence
+  descending, plus this scope's scan progress for the banner.
+* ``POST /dedup/counts``            — the sidebar badge, the per-tier counts, and
+  as many scoped counts as the context menus need, in one request. Read-only
+  despite the verb: the scope list does not fit in a URL.
+* ``POST /dedup/scan``              — queue a scoped scan; returns immediately.
+* ``POST /dedup/verdicts/stack``    — stack a group behind a chosen cover.
+* ``POST /dedup/verdicts/keep-separate`` — remember that a group is not
+  duplicates; permanent until reopened.
+* ``POST /dedup/verdicts/reopen``   — return a decided group to the queue.
+* ``POST /dedup/auto-stack``        — the exact tier's bulk action, one
+  operation-log batch id so N stacks reverse with one undo.
 
-Authorization is declared in ``pixlstash/authz/registry.py`` (both routes
+**The vault-wide sweep dry run** (:mod:`pixlstash.services.dedup_sweep_service`),
+unchanged and still non-destructive:
+
+* ``GET  /dedup/sweep/policy``  — the default confidence policy plus its bounds.
+* ``POST /dedup/sweep/dry-run`` — the vault-wide plan behind "N groups
+  auto-collapse, M need review".
+
+**Nothing in v1.9 deletes a picture.** A verdict is either a stack (additive, and
+a stack is a grouping row plus a cover pointer) or a note that the group is not
+duplicates. There is no destructive route on this surface.
+
+Authorization is declared in ``pixlstash/authz/registry.py`` (every route
 ``OWNER_ONLY``) and enforced by the central gate before these handlers run; per
 §16.1 there is deliberately no inline scope check here. A vault-wide aggregate
 cannot be narrowed to a share token's scope without leaking counts about pictures
-outside it, which is the same reasoning that makes the tag-health board owner-only.
+outside it, which is the same reasoning that makes the tag-health board
+owner-only, and the verdict routes mutate stacks across arbitrary pictures.
 """
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
-from fastapi import APIRouter, Body, HTTPException
+from fastapi import APIRouter, Body, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
 
 from pixlstash.pixl_logging import get_logger
-from pixlstash.services import dedup_sweep_service
+from pixlstash.services import dedup_sweep_service, dedup_tier_service
+from pixlstash.services import dedup_verdict_service
+from pixlstash.services.dedup_tier_service import (
+    DEFAULT_PAGE_SIZE,
+    DEFAULT_THRESHOLD,
+    MAX_PAGE_SIZE,
+    MAX_THRESHOLD,
+    MIN_THRESHOLD,
+    DedupScope,
+    DedupTier,
+    ScopeType,
+    TierPolicy,
+)
+from pixlstash.services.dedup_verdict_service import DedupVerdictError
 from pixlstash.services.dedup_sweep_service import (
     DEFAULT_AUTO_RESOLVE_LIKENESS,
     DEFAULT_LIKENESS_THRESHOLD,
@@ -373,8 +405,724 @@ class SweepReportResponse(BaseModel):
     )
 
 
+# --- Tiered queue models ----------------------------------------------------
+
+
+class TierPolicyModel(BaseModel):
+    """Which tiers feed the queue, and how similar counts as similar.
+
+    Tier 1 (exact) has no switch: it is always included and cannot be turned
+    off. Each looser tier is a separate opt-in, and enabling one requires the
+    tier above it, so a user cannot land on "same scene" suggestions without
+    having deliberately walked down to them.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    near_enabled: bool = Field(
+        default=False,
+        description=(
+            "Tier 2: perceptual hashes compared inside candidate buckets (same "
+            "dimensions / capture minute / import batch / folder). Opt-in."
+        ),
+    )
+    embedding_enabled: bool = Field(
+        default=False,
+        description=(
+            "Tier 3: full embedding similarity, for cross-folder and "
+            "differently-framed near-duplicates. Opt-in, and requires "
+            "`near_enabled` - enabling a tier requires the tier above it."
+        ),
+    )
+    threshold: float = Field(
+        default=DEFAULT_THRESHOLD,
+        ge=MIN_THRESHOLD,
+        le=MAX_THRESHOLD,
+        description=(
+            f"Minimum similarity for a near or embedding group to be suggested. "
+            f"Defaults to {DEFAULT_THRESHOLD}. Exact matches are always shown "
+            f"regardless. Below {MIN_THRESHOLD} nothing is suggested at all: a "
+            "low threshold produces confident-looking garbage and destroys trust "
+            "in the count, so a lower value is a 400, never a silent clamp."
+        ),
+    )
+
+    def to_policy(self) -> TierPolicy:
+        """Convert to the service parameter object, raising ``ValueError``."""
+        return TierPolicy(
+            near_enabled=self.near_enabled,
+            embedding_enabled=self.embedding_enabled,
+            threshold=self.threshold,
+        )
+
+
+class TierPolicyBoundsModel(BaseModel):
+    """The values a client should render its tier controls from."""
+
+    model_config = ConfigDict(extra="allow")
+
+    min_threshold: float = Field(
+        description="Hard floor. Nothing below this is ever suggested."
+    )
+    max_threshold: float = Field(description="Upper bound for the threshold.")
+    tiers: list[str] = Field(
+        description=("Every tier id, strongest evidence first. `exact` is always on.")
+    )
+    always_on_tiers: list[str] = Field(description="Tiers the user cannot switch off.")
+    tier_requires: dict[str, Optional[str]] = Field(
+        description=(
+            "Per tier, the tier that must be enabled before it can be. `null` "
+            "for a tier with no prerequisite."
+        )
+    )
+    scope_types: list[str] = Field(
+        description="Every accepted `scope_type` for a scoped scan or count."
+    )
+    verdicts: list[str] = Field(
+        description=("Every verdict a group can carry. There is no deletion verdict.")
+    )
+    max_page_size: int = Field(description="Largest accepted queue page size.")
+
+
+class TierPolicyResponse(BaseModel):
+    """Server defaults plus the bounds and closed vocabularies."""
+
+    model_config = ConfigDict(extra="allow")
+
+    defaults: TierPolicyModel = Field(
+        description="The policy used when a request omits a field."
+    )
+    bounds: TierPolicyBoundsModel = Field(
+        description="Validation bounds and closed vocabularies."
+    )
+
+
+class WhyPillModel(BaseModel):
+    """One piece of evidence, in either direction.
+
+    Signals cut both ways: matching evidence renders as an olive check, and
+    anything arguing against a stack (different resolution, different aspect
+    ratio, fewer tags) as a red x. A group carrying red pills is exactly the one
+    that needs a closer look, so the pills do the warning rather than generic
+    "review carefully" copy. The server reports reasons; the user concludes.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    text: str = Field(description="The pill's label, ready to render.")
+    against: bool = Field(
+        description="True when this argues against stacking the group."
+    )
+
+
+class DedupCandidateModel(BaseModel):
+    """One picture in a group, with the fields Compare shows column by column."""
+
+    model_config = ConfigDict(extra="allow")
+
+    picture_id: int = Field(description="The picture.")
+    width: Optional[int] = Field(default=None, description="Stored pixel width.")
+    height: Optional[int] = Field(default=None, description="Stored pixel height.")
+    megapixels: float = Field(
+        description="Total pixels in millions - the cover formula's first term."
+    )
+    size_bytes: Optional[int] = Field(
+        default=None, description="Size of the stored file."
+    )
+    format: Optional[str] = Field(default=None, description="Stored image format.")
+    is_raw: bool = Field(
+        description="Whether this is a camera original, which earns a cover bonus."
+    )
+    score: Optional[int] = Field(default=None, description="The user's own rating.")
+    tag_count: int = Field(description="How many tags this picture carries.")
+    created_at: Optional[datetime] = Field(
+        default=None, description="Capture time; the cover tie-break, oldest wins."
+    )
+    imported_at: Optional[datetime] = Field(
+        default=None, description="When it entered the library."
+    )
+    stack_id: Optional[int] = Field(
+        default=None, description="Stack it already belongs to, if any."
+    )
+    reference_folder_id: Optional[int] = Field(
+        default=None, description="Reference folder it belongs to, if any."
+    )
+    file_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Full path, populated **only for reference-folder pictures**, where "
+            "the user manages the files and needs to know which copy is which. "
+            "Null for managed-library pictures, where the path is an "
+            "implementation detail."
+        ),
+    )
+    cover_score: float = Field(
+        description=(
+            "`megapixels*4 + tags*3 + score*2 + 8 if RAW`. The highest wins the "
+            "cover preselection; ties break to the oldest capture time."
+        )
+    )
+    why: list[WhyPillModel] = Field(
+        default_factory=list,
+        description=(
+            "Per-candidate evidence, both directions: what this picture is best "
+            "at and where it loses. Rendered so the user can disagree with the "
+            "preselection knowing why it was made."
+        ),
+    )
+
+
+class DedupGroupModel(BaseModel):
+    """One queue row: a group, its evidence, and its cover preselection."""
+
+    model_config = ConfigDict(extra="allow")
+
+    signature: str = Field(
+        description=(
+            "Stable identity of this *set of files* (a hash of the sorted member "
+            "content hashes). Verdicts are keyed on it, so a rescan or a "
+            "re-import never re-asks. This is the id every verdict route takes."
+        )
+    )
+    tier: DedupTier = Field(
+        description="Which tier found the group: `exact`, `near` or `embedding`."
+    )
+    confidence: float = Field(
+        description=(
+            "1.0 for an exact match; otherwise the group's **weakest** pairwise "
+            "similarity, so a transitive chain is judged by its weak link. The "
+            "queue is ordered by this, descending."
+        )
+    )
+    member_count: int = Field(description="How many pictures are in the group.")
+    cover_picture_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "The server's cover preselection. Always a preselection, never a "
+            "silent decision: the client shows it and the user may override it."
+        ),
+    )
+    why: list[WhyPillModel] = Field(
+        default_factory=list, description="Group-level evidence, both directions."
+    )
+    created_at: Optional[datetime] = Field(
+        default=None, description="When the group was first detected."
+    )
+    candidates: list[DedupCandidateModel] = Field(
+        default_factory=list,
+        description="Every member, cover first, with its own evidence.",
+    )
+
+
+class ScanProgressModel(BaseModel):
+    """The "scanned N of M" banner's data."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = Field(
+        description="`idle`, `pending`, `running`, `complete` or `failed`."
+    )
+    scanned_pictures: int = Field(description="Pictures covered so far.")
+    total_pictures: int = Field(description="Pictures in scope.")
+    scanned_buckets: int = Field(
+        description="Tier-2 candidate buckets finished. Groups appear as these land."
+    )
+    total_buckets: int = Field(description="Tier-2 candidate buckets in total.")
+    groups_found: int = Field(description="Unresolved groups this scan produced.")
+    error: Optional[str] = Field(
+        default=None, description="Why the scan failed, when it did."
+    )
+
+
+class DedupQueueResponse(BaseModel):
+    """One page of the queue plus everything the header needs."""
+
+    model_config = ConfigDict(extra="allow")
+
+    groups: list[DedupGroupModel] = Field(
+        default_factory=list, description="This page, confidence descending."
+    )
+    total: int = Field(
+        description=(
+            "Complete unresolved-group count in scope, so the client can size "
+            "its scrollbar without a second request. The queue is paged from the "
+            "database and is never loaded whole."
+        )
+    )
+    offset: int = Field(description="Echo of the requested offset.")
+    limit: int = Field(description="Effective page size after clamping.")
+    policy: TierPolicyModel = Field(description="The policy this page was read under.")
+    scope: dict[str, Any] = Field(description="The scope this page was read under.")
+    scan: ScanProgressModel = Field(description="Scan progress for this scope.")
+
+
+class ScopeRequestModel(BaseModel):
+    """A scope to scan or count."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope_type: ScopeType = Field(
+        default=ScopeType.GLOBAL,
+        description=(
+            "`global` for the whole vault, or the collection kind behind a "
+            '"Find duplicates in ..." context-menu entry.'
+        ),
+    )
+    scope_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "The collection's id, or the absolute folder path for "
+            "`scope_type=folder`. Required unless `scope_type` is `global`."
+        ),
+    )
+
+    def to_scope(self) -> DedupScope:
+        """Convert to the service scope, raising ``ValueError``."""
+        return DedupScope(scope_type=self.scope_type, scope_id=self.scope_id)
+
+
+class DedupCountsRequestModel(BaseModel):
+    """Ask for the sidebar badge and any number of scoped counts at once."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    policy: Optional[TierPolicyModel] = Field(
+        default=None, description="Tier policy; server defaults when omitted."
+    )
+    scopes: list[ScopeRequestModel] = Field(
+        default_factory=list,
+        description=(
+            "Extra scopes to count. The global count is always returned, so a "
+            "context menu can ask for its own scopes and get the badge for free."
+        ),
+    )
+
+
+class DedupCountsResponse(BaseModel):
+    """Live counts: the sidebar badge, the per-tier split, and scoped counts."""
+
+    model_config = ConfigDict(extra="allow")
+
+    unresolved_groups: int = Field(
+        description=(
+            "The sidebar badge: duplicate decisions still to make across the "
+            "whole vault, under the supplied policy."
+        )
+    )
+    by_tier: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Unresolved groups per tier, **including tiers that are switched "
+            "off**, so the user can see what enabling a tier would add before "
+            "enabling it."
+        ),
+    )
+    scopes: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="One `{scope_type, scope_id, key, unresolved_groups}` per requested scope.",
+    )
+    policy: TierPolicyModel = Field(
+        description="The policy these counts were read under."
+    )
+    scan: ScanProgressModel = Field(description="Global scan progress.")
+
+
+class DedupScanRequestModel(BaseModel):
+    """Queue a scan. Returns immediately; poll ``GET /dedup/groups`` for progress."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    policy: Optional[TierPolicyModel] = Field(
+        default=None, description="Tier policy; server defaults when omitted."
+    )
+    scope: Optional[ScopeRequestModel] = Field(
+        default=None, description="Scope to scan; the whole vault when omitted."
+    )
+
+
+class StackVerdictRequestModel(BaseModel):
+    """Stack a group behind a chosen cover."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    signature: str = Field(description="The group signature from the queue.")
+    cover_picture_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "The cover the user chose or confirmed. Defaults to the server's "
+            "preselection stored on the group. Must be an included member."
+        ),
+    )
+    excluded_picture_ids: list[int] = Field(
+        default_factory=list,
+        description=(
+            "Members the user left out of the stack. They are untouched and "
+            "recorded on the verdict, so a rescan does not treat the exclusion "
+            "as an unfinished decision."
+        ),
+    )
+    batch_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Operation-log batch to record this verdict under. Supply the same "
+            "id across several calls to make them reverse as one undo."
+        ),
+    )
+
+
+class SignatureRequestModel(BaseModel):
+    """A verdict route that needs nothing but the group signature."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    signature: str = Field(description="The group signature.")
+    batch_id: Optional[str] = Field(
+        default=None, description="Operation-log batch to record under."
+    )
+
+
+class VerdictResponse(BaseModel):
+    """What a verdict did, for the action receipt."""
+
+    model_config = ConfigDict(extra="allow")
+
+    signature: str = Field(description="The signature the verdict was recorded on.")
+    verdict: str = Field(description="`stacked` or `keep_separate`.")
+    stack_id: Optional[int] = Field(
+        default=None, description="The resulting stack, for a stack verdict."
+    )
+    cover_picture_id: Optional[int] = Field(
+        default=None, description="The picture the stack leads with."
+    )
+    picture_ids: list[int] = Field(
+        default_factory=list, description="Members the verdict covers."
+    )
+    excluded_picture_ids: list[int] = Field(
+        default_factory=list, description="Members deliberately left out."
+    )
+    batch_id: Optional[str] = Field(
+        default=None, description="Operation-log batch this verdict belongs to."
+    )
+    metadata_union: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "What the metadata union changed: `tags_added`, `scores_lifted`, "
+            "`characters_pending`, `membership_changed`. Stacking unions tags, "
+            "project and set membership onto every member and lifts every member "
+            "to the highest score. Nothing is overwritten or lost."
+        ),
+    )
+
+
+class ReopenResponse(BaseModel):
+    """The result of returning a decided group to the queue."""
+
+    model_config = ConfigDict(extra="allow")
+
+    signature: str = Field(description="The reopened signature.")
+    previous_verdict: str = Field(description="The verdict that was in force.")
+    reopened_at: Optional[datetime] = Field(
+        default=None, description="When it was reopened."
+    )
+    group_returned_to_queue: bool = Field(
+        description=(
+            "Whether a group row for this signature exists and is back in the "
+            "queue. False when the group has not been re-detected yet; the next "
+            "scan will bring it back."
+        )
+    )
+
+
+class AutoStackRequestModel(BaseModel):
+    """The exact tier's bulk action, behind one consent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope: Optional[ScopeRequestModel] = Field(
+        default=None, description="Restrict to a scope; the whole vault when omitted."
+    )
+    dry_run: bool = Field(
+        default=True,
+        description=(
+            "True (the default) counts what would happen and writes nothing - "
+            "this is what the consent dialog reads. Send `false` to apply."
+        ),
+    )
+    batch_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Operation-log batch id. Omit to have the server mint one; every "
+            "stack in the run shares it, so N stacks reverse with one undo."
+        ),
+    )
+    limit: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Cap the number of groups acted on, for a paged run.",
+    )
+
+
+class AutoStackResponse(BaseModel):
+    """What the bulk auto-stack did, or would do."""
+
+    model_config = ConfigDict(extra="allow")
+
+    batch_id: Optional[str] = Field(
+        default=None,
+        description="The shared batch id. Null only for a dry run with none supplied.",
+    )
+    dry_run: bool = Field(description="Whether anything was written.")
+    groups: int = Field(description="Exact groups stacked (or that would be).")
+    pictures: int = Field(description="Pictures across those groups.")
+    scope: dict[str, Any] = Field(description="The scope the run covered.")
+    results: list[VerdictResponse] = Field(
+        default_factory=list, description="Per-group results. Empty for a dry run."
+    )
+    failures: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Groups skipped and why. A single unstackable group never aborts the "
+            "run, so a partial result is reported honestly rather than hidden."
+        ),
+    )
+
+
 def create_router(server) -> APIRouter:
     router = APIRouter()
+
+    def _policy(model: Optional[TierPolicyModel]) -> TierPolicy:
+        """Build the service policy from a request model, 400 on a bad one."""
+        try:
+            return (model or TierPolicyModel()).to_policy()
+        except ValueError as exc:
+            logger.info("[dedup] rejected tier policy %s: %s", model, exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    def _scope(model: Optional[ScopeRequestModel]) -> DedupScope:
+        """Build the service scope from a request model, 400 on a bad one."""
+        try:
+            return (model or ScopeRequestModel()).to_scope()
+        except ValueError as exc:
+            logger.info("[dedup] rejected scope %s: %s", model, exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.get(
+        "/dedup/policy",
+        summary="Duplicate detection tier defaults",
+        description=(
+            "Returns the tier gating defaults plus the bounds and closed "
+            "vocabularies a client builds its tier switches and threshold "
+            "slider from, so 0.90 and the 0.65 floor are never hardcoded twice. "
+            "Read-only."
+        ),
+        response_model=TierPolicyResponse,
+    )
+    def get_tier_policy():
+        return {
+            "defaults": TierPolicyModel(),
+            "bounds": {
+                "min_threshold": MIN_THRESHOLD,
+                "max_threshold": MAX_THRESHOLD,
+                "tiers": [tier.value for tier in dedup_tier_service.TIER_ORDER],
+                "always_on_tiers": [DedupTier.EXACT.value],
+                "tier_requires": {
+                    DedupTier.EXACT.value: None,
+                    DedupTier.NEAR.value: DedupTier.EXACT.value,
+                    DedupTier.EMBEDDING.value: DedupTier.NEAR.value,
+                },
+                "scope_types": [item.value for item in ScopeType],
+                "verdicts": [
+                    dedup_tier_service.VERDICT_STACKED,
+                    dedup_tier_service.VERDICT_KEEP_SEPARATE,
+                ],
+                "max_page_size": MAX_PAGE_SIZE,
+            },
+        }
+
+    @router.get(
+        "/dedup/groups",
+        summary="One page of the duplicate queue",
+        description=(
+            "Returns unresolved duplicate groups, confidence descending, with "
+            "each group's evidence pills, its cover preselection and every "
+            "candidate's own evidence - so the client renders reasons rather "
+            "than conclusions. The queue is paged from the database and is never "
+            "loaded whole: 10 groups and 10,000 cost the same per page. The "
+            "response also carries this scope's scan progress for the banner."
+        ),
+        response_model=DedupQueueResponse,
+    )
+    def get_dedup_groups(
+        near_enabled: bool = Query(
+            default=False, description="Include tier 2 (bucketed near-duplicates)."
+        ),
+        embedding_enabled: bool = Query(
+            default=False,
+            description="Include tier 3. Requires `near_enabled`.",
+        ),
+        threshold: float = Query(
+            default=DEFAULT_THRESHOLD,
+            ge=MIN_THRESHOLD,
+            le=MAX_THRESHOLD,
+            description="Minimum similarity; exact matches are always included.",
+        ),
+        scope_type: ScopeType = Query(
+            default=ScopeType.GLOBAL, description="Scope kind."
+        ),
+        scope_id: Optional[str] = Query(
+            default=None, description="Scope id, required unless scope is global."
+        ),
+        offset: int = Query(default=0, ge=0, description="Groups to skip."),
+        limit: int = Query(
+            default=DEFAULT_PAGE_SIZE,
+            ge=1,
+            le=MAX_PAGE_SIZE,
+            description="Groups per page.",
+        ),
+    ):
+        policy = _policy(
+            TierPolicyModel(
+                near_enabled=near_enabled,
+                embedding_enabled=embedding_enabled,
+                threshold=threshold,
+            )
+        )
+        scope = _scope(ScopeRequestModel(scope_type=scope_type, scope_id=scope_id))
+        return dedup_tier_service.queue_response(
+            server.vault, policy, scope, offset, limit
+        )
+
+    @router.post(
+        "/dedup/counts",
+        summary="Live duplicate counts, global and scoped",
+        description=(
+            "Returns the sidebar badge (unresolved duplicate groups across the "
+            "vault), the per-tier split including tiers that are switched off, "
+            "and one count per requested scope so a context menu can label every "
+            'its "Find duplicates in ..." entries in a single request. '
+            "Read-only despite being a POST: the scope list does not fit a URL."
+        ),
+        response_model=DedupCountsResponse,
+    )
+    def post_dedup_counts(
+        payload: Optional[DedupCountsRequestModel] = Body(default=None),
+    ):
+        request_model = payload or DedupCountsRequestModel()
+        policy = _policy(request_model.policy)
+        scopes = [_scope(item) for item in request_model.scopes]
+        return dedup_tier_service.counts_response(server.vault, policy, scopes)
+
+    @router.post(
+        "/dedup/scan",
+        summary="Queue a duplicate scan",
+        description=(
+            "Queues a scan for the given scope and returns its progress row "
+            "immediately - the queue can be opened while it runs. Cached hashes "
+            "are reused (`pixel_sha` and `perceptual_hash` are computed on "
+            "import), so a scoped scan only reads and compares them. Tier 1 "
+            "completes in milliseconds; tier 2 streams its groups in as each "
+            "candidate bucket finishes."
+        ),
+        response_model=ScanProgressModel,
+    )
+    def post_dedup_scan(payload: Optional[DedupScanRequestModel] = Body(default=None)):
+        request_model = payload or DedupScanRequestModel()
+        policy = _policy(request_model.policy)
+        scope = _scope(request_model.scope)
+        return dedup_tier_service.request_scan(server.vault, policy, scope)
+
+    @router.post(
+        "/dedup/verdicts/stack",
+        summary="Stack a duplicate group",
+        description=(
+            "Stacks the group's included members behind the chosen cover and "
+            "applies the metadata union: tags, project and set membership are "
+            "unioned onto every member and every member is lifted to the highest "
+            "score. Nothing is overwritten, nothing is deleted, and no file "
+            "moves - a stack is a grouping row plus a cover pointer, so dropping "
+            "it restores the flat grid exactly. The verdict is remembered "
+            "against the group signature, so a rescan never re-asks."
+        ),
+        response_model=VerdictResponse,
+    )
+    def post_stack_verdict(payload: StackVerdictRequestModel):
+        try:
+            result = dedup_verdict_service.apply_stack_verdict(
+                server.vault,
+                payload.signature,
+                payload.cover_picture_id,
+                list(payload.excluded_picture_ids),
+                payload.batch_id,
+            )
+        except DedupVerdictError as exc:
+            logger.info("[dedup] stack verdict rejected: %s", exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return result.as_dict()
+
+    @router.post(
+        "/dedup/verdicts/keep-separate",
+        summary="Record that a group is not duplicates",
+        description=(
+            "Remembers that these pictures should stay separate. No picture row "
+            "changes. The decision is permanent until it is reopened from the "
+            "Stacks view, which is what lets the sidebar count reach zero and "
+            "stay there across rescans and re-imports."
+        ),
+        response_model=VerdictResponse,
+    )
+    def post_keep_separate_verdict(payload: SignatureRequestModel):
+        try:
+            result = dedup_verdict_service.apply_keep_separate(
+                server.vault, payload.signature, payload.batch_id
+            )
+        except DedupVerdictError as exc:
+            logger.info("[dedup] keep-separate verdict rejected: %s", exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return result.as_dict()
+
+    @router.post(
+        "/dedup/verdicts/reopen",
+        summary="Return a decided group to the queue",
+        description=(
+            "Clears the memory of a verdict so the group is offered again. The "
+            "pictures are untouched: reopening a `stacked` verdict does not "
+            "unstack anything, because unstacking is the Stacks view's own "
+            "action. The verdict row is kept and marked reopened rather than "
+            "deleted, so the decision history survives."
+        ),
+        response_model=ReopenResponse,
+    )
+    def post_reopen_verdict(payload: SignatureRequestModel):
+        try:
+            return dedup_verdict_service.reopen_verdict(server.vault, payload.signature)
+        except DedupVerdictError as exc:
+            logger.info("[dedup] reopen rejected: %s", exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.post(
+        "/dedup/auto-stack",
+        summary="Bulk auto-stack the exact tier",
+        description=(
+            "Stacks every unresolved **exact** group under one operation-log "
+            "batch id, so a thousand stacks reverse with a single undo. Exact "
+            "matches are the tier with no human judgment left in them, which is "
+            "why they get one consent dialog instead of per-group adjudication; "
+            "near and embedding groups always go through the queue no matter how "
+            "confident they look. Defaults to `dry_run=true`, which returns the "
+            "counts the dialog shows and writes nothing."
+        ),
+        response_model=AutoStackResponse,
+    )
+    def post_auto_stack(payload: Optional[AutoStackRequestModel] = Body(default=None)):
+        request_model = payload or AutoStackRequestModel()
+        scope = _scope(request_model.scope)
+        return dedup_verdict_service.bulk_auto_stack(
+            server.vault,
+            scope,
+            request_model.batch_id,
+            request_model.dry_run,
+            request_model.limit,
+        )
 
     @router.get(
         "/dedup/sweep/policy",

--- a/pixlstash/routes/dedup.py
+++ b/pixlstash/routes/dedup.py
@@ -43,12 +43,12 @@ owner-only, and the verdict routes mutate stacks across arbitrary pictures.
 from datetime import datetime
 from typing import Any, Optional
 
-from fastapi import APIRouter, Body, HTTPException, Query
+from fastapi import APIRouter, Body, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services import dedup_sweep_service, dedup_tier_service
-from pixlstash.services import dedup_verdict_service
+from pixlstash.services import dedup_verdict_service, operation_log_service
 from pixlstash.services.dedup_tier_service import (
     DEFAULT_PAGE_SIZE,
     DEFAULT_THRESHOLD,
@@ -78,6 +78,14 @@ from pixlstash.services.dedup_sweep_service import (
 )
 
 logger = get_logger(__name__)
+
+MAX_COUNT_SCOPES = 200
+"""Cap on the scope list of one ``POST /dedup/counts``.
+
+Each scope is a separate correlated ``COUNT`` subquery, so an uncapped list turns
+one request into thousands of queries against the owner's own server. 200 is far
+more than any real context menu needs (the sidebar asks for a handful) and keeps
+the worst case bounded."""
 
 
 class SweepPolicyModel(BaseModel):
@@ -573,6 +581,16 @@ class DedupCandidateModel(BaseModel):
             "implementation detail."
         ),
     )
+    thumbnail_version: str = Field(
+        description=(
+            "Cache-buster token for this picture's thumbnail URL: append it as "
+            "`?v=`, exactly as the batch-thumbnail endpoint does (both call the "
+            "same helper). It changes whenever the stored bitmap is regenerated, "
+            "so a thumbnail rebuilt mid-triage refetches instead of the queue "
+            'painting the stale cached image. `"0"` until the picture has been '
+            "processed."
+        )
+    )
     cover_score: float = Field(
         description=(
             "`megapixels*4 + tags*3 + score*2 + 8 if RAW`. The highest wins the "
@@ -708,9 +726,13 @@ class DedupCountsRequestModel(BaseModel):
     )
     scopes: list[ScopeRequestModel] = Field(
         default_factory=list,
+        max_length=MAX_COUNT_SCOPES,
         description=(
             "Extra scopes to count. The global count is always returned, so a "
-            "context menu can ask for its own scopes and get the badge for free."
+            "context menu can ask for its own scopes and get the badge for free. "
+            f"At most {MAX_COUNT_SCOPES} per request: each scope is a separate "
+            "correlated COUNT, so an uncapped list turns one request into "
+            "thousands of queries."
         ),
     )
 
@@ -879,6 +901,38 @@ class AutoStackRequestModel(BaseModel):
     )
 
 
+class AutoStackDryRunSummaryModel(BaseModel):
+    """Aggregates for the consent dialog, from the dry run's own snapshot."""
+
+    model_config = ConfigDict(extra="allow")
+
+    groups: int = Field(description="Groups the run would act on.")
+    groups_by_tier: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Group count per tier, zero-filled for every tier. Only `exact` is "
+            "ever non-zero today - auto-stack is exact-only - but the shape is "
+            "stable so the dialog does not need a special case if that changes."
+        ),
+    )
+    pictures: int = Field(description="Pictures across those groups.")
+    covers_gaining_tags: int = Field(
+        description="Covers that would gain at least one tag from the union."
+    )
+    covers_gaining_score: int = Field(
+        description="Covers whose score the union would lift."
+    )
+    covers_gaining_metadata: int = Field(
+        description=(
+            "Covers gaining tags **or** score - the design's "
+            '"covers gaining metadata" row. Derived from the planned verdicts in '
+            "the same read as the counts above, so the dialog's numbers can never "
+            "disagree with each other; the union itself is not run and nothing is "
+            "written."
+        )
+    )
+
+
 class AutoStackResponse(BaseModel):
     """What the bulk auto-stack did, or would do."""
 
@@ -886,22 +940,46 @@ class AutoStackResponse(BaseModel):
 
     batch_id: Optional[str] = Field(
         default=None,
-        description="The shared batch id. Null only for a dry run with none supplied.",
+        description=(
+            "The shared batch id, and the `POST /operations/batches/{batch_id}/"
+            "undo` handle for the whole run. Always present on an applied run - "
+            "including a partially applied one - so work that did happen is "
+            "never left without a way to reverse it. Null only for a dry run "
+            "with none supplied."
+        ),
     )
     dry_run: bool = Field(description="Whether anything was written.")
-    groups: int = Field(description="Exact groups stacked (or that would be).")
-    pictures: int = Field(description="Pictures across those groups.")
+    groups: int = Field(
+        description="Exact groups actually stacked (or, on a dry run, that would be)."
+    )
+    pictures: int = Field(description="Pictures across the stacked groups.")
     scope: dict[str, Any] = Field(description="The scope the run covered.")
+    dry_run_summary: Optional[AutoStackDryRunSummaryModel] = Field(
+        default=None,
+        description="Consent-dialog aggregates. Present on a dry run only.",
+    )
     results: list[VerdictResponse] = Field(
-        default_factory=list, description="Per-group results. Empty for a dry run."
+        default_factory=list,
+        description=(
+            'One entry per applied group, each with `outcome: "applied"`. Empty '
+            "for a dry run."
+        ),
     )
     failures: list[dict[str, Any]] = Field(
         default_factory=list,
         description=(
-            "Groups skipped and why. A single unstackable group never aborts the "
-            "run, so a partial result is reported honestly rather than hidden."
+            "One entry per group that was not applied: `{signature, outcome, "
+            "status_code, error}`, where `outcome` is `blocked` (a guard refused "
+            "it - in practice a locked picture set, 423) or `failed` (it could "
+            "not be resolved at all). A single unstackable group never aborts "
+            "the run, so a partial result is reported honestly rather than "
+            "hidden, and the run still returns its `batch_id`."
         ),
     )
+    blocked: int = Field(
+        default=0, description="Groups refused by a guard, typically a locked set."
+    )
+    failed: int = Field(default=0, description="Groups that could not be resolved.")
 
 
 def create_router(server) -> APIRouter:
@@ -1062,7 +1140,12 @@ def create_router(server) -> APIRouter:
         ),
         response_model=VerdictResponse,
     )
-    def post_stack_verdict(payload: StackVerdictRequestModel):
+    def post_stack_verdict(request: Request, payload: StackVerdictRequestModel):
+        # §21 origin discipline: actor / source / origin_client_id are read from
+        # the request HERE, on the request's own task, and passed down
+        # explicitly. The contextvar is dead on the DB worker thread, so the
+        # service must never read it for itself.
+        context = operation_log_service.request_context(request)
         try:
             result = dedup_verdict_service.apply_stack_verdict(
                 server.vault,
@@ -1070,6 +1153,7 @@ def create_router(server) -> APIRouter:
                 payload.cover_picture_id,
                 list(payload.excluded_picture_ids),
                 payload.batch_id,
+                **context,
             )
         except DedupVerdictError as exc:
             logger.info("[dedup] stack verdict rejected: %s", exc)
@@ -1088,6 +1172,11 @@ def create_router(server) -> APIRouter:
         response_model=VerdictResponse,
     )
     def post_keep_separate_verdict(payload: SignatureRequestModel):
+        # No request_context here on purpose: keep-separate writes no operation
+        # row (it changes no reversible picture facet — see
+        # dedup_verdict_service.OP_TYPE_STACK), so actor / source would be dead
+        # arguments. If this verdict ever starts recording, wire it up like
+        # post_stack_verdict does.
         try:
             result = dedup_verdict_service.apply_keep_separate(
                 server.vault, payload.signature, payload.batch_id
@@ -1110,6 +1199,7 @@ def create_router(server) -> APIRouter:
         response_model=ReopenResponse,
     )
     def post_reopen_verdict(payload: SignatureRequestModel):
+        # No request_context here on purpose — see post_keep_separate_verdict.
         try:
             return dedup_verdict_service.reopen_verdict(server.vault, payload.signature)
         except DedupVerdictError as exc:
@@ -1130,15 +1220,23 @@ def create_router(server) -> APIRouter:
         ),
         response_model=AutoStackResponse,
     )
-    def post_auto_stack(payload: Optional[AutoStackRequestModel] = Body(default=None)):
+    def post_auto_stack(
+        request: Request,
+        payload: Optional[AutoStackRequestModel] = Body(default=None),
+    ):
         request_model = payload or AutoStackRequestModel()
         scope = _scope(request_model.scope)
+        # §21 origin discipline, read in the handler — see post_stack_verdict.
+        # This is the most far-reaching mutation on the surface, so it is the one
+        # that most needs an attributed audit row.
+        context = operation_log_service.request_context(request)
         return dedup_verdict_service.bulk_auto_stack(
             server.vault,
             scope,
             request_model.batch_id,
             request_model.dry_run,
             request_model.limit,
+            **context,
         )
 
     @router.get(

--- a/pixlstash/routes/dedup.py
+++ b/pixlstash/routes/dedup.py
@@ -40,6 +40,7 @@ outside it, which is the same reasoning that makes the tag-health board
 owner-only, and the verdict routes mutate stacks across arbitrary pictures.
 """
 
+import re
 from datetime import datetime
 from typing import Any, Optional
 
@@ -55,6 +56,7 @@ from pixlstash.services.dedup_tier_service import (
     MAX_PAGE_SIZE,
     MAX_THRESHOLD,
     MIN_THRESHOLD,
+    DedupCursorError,
     DedupScope,
     DedupTier,
     ScopeType,
@@ -78,6 +80,33 @@ from pixlstash.services.dedup_sweep_service import (
 )
 
 logger = get_logger(__name__)
+
+CLIENT_BATCH_ID_PREFIX = "cli-"
+MAX_BATCH_ID_LENGTH = 80
+CLIENT_BATCH_ID_RE = re.compile(r"^cli-[A-Za-z0-9_-]{4,76}$")
+"""The shape a **client-supplied** operation batch id must have.
+
+Batch ids are namespaced so the log can tell who minted one: the server mints
+``srv-<uuid4hex>`` (:func:`operation_log_service.new_batch_id`) and a client may
+group its own gestures under ``cli-…``. Taken verbatim, a client could submit
+``srv-…`` and have its rows read as a server batch — and, worse, graft them into
+an existing batch so one Ctrl+Z reverses more than the user did.
+
+The pattern is duplicated here on purpose: the shared definition lands in
+``pixlstash/utils/request_origin.py`` with the ``X-Operation-Batch-Id`` header
+contract (branch ``feature/gesture-batch-id``), which is not on this branch.
+When that merges, both sites must import it from there instead. Note the
+difference in disposition: an unusable *header* is dropped and ignored, because a
+header is ambient; an unusable *body* field is a 400, because the client named it
+deliberately and silently ignoring it would mis-group its undo.
+"""
+
+MAX_CURSOR_LENGTH = 128
+"""Cap on the opaque queue cursor a client may send back.
+
+The cursors this server mints are ~40 characters; anything longer is not one of
+ours, and bounding it here keeps a malformed value from reaching the base64
+decoder as an unbounded string."""
 
 MAX_COUNT_SCOPES = 200
 """Cap on the scope list of one ``POST /dedup/counts``.
@@ -451,7 +480,8 @@ class TierPolicyModel(BaseModel):
             f"Defaults to {DEFAULT_THRESHOLD}. Exact matches are always shown "
             f"regardless. Below {MIN_THRESHOLD} nothing is suggested at all: a "
             "low threshold produces confident-looking garbage and destroys trust "
-            "in the count, so a lower value is a 400, never a silent clamp."
+            "in the count, so a lower value is refused (422 from this bound), "
+            "never a silent clamp."
         ),
     )
 
@@ -684,8 +714,26 @@ class DedupQueueResponse(BaseModel):
             "database and is never loaded whole."
         )
     )
-    offset: int = Field(description="Echo of the requested offset.")
+    offset: int = Field(
+        description=(
+            "Echo of the requested offset. **Deprecated** - offset paging skips "
+            "groups whenever the queue changes underneath it (a verdict on a "
+            "delivered row, or a tier-2 scan committing a bucket, shifts every "
+            "later row up). Page with `cursor` instead; `0` is echoed when "
+            "cursor paging."
+        )
+    )
     limit: int = Field(description="Effective page size after clamping.")
+    cursor: Optional[str] = Field(
+        default=None, description="Echo of the cursor this page was read from."
+    )
+    next_cursor: Optional[str] = Field(
+        default=None,
+        description=(
+            "Pass as `cursor` to fetch the next page. `null` at end-of-found. "
+            "Opaque: pass it back verbatim, never construct or parse one."
+        ),
+    )
     policy: TierPolicyModel = Field(description="The policy this page was read under.")
     scope: dict[str, Any] = Field(description="The scope this page was read under.")
     scan: ScanProgressModel = Field(description="Scan progress for this scope.")
@@ -804,7 +852,10 @@ class StackVerdictRequestModel(BaseModel):
         default=None,
         description=(
             "Operation-log batch to record this verdict under. Supply the same "
-            "id across several calls to make them reverse as one undo."
+            "`cli-<4-76 chars of A-Z a-z 0-9 _ ->` id across several calls to "
+            "make them reverse as one undo. Omit it and the server mints its own "
+            "`srv-` id; any other shape is a 400, so a client cannot mint what "
+            "reads as a server batch or graft its rows into one."
         ),
     )
 
@@ -816,7 +867,11 @@ class SignatureRequestModel(BaseModel):
 
     signature: str = Field(description="The group signature.")
     batch_id: Optional[str] = Field(
-        default=None, description="Operation-log batch to record under."
+        default=None,
+        description=(
+            "Operation-log batch to record under. Must be a client-namespaced "
+            "`cli-…` id; omit it to have the server mint one."
+        ),
     )
 
 
@@ -890,8 +945,9 @@ class AutoStackRequestModel(BaseModel):
     batch_id: Optional[str] = Field(
         default=None,
         description=(
-            "Operation-log batch id. Omit to have the server mint one; every "
-            "stack in the run shares it, so N stacks reverse with one undo."
+            "Operation-log batch id. Omit to have the server mint one (`srv-…`); "
+            "every stack in the run shares it, so N stacks reverse with one "
+            "undo. A supplied id must be client-namespaced `cli-…`."
         ),
     )
     limit: Optional[int] = Field(
@@ -993,6 +1049,29 @@ def create_router(server) -> APIRouter:
             logger.info("[dedup] rejected tier policy %s: %s", model, exc)
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    def _batch_id(value: Optional[str]) -> Optional[str]:
+        """Accept only a client-namespaced batch id, 400 on anything else.
+
+        The server mints ``srv-…`` for a verdict that arrives without one; a
+        client that wants several verdicts to reverse together supplies its own
+        ``cli-…``. Accepting an arbitrary string let a client mint what reads as
+        a server batch, or graft its rows into someone else's batch so one undo
+        reverses more than the user did.
+        """
+        if value is None:
+            return None
+        text = str(value)
+        if len(text) > MAX_BATCH_ID_LENGTH or not CLIENT_BATCH_ID_RE.fullmatch(text):
+            logger.info("[dedup] rejected client batch_id %r", text[:120])
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"batch_id must match {CLIENT_BATCH_ID_PREFIX}<4-76 chars of "
+                    "A-Z a-z 0-9 _ ->; omit it to have the server mint one"
+                ),
+            )
+        return text
+
     def _scope(model: Optional[ScopeRequestModel]) -> DedupScope:
         """Build the service scope from a request model, 400 on a bad one."""
         try:
@@ -1043,7 +1122,14 @@ def create_router(server) -> APIRouter:
             "candidate's own evidence - so the client renders reasons rather "
             "than conclusions. The queue is paged from the database and is never "
             "loaded whole: 10 groups and 10,000 cost the same per page. The "
-            "response also carries this scope's scan progress for the banner."
+            "response also carries this scope's scan progress for the banner.\n\n"
+            "Page with `cursor`: pass the previous page's `next_cursor` back "
+            "verbatim, and stop when `next_cursor` is `null`. The queue is a "
+            "live list - deciding a verdict on a delivered group removes it, and "
+            "a tier-2 scan commits new groups after every bucket - so `offset` "
+            "paging skips exactly as many groups as the previous page changed. "
+            "`offset` still works for compatibility but is deprecated, and "
+            "sending both `cursor` and `offset` is a 400."
         ),
         response_model=DedupQueueResponse,
     )
@@ -1067,7 +1153,24 @@ def create_router(server) -> APIRouter:
         scope_id: Optional[str] = Query(
             default=None, description="Scope id, required unless scope is global."
         ),
-        offset: int = Query(default=0, ge=0, description="Groups to skip."),
+        offset: Optional[int] = Query(
+            default=None,
+            ge=0,
+            deprecated=True,
+            description=(
+                "Groups to skip. Deprecated - use `cursor`; offset paging skips "
+                "groups when the queue changes between pages. Mutually exclusive "
+                "with `cursor`."
+            ),
+        ),
+        cursor: Optional[str] = Query(
+            default=None,
+            max_length=MAX_CURSOR_LENGTH,
+            description=(
+                "Opaque keyset position from the previous page's `next_cursor`. "
+                "Omit for the first page. Mutually exclusive with `offset`."
+            ),
+        ),
         limit: int = Query(
             default=DEFAULT_PAGE_SIZE,
             ge=1,
@@ -1075,6 +1178,17 @@ def create_router(server) -> APIRouter:
             description="Groups per page.",
         ),
     ):
+        if cursor is not None and offset is not None:
+            # Refused rather than silently preferring one: a client that sends
+            # both has two different ideas of where it is, and answering either
+            # one hands back a page it did not ask for.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "cursor and offset are mutually exclusive; page with cursor "
+                    "(offset is deprecated)"
+                ),
+            )
         policy = _policy(
             TierPolicyModel(
                 near_enabled=near_enabled,
@@ -1083,9 +1197,13 @@ def create_router(server) -> APIRouter:
             )
         )
         scope = _scope(ScopeRequestModel(scope_type=scope_type, scope_id=scope_id))
-        return dedup_tier_service.queue_response(
-            server.vault, policy, scope, offset, limit
-        )
+        try:
+            return dedup_tier_service.queue_response(
+                server.vault, policy, scope, offset or 0, limit, cursor
+            )
+        except DedupCursorError as exc:
+            logger.info("[dedup] rejected queue cursor: %s", exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post(
         "/dedup/counts",
@@ -1152,7 +1270,7 @@ def create_router(server) -> APIRouter:
                 payload.signature,
                 payload.cover_picture_id,
                 list(payload.excluded_picture_ids),
-                payload.batch_id,
+                _batch_id(payload.batch_id),
                 **context,
             )
         except DedupVerdictError as exc:
@@ -1179,7 +1297,7 @@ def create_router(server) -> APIRouter:
         # post_stack_verdict does.
         try:
             result = dedup_verdict_service.apply_keep_separate(
-                server.vault, payload.signature, payload.batch_id
+                server.vault, payload.signature, _batch_id(payload.batch_id)
             )
         except DedupVerdictError as exc:
             logger.info("[dedup] keep-separate verdict rejected: %s", exc)
@@ -1200,6 +1318,9 @@ def create_router(server) -> APIRouter:
     )
     def post_reopen_verdict(payload: SignatureRequestModel):
         # No request_context here on purpose — see post_keep_separate_verdict.
+        # batch_id is unused by reopen (it records no operation) but is still
+        # validated, so no route on this surface accepts a malformed one.
+        _batch_id(payload.batch_id)
         try:
             return dedup_verdict_service.reopen_verdict(server.vault, payload.signature)
         except DedupVerdictError as exc:
@@ -1233,7 +1354,7 @@ def create_router(server) -> APIRouter:
         return dedup_verdict_service.bulk_auto_stack(
             server.vault,
             scope,
-            request_model.batch_id,
+            _batch_id(request_model.batch_id),
             request_model.dry_run,
             request_model.limit,
             **context,

--- a/pixlstash/routes/dedup.py
+++ b/pixlstash/routes/dedup.py
@@ -447,12 +447,29 @@ class TierPolicyModel(BaseModel):
         ),
     )
 
+    min_group_size: int = Field(
+        default=dedup_tier_service.DEFAULT_MIN_GROUP_SIZE,
+        ge=2,
+        description="Smallest group that counts as a duplicate group at all.",
+    )
+    max_group_size: int = Field(
+        default=dedup_tier_service.DEFAULT_MAX_GROUP_SIZE,
+        ge=2,
+        description=(
+            "Groups larger than this keep every member but carry an "
+            "`Unusually large group` evidence-against pill, because a large "
+            "transitively-chained blob is rarely one duplicate cluster."
+        ),
+    )
+
     def to_policy(self) -> TierPolicy:
         """Convert to the service parameter object, raising ``ValueError``."""
         return TierPolicy(
             near_enabled=self.near_enabled,
             embedding_enabled=self.embedding_enabled,
             threshold=self.threshold,
+            min_group_size=self.min_group_size,
+            max_group_size=self.max_group_size,
         )
 
 

--- a/pixlstash/routes/pictures/_thumbnails.py
+++ b/pixlstash/routes/pictures/_thumbnails.py
@@ -551,9 +551,10 @@ def register_routes(router, server):
                 # old key was imported_at, which never changed on regen -> the
                 # browser kept painting the pre-upgrade square bitmap into the
                 # justified layout's AR cell -> squashed thumbnails.
-                tw = getattr(pic, "thumbnail_width", None)
-                th = getattr(pic, "thumbnail_height", None)
-                v = f"{tw}x{th}" if tw and th else "0"
+                v = ImageUtils.thumbnail_cache_token(
+                    getattr(pic, "thumbnail_width", None),
+                    getattr(pic, "thumbnail_height", None),
+                )
                 thumbnail_url = f"/pictures/thumbnails/{pic.id}.webp?v={v}"
                 # Whole-frame AR-bitmap dimensions and the face-weighted square-crop
                 # rectangle (bitmap pixel space). All are NULL until the picture is

--- a/pixlstash/services/dedup_tier_service.py
+++ b/pixlstash/services/dedup_tier_service.py
@@ -1,0 +1,1721 @@
+"""Tiered duplicate detection: exact, bucketed near, and embedding.
+
+The v1.9 Dedup -> Stacks design replaces the "Similarity to ..." sort order with
+a **Duplicates** destination whose queue is filled by three tiers of increasing
+cost and decreasing certainty. This module owns detection, the tier policy, the
+cover preselection and the evidence pills; :mod:`pixlstash.services.dedup_verdict_service`
+owns what happens when the user decides.
+
+Tier 1 — exact
+--------------
+``GROUP BY`` on an indexed hash column. **The column is the existing
+``picture.pixel_sha``** (``Field(default=None, index=True)`` in
+:mod:`pixlstash.db_models.picture`), not a new one. Being honest about what it
+is: ``ImageUtils._calculate_sha256_digest`` hashes the whole file only up to
+128 KiB and otherwise samples 8 chunks of 8 KiB spread across the file, so it is
+a *sampled* content digest, not a full-file SHA-256. Two files can in principle
+share a ``pixel_sha`` while differing in an unsampled region.
+
+That is why tier 1 groups on ``(pixel_sha, size_bytes)`` rather than
+``pixel_sha`` alone: the sample offsets are derived from the file size, so equal
+size plus equal sampled digest is a far stronger claim than the digest alone,
+and the extra column costs nothing (the ``pixel_sha`` index already narrows the
+group). It is still not a cryptographic identity proof, which is exactly why the
+design routes exact matches through a bulk auto-stack **dialog** with a dry-run
+count rather than stacking them at import without consent, and why no tier ever
+deletes anything.
+
+A new full-file hash column was considered and rejected: it would mean re-reading
+every byte of every file in the library on upgrade to buy a guarantee the feature
+does not need (the failure mode of a false exact match is two genuinely different
+pictures ending up in one *stack*, which is reversible with one keystroke).
+``pixel_sha`` is already computed incrementally on every import path, and
+:class:`~pixlstash.tasks.missing_pixel_sha_finder.MissingPixelShaFinder` backfills
+the rows that predate it.
+
+Tier 2 — bucketed near
+----------------------
+Perceptual hashes compared **only within candidate buckets**, never library-wide.
+The buckets reuse what the library already precomputes:
+
+* ``picture.size_bin_index`` — an indexed ``(width << 32) + height`` column
+  maintained by ``LikenessParameterUtils.size_bin_index``. Exact-dimension
+  bucket; catches re-saves, re-encodes and burst frames.
+* capture minute — ``created_at`` truncated to the minute; catches bursts and
+  re-exports that changed dimensions.
+* import batch / folder — ``import_source_folder``, and the containing directory
+  of ``file_path`` for reference-folder pictures.
+
+``LikenessParameter.PHASH_PREFIX`` was investigated and is deliberately **not**
+used as a bucket key. Despite the name it stores the *entire* 64-bit dHash
+linearly normalised into ``[0, 1]`` (``int(phash[:16], 16) / (2**64 - 1)``), so
+numeric proximity in that slot is dominated by the top bit and says nothing about
+Hamming proximity. ``LikenessUtils.PHASH_PREFIX_LEN = 3`` is dead code with no
+reader. Within a bucket this module does the real thing: XOR + popcount over the
+64-bit dHash, vectorised with numpy.
+
+Each bucket is an independent unit of work, so buckets stream into the queue as
+they finish rather than the queue waiting for a full pass.
+
+Tier 3 — embedding
+------------------
+The existing :class:`~pixlstash.db_models.picture_likeness.PictureLikeness` edge
+table, folded into components by the shipped
+:mod:`pixlstash.services.dedup_sweep_service` planner. Opt-in, appended to the
+same queue. Nothing is recomputed: this tier is a different reading of data the
+image-embedding worker already produced.
+
+Policy
+------
+:class:`TierPolicy` replaces the shipped :class:`~pixlstash.services.dedup_sweep_service.SweepPolicy`
+auto/review split *for the queue*. Tier 1 is always on and cannot be switched
+off; each looser tier is a separate opt-in that requires the tier above it; the
+similarity threshold defaults to 0.90 and **nothing below 0.65 is ever
+suggested**. The dry-run planner and its report stay exactly as shipped — they
+are the non-destructive foundation this builds on, and ``SweepPolicy`` remains
+the parameter object for that surface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Optional
+
+import numpy as np
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from pixlstash.db_models import Picture
+from pixlstash.db_models.dedup import (
+    SCAN_PENDING,
+    TIER_EMBEDDING,
+    TIER_EXACT,
+    TIER_NEAR,
+    VERDICT_KEEP_SEPARATE,
+    VERDICT_STACKED,
+    DedupGroup,
+    DedupGroupMember,
+    DedupScan,
+    DedupVerdict,
+)
+from pixlstash.db_models.picture_project import PictureProjectMember
+from pixlstash.db_models.picture_set import PictureSetMember
+from pixlstash.db_models.face import Face
+from pixlstash.db_models.tag import Tag
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services import dedup_sweep_service
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pixlstash.vault import Vault
+
+logger = get_logger(__name__)
+
+# --- Policy constants -------------------------------------------------------
+
+DEFAULT_THRESHOLD = 0.90
+"""The near-duplicate similarity default (design §7 "Threshold")."""
+
+MIN_THRESHOLD = 0.65
+"""Hard floor. Below this nothing is suggested at all — a low threshold produces
+confident-looking garbage and destroys trust in the sidebar count. Requests below
+it are a 400, never a silent clamp."""
+
+MAX_THRESHOLD = 0.99999
+
+DEFAULT_MIN_GROUP_SIZE = 2
+DEFAULT_MAX_GROUP_SIZE = 24
+"""Ceiling on a single detected group. A larger transitively-chained blob is
+almost never one duplicate cluster; it is split no further but reported with a
+lower confidence so it sorts to the bottom of the queue."""
+
+DEFAULT_PAGE_SIZE = 20
+MAX_PAGE_SIZE = 200
+
+MAX_BUCKET_MEMBERS = 4000
+"""Cap on one tier-2 bucket. The within-bucket comparison is O(k^2) popcounts,
+which numpy does in milliseconds at k=4000 (~8M pairs); beyond that the bucket is
+split by hash prefix rather than being dropped, so nothing is silently skipped."""
+
+PHASH_BITS = 64
+PHASH_HEX_LEN = PHASH_BITS // 4
+
+RAW_FORMATS = frozenset(
+    {
+        "raw",
+        "arw",
+        "cr2",
+        "cr3",
+        "crw",
+        "dng",
+        "erf",
+        "nef",
+        "nrw",
+        "orf",
+        "pef",
+        "raf",
+        "rw2",
+        "sr2",
+        "srw",
+        "x3f",
+    }
+)
+"""Formats treated as a camera original by the cover formula's RAW bonus."""
+
+COVER_RAW_BONUS = 8.0
+COVER_PIXEL_WEIGHT = 4.0
+COVER_TAG_WEIGHT = 3.0
+COVER_SCORE_WEIGHT = 2.0
+
+ID_CHUNK = 900
+"""SQLite bound-variable safety margin for ``IN`` loads."""
+
+
+class DedupTier(str, Enum):
+    """The three detection tiers, ordered strongest evidence first."""
+
+    EXACT = TIER_EXACT
+    NEAR = TIER_NEAR
+    EMBEDDING = TIER_EMBEDDING
+
+
+TIER_ORDER: tuple[DedupTier, ...] = (
+    DedupTier.EXACT,
+    DedupTier.NEAR,
+    DedupTier.EMBEDDING,
+)
+
+
+class ScopeType(str, Enum):
+    """Where a scan or a count is scoped to.
+
+    ``GLOBAL`` is the sidebar's vault-wide badge; the rest are the context-menu
+    "Find duplicates in ..." entry points.
+    """
+
+    GLOBAL = "global"
+    PROJECT = "project"
+    SET = "set"
+    CHARACTER = "character"
+    FOLDER = "folder"
+
+
+@dataclass(frozen=True)
+class DedupScope:
+    """A scan / count scope and the SQL that narrows a picture query to it.
+
+    Attributes:
+        scope_type: Which collection kind, or :attr:`ScopeType.GLOBAL`.
+        scope_id: The collection's id, or the absolute folder path for
+            :attr:`ScopeType.FOLDER`. ``None`` only for ``GLOBAL``.
+    """
+
+    scope_type: ScopeType = ScopeType.GLOBAL
+    scope_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope_type, ScopeType):
+            object.__setattr__(self, "scope_type", ScopeType(str(self.scope_type)))
+        if self.scope_type is ScopeType.GLOBAL:
+            object.__setattr__(self, "scope_id", None)
+        elif self.scope_id is None or str(self.scope_id) == "":
+            raise ValueError(f"scope_id is required for scope_type={self.scope_type}")
+
+    @property
+    def key(self) -> str:
+        """Canonical ``DedupScan.scope_key`` for this scope."""
+        if self.scope_type is ScopeType.GLOBAL:
+            return "global"
+        return f"{self.scope_type.value}:{self.scope_id}"
+
+    def picture_predicate(self):
+        """Return the SQLAlchemy predicate restricting ``Picture`` to this scope.
+
+        ``None`` for the global scope, so a caller can skip the ``WHERE`` entirely
+        rather than emitting a tautology.
+        """
+        if self.scope_type is ScopeType.GLOBAL:
+            return None
+        if self.scope_type is ScopeType.PROJECT:
+            return Picture.id.in_(
+                select(PictureProjectMember.picture_id).where(
+                    PictureProjectMember.project_id == int(self.scope_id)
+                )
+            )
+        if self.scope_type is ScopeType.SET:
+            return Picture.id.in_(
+                select(PictureSetMember.picture_id).where(
+                    PictureSetMember.set_id == int(self.scope_id)
+                )
+            )
+        if self.scope_type is ScopeType.CHARACTER:
+            return Picture.id.in_(
+                select(Face.picture_id).where(Face.character_id == int(self.scope_id))
+            )
+        # FOLDER: a picture is in the folder when it was imported from it or its
+        # file lives under it. Both are prefix matches on an indexed column.
+        prefix = str(self.scope_id).rstrip("/\\")
+        return (Picture.import_source_folder == prefix) | (
+            Picture.file_path.like(f"{prefix}%")
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "scope_type": self.scope_type.value,
+            "scope_id": self.scope_id,
+            "key": self.key,
+        }
+
+
+@dataclass(frozen=True)
+class TierPolicy:
+    """Which tiers feed the queue, and how similar is similar enough.
+
+    This is the design's tier gating, and it replaces ``SweepPolicy``'s
+    auto/review split as the queue's policy surface. Validated in
+    ``__post_init__``: an invalid combination raises :class:`ValueError` (the
+    route turns that into a 400) rather than being silently corrected, because a
+    silently-retuned duplicate scan is exactly the surprise the feature cannot
+    afford.
+
+    Attributes:
+        near_enabled: Tier 2. Opt-in.
+        embedding_enabled: Tier 3. Opt-in, and requires ``near_enabled`` — the
+            design's "enabling one requires the tier above it", so a user cannot
+            land on "same scene" suggestions without having deliberately walked
+            down to them.
+        threshold: Minimum similarity for a near / embedding group to be
+            suggested at all. Defaults to :data:`DEFAULT_THRESHOLD`; may never go
+            below :data:`MIN_THRESHOLD`.
+        min_group_size: Smallest group that counts.
+        max_group_size: Groups larger than this keep their members but are
+            flagged in their evidence and pushed down the queue.
+
+    Tier 1 (exact) has no flag. It is always included and cannot be switched off.
+    """
+
+    near_enabled: bool = False
+    embedding_enabled: bool = False
+    threshold: float = DEFAULT_THRESHOLD
+    min_group_size: int = DEFAULT_MIN_GROUP_SIZE
+    max_group_size: int = DEFAULT_MAX_GROUP_SIZE
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.threshold, (int, float)) or not (
+            MIN_THRESHOLD <= float(self.threshold) <= MAX_THRESHOLD
+        ):
+            raise ValueError(
+                f"threshold must be between {MIN_THRESHOLD} and {MAX_THRESHOLD}, "
+                f"got {self.threshold!r}. Below {MIN_THRESHOLD} nothing is "
+                "suggested at all."
+            )
+        if self.embedding_enabled and not self.near_enabled:
+            raise ValueError(
+                "embedding_enabled requires near_enabled: each looser tier "
+                "requires the tier above it"
+            )
+        if int(self.min_group_size) < 2:
+            raise ValueError(
+                f"min_group_size must be at least 2, got {self.min_group_size!r}"
+            )
+        if int(self.max_group_size) < int(self.min_group_size):
+            raise ValueError(
+                "max_group_size must be >= min_group_size "
+                f"({self.max_group_size} < {self.min_group_size})"
+            )
+
+    @property
+    def tiers(self) -> tuple[DedupTier, ...]:
+        """The enabled tiers, strongest first. Always starts with EXACT."""
+        enabled = [DedupTier.EXACT]
+        if self.near_enabled:
+            enabled.append(DedupTier.NEAR)
+        if self.embedding_enabled:
+            enabled.append(DedupTier.EMBEDDING)
+        return tuple(enabled)
+
+    def includes(self, tier: DedupTier) -> bool:
+        """Whether *tier* is switched on."""
+        return tier in self.tiers
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "near_enabled": bool(self.near_enabled),
+            "embedding_enabled": bool(self.embedding_enabled),
+            "threshold": float(self.threshold),
+            "min_group_size": int(self.min_group_size),
+            "max_group_size": int(self.max_group_size),
+        }
+
+
+@dataclass
+class CandidateMember:
+    """One picture in a detected group, with everything cover + evidence need.
+
+    Loaded once per group by :func:`load_candidates`; the queue page never reads
+    a picture row a second time.
+    """
+
+    id: int
+    file_path: Optional[str] = None
+    format: Optional[str] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    size_bytes: Optional[int] = None
+    score: Optional[int] = None
+    created_at: Optional[datetime] = None
+    imported_at: Optional[datetime] = None
+    stack_id: Optional[int] = None
+    reference_folder_id: Optional[int] = None
+    pixel_sha: Optional[str] = None
+    perceptual_hash: Optional[str] = None
+    tag_count: int = 0
+
+    @property
+    def pixels(self) -> int:
+        """Total pixel count; 0 when the dimensions were never recorded."""
+        return int(self.width or 0) * int(self.height or 0)
+
+    @property
+    def megapixels(self) -> float:
+        return round(self.pixels / 1_000_000.0, 2)
+
+    @property
+    def is_raw(self) -> bool:
+        """Whether this is a camera original, by format or by file extension."""
+        fmt = (self.format or "").strip().lower().lstrip(".")
+        if fmt in RAW_FORMATS:
+            return True
+        path = self.file_path or ""
+        suffix = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+        return suffix in RAW_FORMATS
+
+    @property
+    def aspect_ratio(self) -> Optional[float]:
+        if not self.width or not self.height:
+            return None
+        return round(float(self.width) / float(self.height), 4)
+
+    @property
+    def content_key(self) -> str:
+        """The member's contribution to the group signature.
+
+        ``pixel_sha`` when it exists. A picture whose hash has not been computed
+        yet falls back to ``id:<n>``, which is stable but *not* stable across a
+        re-import of the same file — so a verdict made on a group containing such
+        a member will be re-asked after a re-import. That is the honest
+        behaviour: pretending two un-hashed rows are the same file would make the
+        verdict memory lie. ``MissingPixelShaFinder`` closes the gap in the
+        background.
+        """
+        return self.pixel_sha or f"id:{self.id}"
+
+    @property
+    def cover_score(self) -> float:
+        """The design's cover formula: ``px*4 + tags*3 + userScore*2 + RAW``."""
+        return (
+            self.megapixels * COVER_PIXEL_WEIGHT
+            + float(self.tag_count) * COVER_TAG_WEIGHT
+            + float(self.score or 0) * COVER_SCORE_WEIGHT
+            + (COVER_RAW_BONUS if self.is_raw else 0.0)
+        )
+
+    def as_dict(self, *, why: Optional[list[dict[str, Any]]] = None) -> dict[str, Any]:
+        """Serialise for the queue / compare API.
+
+        ``file_path`` is included **only for reference-folder pictures** (design
+        §7 "Paths only where they matter"): there the user manages the files and
+        needs to know which copy is which, while for a managed-library picture
+        the path is an implementation detail.
+        """
+        return {
+            "picture_id": self.id,
+            "width": self.width,
+            "height": self.height,
+            "megapixels": self.megapixels,
+            "size_bytes": self.size_bytes,
+            "format": self.format,
+            "is_raw": self.is_raw,
+            "score": self.score,
+            "tag_count": self.tag_count,
+            "created_at": self.created_at,
+            "imported_at": self.imported_at,
+            "stack_id": self.stack_id,
+            "reference_folder_id": self.reference_folder_id,
+            "file_path": (
+                self.file_path if self.reference_folder_id is not None else None
+            ),
+            "cover_score": round(self.cover_score, 4),
+            "why": why if why is not None else [],
+        }
+
+
+@dataclass
+class DetectedGroup:
+    """A group produced by one of the tiers, before it is persisted.
+
+    Attributes:
+        tier: Which tier found it.
+        confidence: 1.0 for exact; the weakest pairwise similarity otherwise.
+        members: Every member, in cover-preselection order (cover first).
+        cover_picture_id: The cover preselection.
+        evidence: The group-level why-pills.
+        signature: The verdict-memory key.
+    """
+
+    tier: DedupTier
+    confidence: float
+    members: list[CandidateMember]
+    cover_picture_id: int
+    evidence: list[dict[str, Any]] = field(default_factory=list)
+    signature: str = ""
+
+    @property
+    def picture_ids(self) -> list[int]:
+        return [member.id for member in self.members]
+
+
+# --- Signature --------------------------------------------------------------
+
+
+def group_signature(content_keys: Iterable[str]) -> str:
+    """Stable identity for a *set of files*, independent of ids and order.
+
+    The design keys verdict memory on "sorted member content hashes"; this is
+    that, hashed down to a fixed-width string so it indexes cheaply. Sorting
+    first is what makes the signature survive a rescan finding the members in a
+    different order, and hashing content rather than ids is what makes it survive
+    a re-import that assigns new picture ids.
+
+    Args:
+        content_keys: Per-member content keys (see
+            :attr:`CandidateMember.content_key`).
+
+    Returns:
+        A 64-character lowercase hex digest.
+    """
+    joined = "\x1f".join(sorted(str(key) for key in content_keys))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+# --- Cover selection --------------------------------------------------------
+
+
+def cover_order_key(member: CandidateMember) -> tuple[float, float, int]:
+    """Sort key implementing the design's cover rule.
+
+    ``pixels*4 + tags*3 + userScore*2 + RAW bonus``, highest wins; ties break to
+    the **oldest capture time** (the original, not a later re-export), then to
+    the lowest id so the choice is deterministic for two rows with no timestamp.
+    """
+    created = member.created_at
+    created_ts = created.timestamp() if isinstance(created, datetime) else float("inf")
+    return (-member.cover_score, created_ts, int(member.id))
+
+
+def select_cover(members: list[CandidateMember]) -> int:
+    """Return the preselected cover's picture id.
+
+    Never silent: the caller surfaces this as a *preselection* the user overrides
+    with 1-9, together with the per-candidate evidence that explains it.
+    """
+    if not members:
+        raise ValueError("select_cover requires at least one member")
+    return min(members, key=cover_order_key).id
+
+
+# --- Evidence ---------------------------------------------------------------
+
+
+def _pill(text: str, against: bool = False) -> dict[str, Any]:
+    """One why-pill: matching evidence (olive check) or evidence against (red x)."""
+    return {"text": text, "against": bool(against)}
+
+
+def _humanise_gap(seconds: float) -> str:
+    if seconds < 2:
+        return f"{seconds:.1f}s apart"
+    if seconds < 120:
+        return f"{int(round(seconds))}s apart"
+    if seconds < 7200:
+        return f"{int(round(seconds / 60))} min apart"
+    if seconds < 172800:
+        return f"{int(round(seconds / 3600))} hours apart"
+    return f"{int(round(seconds / 86400))} days apart"
+
+
+def build_group_evidence(
+    tier: DedupTier, confidence: float, members: list[CandidateMember]
+) -> list[dict[str, Any]]:
+    """The group-level why-pills, both directions.
+
+    The design's rule is that signals cut both ways: matching evidence is an
+    olive check, anything arguing *against* a stack is a red x, and a group
+    carrying red pills is exactly the one that needs Compare. So this deliberately
+    reports resolution / aspect-ratio / format mismatches alongside the match.
+
+    Nothing here is a conclusion — the client renders reasons and the user
+    decides.
+    """
+    pills: list[dict[str, Any]] = []
+    if tier is DedupTier.EXACT:
+        pills.append(_pill("Identical file hash"))
+    else:
+        pills.append(_pill(f"{int(round(confidence * 100))}% visual match"))
+
+    dimensions = {(m.width, m.height) for m in members if m.width and m.height}
+    if len(dimensions) == 1:
+        pills.append(_pill("Same dimensions"))
+    elif len(dimensions) > 1:
+        pills.append(_pill("Different resolution", against=True))
+
+    ratios = {m.aspect_ratio for m in members if m.aspect_ratio is not None}
+    if len(ratios) > 1 and max(ratios) - min(ratios) > 0.01:
+        pills.append(_pill("Different aspect ratio", against=True))
+
+    formats = {(m.format or "").lower() for m in members if m.format}
+    if len(formats) > 1:
+        pills.append(_pill("Different file format", against=True))
+
+    captures = sorted(m.created_at for m in members if m.created_at is not None)
+    if len(captures) >= 2:
+        span = (captures[-1] - captures[0]).total_seconds()
+        if span <= 1.0:
+            pills.append(_pill("Same capture second"))
+        elif span <= 5.0:
+            pills.append(_pill(f"Burst - {_humanise_gap(span)}"))
+        else:
+            pills.append(_pill(f"Captured {_humanise_gap(span)}"))
+
+    folders = {_parent_folder(m.file_path) for m in members if m.file_path}
+    folders.discard(None)
+    if len(folders) == 1 and len(members) > 1:
+        pills.append(_pill("Same folder"))
+
+    imports = sorted(m.imported_at for m in members if m.imported_at is not None)
+    if len(imports) >= 2:
+        span = (imports[-1] - imports[0]).total_seconds()
+        if span <= 600:
+            pills.append(_pill(f"Imported {_humanise_gap(span)}"))
+
+    return pills
+
+
+def build_candidate_evidence(
+    member: CandidateMember, members: list[CandidateMember], cover_id: int
+) -> list[dict[str, Any]]:
+    """Per-candidate why-pills, so the client renders reasons, not conclusions.
+
+    These are the signals the cover formula actually used, stated per candidate:
+    what this picture is best at, and where it loses. The client pairs them with
+    the numeric ``cover_score`` so a user can see *why* the preselection landed
+    where it did and disagree with it.
+    """
+    pills: list[dict[str, Any]] = []
+    best_pixels = max((m.pixels for m in members), default=0)
+    best_tags = max((m.tag_count for m in members), default=0)
+    best_score = max((int(m.score or 0) for m in members), default=0)
+
+    if member.pixels and member.pixels == best_pixels:
+        pills.append(_pill("Highest resolution"))
+    elif member.pixels and best_pixels:
+        shortfall = 100 - int(round(100 * member.pixels / best_pixels))
+        pills.append(_pill(f"{shortfall}% fewer pixels than the best", against=True))
+
+    if member.is_raw:
+        pills.append(_pill("Camera original (RAW)"))
+
+    if best_tags and member.tag_count == best_tags:
+        pills.append(_pill(f"Most metadata ({member.tag_count} tags)"))
+    elif best_tags and member.tag_count < best_tags:
+        pills.append(
+            _pill(
+                f"Fewer tags than the best ({member.tag_count} of {best_tags})",
+                against=True,
+            )
+        )
+
+    if best_score and int(member.score or 0) == best_score:
+        pills.append(_pill(f"Highest score ({best_score})"))
+
+    if member.id == cover_id:
+        pills.append(_pill("Preselected as cover"))
+    return pills
+
+
+def _parent_folder(file_path: Optional[str]) -> Optional[str]:
+    if not file_path:
+        return None
+    normalised = file_path.replace("\\", "/")
+    if "/" not in normalised:
+        return None
+    return normalised.rsplit("/", 1)[0]
+
+
+# --- Candidate loading ------------------------------------------------------
+
+
+def load_candidates(
+    session: Session, picture_ids: Iterable[int]
+) -> dict[int, CandidateMember]:
+    """Load the cover / evidence columns for *picture_ids*, plus their tag counts.
+
+    One query per id chunk for the picture columns and one for the tag counts —
+    never a per-picture round trip, because the queue loads a whole page of
+    groups at once.
+    """
+    ordered = sorted({int(pid) for pid in picture_ids})
+    if not ordered:
+        return {}
+    members: dict[int, CandidateMember] = {}
+    for start in range(0, len(ordered), ID_CHUNK):
+        chunk = ordered[start : start + ID_CHUNK]
+        rows = session.exec(
+            select(
+                Picture.id,
+                Picture.file_path,
+                Picture.format,
+                Picture.width,
+                Picture.height,
+                Picture.size_bytes,
+                Picture.score,
+                Picture.created_at,
+                Picture.imported_at,
+                Picture.stack_id,
+                Picture.reference_folder_id,
+                Picture.pixel_sha,
+                Picture.perceptual_hash,
+            ).where(Picture.id.in_(chunk), Picture.deleted.is_(False))
+        ).all()
+        for row in rows:
+            members[int(row[0])] = CandidateMember(
+                id=int(row[0]),
+                file_path=row[1],
+                format=row[2],
+                width=row[3],
+                height=row[4],
+                size_bytes=row[5],
+                score=row[6],
+                created_at=row[7],
+                imported_at=row[8],
+                stack_id=row[9],
+                reference_folder_id=row[10],
+                pixel_sha=row[11],
+                perceptual_hash=row[12],
+            )
+        tag_rows = session.exec(
+            select(Tag.picture_id, func.count(Tag.id))
+            .where(Tag.picture_id.in_(chunk))
+            .group_by(Tag.picture_id)
+        ).all()
+        for picture_id, count in tag_rows:
+            member = members.get(int(picture_id))
+            if member is not None:
+                member.tag_count = int(count or 0)
+    return members
+
+
+def assemble_group(
+    tier: DedupTier, confidence: float, members: list[CandidateMember]
+) -> DetectedGroup:
+    """Turn raw members into a :class:`DetectedGroup` with cover and evidence."""
+    ordered = sorted(members, key=cover_order_key)
+    cover_id = ordered[0].id
+    return DetectedGroup(
+        tier=tier,
+        confidence=round(float(confidence), 6),
+        members=ordered,
+        cover_picture_id=cover_id,
+        evidence=build_group_evidence(tier, confidence, ordered),
+        signature=group_signature(m.content_key for m in ordered),
+    )
+
+
+# --- Tier 1: exact ----------------------------------------------------------
+
+
+def find_exact_groups_in_session(
+    session: Session, scope: Optional[DedupScope] = None
+) -> list[DetectedGroup]:
+    """Tier 1. ``GROUP BY pixel_sha, size_bytes HAVING count(*) > 1``.
+
+    Two indexed-column queries: one aggregate to find the duplicated hashes, one
+    to pull the member ids for exactly those hashes. No image is decoded, no
+    model runs, and the whole tier is milliseconds on a library-sized table
+    because ``picture.pixel_sha`` is indexed.
+
+    See the module docstring for why ``size_bytes`` is a co-key.
+    """
+    scope = scope or DedupScope()
+    predicate = scope.picture_predicate()
+
+    duplicated = (
+        select(Picture.pixel_sha, Picture.size_bytes)
+        .where(
+            Picture.pixel_sha.is_not(None),
+            Picture.deleted.is_(False),
+        )
+        .group_by(Picture.pixel_sha, Picture.size_bytes)
+        .having(func.count(Picture.id) > 1)
+    )
+    if predicate is not None:
+        duplicated = duplicated.where(predicate)
+    keys = [(row[0], row[1]) for row in session.exec(duplicated).all()]
+    if not keys:
+        return []
+
+    shas = sorted({key[0] for key in keys})
+    wanted = set(keys)
+    by_key: dict[tuple[Optional[str], Optional[int]], list[int]] = defaultdict(list)
+    for start in range(0, len(shas), ID_CHUNK):
+        chunk = shas[start : start + ID_CHUNK]
+        member_query = select(Picture.id, Picture.pixel_sha, Picture.size_bytes).where(
+            Picture.pixel_sha.in_(chunk), Picture.deleted.is_(False)
+        )
+        if predicate is not None:
+            member_query = member_query.where(predicate)
+        for picture_id, sha, size_bytes in session.exec(member_query).all():
+            key = (sha, size_bytes)
+            if key in wanted:
+                by_key[key].append(int(picture_id))
+
+    member_ids = [ids for ids in by_key.values() if len(ids) > 1]
+    candidates = load_candidates(session, [pid for ids in member_ids for pid in ids])
+    groups: list[DetectedGroup] = []
+    for ids in member_ids:
+        members = [candidates[pid] for pid in ids if pid in candidates]
+        if len(members) < 2:
+            continue
+        groups.append(assemble_group(DedupTier.EXACT, 1.0, members))
+    logger.info(
+        "[dedup-tier1] scope=%s produced %d exact group(s) from %d hash key(s)",
+        scope.key,
+        len(groups),
+        len(keys),
+    )
+    return groups
+
+
+# --- Tier 2: bucketed near --------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NearBucket:
+    """One candidate bucket: a bucket key and the picture ids inside it.
+
+    A bucket is a unit of work. It is scanned on its own, its groups become
+    visible in the queue as soon as it finishes, and its cost is bounded by
+    :data:`MAX_BUCKET_MEMBERS`.
+    """
+
+    kind: str
+    key: str
+    picture_ids: tuple[int, ...]
+
+
+def _bucket_rows(session: Session, scope: DedupScope) -> list[tuple]:
+    """Load the bucketing columns for every picture that has a perceptual hash."""
+    query = select(
+        Picture.id,
+        Picture.size_bin_index,
+        Picture.created_at,
+        Picture.import_source_folder,
+        Picture.file_path,
+    ).where(
+        Picture.deleted.is_(False),
+        Picture.perceptual_hash.is_not(None),
+    )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(predicate)
+    return list(session.exec(query).all())
+
+
+def build_near_buckets(
+    session: Session, scope: Optional[DedupScope] = None
+) -> list[NearBucket]:
+    """Group the scope's pictures into tier-2 candidate buckets.
+
+    Four bucket kinds, all cheap and all reusing precomputed columns:
+
+    * ``size_bin`` — the indexed ``picture.size_bin_index`` (exact width/height).
+    * ``capture_minute`` — ``created_at`` truncated to the minute.
+    * ``import_folder`` — the ``import_source_folder`` batch.
+    * ``folder`` — the containing directory of ``file_path``.
+
+    A picture appears in several buckets; that is the point. Buckets larger than
+    :data:`MAX_BUCKET_MEMBERS` are split on the leading hex digits of the picture
+    id ordering rather than dropped, so no candidate is silently skipped.
+
+    Singleton buckets are discarded here rather than in the scan, so the scan's
+    "N of M buckets" progress describes real work.
+    """
+    scope = scope or DedupScope()
+    grouped: dict[tuple[str, str], list[int]] = defaultdict(list)
+    for picture_id, size_bin, created_at, import_folder, file_path in _bucket_rows(
+        session, scope
+    ):
+        picture_id = int(picture_id)
+        if size_bin is not None:
+            grouped[("size_bin", str(size_bin))].append(picture_id)
+        if isinstance(created_at, datetime):
+            grouped[("capture_minute", created_at.strftime("%Y-%m-%dT%H:%M"))].append(
+                picture_id
+            )
+        if import_folder:
+            grouped[("import_folder", str(import_folder))].append(picture_id)
+        folder = _parent_folder(file_path)
+        if folder:
+            grouped[("folder", folder)].append(picture_id)
+
+    buckets: list[NearBucket] = []
+    for (kind, key), ids in grouped.items():
+        if len(ids) < 2:
+            continue
+        ordered = sorted(set(ids))
+        if len(ordered) <= MAX_BUCKET_MEMBERS:
+            buckets.append(NearBucket(kind=kind, key=key, picture_ids=tuple(ordered)))
+            continue
+        # Oversized bucket: split into contiguous shards. Neighbouring ids come
+        # from the same import run, so a shard boundary rarely separates a real
+        # pair, and the alternative (dropping the bucket) would hide duplicates.
+        logger.info(
+            "[dedup-tier2] bucket %s=%s has %d members; splitting into shards of %d",
+            kind,
+            key,
+            len(ordered),
+            MAX_BUCKET_MEMBERS,
+        )
+        for start in range(0, len(ordered), MAX_BUCKET_MEMBERS):
+            shard = ordered[start : start + MAX_BUCKET_MEMBERS]
+            if len(shard) < 2:
+                continue
+            buckets.append(
+                NearBucket(
+                    kind=kind,
+                    key=f"{key}#{start // MAX_BUCKET_MEMBERS}",
+                    picture_ids=tuple(shard),
+                )
+            )
+    buckets.sort(key=lambda bucket: (bucket.kind, bucket.key))
+    logger.info(
+        "[dedup-tier2] scope=%s produced %d candidate bucket(s)",
+        scope.key,
+        len(buckets),
+    )
+    return buckets
+
+
+def _popcount64(values: np.ndarray) -> np.ndarray:
+    """Vectorised 64-bit population count (SWAR), matching ``likeness_utils``."""
+    counts = values - ((values >> np.uint64(1)) & np.uint64(0x5555555555555555))
+    counts = (counts & np.uint64(0x3333333333333333)) + (
+        (counts >> np.uint64(2)) & np.uint64(0x3333333333333333)
+    )
+    counts = (counts + (counts >> np.uint64(4))) & np.uint64(0x0F0F0F0F0F0F0F0F)
+    return (counts * np.uint64(0x0101010101010101)) >> np.uint64(56)
+
+
+def near_pairs_in_bucket(
+    session: Session, bucket: NearBucket, threshold: float
+) -> list[tuple[int, int, float]]:
+    """Compare perceptual hashes **within one bucket** and return the near pairs.
+
+    ``similarity = 1 - hamming(dhash_a, dhash_b) / 64`` over the 64-bit dHash
+    stored in ``picture.perceptual_hash``. The comparison is a numpy XOR plus a
+    SWAR popcount over the bucket's upper triangle, so a 4000-member bucket is
+    ~8M popcounts — milliseconds — and the library-wide O(n^2) never happens.
+
+    Returns:
+        ``(picture_id_a, picture_id_b, similarity)`` with ``a < b``, similarity
+        at or above *threshold*.
+    """
+    ids = list(bucket.picture_ids)
+    if len(ids) < 2:
+        return []
+    values: list[int] = []
+    kept: list[int] = []
+    for start in range(0, len(ids), ID_CHUNK):
+        chunk = ids[start : start + ID_CHUNK]
+        rows = session.exec(
+            select(Picture.id, Picture.perceptual_hash).where(
+                Picture.id.in_(chunk),
+                Picture.deleted.is_(False),
+                Picture.perceptual_hash.is_not(None),
+            )
+        ).all()
+        for picture_id, phash in rows:
+            text = str(phash or "")
+            if len(text) < PHASH_HEX_LEN:
+                logger.warning(
+                    "[dedup-tier2] picture %s has a %d-char perceptual_hash %r "
+                    "(expected %d); excluded from bucket %s=%s",
+                    picture_id,
+                    len(text),
+                    text,
+                    PHASH_HEX_LEN,
+                    bucket.kind,
+                    bucket.key,
+                )
+                continue
+            try:
+                values.append(int(text[:PHASH_HEX_LEN], 16))
+            except ValueError:
+                logger.warning(
+                    "[dedup-tier2] picture %s has an unparseable perceptual_hash "
+                    "%r; excluded from bucket %s=%s",
+                    picture_id,
+                    text,
+                    bucket.kind,
+                    bucket.key,
+                )
+                continue
+            kept.append(int(picture_id))
+    if len(kept) < 2:
+        return []
+
+    hashes = np.array(values, dtype=np.uint64)
+    id_array = np.array(kept, dtype=np.int64)
+    max_hamming = int((1.0 - float(threshold)) * PHASH_BITS)
+    pairs: list[tuple[int, int, float]] = []
+    for offset in range(1, len(kept)):
+        distances = _popcount64(hashes[:-offset] ^ hashes[offset:])
+        hits = np.nonzero(distances <= max_hamming)[0]
+        if hits.size == 0:
+            continue
+        for index in hits:
+            left = int(id_array[index])
+            right = int(id_array[index + offset])
+            similarity = 1.0 - float(distances[index]) / PHASH_BITS
+            pairs.append((min(left, right), max(left, right), round(similarity, 6)))
+    return pairs
+
+
+def groups_from_pairs(
+    session: Session,
+    pairs: list[tuple[int, int, float]],
+    policy: TierPolicy,
+    tier: DedupTier = DedupTier.NEAR,
+) -> list[DetectedGroup]:
+    """Fold near pairs into connected components and assemble them.
+
+    Reuses :class:`~pixlstash.services.dedup_sweep_service._LikenessForest` — the
+    shipped union-find that already accumulates per-component min/max similarity,
+    so the group's confidence is its **weakest link**, not its strongest.
+    """
+    if not pairs:
+        return []
+    forest = dedup_sweep_service._LikenessForest()
+    for picture_id_a, picture_id_b, similarity in pairs:
+        forest.add_edge(picture_id_a, picture_id_b, similarity)
+    components = forest.components(policy.min_group_size)
+    candidates = load_candidates(
+        session, [pid for member_ids, _, _ in components for pid in member_ids]
+    )
+    groups: list[DetectedGroup] = []
+    for member_ids, similarity_min, _similarity_max in components:
+        members = [candidates[pid] for pid in member_ids if pid in candidates]
+        if len(members) < policy.min_group_size:
+            continue
+        confidence = float(similarity_min)
+        if confidence < policy.threshold:
+            continue
+        group = assemble_group(tier, confidence, members)
+        if len(members) > policy.max_group_size:
+            group.evidence.append(
+                _pill(f"Unusually large group ({len(members)} pictures)", against=True)
+            )
+        groups.append(group)
+    return groups
+
+
+def find_near_groups_in_session(
+    session: Session,
+    policy: TierPolicy,
+    scope: Optional[DedupScope] = None,
+    buckets: Optional[list[NearBucket]] = None,
+) -> list[DetectedGroup]:
+    """Tier 2 end to end: build buckets, compare inside them, assemble groups.
+
+    Callers that want the streaming behaviour (groups visible as each bucket
+    finishes) drive :func:`build_near_buckets` and :func:`near_pairs_in_bucket`
+    themselves from the task system; this convenience wrapper runs the whole
+    tier in one call and is what the tests and the synchronous scoped scan use.
+    """
+    scope = scope or DedupScope()
+    buckets = buckets if buckets is not None else build_near_buckets(session, scope)
+    pairs: dict[tuple[int, int], float] = {}
+    for bucket in buckets:
+        for picture_id_a, picture_id_b, similarity in near_pairs_in_bucket(
+            session, bucket, policy.threshold
+        ):
+            key = (picture_id_a, picture_id_b)
+            # The same pair can surface in several buckets; keep the strongest
+            # observation, which is the same number either way (the hashes do
+            # not change between buckets) but makes the merge order-independent.
+            if similarity > pairs.get(key, 0.0):
+                pairs[key] = similarity
+    edges = [(a, b, similarity) for (a, b), similarity in pairs.items()]
+    return groups_from_pairs(session, edges, policy, DedupTier.NEAR)
+
+
+# --- Tier 3: embedding ------------------------------------------------------
+
+
+def find_embedding_groups_in_session(
+    session: Session, policy: TierPolicy, scope: Optional[DedupScope] = None
+) -> list[DetectedGroup]:
+    """Tier 3. Fold the existing likeness edge table into groups.
+
+    Nothing is recomputed: this reads the ``PictureLikeness`` rows the image
+    embedding worker already produced, through the shipped keyset-paginated
+    edge stream, so the tier costs one table scan and no GPU time. Opt-in
+    because that table is only complete once the embedding worker has caught up.
+    """
+    scope = scope or DedupScope()
+    in_scope: Optional[set[int]] = None
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        in_scope = {
+            int(row)
+            for row in session.exec(
+                select(Picture.id).where(Picture.deleted.is_(False), predicate)
+            ).all()
+        }
+        if not in_scope:
+            return []
+
+    pairs: list[tuple[int, int, float]] = []
+    for (
+        picture_id_a,
+        picture_id_b,
+        likeness,
+    ) in dedup_sweep_service.stream_likeness_edges(session, policy.threshold):
+        if in_scope is not None and (
+            picture_id_a not in in_scope or picture_id_b not in in_scope
+        ):
+            continue
+        pairs.append((picture_id_a, picture_id_b, likeness))
+    return groups_from_pairs(session, pairs, policy, DedupTier.EMBEDDING)
+
+
+# --- Persistence ------------------------------------------------------------
+
+
+def verdict_signatures_in_session(
+    session: Session, signatures: Iterable[str]
+) -> set[str]:
+    """Return the subset of *signatures* that already carry a live verdict.
+
+    A verdict with ``reopened_at`` set is not live: reopening returns the group
+    to the queue, which is exactly what "permanent until the user reopens it"
+    means.
+    """
+    wanted = sorted({str(signature) for signature in signatures})
+    if not wanted:
+        return set()
+    found: set[str] = set()
+    for start in range(0, len(wanted), ID_CHUNK):
+        chunk = wanted[start : start + ID_CHUNK]
+        rows = session.exec(
+            select(DedupVerdict.signature).where(
+                DedupVerdict.signature.in_(chunk),
+                DedupVerdict.reopened_at.is_(None),
+            )
+        ).all()
+        found.update(str(row) for row in rows)
+    return found
+
+
+def persist_groups_in_session(
+    session: Session,
+    groups: list[DetectedGroup],
+    scan_id: Optional[int] = None,
+) -> int:
+    """Upsert detected groups on their signature; return how many are unresolved.
+
+    Upserting rather than inserting is what makes a rescan idempotent: the same
+    files produce the same signature, so the row is refreshed in place and the
+    queue does not grow duplicates of its own. A group whose signature already
+    carries a live verdict is stored ``resolved=True`` and never re-asked.
+    """
+    if not groups:
+        return 0
+    resolved_signatures = verdict_signatures_in_session(
+        session, (group.signature for group in groups)
+    )
+    unresolved = 0
+    for group in groups:
+        existing = session.exec(
+            select(DedupGroup).where(DedupGroup.signature == group.signature)
+        ).first()
+        resolved = group.signature in resolved_signatures
+        if existing is None:
+            row = DedupGroup(
+                signature=group.signature,
+                tier=group.tier.value,
+                confidence=group.confidence,
+                member_count=len(group.members),
+                cover_picture_id=group.cover_picture_id,
+                evidence=json.dumps(group.evidence),
+                resolved=resolved,
+                scan_id=scan_id,
+            )
+            session.add(row)
+            session.flush()
+        else:
+            row = existing
+            row.tier = group.tier.value
+            row.confidence = group.confidence
+            row.member_count = len(group.members)
+            row.cover_picture_id = group.cover_picture_id
+            row.evidence = json.dumps(group.evidence)
+            row.resolved = resolved
+            row.scan_id = scan_id
+            session.add(row)
+            session.exec(
+                DedupGroupMember.__table__.delete().where(
+                    DedupGroupMember.__table__.c.group_id == row.id
+                )
+            )
+        for position, member in enumerate(group.members):
+            session.add(
+                DedupGroupMember(
+                    group_id=int(row.id), picture_id=member.id, position=position
+                )
+            )
+        if not resolved:
+            unresolved += 1
+    session.commit()
+    return unresolved
+
+
+def prune_stale_groups_in_session(session: Session) -> int:
+    """Drop groups whose members no longer exist or no longer number two.
+
+    Called after any verdict and at the start of a rescan. Without it a group
+    whose members were soft-deleted would keep inflating the sidebar badge, and
+    the badge is the whole reason the verdict memory exists.
+    """
+    live_counts = dict(
+        session.exec(
+            select(DedupGroupMember.group_id, func.count(DedupGroupMember.picture_id))
+            .join(Picture, Picture.id == DedupGroupMember.picture_id)
+            .where(Picture.deleted.is_(False))
+            .group_by(DedupGroupMember.group_id)
+        ).all()
+    )
+    removed = 0
+    for row in session.exec(select(DedupGroup)).all():
+        if live_counts.get(int(row.id), 0) >= 2:
+            continue
+        session.delete(row)
+        removed += 1
+    if removed:
+        session.commit()
+        logger.info("[dedup] pruned %d stale group(s)", removed)
+    return removed
+
+
+# --- Queue reads ------------------------------------------------------------
+
+
+def _tier_filter(policy: TierPolicy):
+    return DedupGroup.tier.in_([tier.value for tier in policy.tiers])
+
+
+def count_unresolved_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> int:
+    """The sidebar badge / context-menu count: unresolved groups in scope.
+
+    Groups, not pictures: the to-do count is the number of decisions left to
+    make, which is what the queue actually asks the user for.
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    query = select(func.count(func.distinct(DedupGroup.id))).where(
+        DedupGroup.resolved.is_(False),
+        _tier_filter(policy),
+        DedupGroup.confidence >= policy.threshold,
+    )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(
+            DedupGroup.id.in_(
+                select(DedupGroupMember.group_id)
+                .join(Picture, Picture.id == DedupGroupMember.picture_id)
+                .where(Picture.deleted.is_(False), predicate)
+            )
+        )
+    return int(session.exec(query).one())
+
+
+def count_by_tier_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> dict[str, int]:
+    """Unresolved group count per tier, including the tiers that are switched off.
+
+    The design gives each tier its own live count so the user can see what
+    turning a tier on would add before turning it on. That means this ignores
+    the policy's tier gating on purpose and reports every tier; only the
+    threshold applies, and exact is always counted in full.
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    query = select(DedupGroup.tier, func.count(DedupGroup.id)).where(
+        DedupGroup.resolved.is_(False)
+    )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(
+            DedupGroup.id.in_(
+                select(DedupGroupMember.group_id)
+                .join(Picture, Picture.id == DedupGroupMember.picture_id)
+                .where(Picture.deleted.is_(False), predicate)
+            )
+        )
+    # An exact match is always shown regardless of where the threshold sits, so
+    # the threshold is applied to the looser tiers only.
+    query = query.where(
+        (DedupGroup.tier == TIER_EXACT) | (DedupGroup.confidence >= policy.threshold)
+    )
+    counts = {tier.value: 0 for tier in DedupTier}
+    for tier, count in session.exec(query.group_by(DedupGroup.tier)).all():
+        counts[str(tier)] = int(count)
+    return counts
+
+
+def page_queue_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+    offset: int = 0,
+    limit: int = DEFAULT_PAGE_SIZE,
+) -> tuple[list[dict[str, Any]], int]:
+    """One page of the queue, confidence descending. Never loads the whole list.
+
+    Exactly ``limit`` group rows are read, then one candidate load for that
+    page's members. 10 groups and 10,000 cost the same per page, which is the
+    design's virtual-queue requirement expressed on the server side.
+
+    Returns:
+        ``(groups, total)`` where *total* is the complete unresolved count in
+        scope, so the client can size its scrollbar without a second request.
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    limit = max(1, min(int(limit), MAX_PAGE_SIZE))
+    offset = max(0, int(offset))
+
+    query = select(DedupGroup).where(
+        DedupGroup.resolved.is_(False),
+        _tier_filter(policy),
+        DedupGroup.confidence >= policy.threshold,
+    )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(
+            DedupGroup.id.in_(
+                select(DedupGroupMember.group_id)
+                .join(Picture, Picture.id == DedupGroupMember.picture_id)
+                .where(Picture.deleted.is_(False), predicate)
+            )
+        )
+    rows = session.exec(
+        query.order_by(
+            DedupGroup.confidence.desc(),
+            DedupGroup.id.asc(),
+        )
+        .offset(offset)
+        .limit(limit)
+    ).all()
+    total = count_unresolved_in_session(session, policy, scope)
+    if not rows:
+        return [], total
+
+    group_ids = [int(row.id) for row in rows]
+    member_rows = session.exec(
+        select(
+            DedupGroupMember.group_id,
+            DedupGroupMember.picture_id,
+            DedupGroupMember.position,
+        )
+        .where(DedupGroupMember.group_id.in_(group_ids))
+        .order_by(DedupGroupMember.group_id, DedupGroupMember.position)
+    ).all()
+    ids_by_group: dict[int, list[int]] = defaultdict(list)
+    for group_id, picture_id, _position in member_rows:
+        ids_by_group[int(group_id)].append(int(picture_id))
+    candidates = load_candidates(
+        session, [pid for ids in ids_by_group.values() for pid in ids]
+    )
+
+    payload: list[dict[str, Any]] = []
+    for row in rows:
+        members = [
+            candidates[pid]
+            for pid in ids_by_group.get(int(row.id), [])
+            if pid in candidates
+        ]
+        if len(members) < 2:
+            # Members disappeared between the scan and this read. Report the row
+            # as-is rather than dropping it silently; prune_stale_groups removes
+            # it on the next verdict or scan.
+            logger.info(
+                "[dedup-queue] group %s has %d live member(s); it will be pruned",
+                row.signature,
+                len(members),
+            )
+        cover_id = (
+            int(row.cover_picture_id)
+            if row.cover_picture_id is not None
+            else (members[0].id if members else None)
+        )
+        payload.append(
+            {
+                "signature": row.signature,
+                "tier": row.tier,
+                "confidence": float(row.confidence or 0.0),
+                "member_count": int(row.member_count or len(members)),
+                "cover_picture_id": cover_id,
+                "why": json.loads(row.evidence) if row.evidence else [],
+                "created_at": row.created_at,
+                "candidates": [
+                    member.as_dict(
+                        why=build_candidate_evidence(member, members, cover_id)
+                    )
+                    for member in members
+                ],
+            }
+        )
+    return payload, total
+
+
+def scope_counts_in_session(
+    session: Session,
+    scopes: list[DedupScope],
+    policy: Optional[TierPolicy] = None,
+) -> list[dict[str, Any]]:
+    """Unresolved counts for several scopes in one request.
+
+    The context menus need a count per project / set / character / folder; asking
+    for them one at a time would be a request per menu item.
+    """
+    policy = policy or TierPolicy()
+    return [
+        {
+            **scope.as_dict(),
+            "unresolved_groups": count_unresolved_in_session(session, policy, scope),
+        }
+        for scope in scopes
+    ]
+
+
+# --- Scan requests and progress ---------------------------------------------
+
+
+def request_scan_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> dict[str, Any]:
+    """Queue a scan for *scope* and return its progress row immediately.
+
+    The route returns as soon as this row exists, which is what makes the
+    context-menu "Find duplicates in ..." entry feel instant: the hashes are
+    already cached (``pixel_sha`` and ``perceptual_hash`` are computed on import),
+    so the scan only has to read and compare them, and the queue can be opened
+    while it does.
+
+    One row per scope key, reused across rescans, so a scope has exactly one
+    place to read progress from.
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    row = session.exec(
+        select(DedupScan).where(DedupScan.scope_key == scope.key)
+    ).first()
+    now = datetime.utcnow()
+    if row is None:
+        row = DedupScan(scope_key=scope.key)
+    row.scope_type = scope.scope_type.value
+    row.scope_id = scope.scope_id
+    row.tiers = json.dumps([tier.value for tier in policy.tiers])
+    row.threshold = float(policy.threshold)
+    row.status = SCAN_PENDING
+    row.error = None
+    row.started_at = now
+    row.updated_at = now
+    row.finished_at = None
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    logger.info(
+        "[dedup-scan] requested scan for scope=%s tiers=%s threshold=%.4f",
+        scope.key,
+        row.tiers,
+        policy.threshold,
+    )
+    return scan_progress(row)
+
+
+def scan_progress(row: Optional[DedupScan]) -> dict[str, Any]:
+    """Serialise a scan row for the "scanned N of M" banner.
+
+    ``None`` (no scan has ever run for this scope) is reported as an idle scan
+    rather than as an error: the queue is still perfectly usable, it just shows
+    whatever an earlier global scan found.
+    """
+    if row is None:
+        return {
+            "status": "idle",
+            "scanned_pictures": 0,
+            "total_pictures": 0,
+            "scanned_buckets": 0,
+            "total_buckets": 0,
+            "groups_found": 0,
+            "started_at": None,
+            "finished_at": None,
+            "error": None,
+        }
+    return {
+        "scan_id": row.id,
+        "scope_key": row.scope_key,
+        "status": row.status,
+        "tiers": json.loads(row.tiers or "[]"),
+        "threshold": float(row.threshold or DEFAULT_THRESHOLD),
+        "scanned_pictures": int(row.scanned_pictures or 0),
+        "total_pictures": int(row.total_pictures or 0),
+        "scanned_buckets": int(row.scanned_buckets or 0),
+        "total_buckets": int(row.total_buckets or 0),
+        "groups_found": int(row.groups_found or 0),
+        "started_at": row.started_at,
+        "updated_at": row.updated_at,
+        "finished_at": row.finished_at,
+        "error": row.error,
+    }
+
+
+def scan_progress_in_session(
+    session: Session, scope: Optional[DedupScope] = None
+) -> dict[str, Any]:
+    """Current scan progress for *scope*."""
+    scope = scope or DedupScope()
+    row = session.exec(
+        select(DedupScan).where(DedupScan.scope_key == scope.key)
+    ).first()
+    return scan_progress(row)
+
+
+def run_scan_now_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> dict[str, Any]:
+    """Run every enabled tier synchronously and persist the groups.
+
+    The background path is :class:`~pixlstash.tasks.dedup_scan_task.DedupScanTask`;
+    this is the same work without the task system, for tests and for a caller
+    that genuinely wants to block (a small scope where the round trip is cheaper
+    than polling).
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    prune_stale_groups_in_session(session)
+    found = 0
+    for tier in iter_tiers(policy):
+        if tier is DedupTier.EXACT:
+            groups = find_exact_groups_in_session(session, scope)
+        elif tier is DedupTier.NEAR:
+            groups = find_near_groups_in_session(session, policy, scope)
+        else:
+            groups = find_embedding_groups_in_session(session, policy, scope)
+        found += persist_groups_in_session(session, groups)
+    return {
+        "scope": scope.as_dict(),
+        "policy": policy.as_dict(),
+        "unresolved_groups": found,
+    }
+
+
+# --- Vault wrappers ---------------------------------------------------------
+
+
+def count_unresolved(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> int:
+    """Read-only vault wrapper around :func:`count_unresolved_in_session`."""
+    return vault.db.run_immediate_read_task(count_unresolved_in_session, policy, scope)
+
+
+def page_queue(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+    offset: int = 0,
+    limit: int = DEFAULT_PAGE_SIZE,
+) -> tuple[list[dict[str, Any]], int]:
+    """Read-only vault wrapper around :func:`page_queue_in_session`."""
+    return vault.db.run_immediate_read_task(
+        page_queue_in_session, policy, scope, offset, limit
+    )
+
+
+def _queue_response_in_session(
+    session: Session,
+    policy: TierPolicy,
+    scope: DedupScope,
+    offset: int,
+    limit: int,
+) -> dict[str, Any]:
+    """The whole ``GET /dedup/groups`` payload, on one session.
+
+    Assembled here rather than in the route so the page and the scan progress it
+    is captioned with come from the same read, and so the route never touches
+    ``vault.db`` (§10.1).
+    """
+    groups, total = page_queue_in_session(session, policy, scope, offset, limit)
+    return {
+        "groups": groups,
+        "total": total,
+        "offset": offset,
+        "limit": min(int(limit), MAX_PAGE_SIZE),
+        "policy": policy.as_dict(),
+        "scope": scope.as_dict(),
+        "scan": scan_progress_in_session(session, scope),
+    }
+
+
+def queue_response(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+    offset: int = 0,
+    limit: int = DEFAULT_PAGE_SIZE,
+) -> dict[str, Any]:
+    """Read-only vault wrapper producing the full queue-page response."""
+    return vault.db.run_immediate_read_task(
+        _queue_response_in_session,
+        policy or TierPolicy(),
+        scope or DedupScope(),
+        offset,
+        limit,
+    )
+
+
+def _counts_response_in_session(
+    session: Session, policy: TierPolicy, scopes: list[DedupScope]
+) -> dict[str, Any]:
+    """The whole ``POST /dedup/counts`` payload, on one session."""
+    return {
+        "unresolved_groups": count_unresolved_in_session(session, policy),
+        "by_tier": count_by_tier_in_session(session, policy),
+        "scopes": scope_counts_in_session(session, scopes, policy),
+        "policy": policy.as_dict(),
+        "scan": scan_progress_in_session(session),
+    }
+
+
+def counts_response(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scopes: Optional[list[DedupScope]] = None,
+) -> dict[str, Any]:
+    """Read-only vault wrapper producing the live-counts response."""
+    return vault.db.run_immediate_read_task(
+        _counts_response_in_session, policy or TierPolicy(), list(scopes or [])
+    )
+
+
+def request_scan(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> dict[str, Any]:
+    """Queue a scan and wake the work planner so it starts now.
+
+    Write-path vault wrapper: the row is the request, and the planner turns it
+    into a :class:`~pixlstash.tasks.dedup_scan_task.DedupScanTask`.
+    """
+    progress = vault.db.run_task(
+        request_scan_in_session,
+        policy or TierPolicy(),
+        scope or DedupScope(),
+    )
+    vault.wake()
+    return progress
+
+
+def iter_tiers(policy: TierPolicy) -> Iterator[DedupTier]:
+    """Yield the enabled tiers strongest first (exact, near, embedding)."""
+    for tier in TIER_ORDER:
+        if policy.includes(tier):
+            yield tier
+
+
+__all__ = [
+    "COVER_PIXEL_WEIGHT",
+    "COVER_RAW_BONUS",
+    "COVER_SCORE_WEIGHT",
+    "COVER_TAG_WEIGHT",
+    "DEFAULT_MAX_GROUP_SIZE",
+    "DEFAULT_MIN_GROUP_SIZE",
+    "DEFAULT_PAGE_SIZE",
+    "DEFAULT_THRESHOLD",
+    "MAX_BUCKET_MEMBERS",
+    "MAX_PAGE_SIZE",
+    "MAX_THRESHOLD",
+    "MIN_THRESHOLD",
+    "RAW_FORMATS",
+    "TIER_ORDER",
+    "CandidateMember",
+    "DedupScope",
+    "DedupTier",
+    "DetectedGroup",
+    "NearBucket",
+    "ScopeType",
+    "TierPolicy",
+    "VERDICT_KEEP_SEPARATE",
+    "VERDICT_STACKED",
+    "assemble_group",
+    "build_candidate_evidence",
+    "build_group_evidence",
+    "build_near_buckets",
+    "count_by_tier_in_session",
+    "count_unresolved",
+    "count_unresolved_in_session",
+    "counts_response",
+    "cover_order_key",
+    "find_embedding_groups_in_session",
+    "find_exact_groups_in_session",
+    "find_near_groups_in_session",
+    "group_signature",
+    "groups_from_pairs",
+    "iter_tiers",
+    "load_candidates",
+    "near_pairs_in_bucket",
+    "page_queue",
+    "page_queue_in_session",
+    "persist_groups_in_session",
+    "prune_stale_groups_in_session",
+    "queue_response",
+    "request_scan",
+    "request_scan_in_session",
+    "run_scan_now_in_session",
+    "scan_progress",
+    "scan_progress_in_session",
+    "scope_counts_in_session",
+    "select_cover",
+    "verdict_signatures_in_session",
+]

--- a/pixlstash/services/dedup_tier_service.py
+++ b/pixlstash/services/dedup_tier_service.py
@@ -78,8 +78,10 @@ the parameter object for that surface.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
+from binascii import Error as BinasciiError
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -123,8 +125,10 @@ DEFAULT_THRESHOLD = 0.90
 
 MIN_THRESHOLD = 0.65
 """Hard floor. Below this nothing is suggested at all — a low threshold produces
-confident-looking garbage and destroys trust in the sidebar count. Requests below
-it are a 400, never a silent clamp."""
+confident-looking garbage and destroys trust in the sidebar count. Never a silent
+clamp: :class:`TierPolicy` raises ``ValueError`` here, and every route carries the
+same bound as a pydantic ``ge=``, so over HTTP a low threshold is refused with a
+**422** before any handler runs."""
 
 MAX_THRESHOLD = 0.99999
 
@@ -150,9 +154,19 @@ MAX_PAIRS_PER_BUCKET = 50_000
 A bucket whose members are mutually near-identical (a burst of near-black frames,
 a folder of solid-colour placeholders, one image copied 4000 times) yields
 ``k*(k-1)/2`` pairs: ~8M tuples, roughly 580 MB, for a component the union-find
-only needs a spanning subset of. 50 000 pairs is ~4 MB and still connects every
-matching member of any realistic bucket. Hitting it logs a warning naming the
-bucket — the cap is never silent."""
+only needs a spanning subset of. 50 000 pairs is ~4 MB.
+
+**The cap can lose membership.** Pairs are emitted in increasing member-offset
+order, so the cap keeps the nearest-offset edges and drops the wider ones. For a
+uniformly near-identical bucket that costs only confidence resolution (the
+offset-1 edges alone span the block). For a dense but *non-uniform* block —
+~700 mutually matching members exhaust the cap well inside the low offsets — a
+member whose only match sits at a wider offset gets no edge at all and is split
+off into its own group or drops out of the queue. Hitting the cap logs a warning
+naming the bucket, the offset it stopped at and that consequence; the cap is
+never silent and the comment is not reassuring about a case it cannot cover.
+Mitigation: resolve the dense block and rescan, narrow the bucket, or raise this
+constant for the memory it costs."""
 
 MAX_TRACKED_PAIRS = 400_000
 """Cap on the pairs a whole streaming scan keeps in memory across buckets.
@@ -208,6 +222,26 @@ TIER_ORDER: tuple[DedupTier, ...] = (
     DedupTier.NEAR,
     DedupTier.EMBEDDING,
 )
+
+TIER_STRENGTH: dict[str, int] = {
+    TIER_EXACT: 3,
+    TIER_NEAR: 2,
+    TIER_EMBEDDING: 1,
+}
+"""How strong each tier's evidence is, for the upsert's tier precedence.
+
+Two tiers can find the *same* group: a byte-identical pair is also perceptually
+identical, so a near-enabled rescan rediscovers every exact pair. The upsert is
+keyed on the signature, so without precedence the later (weaker) tier overwrote
+the stronger one — and an ``exact`` pair silently downgraded to ``near``
+disappeared from the exact-only default queue *and* from ``POST
+/dedup/auto-stack``, which only ever acts on ``exact``.
+"""
+
+
+def tier_strength(tier: Optional[str]) -> int:
+    """Rank a stored tier value; an unknown or missing tier ranks lowest."""
+    return TIER_STRENGTH.get(str(tier or ""), 0)
 
 
 class ScopeType(str, Enum):
@@ -268,6 +302,23 @@ class DedupScope:
                     f"scope_id for scope_type={self.scope_type.value} must be an "
                     f"integer id, got {self.scope_id!r}"
                 ) from exc
+            return
+        if self.scope_type is ScopeType.FOLDER:
+            # Normalise here, not at query time, and reject what normalises away.
+            # The predicate strips trailing separators before building its LIKE
+            # prefix, so "/", "\", "///" all became an empty prefix and a LIKE
+            # pattern of "%" — a "Find duplicates in this folder" request that
+            # silently meant the whole vault, and a persisted dedupscan row whose
+            # scope_key claimed otherwise. Normalising at construction also makes
+            # "/photos" and "/photos/" the same scope key instead of two scans.
+            prefix = str(self.scope_id).rstrip("/\\")
+            if not prefix:
+                raise ValueError(
+                    "scope_id for scope_type=folder must name a folder; "
+                    f"{self.scope_id!r} normalises to an empty prefix, which "
+                    "would match the whole vault"
+                )
+            object.__setattr__(self, "scope_id", prefix)
 
     @property
     def key(self) -> str:
@@ -307,8 +358,9 @@ class DedupScope:
         # unescaped, a scope_id of "%" would silently mean "everywhere", so a
         # "Find duplicates in this folder" entry could match far more than the
         # folder it named. The literal path is still compared exactly on
-        # import_source_folder.
-        prefix = str(self.scope_id).rstrip("/\\")
+        # import_source_folder. ``scope_id`` was already stripped of trailing
+        # separators and rejected if that left it empty (__post_init__).
+        prefix = str(self.scope_id)
         pattern = (
             prefix.replace(LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CHAR * 2)
             .replace("%", f"{LIKE_ESCAPE_CHAR}%")
@@ -1069,7 +1121,7 @@ def near_pairs_in_bucket(
     id_array = np.array(kept, dtype=np.int64)
     max_hamming = int((1.0 - float(threshold)) * PHASH_BITS)
     pairs: list[tuple[int, int, float]] = []
-    truncated = False
+    truncated_at_offset: Optional[int] = None
     for offset in range(1, len(kept)):
         distances = _popcount64(hashes[:-offset] ^ hashes[offset:])
         hits = np.nonzero(distances <= max_hamming)[0]
@@ -1077,31 +1129,44 @@ def near_pairs_in_bucket(
             continue
         for index in hits:
             if len(pairs) >= MAX_PAIRS_PER_BUCKET:
-                truncated = True
+                truncated_at_offset = offset
                 break
             left = int(id_array[index])
             right = int(id_array[index + offset])
             similarity = 1.0 - float(distances[index]) / PHASH_BITS
             pairs.append((min(left, right), max(left, right), round(similarity, 6)))
-        if truncated:
+        if truncated_at_offset is not None:
             break
-    if truncated:
-        # Never silent (CLAUDE.md's no-silent-caps rule). The cap only bites on a
-        # bucket where a large fraction of members are mutually near-identical —
-        # k members that all match produce k*(k-1)/2 pairs, so 4000 members would
-        # be ~8M tuples (~580 MB) for a group the union-find only needs a
-        # spanning subset of. The retained pairs are the lowest-offset ones,
-        # which still connect every matching member into the same component; the
-        # loss is confidence *resolution* (the group's weakest-link value may be
-        # measured over fewer edges), not group membership.
+    if truncated_at_offset is not None:
+        # Never silent (CLAUDE.md's no-silent-caps rule), and never dishonest.
+        # Pairs are emitted in increasing member-offset order, so the cap keeps
+        # the *nearest-offset* edges and drops every edge at a wider offset. In a
+        # bucket where members are mutually near-identical that is harmless: the
+        # offset-1 edges alone form a spanning path (k-1 <= MAX_PAIRS_PER_BUCKET
+        # for any bucket, since MAX_BUCKET_MEMBERS is far smaller), so every
+        # member still lands in one component and only confidence *resolution*
+        # suffers.
+        #
+        # It is NOT harmless in a dense but non-uniform block. ~700 mutually
+        # matching members exhaust the cap inside the low offsets; a member whose
+        # only match sits at a wider offset then never gets an edge at all, so it
+        # is split into a separate group or drops out of the queue entirely. The
+        # cap can therefore lose membership, and this warning says so. The
+        # mitigations are to resolve the dense block and rescan (the survivors
+        # then fit under the cap), to narrow the bucket, or to raise
+        # MAX_PAIRS_PER_BUCKET for the memory it costs.
         logger.warning(
-            "[dedup-tier2] bucket %s=%s hit the %d-pair cap with %d members; "
-            "the group's members are still all connected, but its confidence is "
-            "measured over a subset of its edges. Raise MAX_PAIRS_PER_BUCKET if "
-            "this bucket matters, or narrow the bucket.",
+            "[dedup-tier2] bucket %s=%s hit the %d-pair cap at member offset %d "
+            "of %d with %d members: no edge at a wider offset was emitted, so a "
+            "member whose only match is further away may be split into its own "
+            "group or missing from the queue, and reported confidences are "
+            "measured over a subset of the edges. Resolve this block and rescan, "
+            "narrow the bucket, or raise MAX_PAIRS_PER_BUCKET.",
             bucket.kind,
             bucket.key,
             MAX_PAIRS_PER_BUCKET,
+            truncated_at_offset,
+            len(kept) - 1,
             len(kept),
         )
     return pairs
@@ -1281,11 +1346,31 @@ def persist_groups_in_session(
             session.flush()
         else:
             row = existing
-            row.tier = group.tier.value
-            row.confidence = group.confidence
+            # Tier precedence: a stronger tier is never downgraded by a weaker
+            # one rediscovering the same signature. Exact pairs are perceptually
+            # identical too, so a near-enabled rescan finds every one of them
+            # again; overwriting unconditionally moved them out of the
+            # exact-only default view and out of auto-stack's eligibility.
+            # Tier, confidence and evidence describe the *same* finding, so they
+            # move together — mixing a stored exact tier with a near
+            # confidence would misreport both.
+            if tier_strength(group.tier.value) >= tier_strength(row.tier):
+                row.tier = group.tier.value
+                row.confidence = group.confidence
+                row.evidence = json.dumps(group.evidence)
+                row.cover_picture_id = group.cover_picture_id
+            else:
+                logger.debug(
+                    "[dedup] keeping tier %s for signature %s; %s rediscovered "
+                    "the same group with weaker evidence",
+                    row.tier,
+                    group.signature,
+                    group.tier.value,
+                )
+            # Membership is pinned by the signature (it hashes the sorted member
+            # content keys), so it is refreshed either way: a re-import can give
+            # the same content new picture ids.
             row.member_count = len(group.members)
-            row.cover_picture_id = group.cover_picture_id
-            row.evidence = json.dumps(group.evidence)
             row.resolved = resolved
             row.scan_id = scan_id
             session.add(row)
@@ -1338,6 +1423,68 @@ def prune_stale_groups_in_session(session: Session) -> int:
 
 def _tier_filter(policy: TierPolicy):
     return DedupGroup.tier.in_([tier.value for tier in policy.tiers])
+
+
+CURSOR_VERSION = "1"
+"""Version tag inside the opaque queue cursor, so its encoding can change."""
+
+
+class DedupCursorError(ValueError):
+    """A queue cursor could not be decoded (truncated, edited or foreign)."""
+
+
+def encode_queue_cursor(confidence: float, group_id: int) -> str:
+    """Encode the keyset position of the last delivered row.
+
+    The queue's order is ``(confidence DESC, id ASC)``, so the position after a
+    row is exactly that pair. The wire form is base64url (unpadded) over
+    ``"1|<confidence>|<group id>"``, with the confidence written at 17
+    significant digits so a float round-trips exactly and the ``=`` tie-break
+    branch of the keyset predicate is reliable. It is opaque by intent — clients
+    must pass it back verbatim, never construct or interpret one.
+
+    Args:
+        confidence: The last delivered group's confidence.
+        group_id: The last delivered group's row id.
+
+    Returns:
+        The cursor to hand back as ``next_cursor``.
+    """
+    raw = f"{CURSOR_VERSION}|{float(confidence):.17g}|{int(group_id)}"
+    return base64.urlsafe_b64encode(raw.encode("ascii")).decode("ascii").rstrip("=")
+
+
+def decode_queue_cursor(cursor: str) -> tuple[float, int]:
+    """Decode a cursor produced by :func:`encode_queue_cursor`.
+
+    Raises:
+        DedupCursorError: The cursor is not a cursor this server minted. A bad
+            cursor is a 400, never a silent restart from the top — silently
+            paging from offset 0 would hand the client the same page forever.
+    """
+    text = str(cursor or "")
+    try:
+        padded = text + "=" * (-len(text) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode("ascii")).decode("ascii")
+        version, confidence, group_id = raw.split("|")
+        if version != CURSOR_VERSION:
+            raise ValueError(f"unsupported cursor version {version!r}")
+        return float(confidence), int(group_id)
+    except (ValueError, UnicodeDecodeError, BinasciiError) as exc:
+        raise DedupCursorError(f"malformed queue cursor {cursor!r}: {exc}") from exc
+
+
+def _keyset_predicate(cursor: str):
+    """The ``WHERE`` that resumes ``(confidence DESC, id ASC)`` after *cursor*.
+
+    The tie-break half is load-bearing: several groups routinely share a
+    confidence (every exact group is 1.0), so ``confidence < c`` alone would skip
+    the rest of the tied run and ``confidence <= c`` would repeat it forever.
+    """
+    confidence, group_id = decode_queue_cursor(cursor)
+    return (DedupGroup.confidence < confidence) | (
+        (DedupGroup.confidence == confidence) & (DedupGroup.id > group_id)
+    )
 
 
 def count_unresolved_in_session(
@@ -1412,16 +1559,40 @@ def page_queue_in_session(
     scope: Optional[DedupScope] = None,
     offset: int = 0,
     limit: int = DEFAULT_PAGE_SIZE,
-) -> tuple[list[dict[str, Any]], int]:
+    cursor: Optional[str] = None,
+) -> tuple[list[dict[str, Any]], int, Optional[str]]:
     """One page of the queue, confidence descending. Never loads the whole list.
 
     Exactly ``limit`` group rows are read, then one candidate load for that
     page's members. 10 groups and 10,000 cost the same per page, which is the
     design's virtual-queue requirement expressed on the server side.
 
+    **Page with the cursor, not the offset.** The queue is a live list: deciding
+    a verdict on a delivered row removes it from ``resolved=False``, and a tier-2
+    scan commits new groups after every bucket. Both shift every later row's
+    offset, so ``offset=limit`` on the second request skips exactly as many
+    groups as the first page's decisions removed — a deterministic, silent skip
+    reproduced with a single verdict between two pages. The keyset cursor encodes
+    *where the last row was in the ordering* rather than *how many rows to
+    discard*, so a row that never moved is never skipped.
+
+    Args:
+        session: Pre-opened session.
+        policy: Tier gating and threshold; server defaults when omitted.
+        scope: Scope to page within; the whole vault when omitted.
+        offset: Deprecated rows-to-skip paging. Ignored when *cursor* is given —
+            the route rejects the combination before it reaches here.
+        limit: Page size, clamped to :data:`MAX_PAGE_SIZE`.
+        cursor: Opaque keyset position from a previous page's ``next_cursor``.
+
     Returns:
-        ``(groups, total)`` where *total* is the complete unresolved count in
-        scope, so the client can size its scrollbar without a second request.
+        ``(groups, total, next_cursor)``. *total* is the complete unresolved
+        count in scope, so the client can size its scrollbar without a second
+        request. *next_cursor* is ``None`` once the page is not full, which is
+        end-of-found.
+
+    Raises:
+        DedupCursorError: *cursor* is not a cursor this server minted.
     """
     policy = policy or TierPolicy()
     scope = scope or DedupScope()
@@ -1442,17 +1613,26 @@ def page_queue_in_session(
                 .where(Picture.deleted.is_(False), predicate)
             )
         )
-    rows = session.exec(
-        query.order_by(
-            DedupGroup.confidence.desc(),
-            DedupGroup.id.asc(),
-        )
-        .offset(offset)
-        .limit(limit)
-    ).all()
+    if cursor:
+        query = query.where(_keyset_predicate(cursor))
+    query = query.order_by(
+        DedupGroup.confidence.desc(),
+        DedupGroup.id.asc(),
+    ).limit(limit)
+    if not cursor:
+        query = query.offset(offset)
+    rows = session.exec(query).all()
     total = count_unresolved_in_session(session, policy, scope)
     if not rows:
-        return [], total
+        return [], total, None
+    # A short page is end-of-found; a full page may or may not be, and handing
+    # back a cursor that yields one empty page is cheaper than the extra COUNT
+    # that would be needed to know for certain.
+    next_cursor = (
+        encode_queue_cursor(float(rows[-1].confidence or 0.0), int(rows[-1].id))
+        if len(rows) == limit
+        else None
+    )
 
     group_ids = [int(row.id) for row in rows]
     member_rows = session.exec(
@@ -1509,7 +1689,7 @@ def page_queue_in_session(
                 ],
             }
         )
-    return payload, total
+    return payload, total, next_cursor
 
 
 def scope_counts_in_session(
@@ -1677,10 +1857,11 @@ def page_queue(
     scope: Optional[DedupScope] = None,
     offset: int = 0,
     limit: int = DEFAULT_PAGE_SIZE,
-) -> tuple[list[dict[str, Any]], int]:
+    cursor: Optional[str] = None,
+) -> tuple[list[dict[str, Any]], int, Optional[str]]:
     """Read-only vault wrapper around :func:`page_queue_in_session`."""
     return vault.db.run_immediate_read_task(
-        page_queue_in_session, policy, scope, offset, limit
+        page_queue_in_session, policy, scope, offset, limit, cursor
     )
 
 
@@ -1690,6 +1871,7 @@ def _queue_response_in_session(
     scope: DedupScope,
     offset: int,
     limit: int,
+    cursor: Optional[str] = None,
 ) -> dict[str, Any]:
     """The whole ``GET /dedup/groups`` payload, on one session.
 
@@ -1697,12 +1879,16 @@ def _queue_response_in_session(
     is captioned with come from the same read, and so the route never touches
     ``vault.db`` (§10.1).
     """
-    groups, total = page_queue_in_session(session, policy, scope, offset, limit)
+    groups, total, next_cursor = page_queue_in_session(
+        session, policy, scope, offset, limit, cursor
+    )
     return {
         "groups": groups,
         "total": total,
         "offset": offset,
         "limit": min(int(limit), MAX_PAGE_SIZE),
+        "cursor": cursor,
+        "next_cursor": next_cursor,
         "policy": policy.as_dict(),
         "scope": scope.as_dict(),
         "scan": scan_progress_in_session(session, scope),
@@ -1715,6 +1901,7 @@ def queue_response(
     scope: Optional[DedupScope] = None,
     offset: int = 0,
     limit: int = DEFAULT_PAGE_SIZE,
+    cursor: Optional[str] = None,
 ) -> dict[str, Any]:
     """Read-only vault wrapper producing the full queue-page response."""
     return vault.db.run_immediate_read_task(
@@ -1723,6 +1910,7 @@ def queue_response(
         scope or DedupScope(),
         offset,
         limit,
+        cursor,
     )
 
 
@@ -1781,6 +1969,7 @@ __all__ = [
     "COVER_RAW_BONUS",
     "COVER_SCORE_WEIGHT",
     "COVER_TAG_WEIGHT",
+    "CURSOR_VERSION",
     "DEFAULT_MAX_GROUP_SIZE",
     "DEFAULT_MIN_GROUP_SIZE",
     "DEFAULT_PAGE_SIZE",
@@ -1791,15 +1980,17 @@ __all__ = [
     "MIN_THRESHOLD",
     "RAW_FORMATS",
     "TIER_ORDER",
+    "TIER_STRENGTH",
+    "VERDICT_KEEP_SEPARATE",
+    "VERDICT_STACKED",
     "CandidateMember",
+    "DedupCursorError",
     "DedupScope",
     "DedupTier",
     "DetectedGroup",
     "NearBucket",
     "ScopeType",
     "TierPolicy",
-    "VERDICT_KEEP_SEPARATE",
-    "VERDICT_STACKED",
     "assemble_group",
     "build_candidate_evidence",
     "build_group_evidence",
@@ -1809,6 +2000,8 @@ __all__ = [
     "count_unresolved_in_session",
     "counts_response",
     "cover_order_key",
+    "decode_queue_cursor",
+    "encode_queue_cursor",
     "find_embedding_groups_in_session",
     "find_exact_groups_in_session",
     "find_near_groups_in_session",
@@ -1829,5 +2022,6 @@ __all__ = [
     "scan_progress_in_session",
     "scope_counts_in_session",
     "select_cover",
+    "tier_strength",
     "verdict_signatures_in_session",
 ]

--- a/pixlstash/services/dedup_tier_service.py
+++ b/pixlstash/services/dedup_tier_service.py
@@ -109,6 +109,7 @@ from pixlstash.db_models.face import Face
 from pixlstash.db_models.tag import Tag
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services import dedup_sweep_service
+from pixlstash.utils.image_processing.image_utils import ImageUtils
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from pixlstash.vault import Vault
@@ -138,8 +139,27 @@ MAX_PAGE_SIZE = 200
 
 MAX_BUCKET_MEMBERS = 4000
 """Cap on one tier-2 bucket. The within-bucket comparison is O(k^2) popcounts,
-which numpy does in milliseconds at k=4000 (~8M pairs); beyond that the bucket is
-split by hash prefix rather than being dropped, so nothing is silently skipped."""
+which numpy does in milliseconds at k=4000 (~8M comparisons); beyond that the
+bucket is split into shards rather than being dropped, so nothing is silently
+skipped. This bounds **CPU**, not memory — see :data:`MAX_PAIRS_PER_BUCKET`."""
+
+MAX_PAIRS_PER_BUCKET = 50_000
+"""Cap on the *materialised* near-pairs of one bucket.
+
+``MAX_BUCKET_MEMBERS`` bounds the comparison work; it does not bound the result.
+A bucket whose members are mutually near-identical (a burst of near-black frames,
+a folder of solid-colour placeholders, one image copied 4000 times) yields
+``k*(k-1)/2`` pairs: ~8M tuples, roughly 580 MB, for a component the union-find
+only needs a spanning subset of. 50 000 pairs is ~4 MB and still connects every
+matching member of any realistic bucket. Hitting it logs a warning naming the
+bucket — the cap is never silent."""
+
+MAX_TRACKED_PAIRS = 400_000
+"""Cap on the pairs a whole streaming scan keeps in memory across buckets.
+
+A scan holds pairs from every finished bucket so a chain spanning two buckets
+becomes one group. That set is what grows without bound over a large library;
+capping it at ~32 MB keeps the scan's footprint flat. Reaching it is logged."""
 
 PHASH_BITS = 64
 PHASH_HEX_LEN = PHASH_BITS // 4
@@ -204,6 +224,15 @@ class ScopeType(str, Enum):
     FOLDER = "folder"
 
 
+_NUMERIC_SCOPE_TYPES = frozenset(
+    {ScopeType.PROJECT, ScopeType.SET, ScopeType.CHARACTER}
+)
+"""Scopes whose ``scope_id`` is a row id and must parse as an integer."""
+
+LIKE_ESCAPE_CHAR = "\\"
+"""Escape character for the folder scope's ``LIKE`` prefix match."""
+
+
 @dataclass(frozen=True)
 class DedupScope:
     """A scan / count scope and the SQL that narrows a picture query to it.
@@ -222,8 +251,23 @@ class DedupScope:
             object.__setattr__(self, "scope_type", ScopeType(str(self.scope_type)))
         if self.scope_type is ScopeType.GLOBAL:
             object.__setattr__(self, "scope_id", None)
-        elif self.scope_id is None or str(self.scope_id) == "":
+            return
+        if self.scope_id is None or str(self.scope_id) == "":
             raise ValueError(f"scope_id is required for scope_type={self.scope_type}")
+        if self.scope_type in _NUMERIC_SCOPE_TYPES:
+            # Validate at construction, not at query time. The id reaches SQL as
+            # ``int(...)`` in picture_predicate(); leaving a non-numeric string to
+            # blow up there turned a bad request into a 500 on three read routes,
+            # and POST /dedup/scan *persisted* the unparseable scope before
+            # anything ever tried to parse it. Failing here makes it a 400 at the
+            # boundary, before any write.
+            try:
+                object.__setattr__(self, "scope_id", str(int(str(self.scope_id))))
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"scope_id for scope_type={self.scope_type.value} must be an "
+                    f"integer id, got {self.scope_id!r}"
+                ) from exc
 
     @property
     def key(self) -> str:
@@ -258,9 +302,20 @@ class DedupScope:
             )
         # FOLDER: a picture is in the folder when it was imported from it or its
         # file lives under it. Both are prefix matches on an indexed column.
+        #
+        # The LIKE pattern escapes ``%`` / ``_`` / the escape character itself:
+        # unescaped, a scope_id of "%" would silently mean "everywhere", so a
+        # "Find duplicates in this folder" entry could match far more than the
+        # folder it named. The literal path is still compared exactly on
+        # import_source_folder.
         prefix = str(self.scope_id).rstrip("/\\")
+        pattern = (
+            prefix.replace(LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CHAR * 2)
+            .replace("%", f"{LIKE_ESCAPE_CHAR}%")
+            .replace("_", f"{LIKE_ESCAPE_CHAR}_")
+        )
         return (Picture.import_source_folder == prefix) | (
-            Picture.file_path.like(f"{prefix}%")
+            Picture.file_path.like(f"{pattern}%", escape=LIKE_ESCAPE_CHAR)
         )
 
     def as_dict(self) -> dict[str, Any]:
@@ -373,7 +428,22 @@ class CandidateMember:
     reference_folder_id: Optional[int] = None
     pixel_sha: Optional[str] = None
     perceptual_hash: Optional[str] = None
+    thumbnail_width: Optional[int] = None
+    thumbnail_height: Optional[int] = None
     tag_count: int = 0
+
+    @property
+    def thumbnail_version(self) -> str:
+        """The ``?v=`` token the queue's thumbnail URLs must carry.
+
+        Same value and same semantics as the batch-thumbnail endpoint's — both
+        call :meth:`ImageUtils.thumbnail_cache_token`. Without it a thumbnail
+        regenerated mid-triage would keep painting the stale cached bitmap in the
+        queue, because the queue's URL would never change.
+        """
+        return ImageUtils.thumbnail_cache_token(
+            self.thumbnail_width, self.thumbnail_height
+        )
 
     @property
     def pixels(self) -> int:
@@ -404,15 +474,27 @@ class CandidateMember:
     def content_key(self) -> str:
         """The member's contribution to the group signature.
 
-        ``pixel_sha`` when it exists. A picture whose hash has not been computed
-        yet falls back to ``id:<n>``, which is stable but *not* stable across a
-        re-import of the same file — so a verdict made on a group containing such
-        a member will be re-asked after a re-import. That is the honest
-        behaviour: pretending two un-hashed rows are the same file would make the
-        verdict memory lie. ``MissingPixelShaFinder`` closes the gap in the
-        background.
+        ``pixel_sha:size_bytes`` when the hash exists. **The size is a co-key
+        here for the same reason it is one in tier-1 detection** (§22.1):
+        ``pixel_sha`` is a *sampled* digest above 128 KiB, so the digest alone
+        does not identify a file. Detection has always grouped on
+        ``(pixel_sha, size_bytes)``; identity omitting the size made
+        :func:`group_signature` non-injective over groups, which meant two
+        distinct exact groups differing only in size collapsed onto one
+        signature — the upsert dropped one from the queue, a ``keep_separate``
+        silenced both file sets, and a stack verdict's write target depended on
+        scan order rather than on what the user saw.
+
+        A picture whose hash has not been computed yet falls back to ``id:<n>``,
+        which is stable but *not* stable across a re-import of the same file — so
+        a verdict made on a group containing such a member will be re-asked after
+        a re-import. That is the honest behaviour: pretending two un-hashed rows
+        are the same file would make the verdict memory lie.
+        ``MissingPixelShaFinder`` closes the gap in the background.
         """
-        return self.pixel_sha or f"id:{self.id}"
+        if self.pixel_sha:
+            return f"{self.pixel_sha}:{self.size_bytes}"
+        return f"id:{self.id}"
 
     @property
     def cover_score(self) -> float:
@@ -449,6 +531,7 @@ class CandidateMember:
             "file_path": (
                 self.file_path if self.reference_folder_id is not None else None
             ),
+            "thumbnail_version": self.thumbnail_version,
             "cover_score": round(self.cover_score, 4),
             "why": why if why is not None else [],
         }
@@ -689,6 +772,8 @@ def load_candidates(
                 Picture.reference_folder_id,
                 Picture.pixel_sha,
                 Picture.perceptual_hash,
+                Picture.thumbnail_width,
+                Picture.thumbnail_height,
             ).where(Picture.id.in_(chunk), Picture.deleted.is_(False))
         ).all()
         for row in rows:
@@ -706,6 +791,8 @@ def load_candidates(
                 reference_folder_id=row[10],
                 pixel_sha=row[11],
                 perceptual_hash=row[12],
+                thumbnail_width=row[13],
+                thumbnail_height=row[14],
             )
         tag_rows = session.exec(
             select(Tag.picture_id, func.count(Tag.id))
@@ -982,16 +1069,41 @@ def near_pairs_in_bucket(
     id_array = np.array(kept, dtype=np.int64)
     max_hamming = int((1.0 - float(threshold)) * PHASH_BITS)
     pairs: list[tuple[int, int, float]] = []
+    truncated = False
     for offset in range(1, len(kept)):
         distances = _popcount64(hashes[:-offset] ^ hashes[offset:])
         hits = np.nonzero(distances <= max_hamming)[0]
         if hits.size == 0:
             continue
         for index in hits:
+            if len(pairs) >= MAX_PAIRS_PER_BUCKET:
+                truncated = True
+                break
             left = int(id_array[index])
             right = int(id_array[index + offset])
             similarity = 1.0 - float(distances[index]) / PHASH_BITS
             pairs.append((min(left, right), max(left, right), round(similarity, 6)))
+        if truncated:
+            break
+    if truncated:
+        # Never silent (CLAUDE.md's no-silent-caps rule). The cap only bites on a
+        # bucket where a large fraction of members are mutually near-identical —
+        # k members that all match produce k*(k-1)/2 pairs, so 4000 members would
+        # be ~8M tuples (~580 MB) for a group the union-find only needs a
+        # spanning subset of. The retained pairs are the lowest-offset ones,
+        # which still connect every matching member into the same component; the
+        # loss is confidence *resolution* (the group's weakest-link value may be
+        # measured over fewer edges), not group membership.
+        logger.warning(
+            "[dedup-tier2] bucket %s=%s hit the %d-pair cap with %d members; "
+            "the group's members are still all connected, but its confidence is "
+            "measured over a subset of its edges. Raise MAX_PAIRS_PER_BUCKET if "
+            "this bucket matters, or narrow the bucket.",
+            bucket.kind,
+            bucket.key,
+            MAX_PAIRS_PER_BUCKET,
+            len(kept),
+        )
     return pairs
 
 

--- a/pixlstash/services/dedup_verdict_service.py
+++ b/pixlstash/services/dedup_verdict_service.py
@@ -40,26 +40,39 @@ module calls it and adds the three the design requires on top:
   characters is left alone and logged; the members keep their own faces, which is
   the non-lossy outcome.
 
-Operation log
--------------
-Every verdict is meant to raise an action receipt and land in the operation log,
-with a bulk auto-stack coalescing into one batch id so N stacks reverse with one
-undo. The operation log ships on its own lane (``feature/operation-log``); this
-branch is stacked on the dedup sweep planner and does not contain it, so the call
-is made through :func:`_record_operation`, which imports the service lazily and
-logs a clear warning naming the missing module when it is absent. Wiring the two
-lanes together at merge time is a no-op: the seam already passes ``batch_id``,
-``op_type`` and the before/after picture id set.
+Operation log (§21)
+-------------------
+Every verdict raises an action receipt and lands in the operation log. Each
+verdict records **exactly one** :class:`~pixlstash.db_models.operation.Operation`
+row, and a bulk auto-stack shares a single ``batch_id`` across every group in the
+run, so ``POST /operations/batches/{batch_id}/undo`` reverses a thousand stacks in
+one step.
+
+Two details this module owns rather than inherits:
+
+* **It does not go through** ``routes/stacks.py``. Those handlers already wrap
+  themselves in ``run_recorded_metadata_task``; calling them would produce a
+  second operation row per verdict, and "one verdict, one undo" would stop being
+  true. :func:`_stack_members` does the stacking in-session instead, and this
+  module records once around the whole verdict.
+* **It snapshots the stack-expanded set**, not just the group's members
+  (§21's ``expand_stacks`` rule). Folding an existing stack into the new one
+  reparents co-members the group never named, and ``normalize_stack_positions``
+  renumbers *every* member including soft-deleted ones — so the snapshot is taken
+  over :func:`expand_picture_ids_to_stacks` with ``include_deleted=True``, or an
+  undo would restore the group and leave its siblings behind.
 """
 
 from __future__ import annotations
 
 import json
 import uuid
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
+from fastapi import HTTPException
 from sqlalchemy import func
 from sqlmodel import Session, select
 
@@ -75,11 +88,16 @@ from pixlstash.db_models.dedup import (
 from pixlstash.db_models.face import Face
 from pixlstash.db_models.tag import Tag, is_tag_sentinel
 from pixlstash.pixl_logging import get_logger
+from pixlstash.services import operation_log_service
 from pixlstash.services.dedup_tier_service import (
     DedupScope,
+    DedupTier,
     prune_stale_groups_in_session,
 )
-from pixlstash.services.stack_membership import reconcile_stack_membership
+from pixlstash.services.stack_membership import (
+    expand_picture_ids_to_stacks,
+    reconcile_stack_membership,
+)
 from pixlstash.stacking import normalize_stack_positions
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -87,10 +105,24 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 logger = get_logger(__name__)
 
-# One op-log entry per verdict; the bulk path shares a single batch id.
+# The one op_type this module records. Stable — part of the API contract the
+# frontend keys its undo affordances off. A bulk auto-stack shares one batch_id
+# across every row it writes, so the whole run reverses in a single step.
+#
+# Keep-separate and reopen have no op_type on purpose: they change no reversible
+# picture facet, so they record nothing rather than writing a no-op row that
+# would still consume a Ctrl+Z.
 OP_TYPE_STACK = "dedup.stack"
-OP_TYPE_KEEP_SEPARATE = "dedup.keep_separate"
-OP_TYPE_REOPEN = "dedup.reopen"
+
+# Per-group outcome vocabulary for a bulk auto-stack. Closed set; the response
+# reports every group under exactly one of these, so a partial run is legible
+# rather than inferred from a count mismatch.
+BULK_REASON_APPLIED = "applied"
+BULK_REASON_BLOCKED = "blocked"
+"""The group was refused by a guard that returns an HTTP status — in practice a
+locked picture set (423). Nothing was written for it."""
+BULK_REASON_FAILED = "failed"
+"""The group could not be resolved at all (stale signature, too few members)."""
 
 
 class DedupVerdictError(Exception):
@@ -144,35 +176,22 @@ def _record_operation(
     session: Session,
     *,
     op_type: str,
-    picture_ids: list[int],
     before: dict[str, dict],
     after: dict[str, dict],
     batch_id: Optional[str],
     summary: str,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
 ) -> None:
-    """Append this verdict to the operation log, if that lane is present.
+    """Append **one** operation row for this verdict.
 
-    Cross-lane seam, not a fallback: ``pixlstash.services.operation_log_service``
-    lands on ``feature/operation-log`` and is not on this branch. When it is
-    missing the verdict still applies (it is an ordinary, individually reversible
-    stacking action) but is not undoable in one keystroke, and that consequence is
-    logged with the module name so the gap is visible rather than silent.
+    Called once per verdict, around the whole mutation, on the verdict's own
+    session — so the row and the change it describes commit against the same
+    serialised writer (§21). The verdict path deliberately does not reuse
+    ``routes/stacks.py``, which records itself; going through it would produce a
+    second row and break "one verdict, one undo".
     """
-    try:
-        from pixlstash.services import operation_log_service
-    except ImportError as exc:
-        logger.warning(
-            "[dedup-verdict] operation log unavailable (%s): %s %s on %d picture(s) "
-            "batch=%s applied but NOT recorded, so Ctrl+Z will not reverse it. "
-            "This is the feature/operation-log lane seam; wiring it up needs no "
-            "change here.",
-            exc,
-            op_type,
-            summary,
-            len(picture_ids),
-            batch_id,
-        )
-        return
     operation_log_service.record_operation_in_session(
         session,
         op_type=op_type,
@@ -180,18 +199,28 @@ def _record_operation(
         after=after,
         batch_id=batch_id,
         summary=summary,
+        actor=actor,
+        source=source,
+        origin_client_id=origin_client_id,
     )
 
 
 def _capture_state(session: Session, picture_ids: list[int]) -> dict[str, dict]:
-    """Snapshot the picture state an undo would restore, if the log is present."""
-    try:
-        from pixlstash.services import operation_log_service
-    except ImportError:
-        # Already reported by _record_operation with full context; capturing
-        # nothing here keeps the verdict path free of a second identical warning.
-        return {}
+    """Snapshot every reversible facet of *picture_ids* (§21's undo payload)."""
     return operation_log_service.capture_state_in_session(session, picture_ids)
+
+
+def _undo_targets(session: Session, picture_ids: list[int]) -> list[int]:
+    """The ids an undo of this verdict has to restore.
+
+    Stacking is stack-atomic: folding an existing stack into the verdict's stack
+    reparents co-members the group never named, and ``normalize_stack_positions``
+    renumbers **every** member of an affected stack, soft-deleted ones included.
+    Snapshotting only the group's members would leave those siblings stranded on
+    undo, which is exactly the ``expand_stacks`` /
+    ``expand_stacks_include_deleted`` pairing §21 requires of a grouping mutation.
+    """
+    return expand_picture_ids_to_stacks(session, picture_ids, include_deleted=True)
 
 
 # --- Group lookup -----------------------------------------------------------
@@ -444,6 +473,89 @@ def _stack_members(
     return stack_id
 
 
+# --- Bulk dry-run aggregates -------------------------------------------------
+
+
+def _dry_run_summary_in_session(
+    session: Session, groups: list[DedupGroup]
+) -> dict[str, Any]:
+    """Aggregate what a bulk auto-stack would do, for the consent dialog.
+
+    Computed from the **same** ``groups`` list the dry-run counts come from, in
+    the same read, so the dialog's "N groups" and its "M covers gain metadata"
+    row cannot disagree because a scan landed between two queries.
+
+    The union is **not** run to work this out — nothing is written and no
+    membership is reconciled. Each figure is derived from the planned verdict:
+    the cover is the group's stored preselection, and a cover "gains" a facet
+    when some other member of its group already carries something the cover does
+    not (which is exactly what :func:`apply_metadata_union_in_session` would then
+    copy onto it).
+
+    Returns:
+        ``groups_by_tier`` (always keyed by every tier, zero-filled),
+        ``pictures``, ``covers_gaining_tags``, ``covers_gaining_score`` and
+        ``covers_gaining_metadata`` (the union of the previous two — the row the
+        design's dialog promises).
+    """
+    summary: dict[str, Any] = {
+        "groups_by_tier": {tier.value: 0 for tier in DedupTier},
+        "groups": len(groups),
+        "pictures": 0,
+        "covers_gaining_tags": 0,
+        "covers_gaining_score": 0,
+        "covers_gaining_metadata": 0,
+    }
+    if not groups:
+        return summary
+
+    group_ids = [int(group.id) for group in groups]
+    members_by_group: dict[int, list[int]] = defaultdict(list)
+    for group_id, picture_id in session.exec(
+        select(DedupGroupMember.group_id, DedupGroupMember.picture_id)
+        .join(Picture, Picture.id == DedupGroupMember.picture_id)
+        .where(
+            DedupGroupMember.group_id.in_(group_ids),
+            Picture.deleted.is_(False),
+        )
+    ).all():
+        members_by_group[int(group_id)].append(int(picture_id))
+
+    all_ids = [pid for ids in members_by_group.values() for pid in ids]
+    scores = dict(
+        session.exec(
+            select(Picture.id, Picture.score).where(Picture.id.in_(all_ids))
+        ).all()
+    )
+    tags_by_picture: dict[int, set[str]] = defaultdict(set)
+    for picture_id, tag in session.exec(
+        select(Tag.picture_id, Tag.tag).where(Tag.picture_id.in_(all_ids))
+    ).all():
+        if not is_tag_sentinel(tag):
+            tags_by_picture[int(picture_id)].add(str(tag))
+
+    for group in groups:
+        member_ids = members_by_group.get(int(group.id), [])
+        summary["groups_by_tier"][str(group.tier)] = (
+            summary["groups_by_tier"].get(str(group.tier), 0) + 1
+        )
+        summary["pictures"] += len(member_ids)
+        cover_id = int(group.cover_picture_id or (member_ids[0] if member_ids else 0))
+        if cover_id not in member_ids:
+            continue
+        others = [pid for pid in member_ids if pid != cover_id]
+        gains_tags = any(
+            tags_by_picture[pid] - tags_by_picture[cover_id] for pid in others
+        )
+        gains_score = any(
+            int(scores.get(pid) or 0) > int(scores.get(cover_id) or 0) for pid in others
+        )
+        summary["covers_gaining_tags"] += int(gains_tags)
+        summary["covers_gaining_score"] += int(gains_score)
+        summary["covers_gaining_metadata"] += int(gains_tags or gains_score)
+    return summary
+
+
 # --- Verdicts ---------------------------------------------------------------
 
 
@@ -453,6 +565,9 @@ def apply_stack_verdict_in_session(
     cover_picture_id: Optional[int] = None,
     excluded_picture_ids: Optional[Iterable[int]] = None,
     batch_id: Optional[str] = None,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
 ) -> VerdictResult:
     """Stack a group's members and remember the decision.
 
@@ -467,6 +582,10 @@ def apply_stack_verdict_in_session(
             rescan does not treat the exclusion as an unfinished decision.
         batch_id: Operation-log batch. Bulk auto-stack passes one id for every
             group so the whole run reverses with a single undo.
+        actor: Who performed the change, from ``request_context`` in the handler.
+        source: WS-envelope source, likewise read from the request (§21 origin
+            discipline: never from a contextvar, which is dead on this thread).
+        origin_client_id: WS-envelope per-tab origin, likewise.
 
     Returns:
         The :class:`VerdictResult` behind the action receipt.
@@ -499,7 +618,10 @@ def apply_stack_verdict_in_session(
             f"cover {cover_id} is not an included member of group {signature!r}"
         )
 
-    before = _capture_state(session, included)
+    # Snapshot the stack-expanded set: folding an existing stack in reparents
+    # co-members this group never named, and they must be restorable too.
+    undo_targets = _undo_targets(session, included)
+    before = _capture_state(session, undo_targets)
     stack_id = _stack_members(session, included, cover_id)
     union = apply_metadata_union_in_session(session, included, stack_id)
     _upsert_verdict(
@@ -512,15 +634,17 @@ def apply_stack_verdict_in_session(
         stack_id=stack_id,
         batch_id=batch_id,
     )
-    after = _capture_state(session, included)
+    after = _capture_state(session, undo_targets)
     _record_operation(
         session,
         op_type=OP_TYPE_STACK,
-        picture_ids=included,
         before=before,
         after=after,
         batch_id=batch_id,
         summary=f"Stacked {len(included)} duplicates",
+        actor=actor,
+        source=source,
+        origin_client_id=origin_client_id,
     )
     session.commit()
     logger.info(
@@ -565,15 +689,11 @@ def apply_keep_separate_in_session(
         stack_id=None,
         batch_id=batch_id,
     )
-    _record_operation(
-        session,
-        op_type=OP_TYPE_KEEP_SEPARATE,
-        picture_ids=member_ids,
-        before={},
-        after={},
-        batch_id=batch_id,
-        summary=f"Kept {len(member_ids)} pictures separate",
-    )
+    # No operation row: keep-separate changes no reversible picture facet, so
+    # there is nothing for undo to restore. Recording an empty diff would be a
+    # no-op row (``record_operation_in_session`` returns None for one) that still
+    # consumed a Ctrl+Z, which is worse than not offering undo here. The user's
+    # way back is the explicit reopen action, which is what the Stacks view shows.
     session.commit()
     logger.info(
         "[dedup-verdict] keep-separate recorded for signature=%s (%d members)",
@@ -615,15 +735,8 @@ def reopen_verdict_in_session(session: Session, signature: str) -> dict[str, Any
     if group is not None:
         group.resolved = False
         session.add(group)
-    _record_operation(
-        session,
-        op_type=OP_TYPE_REOPEN,
-        picture_ids=json.loads(row.picture_ids or "[]"),
-        before={},
-        after={},
-        batch_id=None,
-        summary="Reopened a duplicate decision",
-    )
+    # No operation row, for the same reason as keep-separate: reopening touches
+    # only the verdict row, which is not a reversible picture facet.
     session.commit()
     logger.info("[dedup-verdict] reopened verdict for signature=%s", signature)
     return {
@@ -640,6 +753,9 @@ def bulk_auto_stack_in_session(
     batch_id: Optional[str] = None,
     dry_run: bool = False,
     limit: Optional[int] = None,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
 ) -> dict[str, Any]:
     """Stack every unresolved **exact** group under one batch id.
 
@@ -658,9 +774,17 @@ def bulk_auto_stack_in_session(
         dry_run: Count what would happen and write nothing. This is what the
             consent dialog reads.
         limit: Cap the number of groups acted on, for a paged run.
+        actor: Who performed the change, from ``request_context`` in the handler.
+        source: WS-envelope source, likewise read from the request.
+        origin_client_id: WS-envelope per-tab origin, likewise.
 
     Returns:
-        Counts, the batch id, and the per-group results (empty for a dry run).
+        The batch id, the counts, and a per-group outcome for **every** group the
+        run considered: ``results`` for the applied ones and ``failures`` for the
+        rest, each carrying an ``outcome`` of :data:`BULK_REASON_APPLIED`,
+        :data:`BULK_REASON_BLOCKED` or :data:`BULK_REASON_FAILED`. The batch id is
+        always present, so a partially applied run always hands back its undo
+        handle.
     """
     scope = scope or DedupScope()
     query = select(DedupGroup).where(
@@ -685,6 +809,7 @@ def bulk_auto_stack_in_session(
         for group in groups:
             picture_total += int(group.member_count or 0)
         return {
+            "dry_run_summary": _dry_run_summary_in_session(session, groups),
             "batch_id": batch_id,
             "dry_run": True,
             "groups": len(groups),
@@ -699,28 +824,62 @@ def bulk_auto_stack_in_session(
     for group in groups:
         try:
             result = apply_stack_verdict_in_session(
-                session, group.signature, batch_id=batch_id
-            )
-        except DedupVerdictError as exc:
-            # One unstackable group must not abort the run; record it so the
-            # response reports an honest partial result instead of pretending
-            # every group succeeded.
-            logger.warning(
-                "[dedup-verdict] auto-stack skipped group %s: %s",
+                session,
                 group.signature,
-                exc,
+                batch_id=batch_id,
+                actor=actor,
+                source=source,
+                origin_client_id=origin_client_id,
             )
-            failures.append({"signature": group.signature, "error": str(exc)})
+        except (DedupVerdictError, HTTPException) as exc:
+            # One unstackable group must never abort the run: every earlier group
+            # has already committed, so aborting here would leave a partially
+            # applied bulk mutation whose batch id the caller never receives —
+            # i.e. no undo handle for work that did happen.
+            #
+            # HTTPException is caught alongside DedupVerdictError because the
+            # locked-set guards raise 423, and a locked member is the *most
+            # likely* reason a group cannot be stacked. Catching only the former
+            # made this function's own API description ("a single unstackable
+            # group never aborts the run") false for the common case.
+            session.rollback()
+            if isinstance(exc, HTTPException):
+                reason, detail, status_code = (
+                    BULK_REASON_BLOCKED,
+                    exc.detail,
+                    exc.status_code,
+                )
+            else:
+                reason, detail, status_code = BULK_REASON_FAILED, str(exc), None
+            logger.warning(
+                "[dedup-verdict] auto-stack %s group %s (batch=%s): %s",
+                reason,
+                group.signature,
+                batch_id,
+                detail,
+            )
+            failures.append(
+                {
+                    "signature": group.signature,
+                    "outcome": reason,
+                    "status_code": status_code,
+                    "error": detail,
+                }
+            )
             continue
-        results.append(result.as_dict())
+        results.append({**result.as_dict(), "outcome": BULK_REASON_APPLIED})
     prune_stale_groups_in_session(session)
     logger.info(
-        "[dedup-verdict] auto-stacked %d exact group(s) under batch %s (%d skipped)",
+        "[dedup-verdict] auto-stacked %d exact group(s) under batch %s "
+        "(%d blocked, %d failed)",
         len(results),
         batch_id,
-        len(failures),
+        sum(1 for f in failures if f["outcome"] == BULK_REASON_BLOCKED),
+        sum(1 for f in failures if f["outcome"] == BULK_REASON_FAILED),
     )
     return {
+        # Always present once anything could have committed, so the caller always
+        # holds the POST /operations/batches/{batch_id}/undo handle.
         "batch_id": batch_id,
         "dry_run": False,
         "groups": len(results),
@@ -728,6 +887,8 @@ def bulk_auto_stack_in_session(
         "scope": scope.as_dict(),
         "results": results,
         "failures": failures,
+        "blocked": sum(1 for f in failures if f["outcome"] == BULK_REASON_BLOCKED),
+        "failed": sum(1 for f in failures if f["outcome"] == BULK_REASON_FAILED),
     }
 
 
@@ -740,14 +901,25 @@ def apply_stack_verdict(
     cover_picture_id: Optional[int] = None,
     excluded_picture_ids: Optional[Iterable[int]] = None,
     batch_id: Optional[str] = None,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
 ) -> VerdictResult:
-    """Write-path vault wrapper around :func:`apply_stack_verdict_in_session`."""
+    """Write-path vault wrapper around :func:`apply_stack_verdict_in_session`.
+
+    ``actor`` / ``source`` / ``origin_client_id`` come from
+    ``operation_log_service.request_context(request)``, evaluated in the handler
+    on the request's own task — never read here, where the contextvar is dead.
+    """
     return vault.db.run_task(
         apply_stack_verdict_in_session,
         signature,
         cover_picture_id,
         list(excluded_picture_ids or []),
         batch_id,
+        actor,
+        source,
+        origin_client_id,
     )
 
 
@@ -769,16 +941,27 @@ def bulk_auto_stack(
     batch_id: Optional[str] = None,
     dry_run: bool = False,
     limit: Optional[int] = None,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
 ) -> dict[str, Any]:
     """Write-path vault wrapper around :func:`bulk_auto_stack_in_session`."""
     return vault.db.run_task(
-        bulk_auto_stack_in_session, scope, batch_id, dry_run, limit
+        bulk_auto_stack_in_session,
+        scope,
+        batch_id,
+        dry_run,
+        limit,
+        actor,
+        source,
+        origin_client_id,
     )
 
 
 __all__ = [
-    "OP_TYPE_KEEP_SEPARATE",
-    "OP_TYPE_REOPEN",
+    "BULK_REASON_APPLIED",
+    "BULK_REASON_BLOCKED",
+    "BULK_REASON_FAILED",
     "OP_TYPE_STACK",
     "DedupVerdictError",
     "VerdictResult",

--- a/pixlstash/services/dedup_verdict_service.py
+++ b/pixlstash/services/dedup_verdict_service.py
@@ -66,7 +66,6 @@ Two details this module owns rather than inherits:
 from __future__ import annotations
 
 import json
-import uuid
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
@@ -86,10 +85,12 @@ from pixlstash.db_models.dedup import (
     DedupVerdict,
 )
 from pixlstash.db_models.face import Face
+from pixlstash.db_models.operation import Operation
 from pixlstash.db_models.tag import Tag, is_tag_sentinel
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services import operation_log_service
 from pixlstash.services.dedup_tier_service import (
+    ID_CHUNK,
     DedupScope,
     DedupTier,
     prune_stale_groups_in_session,
@@ -168,8 +169,15 @@ class VerdictResult:
 
 
 def new_batch_id() -> str:
-    """Mint a batch id grouping one bulk action's operations into one undo."""
-    return uuid.uuid4().hex
+    """Mint a batch id grouping one bulk action's operations into one undo.
+
+    Delegates to :func:`operation_log_service.new_batch_id` rather than minting
+    its own shape: batch ids are namespaced (``srv-`` for server-minted, ``cli-``
+    for a client-supplied one, validated at the request boundary), and a third
+    un-namespaced shape from this module would make a dedup batch
+    indistinguishable from a client-grafted one in the log.
+    """
+    return operation_log_service.new_batch_id()
 
 
 def _record_operation(
@@ -595,6 +603,12 @@ def apply_stack_verdict_in_session(
             fewer than two members left after exclusions.
     """
     group, member_ids = _load_group(session, signature)
+    # Always under a batch id, even for a single verdict. The batch id is the key
+    # that ties the recorded Operation back to the DedupVerdict row, which is how
+    # an undo knows to reopen the verdict as well as restoring the pictures (see
+    # :func:`restore_verdicts_in_session`). A verdict recorded without one would
+    # be undoable on the picture side and permanently decided on the queue side.
+    batch_id = batch_id or new_batch_id()
     excluded = sorted({int(pid) for pid in (excluded_picture_ids or [])})
     unknown = sorted(set(excluded) - set(member_ids))
     if unknown:
@@ -745,6 +759,84 @@ def reopen_verdict_in_session(session: Session, signature: str) -> dict[str, Any
         "reopened_at": row.reopened_at,
         "group_returned_to_queue": group is not None,
     }
+
+
+def restore_verdicts_in_session(
+    session: Session, operations: list[Operation], direction: str
+) -> None:
+    """Reopen (on undo) or re-decide (on redo) the verdicts *operations* recorded.
+
+    Registered with the operation log as the post-restore hook for
+    :data:`OP_TYPE_STACK` (see
+    :func:`pixlstash.services.operation_log_service.register_post_restore_hook`).
+
+    Why this is needed at all: the operation log restores the reversible *picture*
+    facets, and a stack verdict changes two more things that are not picture
+    facets — the ``DedupVerdict`` row (decided) and the ``DedupGroup`` row
+    (resolved). Without this hook an undo unstacked the pictures but left the
+    group decided, so it never returned to the queue, survived a rescan (the
+    signature still carried a live verdict) and was recoverable only through
+    ``POST /dedup/verdicts/reopen``.
+
+    Correlation is by ``batch_id``: a stack verdict is always recorded under one
+    (minted server-side when the caller supplies none), and the verdict row
+    stores the same id. One query covers a 2 700-group batch undo, which is why
+    the hook takes the whole list rather than one operation at a time.
+
+    Args:
+        session: The restore's own session. Not committed here — the operation
+            log commits the restore and this together, so the pictures and the
+            queue can never disagree.
+        operations: Every :data:`OP_TYPE_STACK` operation in this restore.
+        direction: ``operation_log_service.RESTORE_UNDO`` or ``RESTORE_REDO``.
+    """
+    batch_ids = sorted({op.batch_id for op in operations if op.batch_id})
+    unbatched = sorted(int(op.id) for op in operations if not op.batch_id and op.id)
+    if unbatched:
+        # Rows written before verdicts were always batched. Nothing correlates
+        # them to a verdict, so say so rather than silently half-restoring: the
+        # pictures are back but the group stays decided until the user reopens it.
+        logger.warning(
+            "[dedup-verdict] %s: operation(s) %s carry no batch_id, so their "
+            "duplicate verdict cannot be located; the pictures were restored but "
+            "the group stays decided. Use POST /dedup/verdicts/reopen to return "
+            "it to the queue.",
+            direction,
+            unbatched,
+        )
+    if not batch_ids:
+        return
+
+    is_redo = direction == operation_log_service.RESTORE_REDO
+    reopened_at = None if is_redo else datetime.utcnow()
+    signatures: list[str] = []
+    for start in range(0, len(batch_ids), ID_CHUNK):
+        chunk = batch_ids[start : start + ID_CHUNK]
+        for row in session.exec(
+            select(DedupVerdict).where(DedupVerdict.batch_id.in_(chunk))
+        ).all():
+            # decided_at is deliberately not re-stamped on redo: it records when
+            # the user decided, and the row is "live" precisely when reopened_at
+            # is NULL, so one field carries the whole lifecycle honestly.
+            row.reopened_at = reopened_at
+            session.add(row)
+            signatures.append(str(row.signature))
+    if not signatures:
+        return
+    for start in range(0, len(signatures), ID_CHUNK):
+        chunk = signatures[start : start + ID_CHUNK]
+        for group in session.exec(
+            select(DedupGroup).where(DedupGroup.signature.in_(chunk))
+        ).all():
+            group.resolved = is_redo
+            session.add(group)
+    logger.info(
+        "[dedup-verdict] %s returned %d verdict(s) to %s across batch(es) %s",
+        direction,
+        len(signatures),
+        "decided" if is_redo else "the queue",
+        batch_ids,
+    )
 
 
 def bulk_auto_stack_in_session(
@@ -958,6 +1050,15 @@ def bulk_auto_stack(
     )
 
 
+# Registered at import time, and this module is imported by
+# ``pixlstash/routes/dedup.py``, which ``Server`` mounts at startup — so the hook
+# is in place before any request can reach undo. The registration lives here, not
+# in the operation log, so the op-log core keeps no dedup knowledge.
+operation_log_service.register_post_restore_hook(
+    OP_TYPE_STACK, restore_verdicts_in_session
+)
+
+
 __all__ = [
     "BULK_REASON_APPLIED",
     "BULK_REASON_BLOCKED",
@@ -975,4 +1076,5 @@ __all__ = [
     "new_batch_id",
     "reopen_verdict",
     "reopen_verdict_in_session",
+    "restore_verdicts_in_session",
 ]

--- a/pixlstash/services/dedup_verdict_service.py
+++ b/pixlstash/services/dedup_verdict_service.py
@@ -1,0 +1,795 @@
+"""Applying and remembering duplicate verdicts.
+
+There are exactly two verdicts in v1.9 and neither of them deletes anything:
+
+* **stack** — the chosen members become one stack led by the chosen cover, with
+  the metadata union applied; excluded members stay exactly where they were;
+* **keep separate** — nothing changes on disk or in the picture rows, but the
+  group's signature is remembered so no rescan and no re-import ever re-asks.
+
+Both are recorded against the group *signature*, not against picture or group
+ids, which is what makes the memory survive a re-import (see
+:func:`pixlstash.services.dedup_tier_service.group_signature`). "Keep separate"
+is permanent until :func:`reopen_verdict_in_session` is called from the Stacks
+view.
+
+Metadata union (design delta 5)
+-------------------------------
+Stacking unions **tags, project membership, set membership and characters** onto
+every member and lifts every member to the **highest score** in the group.
+Nothing is overwritten and nothing is lost — a union cannot break an album,
+which is the failure mode that burns Immich users.
+
+Project and set membership already had a union in
+:func:`pixlstash.services.stack_membership.reconcile_stack_membership`; this
+module calls it and adds the three the design requires on top:
+
+* **tags** — every member gains every non-sentinel tag any member carries.
+  Sentinel tags (``__tag``, ``__tag:<engine>``) are pipeline markers, not user
+  metadata, so they are deliberately excluded: copying a "needs retagging"
+  marker onto a picture that was already tagged would re-queue it for no reason.
+* **score** — every member is lifted to ``max(score)``. Only lifted: a union
+  never lowers a rating the user set.
+* **characters** — a real face-to-character union is not expressible without
+  fabricating :class:`~pixlstash.db_models.face.Face` rows (a face has a bbox and
+  an embedding that belong to one specific picture), and inventing detection data
+  is worse than not unioning. Instead, when the group's members between them
+  reference exactly **one** character, every member that does not already carry
+  it gets ``Picture.pending_character_id`` set — the shipped deferred-assignment
+  mechanism that the face-extraction task consumes. A group spanning several
+  characters is left alone and logged; the members keep their own faces, which is
+  the non-lossy outcome.
+
+Operation log
+-------------
+Every verdict is meant to raise an action receipt and land in the operation log,
+with a bulk auto-stack coalescing into one batch id so N stacks reverse with one
+undo. The operation log ships on its own lane (``feature/operation-log``); this
+branch is stacked on the dedup sweep planner and does not contain it, so the call
+is made through :func:`_record_operation`, which imports the service lazily and
+logs a clear warning naming the missing module when it is absent. Wiring the two
+lanes together at merge time is a no-op: the seam already passes ``batch_id``,
+``op_type`` and the before/after picture id set.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Iterable, Optional
+
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from pixlstash.db_models import Picture, PictureStack
+from pixlstash.db_models.dedup import (
+    TIER_EXACT,
+    VERDICT_KEEP_SEPARATE,
+    VERDICT_STACKED,
+    DedupGroup,
+    DedupGroupMember,
+    DedupVerdict,
+)
+from pixlstash.db_models.face import Face
+from pixlstash.db_models.tag import Tag, is_tag_sentinel
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services.dedup_tier_service import (
+    DedupScope,
+    prune_stale_groups_in_session,
+)
+from pixlstash.services.stack_membership import reconcile_stack_membership
+from pixlstash.stacking import normalize_stack_positions
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pixlstash.vault import Vault
+
+logger = get_logger(__name__)
+
+# One op-log entry per verdict; the bulk path shares a single batch id.
+OP_TYPE_STACK = "dedup.stack"
+OP_TYPE_KEEP_SEPARATE = "dedup.keep_separate"
+OP_TYPE_REOPEN = "dedup.reopen"
+
+
+class DedupVerdictError(Exception):
+    """A verdict could not be applied (unknown signature, bad cover, ...)."""
+
+
+@dataclass(frozen=True)
+class VerdictResult:
+    """What a verdict did, for the response and the action receipt.
+
+    Attributes:
+        signature: The group signature the verdict was recorded against.
+        verdict: ``"stacked"`` or ``"keep_separate"``.
+        stack_id: The resulting stack, for a stack verdict.
+        cover_picture_id: The cover the stack leads with.
+        picture_ids: Members the verdict covers.
+        excluded_picture_ids: Members deliberately left out of the stack.
+        batch_id: The operation-log batch this verdict belongs to.
+        metadata_union: What the union actually changed, so the receipt can say
+            so instead of claiming a silent merge.
+    """
+
+    signature: str
+    verdict: str
+    stack_id: Optional[int]
+    cover_picture_id: Optional[int]
+    picture_ids: list[int]
+    excluded_picture_ids: list[int]
+    batch_id: Optional[str]
+    metadata_union: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "signature": self.signature,
+            "verdict": self.verdict,
+            "stack_id": self.stack_id,
+            "cover_picture_id": self.cover_picture_id,
+            "picture_ids": list(self.picture_ids),
+            "excluded_picture_ids": list(self.excluded_picture_ids),
+            "batch_id": self.batch_id,
+            "metadata_union": dict(self.metadata_union),
+        }
+
+
+def new_batch_id() -> str:
+    """Mint a batch id grouping one bulk action's operations into one undo."""
+    return uuid.uuid4().hex
+
+
+def _record_operation(
+    session: Session,
+    *,
+    op_type: str,
+    picture_ids: list[int],
+    before: dict[str, dict],
+    after: dict[str, dict],
+    batch_id: Optional[str],
+    summary: str,
+) -> None:
+    """Append this verdict to the operation log, if that lane is present.
+
+    Cross-lane seam, not a fallback: ``pixlstash.services.operation_log_service``
+    lands on ``feature/operation-log`` and is not on this branch. When it is
+    missing the verdict still applies (it is an ordinary, individually reversible
+    stacking action) but is not undoable in one keystroke, and that consequence is
+    logged with the module name so the gap is visible rather than silent.
+    """
+    try:
+        from pixlstash.services import operation_log_service
+    except ImportError as exc:
+        logger.warning(
+            "[dedup-verdict] operation log unavailable (%s): %s %s on %d picture(s) "
+            "batch=%s applied but NOT recorded, so Ctrl+Z will not reverse it. "
+            "This is the feature/operation-log lane seam; wiring it up needs no "
+            "change here.",
+            exc,
+            op_type,
+            summary,
+            len(picture_ids),
+            batch_id,
+        )
+        return
+    operation_log_service.record_operation_in_session(
+        session,
+        op_type=op_type,
+        before=before,
+        after=after,
+        batch_id=batch_id,
+        summary=summary,
+    )
+
+
+def _capture_state(session: Session, picture_ids: list[int]) -> dict[str, dict]:
+    """Snapshot the picture state an undo would restore, if the log is present."""
+    try:
+        from pixlstash.services import operation_log_service
+    except ImportError:
+        # Already reported by _record_operation with full context; capturing
+        # nothing here keeps the verdict path free of a second identical warning.
+        return {}
+    return operation_log_service.capture_state_in_session(session, picture_ids)
+
+
+# --- Group lookup -----------------------------------------------------------
+
+
+def _load_group(session: Session, signature: str) -> tuple[DedupGroup, list[int]]:
+    """Return the group row and its live member ids, or raise."""
+    group = session.exec(
+        select(DedupGroup).where(DedupGroup.signature == signature)
+    ).first()
+    if group is None:
+        raise DedupVerdictError(f"No duplicate group with signature {signature!r}")
+    member_ids = [
+        int(row)
+        for row in session.exec(
+            select(DedupGroupMember.picture_id)
+            .join(Picture, Picture.id == DedupGroupMember.picture_id)
+            .where(
+                DedupGroupMember.group_id == group.id,
+                Picture.deleted.is_(False),
+            )
+            .order_by(DedupGroupMember.position)
+        ).all()
+    ]
+    return group, member_ids
+
+
+def _upsert_verdict(
+    session: Session,
+    *,
+    signature: str,
+    verdict: str,
+    picture_ids: list[int],
+    excluded_picture_ids: list[int],
+    cover_picture_id: Optional[int],
+    stack_id: Optional[int],
+    batch_id: Optional[str],
+) -> DedupVerdict:
+    """Write (or refresh) the verdict row and mark its group resolved."""
+    row = session.exec(
+        select(DedupVerdict).where(DedupVerdict.signature == signature)
+    ).first()
+    if row is None:
+        row = DedupVerdict(signature=signature, verdict=verdict)
+    row.verdict = verdict
+    row.picture_ids = json.dumps(sorted(picture_ids))
+    row.excluded_picture_ids = json.dumps(sorted(excluded_picture_ids))
+    row.cover_picture_id = cover_picture_id
+    row.stack_id = stack_id
+    row.batch_id = batch_id
+    row.decided_at = datetime.utcnow()
+    row.reopened_at = None
+    session.add(row)
+
+    group = session.exec(
+        select(DedupGroup).where(DedupGroup.signature == signature)
+    ).first()
+    if group is not None:
+        group.resolved = True
+        session.add(group)
+    return row
+
+
+# --- Metadata union ---------------------------------------------------------
+
+
+def apply_metadata_union_in_session(
+    session: Session, picture_ids: list[int], stack_id: int
+) -> dict[str, Any]:
+    """Union tags, membership, score and (where safe) characters across a stack.
+
+    Additive only. See the module docstring for why characters go through
+    ``pending_character_id`` rather than through fabricated ``Face`` rows.
+
+    Args:
+        session: Pre-opened session. Not committed here — the caller owns the
+            transaction so a verdict lands as one unit.
+        picture_ids: The stack's members.
+        stack_id: The stack they were just placed in; the project / set union
+            reconciles over the whole stack, not only over the group.
+
+    Returns:
+        A summary of what changed, for the action receipt.
+    """
+    # Imported locally: set_lock_service imports stack_membership, so a
+    # module-level import here would be circular.
+    from pixlstash.services.set_lock_service import enforce_pictures_not_locked
+
+    if len(picture_ids) < 2:
+        return {"tags_added": 0, "scores_lifted": 0, "characters_pending": 0}
+
+    # The union writes tags and scores, which are curation state. A picture
+    # frozen by a locked set must not have either changed behind the user's
+    # back, so this is a hard 423 rather than a skip: a partially applied union
+    # would be worse than a refused one.
+    enforce_pictures_not_locked(session, picture_ids, "union duplicate metadata")
+
+    membership_changed = reconcile_stack_membership(session, stack_id)
+
+    # --- Tags: every member gains every real tag any member carries ---
+    tag_rows = session.exec(
+        select(Tag.picture_id, Tag.tag).where(Tag.picture_id.in_(picture_ids))
+    ).all()
+    tags_by_picture: dict[int, set[str]] = {pid: set() for pid in picture_ids}
+    union: set[str] = set()
+    for picture_id, tag in tag_rows:
+        if is_tag_sentinel(tag):
+            continue
+        tags_by_picture.setdefault(int(picture_id), set()).add(str(tag))
+        union.add(str(tag))
+    tags_added = 0
+    for picture_id in picture_ids:
+        for tag in sorted(union - tags_by_picture.get(picture_id, set())):
+            session.add(Tag(picture_id=picture_id, tag=tag))
+            tags_added += 1
+
+    # --- Score: lift every member to the highest rating in the group ---
+    pictures = session.exec(select(Picture).where(Picture.id.in_(picture_ids))).all()
+    best_score = max((int(pic.score or 0) for pic in pictures), default=0)
+    scores_lifted = 0
+    if best_score > 0:
+        for pic in pictures:
+            if int(pic.score or 0) < best_score:
+                pic.score = best_score
+                session.add(pic)
+                scores_lifted += 1
+
+    # --- Characters: only the unambiguous single-character case ---
+    character_ids = {
+        int(row)
+        for row in session.exec(
+            select(Face.character_id).where(
+                Face.picture_id.in_(picture_ids), Face.character_id.is_not(None)
+            )
+        ).all()
+        if row is not None
+    }
+    characters_pending = 0
+    if len(character_ids) == 1:
+        character_id = next(iter(character_ids))
+        assigned = {
+            int(row)
+            for row in session.exec(
+                select(Face.picture_id).where(
+                    Face.picture_id.in_(picture_ids),
+                    Face.character_id == character_id,
+                )
+            ).all()
+        }
+        for pic in pictures:
+            if int(pic.id) in assigned or pic.pending_character_id == character_id:
+                continue
+            pic.pending_character_id = character_id
+            session.add(pic)
+            characters_pending += 1
+    elif len(character_ids) > 1:
+        logger.info(
+            "[dedup-verdict] stack over pictures %s references %d characters %s; "
+            "characters are left as-is rather than guessing which one the stack "
+            "belongs to (no face data is fabricated)",
+            picture_ids,
+            len(character_ids),
+            sorted(character_ids),
+        )
+
+    return {
+        "tags_added": tags_added,
+        "scores_lifted": scores_lifted,
+        "characters_pending": characters_pending,
+        "membership_changed": bool(membership_changed),
+        "best_score": best_score,
+    }
+
+
+# --- Stacking ---------------------------------------------------------------
+
+
+def _stack_members(
+    session: Session, picture_ids: list[int], cover_picture_id: int
+) -> int:
+    """Put *picture_ids* into one stack led by *cover_picture_id*.
+
+    Reuses an existing stack when the members already share one (growing it
+    rather than orphaning it), and folds several stacks into the cover's when the
+    group spans more than one. Always additive: no picture leaves a stack it was
+    in, and no stack row is dropped that still has members.
+    """
+    # Imported locally: set_lock_service imports stack_membership, which imports
+    # this package's siblings; a module-level import here would be circular.
+    from pixlstash.services.set_lock_service import enforce_stack_membership_not_locked
+
+    pictures = {
+        int(pic.id): pic
+        for pic in session.exec(
+            select(Picture).where(Picture.id.in_(picture_ids))
+        ).all()
+    }
+    missing = sorted(set(picture_ids) - set(pictures))
+    if missing:
+        raise DedupVerdictError(f"pictures {missing} no longer exist")
+
+    existing_stack_ids = sorted(
+        {int(pic.stack_id) for pic in pictures.values() if pic.stack_id is not None}
+    )
+    cover = pictures[cover_picture_id]
+    if cover.stack_id is not None:
+        stack_id = int(cover.stack_id)
+    elif existing_stack_ids:
+        stack_id = existing_stack_ids[0]
+    else:
+        stack = PictureStack(name=None)
+        session.add(stack)
+        session.flush()
+        stack_id = int(stack.id)
+
+    enforce_stack_membership_not_locked(
+        session, list(picture_ids), stack_id, "stack duplicates together"
+    )
+
+    # Pull in every member of any stack this group touches: stacks move as a unit.
+    folded_ids = [sid for sid in existing_stack_ids if sid != stack_id]
+    if folded_ids:
+        for pic in session.exec(
+            select(Picture).where(Picture.stack_id.in_(folded_ids))
+        ).all():
+            pictures.setdefault(int(pic.id), pic)
+
+    # The cover sorts ahead of everything so normalize_stack_positions lands it
+    # at position 0 — the leader convention the whole app reads.
+    for pic in pictures.values():
+        pic.stack_id = stack_id
+        pic.stack_position = -1 if int(pic.id) == cover_picture_id else 1
+        session.add(pic)
+    session.flush()
+
+    for folded_id in folded_ids:
+        remaining = session.exec(
+            select(func.count(Picture.id)).where(Picture.stack_id == folded_id)
+        ).one()
+        if int(remaining) == 0:
+            orphan = session.get(PictureStack, folded_id)
+            if orphan is not None:
+                session.delete(orphan)
+
+    normalize_stack_positions(session, stack_id)
+    stack = session.get(PictureStack, stack_id)
+    if stack is not None:
+        stack.updated_at = datetime.utcnow()
+        session.add(stack)
+    return stack_id
+
+
+# --- Verdicts ---------------------------------------------------------------
+
+
+def apply_stack_verdict_in_session(
+    session: Session,
+    signature: str,
+    cover_picture_id: Optional[int] = None,
+    excluded_picture_ids: Optional[Iterable[int]] = None,
+    batch_id: Optional[str] = None,
+) -> VerdictResult:
+    """Stack a group's members and remember the decision.
+
+    Args:
+        session: Pre-opened session; this function commits once, so the stack,
+            the metadata union and the verdict row land together or not at all.
+        signature: The group signature from the queue.
+        cover_picture_id: The cover the user confirmed. Defaults to the server's
+            preselection stored on the group.
+        excluded_picture_ids: Members the user left out (the design's X key).
+            They keep their current stack and are recorded on the verdict so a
+            rescan does not treat the exclusion as an unfinished decision.
+        batch_id: Operation-log batch. Bulk auto-stack passes one id for every
+            group so the whole run reverses with a single undo.
+
+    Returns:
+        The :class:`VerdictResult` behind the action receipt.
+
+    Raises:
+        DedupVerdictError: Unknown signature, a cover that is not a member, or
+            fewer than two members left after exclusions.
+    """
+    group, member_ids = _load_group(session, signature)
+    excluded = sorted({int(pid) for pid in (excluded_picture_ids or [])})
+    unknown = sorted(set(excluded) - set(member_ids))
+    if unknown:
+        raise DedupVerdictError(
+            f"excluded pictures {unknown} are not members of group {signature!r}"
+        )
+    included = [pid for pid in member_ids if pid not in set(excluded)]
+    if len(included) < 2:
+        raise DedupVerdictError(
+            f"group {signature!r} has {len(included)} member(s) left after "
+            "exclusions; a stack needs at least two"
+        )
+
+    cover_id = (
+        int(cover_picture_id)
+        if cover_picture_id is not None
+        else int(group.cover_picture_id or included[0])
+    )
+    if cover_id not in included:
+        raise DedupVerdictError(
+            f"cover {cover_id} is not an included member of group {signature!r}"
+        )
+
+    before = _capture_state(session, included)
+    stack_id = _stack_members(session, included, cover_id)
+    union = apply_metadata_union_in_session(session, included, stack_id)
+    _upsert_verdict(
+        session,
+        signature=signature,
+        verdict=VERDICT_STACKED,
+        picture_ids=included,
+        excluded_picture_ids=excluded,
+        cover_picture_id=cover_id,
+        stack_id=stack_id,
+        batch_id=batch_id,
+    )
+    after = _capture_state(session, included)
+    _record_operation(
+        session,
+        op_type=OP_TYPE_STACK,
+        picture_ids=included,
+        before=before,
+        after=after,
+        batch_id=batch_id,
+        summary=f"Stacked {len(included)} duplicates",
+    )
+    session.commit()
+    logger.info(
+        "[dedup-verdict] stacked %d picture(s) into stack %s (cover=%s, "
+        "excluded=%s, signature=%s, batch=%s)",
+        len(included),
+        stack_id,
+        cover_id,
+        excluded,
+        signature,
+        batch_id,
+    )
+    return VerdictResult(
+        signature=signature,
+        verdict=VERDICT_STACKED,
+        stack_id=stack_id,
+        cover_picture_id=cover_id,
+        picture_ids=included,
+        excluded_picture_ids=excluded,
+        batch_id=batch_id,
+        metadata_union=union,
+    )
+
+
+def apply_keep_separate_in_session(
+    session: Session, signature: str, batch_id: Optional[str] = None
+) -> VerdictResult:
+    """Remember that this group is *not* duplicates. Changes no picture row.
+
+    Permanent until :func:`reopen_verdict_in_session`. This is the verdict that
+    makes the sidebar count trustworthy: without it every rescan would re-offer
+    the same rejected group and the badge would never reach zero.
+    """
+    _group, member_ids = _load_group(session, signature)
+    _upsert_verdict(
+        session,
+        signature=signature,
+        verdict=VERDICT_KEEP_SEPARATE,
+        picture_ids=member_ids,
+        excluded_picture_ids=[],
+        cover_picture_id=None,
+        stack_id=None,
+        batch_id=batch_id,
+    )
+    _record_operation(
+        session,
+        op_type=OP_TYPE_KEEP_SEPARATE,
+        picture_ids=member_ids,
+        before={},
+        after={},
+        batch_id=batch_id,
+        summary=f"Kept {len(member_ids)} pictures separate",
+    )
+    session.commit()
+    logger.info(
+        "[dedup-verdict] keep-separate recorded for signature=%s (%d members)",
+        signature,
+        len(member_ids),
+    )
+    return VerdictResult(
+        signature=signature,
+        verdict=VERDICT_KEEP_SEPARATE,
+        stack_id=None,
+        cover_picture_id=None,
+        picture_ids=member_ids,
+        excluded_picture_ids=[],
+        batch_id=batch_id,
+        metadata_union={},
+    )
+
+
+def reopen_verdict_in_session(session: Session, signature: str) -> dict[str, Any]:
+    """Undo the *memory* of a verdict so the group returns to the queue.
+
+    Stamps ``reopened_at`` rather than deleting the row: the decision history is
+    worth keeping, and a reopened verdict is simply no longer live. The pictures
+    are untouched — reopening a ``stacked`` verdict does not unstack anything,
+    because unstacking is the Stacks view's own action.
+    """
+    row = session.exec(
+        select(DedupVerdict).where(DedupVerdict.signature == signature)
+    ).first()
+    if row is None:
+        raise DedupVerdictError(f"No verdict recorded for signature {signature!r}")
+    if row.reopened_at is not None:
+        raise DedupVerdictError(f"Verdict for {signature!r} is already reopened")
+    row.reopened_at = datetime.utcnow()
+    session.add(row)
+    group = session.exec(
+        select(DedupGroup).where(DedupGroup.signature == signature)
+    ).first()
+    if group is not None:
+        group.resolved = False
+        session.add(group)
+    _record_operation(
+        session,
+        op_type=OP_TYPE_REOPEN,
+        picture_ids=json.loads(row.picture_ids or "[]"),
+        before={},
+        after={},
+        batch_id=None,
+        summary="Reopened a duplicate decision",
+    )
+    session.commit()
+    logger.info("[dedup-verdict] reopened verdict for signature=%s", signature)
+    return {
+        "signature": signature,
+        "previous_verdict": row.verdict,
+        "reopened_at": row.reopened_at,
+        "group_returned_to_queue": group is not None,
+    }
+
+
+def bulk_auto_stack_in_session(
+    session: Session,
+    scope: Optional[DedupScope] = None,
+    batch_id: Optional[str] = None,
+    dry_run: bool = False,
+    limit: Optional[int] = None,
+) -> dict[str, Any]:
+    """Stack every unresolved **exact** group under one batch id.
+
+    Tier 1 is the tier with no human judgment left in it, so the design gives it
+    a single consent dialog instead of per-group adjudication: the dialog shows
+    the dry-run counts, and accepting stacks them all under one operation-log
+    batch id so N stacks reverse with one Ctrl+Z.
+
+    Only exact groups are eligible. A near or embedding group always goes through
+    the queue, no matter how confident it looks.
+
+    Args:
+        session: Pre-opened session.
+        scope: Restrict to a scope; defaults to the whole vault.
+        batch_id: The shared batch id. Minted when omitted and returned.
+        dry_run: Count what would happen and write nothing. This is what the
+            consent dialog reads.
+        limit: Cap the number of groups acted on, for a paged run.
+
+    Returns:
+        Counts, the batch id, and the per-group results (empty for a dry run).
+    """
+    scope = scope or DedupScope()
+    query = select(DedupGroup).where(
+        DedupGroup.resolved.is_(False), DedupGroup.tier == TIER_EXACT
+    )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(
+            DedupGroup.id.in_(
+                select(DedupGroupMember.group_id)
+                .join(Picture, Picture.id == DedupGroupMember.picture_id)
+                .where(Picture.deleted.is_(False), predicate)
+            )
+        )
+    query = query.order_by(DedupGroup.confidence.desc(), DedupGroup.id.asc())
+    if limit is not None:
+        query = query.limit(max(1, int(limit)))
+    groups = session.exec(query).all()
+
+    if dry_run:
+        picture_total = 0
+        for group in groups:
+            picture_total += int(group.member_count or 0)
+        return {
+            "batch_id": batch_id,
+            "dry_run": True,
+            "groups": len(groups),
+            "pictures": picture_total,
+            "scope": scope.as_dict(),
+            "results": [],
+        }
+
+    batch_id = batch_id or new_batch_id()
+    results: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for group in groups:
+        try:
+            result = apply_stack_verdict_in_session(
+                session, group.signature, batch_id=batch_id
+            )
+        except DedupVerdictError as exc:
+            # One unstackable group must not abort the run; record it so the
+            # response reports an honest partial result instead of pretending
+            # every group succeeded.
+            logger.warning(
+                "[dedup-verdict] auto-stack skipped group %s: %s",
+                group.signature,
+                exc,
+            )
+            failures.append({"signature": group.signature, "error": str(exc)})
+            continue
+        results.append(result.as_dict())
+    prune_stale_groups_in_session(session)
+    logger.info(
+        "[dedup-verdict] auto-stacked %d exact group(s) under batch %s (%d skipped)",
+        len(results),
+        batch_id,
+        len(failures),
+    )
+    return {
+        "batch_id": batch_id,
+        "dry_run": False,
+        "groups": len(results),
+        "pictures": sum(len(item["picture_ids"]) for item in results),
+        "scope": scope.as_dict(),
+        "results": results,
+        "failures": failures,
+    }
+
+
+# --- Vault wrappers ---------------------------------------------------------
+
+
+def apply_stack_verdict(
+    vault: "Vault",
+    signature: str,
+    cover_picture_id: Optional[int] = None,
+    excluded_picture_ids: Optional[Iterable[int]] = None,
+    batch_id: Optional[str] = None,
+) -> VerdictResult:
+    """Write-path vault wrapper around :func:`apply_stack_verdict_in_session`."""
+    return vault.db.run_task(
+        apply_stack_verdict_in_session,
+        signature,
+        cover_picture_id,
+        list(excluded_picture_ids or []),
+        batch_id,
+    )
+
+
+def apply_keep_separate(
+    vault: "Vault", signature: str, batch_id: Optional[str] = None
+) -> VerdictResult:
+    """Write-path vault wrapper around :func:`apply_keep_separate_in_session`."""
+    return vault.db.run_task(apply_keep_separate_in_session, signature, batch_id)
+
+
+def reopen_verdict(vault: "Vault", signature: str) -> dict[str, Any]:
+    """Write-path vault wrapper around :func:`reopen_verdict_in_session`."""
+    return vault.db.run_task(reopen_verdict_in_session, signature)
+
+
+def bulk_auto_stack(
+    vault: "Vault",
+    scope: Optional[DedupScope] = None,
+    batch_id: Optional[str] = None,
+    dry_run: bool = False,
+    limit: Optional[int] = None,
+) -> dict[str, Any]:
+    """Write-path vault wrapper around :func:`bulk_auto_stack_in_session`."""
+    return vault.db.run_task(
+        bulk_auto_stack_in_session, scope, batch_id, dry_run, limit
+    )
+
+
+__all__ = [
+    "OP_TYPE_KEEP_SEPARATE",
+    "OP_TYPE_REOPEN",
+    "OP_TYPE_STACK",
+    "DedupVerdictError",
+    "VerdictResult",
+    "apply_keep_separate",
+    "apply_keep_separate_in_session",
+    "apply_metadata_union_in_session",
+    "apply_stack_verdict",
+    "apply_stack_verdict_in_session",
+    "bulk_auto_stack",
+    "bulk_auto_stack_in_session",
+    "new_batch_id",
+    "reopen_verdict",
+    "reopen_verdict_in_session",
+]

--- a/pixlstash/services/operation_log_service.py
+++ b/pixlstash/services/operation_log_service.py
@@ -349,9 +349,20 @@ def diff_states(
 SummarySpec = Union[str, Callable[[dict, dict], Optional[str]], None]
 
 
+SERVER_BATCH_ID_PREFIX = "srv-"
+"""Namespace for a batch id the *server* minted.
+
+A batch id can also arrive from a client (the ``cli-`` shape validated at the
+request boundary), and the two must be distinguishable in the log: an
+un-namespaced id makes a client-supplied grouping key indistinguishable from a
+server-minted one, so a client can graft its rows into what reads as a server
+batch. Every minting site in the backend goes through :func:`new_batch_id`.
+"""
+
+
 def new_batch_id() -> str:
     """Return a fresh opaque batch id grouping one bulk action's operations."""
-    return uuid.uuid4().hex
+    return f"{SERVER_BATCH_ID_PREFIX}{uuid.uuid4().hex}"
 
 
 def lifecycle_split(state: dict[str, dict]) -> tuple[list[int], list[int]]:
@@ -924,6 +935,56 @@ def serialize(operation: Operation, include_state: bool = False) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Post-restore hooks — reopening the domain state an operation also decided
+# ---------------------------------------------------------------------------
+
+RESTORE_UNDO = "undo"
+RESTORE_REDO = "redo"
+
+# op_type -> callback(session, operations, direction). Registered by the feature
+# that owns the op_type; this module never imports a feature module, so the core
+# stays free of domain knowledge and an unregistered op_type simply has no hook.
+#
+# Why hooks exist at all: the recorded before/after state covers the reversible
+# *picture* facets (:data:`FACETS`). An operation may additionally have decided
+# something that is not a picture facet — the v1.9 duplicate verdict is the first
+# — and restoring the pictures without reopening that decision leaves the two
+# halves disagreeing. The hook runs inside the restore's own transaction, after
+# every state has been applied, so the decision and the pictures commit together
+# or not at all.
+_POST_RESTORE_HOOKS: dict[str, Callable[[Session, list[Operation], str], None]] = {}
+
+
+def register_post_restore_hook(
+    op_type: str, hook: Callable[[Session, list[Operation], str], None]
+) -> None:
+    """Register *hook* to run after an ``op_type`` operation is undone or redone.
+
+    Args:
+        op_type: The ``Operation.op_type`` this hook owns.
+        hook: ``(session, operations, direction) -> None``, called **once** per
+            restore with every operation of this type in that restore (so a
+            batch of 2 700 rows is one call, not 2 700). *direction* is
+            :data:`RESTORE_UNDO` or :data:`RESTORE_REDO`. It runs on the
+            restore's session, before the commit, and must not commit: raising
+            aborts the whole undo, which is the intended fail-closed behaviour.
+    """
+    _POST_RESTORE_HOOKS[str(op_type)] = hook
+
+
+def _run_post_restore_hooks(
+    session: Session, operations: list[Operation], direction: str
+) -> None:
+    """Dispatch the registered hooks for *operations*, grouped by ``op_type``."""
+    by_type: dict[str, list[Operation]] = {}
+    for operation in operations:
+        if operation.op_type in _POST_RESTORE_HOOKS:
+            by_type.setdefault(operation.op_type, []).append(operation)
+    for op_type, members in by_type.items():
+        _POST_RESTORE_HOOKS[op_type](session, members, direction)
+
+
+# ---------------------------------------------------------------------------
 # Undo / redo
 # ---------------------------------------------------------------------------
 
@@ -957,6 +1018,11 @@ def _restore(
 ) -> tuple[list[int], set[str], dict[str, list[int]]]:
     """Apply the before- (undo) or after- (redo) state of *operations* in order.
 
+    Once every state is written, the registered post-restore hooks run on this
+    same session (see :func:`register_post_restore_hook`) so an operation that
+    also decided something outside the picture facets can reopen that decision in
+    the same transaction. A hook that raises aborts the restore.
+
     Returns:
         ``(touched_ids, facets, lifecycle)`` where *lifecycle* is
         ``{"scrapheaped": [...], "restored": [...]}`` — the pictures this
@@ -978,6 +1044,9 @@ def _restore(
         moved_out, moved_in = lifecycle_split(state)
         scrapheaped.update(moved_out)
         restored.update(moved_in)
+    _run_post_restore_hooks(
+        session, operations, RESTORE_UNDO if to_before else RESTORE_REDO
+    )
     lifecycle = {
         "scrapheaped": sorted(scrapheaped),
         "restored": sorted(restored),

--- a/pixlstash/tasks/__init__.py
+++ b/pixlstash/tasks/__init__.py
@@ -40,6 +40,10 @@ from .scrapheap_retention_purge_task import ScrapheapRetentionPurgeTask
 from .scrapheap_retention_purge_finder import ScrapheapRetentionPurgeFinder
 from .thumbnail_generation_task import ThumbnailGenerationTask
 from .missing_thumbnail_finder import MissingThumbnailFinder
+from .pixel_sha_task import PixelShaTask
+from .missing_pixel_sha_finder import MissingPixelShaFinder
+from .dedup_scan_task import DedupScanTask
+from .dedup_scan_finder import DedupScanFinder
 
 __all__ = [
     "TaskType",
@@ -83,4 +87,8 @@ __all__ = [
     "ScrapheapRetentionPurgeFinder",
     "ThumbnailGenerationTask",
     "MissingThumbnailFinder",
+    "PixelShaTask",
+    "MissingPixelShaFinder",
+    "DedupScanTask",
+    "DedupScanFinder",
 ]

--- a/pixlstash/tasks/dedup_scan_finder.py
+++ b/pixlstash/tasks/dedup_scan_finder.py
@@ -1,0 +1,49 @@
+"""Finder that picks up requested duplicate scans.
+
+A scoped scan is *requested* by writing a
+:class:`~pixlstash.db_models.dedup.DedupScan` row with status ``pending`` (the
+``POST /dedup/scan`` route does exactly that and returns immediately, so the
+context-menu entry point never blocks). This finder turns that row into a
+:class:`~pixlstash.tasks.dedup_scan_task.DedupScanTask`.
+
+It is not a :class:`SimpleMissingFinder`: the unit of work is a scan row, not a
+batch of pictures, so there is nothing to claim.
+"""
+
+from pixlstash.pixl_logging import get_logger
+from pixlstash.tasks.base_task_finder import BaseTaskFinder
+from pixlstash.tasks.dedup_scan_task import DedupScanTask
+from pixlstash.tasks.task_type import TaskType
+
+logger = get_logger(__name__)
+
+
+class DedupScanFinder(BaseTaskFinder):
+    """Create one :class:`DedupScanTask` per pending scan request."""
+
+    def __init__(self, database):
+        super().__init__()
+        self._db = database
+
+    def finder_name(self) -> str:
+        return "DedupScanFinder"
+
+    def max_inflight_tasks(self) -> int:
+        # One scan at a time. Two concurrent scans would fight over the same
+        # upserted group rows for no gain: the work is IO-bound on one table.
+        return 1
+
+    def depends_on(self) -> list:
+        # Tier 1 is only complete once every picture has a pixel_sha, and tier 2
+        # needs the perceptual hash the embedding worker writes. Waiting for both
+        # means a scan reports honest counts instead of a partial library.
+        return [TaskType.PIXEL_SHA, TaskType.IMAGE_EMBEDDING]
+
+    def find_task(self):
+        scan = self._db.run_immediate_read_task(DedupScanTask.find_pending_scan)
+        if scan is None:
+            return None
+        logger.info(
+            "[dedup-scan] queueing scan %s for scope %s", scan.id, scan.scope_key
+        )
+        return DedupScanTask(database=self._db, scan_id=int(scan.id))

--- a/pixlstash/tasks/dedup_scan_task.py
+++ b/pixlstash/tasks/dedup_scan_task.py
@@ -1,0 +1,239 @@
+"""Run one duplicate scan, streaming its groups into the queue as it goes.
+
+The design's first performance rule is that the queue never blocks on a full
+pass: it opens with whatever has been found so far, behind a "scanned N of M"
+banner. This task is what makes that true.
+
+* **Tier 1** runs first and in one shot. It is an indexed ``GROUP BY``, so it
+  completes in milliseconds and the queue is never empty while the slow tiers
+  work.
+* **Tier 2** iterates the candidate buckets built by
+  :func:`~pixlstash.services.dedup_tier_service.build_near_buckets`, persisting
+  and committing after **each bucket**. A bucket's groups are visible in the
+  queue the moment that bucket finishes, and the scan's ``scanned_buckets``
+  counter advances with it.
+* **Tier 3** appends the embedding groups last, because it is the tier whose
+  input (the likeness edge table) is the one that may still be filling.
+
+The task is driven by a :class:`~pixlstash.db_models.dedup.DedupScan` row, which
+is both the request (status ``pending``) and the progress readout. Restarting a
+scan is safe: group persistence upserts on the signature, so a re-run refreshes
+rows rather than duplicating them.
+"""
+
+import json
+import time
+
+from datetime import datetime
+
+from sqlmodel import Session, select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models.dedup import (
+    SCAN_COMPLETE,
+    SCAN_FAILED,
+    SCAN_PENDING,
+    SCAN_RUNNING,
+    DedupScan,
+)
+from pixlstash.db_models.picture import Picture
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services import dedup_tier_service
+from pixlstash.services.dedup_tier_service import (
+    DedupScope,
+    DedupTier,
+    ScopeType,
+    TierPolicy,
+)
+from pixlstash.tasks.base_task import BaseTask, TaskPriority
+
+logger = get_logger(__name__)
+
+
+class DedupScanTask(BaseTask):
+    """Execute the tiers requested by one :class:`DedupScan` row."""
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    def __init__(self, database, scan_id: int):
+        super().__init__(
+            task_type="DedupScanTask",
+            # ``picture_ids`` is the key BaseTaskFinder releases its claims from;
+            # this task claims no pictures, so it is deliberately empty.
+            params={"picture_ids": [], "scan_id": int(scan_id)},
+        )
+        self._db = database
+        self._scan_id = int(scan_id)
+
+    def _run_task(self):
+        start = time.time()
+        try:
+            summary = self._db.run_task(
+                DedupScanTask.run_scan_in_session,
+                self._scan_id,
+                priority=DBPriority.LOW,
+            )
+        except Exception as exc:
+            logger.error("DedupScanTask failed for scan_id=%s: %s", self._scan_id, exc)
+            self._db.run_task(
+                DedupScanTask._mark_failed,
+                self._scan_id,
+                str(exc),
+                priority=DBPriority.LOW,
+            )
+            raise
+        logger.info(
+            "DedupScanTask scan_id=%s finished in %.2fs: %s",
+            self._scan_id,
+            time.time() - start,
+            summary,
+        )
+        return summary
+
+    @staticmethod
+    def _policy_for(scan: DedupScan) -> TierPolicy:
+        """Rebuild the requested tier policy from the persisted scan row."""
+        tiers = set(json.loads(scan.tiers or "[]"))
+        return TierPolicy(
+            near_enabled=DedupTier.NEAR.value in tiers,
+            embedding_enabled=DedupTier.EMBEDDING.value in tiers,
+            threshold=float(scan.threshold or dedup_tier_service.DEFAULT_THRESHOLD),
+        )
+
+    @staticmethod
+    def _scope_for(scan: DedupScan) -> DedupScope:
+        return DedupScope(scope_type=ScopeType(scan.scope_type), scope_id=scan.scope_id)
+
+    @staticmethod
+    def _mark_failed(session: Session, scan_id: int, error: str) -> None:
+        scan = session.get(DedupScan, scan_id)
+        if scan is None:
+            logger.warning(
+                "[dedup-scan] cannot mark scan %s failed: the row is gone", scan_id
+            )
+            return
+        scan.status = SCAN_FAILED
+        scan.error = error[:2000]
+        scan.updated_at = datetime.utcnow()
+        session.add(scan)
+        session.commit()
+
+    @staticmethod
+    def run_scan_in_session(session: Session, scan_id: int) -> dict:
+        """Run every requested tier for *scan_id*, committing as tiers finish."""
+        scan = session.get(DedupScan, scan_id)
+        if scan is None:
+            raise ValueError(f"DedupScan {scan_id} no longer exists")
+        policy = DedupScanTask._policy_for(scan)
+        scope = DedupScanTask._scope_for(scan)
+
+        dedup_tier_service.prune_stale_groups_in_session(session)
+
+        total_query = select(Picture.id).where(Picture.deleted.is_(False))
+        predicate = scope.picture_predicate()
+        if predicate is not None:
+            total_query = total_query.where(predicate)
+        total_pictures = len(session.exec(total_query).all())
+
+        scan.status = SCAN_RUNNING
+        scan.total_pictures = total_pictures
+        scan.scanned_pictures = 0
+        scan.scanned_buckets = 0
+        scan.total_buckets = 0
+        scan.groups_found = 0
+        scan.error = None
+        scan.finished_at = None
+        scan.updated_at = datetime.utcnow()
+        session.add(scan)
+        session.commit()
+
+        found = 0
+
+        # --- Tier 1: exact. Indexed GROUP BY, so the queue fills immediately.
+        exact_groups = dedup_tier_service.find_exact_groups_in_session(session, scope)
+        found += dedup_tier_service.persist_groups_in_session(
+            session, exact_groups, scan_id
+        )
+        scan = session.get(DedupScan, scan_id)
+        scan.groups_found = found
+        scan.scanned_pictures = total_pictures if not policy.near_enabled else 0
+        scan.updated_at = datetime.utcnow()
+        session.add(scan)
+        session.commit()
+
+        # --- Tier 2: bucketed near, one commit per bucket.
+        if policy.near_enabled:
+            buckets = dedup_tier_service.build_near_buckets(session, scope)
+            scan = session.get(DedupScan, scan_id)
+            scan.total_buckets = len(buckets)
+            scan.updated_at = datetime.utcnow()
+            session.add(scan)
+            session.commit()
+
+            seen_pictures: set[int] = set()
+            pair_cache: dict[tuple[int, int], float] = {}
+            for index, bucket in enumerate(buckets, start=1):
+                for a, b, similarity in dedup_tier_service.near_pairs_in_bucket(
+                    session, bucket, policy.threshold
+                ):
+                    key = (a, b)
+                    if similarity > pair_cache.get(key, 0.0):
+                        pair_cache[key] = similarity
+                seen_pictures.update(bucket.picture_ids)
+                # Groups are re-derived from every pair seen so far, so a chain
+                # that spans two buckets becomes one group rather than two.
+                groups = dedup_tier_service.groups_from_pairs(
+                    session,
+                    [(a, b, sim) for (a, b), sim in pair_cache.items()],
+                    policy,
+                    DedupTier.NEAR,
+                )
+                dedup_tier_service.persist_groups_in_session(session, groups, scan_id)
+                scan = session.get(DedupScan, scan_id)
+                scan.scanned_buckets = index
+                scan.scanned_pictures = min(len(seen_pictures), total_pictures)
+                scan.groups_found = found + len(groups)
+                scan.updated_at = datetime.utcnow()
+                session.add(scan)
+                session.commit()
+            found = session.get(DedupScan, scan_id).groups_found
+
+        # --- Tier 3: embedding, appended to the same queue.
+        if policy.embedding_enabled:
+            embedding_groups = dedup_tier_service.find_embedding_groups_in_session(
+                session, policy, scope
+            )
+            found += dedup_tier_service.persist_groups_in_session(
+                session, embedding_groups, scan_id
+            )
+
+        scan = session.get(DedupScan, scan_id)
+        scan.status = SCAN_COMPLETE
+        scan.scanned_pictures = total_pictures
+        scan.groups_found = found
+        scan.finished_at = datetime.utcnow()
+        scan.updated_at = scan.finished_at
+        session.add(scan)
+        session.commit()
+        return {
+            "scan_id": scan_id,
+            "scope": scope.key,
+            "total_pictures": total_pictures,
+            "groups_found": found,
+        }
+
+    @staticmethod
+    def find_pending_scan(session: Session) -> "DedupScan | None":
+        """Oldest scan waiting to run, or the one interrupted mid-flight.
+
+        A ``running`` row with no live task means the server restarted during a
+        scan; picking it up again is correct because group persistence is an
+        upsert on the signature.
+        """
+        return session.exec(
+            select(DedupScan)
+            .where(DedupScan.status.in_([SCAN_PENDING, SCAN_RUNNING]))
+            .order_by(DedupScan.started_at)
+        ).first()

--- a/pixlstash/tasks/dedup_scan_task.py
+++ b/pixlstash/tasks/dedup_scan_task.py
@@ -173,28 +173,74 @@ class DedupScanTask(BaseTask):
             session.commit()
 
             seen_pictures: set[int] = set()
+            # Pairs are kept across buckets so a chain spanning two buckets folds
+            # into ONE group rather than two. That is a real requirement, but it
+            # is also the scan's only unbounded structure, so it is capped —
+            # see MAX_TRACKED_PAIRS.
             pair_cache: dict[tuple[int, int], float] = {}
+            pair_cap_reported = False
+            near_groups = 0
             for index, bucket in enumerate(buckets, start=1):
+                # Ids whose grouping this bucket could have changed. Only groups
+                # touching one of these are re-persisted below; previously the
+                # scan re-derived and re-wrote EVERY group after EVERY bucket,
+                # which is O(buckets x groups) DELETE+INSERT on the single DB
+                # writer thread — every import, tag edit and verdict queues
+                # behind a running scan.
+                touched: set[int] = set()
                 for a, b, similarity in dedup_tier_service.near_pairs_in_bucket(
                     session, bucket, policy.threshold
                 ):
                     key = (a, b)
+                    if key not in pair_cache and len(pair_cache) >= (
+                        dedup_tier_service.MAX_TRACKED_PAIRS
+                    ):
+                        if not pair_cap_reported:
+                            # Never silent: the scan continues and every bucket is
+                            # still compared, but cross-bucket chaining stops
+                            # growing, so two buckets' halves of one chain can be
+                            # reported as two groups instead of one.
+                            logger.warning(
+                                "[dedup-scan] scan %s reached the %d tracked-pair "
+                                "cap at bucket %d of %d; further cross-bucket "
+                                "chaining is dropped and some chains may be "
+                                "reported as separate groups. Narrow the scope or "
+                                "raise MAX_TRACKED_PAIRS.",
+                                scan_id,
+                                dedup_tier_service.MAX_TRACKED_PAIRS,
+                                index,
+                                len(buckets),
+                            )
+                            pair_cap_reported = True
+                        continue
                     if similarity > pair_cache.get(key, 0.0):
                         pair_cache[key] = similarity
+                        touched.update(key)
                 seen_pictures.update(bucket.picture_ids)
-                # Groups are re-derived from every pair seen so far, so a chain
-                # that spans two buckets becomes one group rather than two.
-                groups = dedup_tier_service.groups_from_pairs(
-                    session,
-                    [(a, b, sim) for (a, b), sim in pair_cache.items()],
-                    policy,
-                    DedupTier.NEAR,
-                )
-                dedup_tier_service.persist_groups_in_session(session, groups, scan_id)
+
+                if touched:
+                    groups = dedup_tier_service.groups_from_pairs(
+                        session,
+                        [(a, b, sim) for (a, b), sim in pair_cache.items()],
+                        policy,
+                        DedupTier.NEAR,
+                    )
+                    near_groups = len(groups)
+                    # Persist only the groups this bucket could have changed. A
+                    # group untouched by this bucket is byte-identical to the row
+                    # already stored, so rewriting it buys nothing.
+                    changed = [
+                        group
+                        for group in groups
+                        if touched.intersection(group.picture_ids)
+                    ]
+                    dedup_tier_service.persist_groups_in_session(
+                        session, changed, scan_id
+                    )
                 scan = session.get(DedupScan, scan_id)
                 scan.scanned_buckets = index
                 scan.scanned_pictures = min(len(seen_pictures), total_pictures)
-                scan.groups_found = found + len(groups)
+                scan.groups_found = found + near_groups
                 scan.updated_at = datetime.utcnow()
                 session.add(scan)
                 session.commit()

--- a/pixlstash/tasks/missing_pixel_sha_finder.py
+++ b/pixlstash/tasks/missing_pixel_sha_finder.py
@@ -1,0 +1,29 @@
+"""Finder for pictures missing the tier-1 exact-duplicate hash."""
+
+from pixlstash.tasks.base_task_finder import SimpleMissingFinder
+from pixlstash.tasks.pixel_sha_task import PixelShaTask
+
+
+class MissingPixelShaFinder(SimpleMissingFinder):
+    """Queue :class:`PixelShaTask` for pictures whose ``pixel_sha`` is NULL.
+
+    Tier 1 of the duplicate queue groups on ``picture.pixel_sha``; a NULL there
+    is a duplicate nobody can find. Reading a file to digest it is cheap next to
+    the embedding pipeline, so this runs at one task in flight and gets out of
+    the way.
+    """
+
+    def finder_name(self) -> str:
+        return "MissingPixelShaFinder"
+
+    def max_inflight_tasks(self) -> int:
+        return 1
+
+    def _batch_size(self) -> int:
+        return PixelShaTask.BATCH_SIZE
+
+    def _fetch_candidates(self, session, limit: int) -> list:
+        return PixelShaTask.find_pictures_missing_pixel_sha(session, limit)
+
+    def _create_task(self, pictures: list):
+        return PixelShaTask(database=self._db, pictures=pictures)

--- a/pixlstash/tasks/pixel_sha_task.py
+++ b/pixlstash/tasks/pixel_sha_task.py
@@ -1,0 +1,118 @@
+"""Backfill ``Picture.pixel_sha`` — the tier-1 exact-duplicate key.
+
+Every current import path computes ``pixel_sha`` as the file is written, so this
+task exists for the rows that predate it (and for rows whose file was replaced
+under a reference folder). Tier 1 of the duplicate queue is a ``GROUP BY`` on
+that indexed column, so a NULL there is a duplicate the queue can never see —
+which is the one failure mode that makes the sidebar count untrustworthy.
+
+The digest is ``ImageUtils.calculate_hash_from_file_path``, i.e. exactly what the
+import paths write, so a backfilled row and a freshly imported row of the same
+file agree.
+"""
+
+import time
+
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models.picture import Picture
+from pixlstash.pixl_logging import get_logger
+from pixlstash.tasks.base_task import BaseTask, TaskPriority
+from pixlstash.utils.image_processing.image_utils import ImageUtils
+
+logger = get_logger(__name__)
+
+
+class PixelShaTask(BaseTask):
+    """Compute ``pixel_sha`` for a batch of pictures that have none."""
+
+    BATCH_SIZE = 64
+    SCAN_LIMIT = 512
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    def __init__(self, database, pictures: list):
+        picture_ids = [pic.id for pic in (pictures or []) if getattr(pic, "id", None)]
+        super().__init__(
+            task_type="PixelShaTask",
+            params={"picture_ids": picture_ids, "batch_size": len(picture_ids)},
+        )
+        self._db = database
+        self._pictures = pictures or []
+
+    def _run_task(self):
+        start = time.time()
+        updates: list[tuple[int, str]] = []
+        for pic in self._pictures:
+            file_path = ImageUtils.resolve_picture_path(
+                self._db.image_root, pic.file_path
+            )
+            try:
+                digest = ImageUtils.calculate_hash_from_file_path(str(file_path))
+            except (OSError, ValueError) as exc:
+                logger.warning(
+                    "pixel_sha computation failed for picture_id=%s path=%s: %s. "
+                    "The picture stays invisible to tier-1 exact duplicate "
+                    "detection until the file is readable again.",
+                    pic.id,
+                    file_path,
+                    exc,
+                )
+                continue
+            updates.append((int(pic.id), digest))
+
+        if not updates:
+            return {"changed_count": 0, "changed": []}
+
+        changed = self._db.run_task(
+            PixelShaTask._persist_pixel_shas, updates, priority=DBPriority.LOW
+        )
+        logger.debug(
+            "PixelShaTask completed in %.2fs with %s update(s)",
+            time.time() - start,
+            len(changed or []),
+        )
+        return {"changed_count": len(changed or []), "changed": changed or []}
+
+    @staticmethod
+    def _persist_pixel_shas(session: Session, updates: list[tuple[int, str]]) -> list:
+        """Write the digests in one transaction."""
+        changed = []
+        for picture_id, digest in updates:
+            pic = session.get(Picture, picture_id)
+            if pic is None:
+                continue
+            pic.pixel_sha = digest
+            session.add(pic)
+            changed.append((Picture, picture_id, "pixel_sha", digest))
+        session.commit()
+        return changed
+
+    @staticmethod
+    def find_pictures_missing_pixel_sha(session: Session, limit: int) -> list:
+        """Return non-deleted pictures with a file but no ``pixel_sha``."""
+        return session.exec(
+            select(Picture)
+            .where(Picture.pixel_sha.is_(None))
+            .where(Picture.deleted.is_(False))
+            .where(Picture.file_path.is_not(None))
+            .limit(limit)
+        ).all()
+
+    @staticmethod
+    def count_missing_pixel_sha(session: Session) -> int:
+        """How many pictures tier 1 is still blind to."""
+        result = session.exec(
+            select(func.count())
+            .select_from(Picture)
+            .where(Picture.pixel_sha.is_(None))
+            .where(Picture.deleted.is_(False))
+            .where(Picture.file_path.is_not(None))
+        ).one()
+        if isinstance(result, (tuple, list)):
+            return result[0]
+        return result or 0

--- a/pixlstash/tasks/task_type.py
+++ b/pixlstash/tasks/task_type.py
@@ -27,6 +27,8 @@ class TaskType(str, Enum):
     TAG_HEALTH_AUTO_REBUILD = "TagHealthAutoRebuildTask"
     SCRAPHEAP_RETENTION_PURGE = "ScrapheapRetentionPurgeTask"
     THUMBNAIL_GENERATION = "ThumbnailGenerationTask"
+    PIXEL_SHA = "PixelShaTask"
+    DEDUP_SCAN = "DedupScanTask"
 
     @staticmethod
     def all():

--- a/pixlstash/utils/image_processing/image_utils.py
+++ b/pixlstash/utils/image_processing/image_utils.py
@@ -682,6 +682,32 @@ class ImageUtils:
             )
 
     @staticmethod
+    def thumbnail_cache_token(
+        thumbnail_width: Optional[int], thumbnail_height: Optional[int]
+    ) -> str:
+        """The ``?v=`` cache-buster for a picture's thumbnail URL.
+
+        Keyed on the stored bitmap's own dimensions, so any regeneration that
+        repopulates them changes the URL and the browser refetches instead of
+        painting a stale bitmap. ``"0"`` until the picture has been processed.
+
+        Single source of truth on purpose: the batch-thumbnail endpoint and the
+        duplicate queue both hand this token to the same frontend cache, and two
+        independent copies of the ``WxH`` formula would eventually disagree and
+        reintroduce the stale-thumbnail bug this token exists to fix.
+
+        Args:
+            thumbnail_width: Stored bitmap width, or ``None`` when unprocessed.
+            thumbnail_height: Stored bitmap height, or ``None`` when unprocessed.
+
+        Returns:
+            ``"<width>x<height>"``, or ``"0"`` when either dimension is missing.
+        """
+        if thumbnail_width and thumbnail_height:
+            return f"{thumbnail_width}x{thumbnail_height}"
+        return "0"
+
+    @staticmethod
     def calculate_hash_from_bytes(image_bytes: bytes) -> str:
         """Compute a content hash for raw image bytes."""
         file_size = len(image_bytes)

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -62,6 +62,8 @@ class WorkPlanner:
         )
         from pixlstash.tasks.missing_text_score_finder import MissingTextScoreFinder
         from pixlstash.tasks.missing_thumbnail_finder import MissingThumbnailFinder
+        from pixlstash.tasks.missing_pixel_sha_finder import MissingPixelShaFinder
+        from pixlstash.tasks.dedup_scan_finder import DedupScanFinder
 
         from pixlstash.utils.path_mapper import PathMapper
 
@@ -126,6 +128,12 @@ class WorkPlanner:
                 database=database,
             ),
             TaskType.THUMBNAIL_GENERATION: MissingThumbnailFinder(
+                database=database,
+            ),
+            TaskType.PIXEL_SHA: MissingPixelShaFinder(
+                database=database,
+            ),
+            TaskType.DEDUP_SCAN: DedupScanFinder(
                 database=database,
             ),
         }

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -138,6 +138,8 @@ def test_services_no_direct_db_calls():
     _direct_db_call_service_allowlist = {
         "pixlstash/services/config_service.py",  # vault-injection pattern
         "pixlstash/services/dedup_sweep_service.py",  # vault-injection pattern; read-only wrapper around plan_sweep_in_session
+        "pixlstash/services/dedup_tier_service.py",  # vault-injection pattern; thin wrappers around the *_in_session queue reads and the scan request
+        "pixlstash/services/dedup_verdict_service.py",  # vault-injection pattern; thin wrappers around the *_in_session verdict writers
         "pixlstash/services/impossible_tag_clear_service.py",  # vault-injection pattern; bulk impossible-tag clear/undo
         "pixlstash/services/picture_stats.py",  # pending session injection refactor
         "pixlstash/services/search_query_service.py",  # vault-injection pattern; DB queries for search endpoints

--- a/tests/test_dedup_tier_service.py
+++ b/tests/test_dedup_tier_service.py
@@ -38,6 +38,7 @@ from pixlstash.db_models.picture_likeness import PictureLikeness
 from pixlstash.db_models.tag import Tag
 from pixlstash.server import Server
 from pixlstash.services import dedup_tier_service as tiers
+from pixlstash.services import dedup_verdict_service as verdicts
 from pixlstash.services.dedup_tier_service import (
     CandidateMember,
     DedupScope,
@@ -219,9 +220,11 @@ def test_signature_is_order_independent_and_content_derived():
 
 
 def test_signature_falls_back_to_the_picture_id_when_no_hash_exists():
-    hashed = _member(id=7, pixel_sha="deadbeef")
+    hashed = _member(id=7, pixel_sha="deadbeef", size_bytes=100)
     unhashed = _member(id=7)
-    assert hashed.content_key == "deadbeef"
+    # The hash is never the identity on its own: it is sampled above 128 KiB, so
+    # the size travels with it (see test_content_key_carries_the_size_co_key).
+    assert hashed.content_key == "deadbeef:100"
     assert unhashed.content_key == "id:7"
 
 
@@ -800,3 +803,87 @@ def test_scan_progress_for_an_unscanned_scope_is_idle_not_an_error(server):
     progress = _run(server, tiers.scan_progress_in_session, None)
     assert progress["status"] == "idle"
     assert progress["total_pictures"] == 0
+
+
+# ── R1: the group signature must be injective over groups ─────────────────────
+
+
+def test_two_groups_sharing_a_digest_but_not_a_size_stay_distinct(server):
+    """Regression for the CSO's E1: the signature needs the ``size_bytes`` co-key.
+
+    ``pixel_sha`` is a *sampled* digest above 128 KiB, which is exactly why tier 1
+    detects on ``(pixel_sha, size_bytes)``. Identity that dropped the size made
+    two distinct exact groups collapse onto one signature, and all three
+    consequences were silent: one group vanished from the queue via the
+    upsert-on-signature, a keep-separate on the survivor resolved both file sets,
+    and a stack verdict's write target depended on scan order rather than on what
+    the user saw.
+    """
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+        ],
+    )
+    groups = _run(server, tiers.find_exact_groups_in_session, None)
+    assert len(groups) == 2
+    assert sorted(sorted(g.picture_ids) for g in groups) == [
+        sorted(ids[:2]),
+        sorted(ids[2:]),
+    ]
+    # The whole point: two groups, two signatures.
+    assert len({g.signature for g in groups}) == 2
+
+    # ...and therefore two persisted rows, not one silently overwriting the other.
+    _scan(server)
+    rows = _run(
+        server,
+        lambda session: sorted(
+            (row.signature, row.member_count)
+            for row in session.exec(select(DedupGroup)).all()
+        ),
+    )
+    assert len(rows) == 2
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 2
+
+
+def test_a_verdict_on_one_group_does_not_resolve_its_same_digest_twin(server):
+    """The second half of E1: consent must not leak across file sets."""
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+        ],
+    )
+    _scan(server)
+    page, total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    assert total == 2
+    _run(server, verdicts.apply_keep_separate_in_session, page[0]["signature"], None)
+    # The other group is still waiting for its own decision.
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+    remaining, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    assert len(remaining) == 1
+    assert remaining[0]["signature"] == page[1]["signature"]
+
+    # And a rescan does not resurrect the decided one or silence the open one.
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+
+def test_content_key_carries_the_size_co_key():
+    """Unit-level pin on the identity format itself."""
+    member = tiers.CandidateMember(id=1, pixel_sha="aaa", size_bytes=100)
+    twin = tiers.CandidateMember(id=2, pixel_sha="aaa", size_bytes=999)
+    assert member.content_key == "aaa:100"
+    assert member.content_key != twin.content_key
+    assert tiers.group_signature([member.content_key]) != tiers.group_signature(
+        [twin.content_key]
+    )
+    # An unhashed picture still falls back to its id.
+    assert tiers.CandidateMember(id=7).content_key == "id:7"

--- a/tests/test_dedup_tier_service.py
+++ b/tests/test_dedup_tier_service.py
@@ -605,14 +605,16 @@ def test_the_queue_pages_by_confidence_descending(server):
     )
     policy = TierPolicy(near_enabled=True)
     _scan(server, policy)
-    page, total = _run(server, tiers.page_queue_in_session, policy, None, 0, 2)
+    page, total, _cursor = _run(server, tiers.page_queue_in_session, policy, None, 0, 2)
     assert total == 3
     assert [round(group["confidence"], 4) for group in page] == [
         1.0,
         round(63 / 64, 4),
     ]
     assert page[0]["tier"] == "exact"
-    second, _total = _run(server, tiers.page_queue_in_session, policy, None, 2, 2)
+    second, _total, _cursor = _run(
+        server, tiers.page_queue_in_session, policy, None, 2, 2
+    )
     assert len(second) == 1
     assert second[0]["confidence"] == pytest.approx(60 / 64)
 
@@ -631,7 +633,7 @@ def test_the_queue_carries_the_cover_and_both_evidence_layers(server):
         ],
     )
     _scan(server)
-    page, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    page, _total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
     group = page[0]
     assert group["cover_picture_id"] == ids[0]
     assert any(pill["text"] == "Identical file hash" for pill in group["why"])
@@ -670,7 +672,7 @@ def test_a_recorded_verdict_resolves_the_group_on_the_next_scan(server):
         ],
     )
     _scan(server)
-    page, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    page, _total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
     signature = page[0]["signature"]
 
     def record(session):
@@ -688,7 +690,7 @@ def test_a_recorded_verdict_resolves_the_group_on_the_next_scan(server):
     # A rescan re-derives the same signature and never re-asks.
     _scan(server)
     assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
-    page, total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    page, total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
     assert page == [] and total == 0
 
 
@@ -701,7 +703,7 @@ def test_a_reopened_verdict_puts_the_group_back_in_the_queue(server):
         ],
     )
     _scan(server)
-    page, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    page, _total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
     signature = page[0]["signature"]
 
     def record_and_reopen(session):
@@ -862,12 +864,14 @@ def test_a_verdict_on_one_group_does_not_resolve_its_same_digest_twin(server):
         ],
     )
     _scan(server)
-    page, total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    page, total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
     assert total == 2
     _run(server, verdicts.apply_keep_separate_in_session, page[0]["signature"], None)
     # The other group is still waiting for its own decision.
     assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
-    remaining, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    remaining, _total, _cursor = _run(
+        server, tiers.page_queue_in_session, None, None, 0, 10
+    )
     assert len(remaining) == 1
     assert remaining[0]["signature"] == page[1]["signature"]
 
@@ -887,3 +891,171 @@ def test_content_key_carries_the_size_co_key():
     )
     # An unhashed picture still falls back to its id.
     assert tiers.CandidateMember(id=7).content_key == "id:7"
+
+
+# ── tier precedence on upsert ────────────────────────────────────────────────
+
+
+def _group_row(server, signature):
+    return _run(
+        server,
+        lambda session: session.exec(
+            select(DedupGroup).where(DedupGroup.signature == signature)
+        ).first(),
+    )
+
+
+def test_a_near_scan_does_not_downgrade_an_exact_group(server):
+    """QA blocker 2, the two-scan repro.
+
+    A byte-identical pair is also perceptually identical, so every near-enabled
+    scan rediscovers it as a ``near`` group with the same signature. The upsert
+    wrote ``row.tier`` unconditionally, so the pair was demoted to ``near`` - and
+    a ``near`` group is invisible in the exact-only default queue *and*
+    ineligible for ``POST /dedup/auto-stack``, which only ever acts on ``exact``.
+    """
+    _seed(
+        server,
+        [
+            {
+                "pixel_sha": "same",
+                "size_bytes": 100,
+                "perceptual_hash": PHASH_ZERO,
+            },
+            {
+                "pixel_sha": "same",
+                "size_bytes": 100,
+                "perceptual_hash": PHASH_ZERO,
+            },
+        ],
+    )
+    # Scan 1: exact only.
+    _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+    rows = _run(server, lambda session: session.exec(select(DedupGroup)).all())
+    assert len(rows) == 1
+    signature = rows[0].signature
+    assert rows[0].tier == DedupTier.EXACT.value
+    exact_confidence = rows[0].confidence
+
+    # Scan 2: the user turns tier 2 on.
+    _run(
+        server,
+        tiers.run_scan_now_in_session,
+        TierPolicy(near_enabled=True),
+        None,
+    )
+    row = _group_row(server, signature)
+    assert row.tier == DedupTier.EXACT.value, "exact must never be downgraded"
+    assert row.confidence == exact_confidence
+
+    # And the pair is still where the exact-only default queue and auto-stack
+    # both look for it.
+    page, _total, _cursor = _run(
+        server, tiers.page_queue_in_session, TierPolicy(), None, 0, 10
+    )
+    assert [group["tier"] for group in page] == [DedupTier.EXACT.value]
+
+
+def test_the_upsert_takes_the_stronger_tier_in_either_arrival_order(server):
+    """Precedence is a *maximum*, not a freeze on whatever landed first.
+
+    Driven through :func:`persist_groups_in_session` directly, because a real
+    scan cannot present the same signature under two tiers in the weak-then-
+    strong order: the signature hashes the members' ``<pixel_sha>:<size_bytes>``
+    content keys, so anything tier 1 can group tier 2 also sees, and the reverse
+    change (two files becoming byte-identical) changes the content keys and
+    therefore the signature. The precedence rule still has to hold both ways, or
+    it is an ordering accident rather than a rule.
+    """
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "same", "size_bytes": 100},
+            {"pixel_sha": "same", "size_bytes": 100},
+        ],
+    )
+
+    def upsert(session, first, second):
+        members = tiers.load_candidates(session, ids)
+        ordered = [members[pid] for pid in ids]
+        for tier, confidence in (first, second):
+            tiers.persist_groups_in_session(
+                session, [tiers.assemble_group(tier, confidence, ordered)]
+            )
+        return session.exec(select(DedupGroup)).all()
+
+    strong = (DedupTier.EXACT, 1.0)
+    weak = (DedupTier.NEAR, 0.93)
+
+    rows = _run(server, upsert, strong, weak)
+    assert [row.tier for row in rows] == [DedupTier.EXACT.value]
+    assert rows[0].confidence == 1.0
+
+    rows = _run(server, upsert, weak, strong)
+    assert [row.tier for row in rows] == [DedupTier.EXACT.value]
+    assert rows[0].confidence == 1.0
+
+
+# ── keyset cursor ────────────────────────────────────────────────────────────
+
+
+def test_a_cursor_round_trips_its_position_exactly():
+    """Float equality drives the tie-break branch, so the encoding must be exact."""
+    for confidence in (1.0, 0.9, 0.65, 0.123456789012345, 0.0):
+        cursor = tiers.encode_queue_cursor(confidence, 4242)
+        assert tiers.decode_queue_cursor(cursor) == (confidence, 4242)
+
+
+def test_a_tampered_cursor_is_refused_rather_than_reinterpreted():
+    for bad in ("", "AAAA", "not base64!", tiers.encode_queue_cursor(1.0, 1)[:-4]):
+        with pytest.raises(tiers.DedupCursorError):
+            tiers.decode_queue_cursor(bad)
+    # A cursor from a future encoding version is refused, not misread.
+    import base64
+
+    forged = base64.urlsafe_b64encode(b"9|1.0|1").decode().rstrip("=")
+    with pytest.raises(tiers.DedupCursorError):
+        tiers.decode_queue_cursor(forged)
+
+
+def test_the_cursor_resumes_a_tied_confidence_run_without_gap_or_repeat(server):
+    """Every exact group ties at the same confidence; the id breaks the tie."""
+    for index in range(5):
+        _seed(
+            server,
+            [
+                {"pixel_sha": f"tie-{index}", "size_bytes": 100 + index},
+                {"pixel_sha": f"tie-{index}", "size_bytes": 100 + index},
+            ],
+        )
+    _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+
+    walked = []
+    cursor = None
+    for _ in range(10):
+        page, total, cursor = _run(
+            server, tiers.page_queue_in_session, None, None, 0, 2, cursor
+        )
+        assert total == 5
+        walked.extend(group["signature"] for group in page)
+        if cursor is None:
+            break
+    assert len(walked) == 5, walked
+    assert len(set(walked)) == 5, "a tie must not be delivered twice"
+
+
+# ── folder scope normalisation ───────────────────────────────────────────────
+
+
+def test_a_folder_scope_that_normalises_to_empty_is_refused():
+    """CSO W2: these all rstripped to "" and became a LIKE pattern of "%"."""
+    for bad in ("/", "\\", "///", "\\\\", "/\\/"):
+        with pytest.raises(ValueError):
+            DedupScope(scope_type=ScopeType.FOLDER, scope_id=bad)
+
+
+def test_a_folder_scope_is_normalised_to_one_scope_key():
+    plain = DedupScope(scope_type=ScopeType.FOLDER, scope_id="/photos/2026")
+    trailing = DedupScope(scope_type=ScopeType.FOLDER, scope_id="/photos/2026/")
+    assert plain.key == trailing.key == "folder:/photos/2026"
+    assert trailing.scope_id == "/photos/2026"

--- a/tests/test_dedup_tier_service.py
+++ b/tests/test_dedup_tier_service.py
@@ -1,0 +1,802 @@
+"""Unit tests for the tiered duplicate detection service.
+
+Covers, per tier and per rule:
+
+* **tier 1 (exact)** — groups on the indexed ``pixel_sha``, refuses to group two
+  files that share a digest but differ in ``size_bytes`` (the sampled-digest
+  guard), and stays blind to the scrapheap;
+* **tier 2 (bucketed near)** — candidate buckets come from the precomputed
+  columns, comparison happens only inside a bucket, and the group's confidence is
+  its weakest link;
+* **tier 3 (embedding)** — reuses the shipped likeness edge table;
+* **the tier policy** — exact is always on, each looser tier requires the tier
+  above it, and the 0.65 floor is a hard error rather than a silent clamp;
+* **cover selection** — the design's ``px*4 + tags*3 + score*2 + RAW`` formula
+  and the oldest-capture tie-break;
+* **evidence** — matching pills and evidence-against pills, both directions;
+* **the queue** — paged by confidence descending, verdict-resolved groups never
+  re-offered, and scope-narrowed counts.
+"""
+
+import gc
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta
+
+import pytest
+from sqlmodel import select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models import Picture, PictureSet, PictureSetMember
+from pixlstash.db_models.dedup import (
+    VERDICT_KEEP_SEPARATE,
+    DedupGroup,
+    DedupVerdict,
+)
+from pixlstash.db_models.picture_likeness import PictureLikeness
+from pixlstash.db_models.tag import Tag
+from pixlstash.server import Server
+from pixlstash.services import dedup_tier_service as tiers
+from pixlstash.services.dedup_tier_service import (
+    CandidateMember,
+    DedupScope,
+    DedupTier,
+    ScopeType,
+    TierPolicy,
+)
+
+_BASE_TIME = datetime(2026, 1, 1, 12, 0, 0)
+
+# A 64-bit dHash is 16 hex chars. These differ from ZERO by a controlled number
+# of set bits, so the Hamming distance (and therefore the similarity) is exact.
+PHASH_ZERO = "0000000000000000"
+PHASH_ONE_BIT = "0000000000000001"  # 1 bit  -> similarity 63/64 = 0.984375
+PHASH_FOUR_BITS = "000000000000000f"  # 4 bits -> similarity 60/64 = 0.9375
+PHASH_FAR = "ffffffffffffffff"  # 64 bits -> similarity 0.0
+
+
+@pytest.fixture
+def server():
+    temp_dir = tempfile.TemporaryDirectory()
+    config_path = os.path.join(temp_dir.name, "server-config.json")
+    with open(config_path, "w") as fh:
+        fh.write(json.dumps({"port": 8000, "disable_background_workers": True}))
+    Server.DEFAULT_FORCE_CPU = True
+    srv = Server(config_path)
+    try:
+        yield srv
+    finally:
+        srv.vault.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
+def _run(server, fn, *args):
+    """Run *fn(session, \\*args)* on the DB worker and return its result."""
+    return server.vault.db.run_task(fn, *args, priority=DBPriority.IMMEDIATE)
+
+
+def _seed(server, specs):
+    """Insert one picture per spec; return the ids in order.
+
+    Recognised keys: ``pixel_sha``, ``perceptual_hash``, ``size_bytes``,
+    ``width``, ``height``, ``score``, ``format``, ``file_path``, ``created_at``
+    (an offset in seconds from ``_BASE_TIME``), ``deleted``, ``tags``,
+    ``import_source_folder``, ``reference_folder_id``.
+    """
+
+    def insert(session):
+        picture_ids = []
+        for index, spec in enumerate(specs):
+            width = spec.get("width", 4000)
+            height = spec.get("height", 3000)
+            created_offset = spec.get("created_at")
+            pic = Picture(
+                file_path=spec.get("file_path", f"/vault/pic_{index}.png"),
+                format=spec.get("format", "png"),
+                width=width,
+                height=height,
+                size_bin_index=(width << 32) + height,
+                size_bytes=spec.get("size_bytes", 1000),
+                score=spec.get("score"),
+                pixel_sha=spec.get("pixel_sha"),
+                perceptual_hash=spec.get("perceptual_hash"),
+                import_source_folder=spec.get("import_source_folder"),
+                reference_folder_id=spec.get("reference_folder_id"),
+                deleted=bool(spec.get("deleted", False)),
+                created_at=(
+                    _BASE_TIME + timedelta(seconds=created_offset)
+                    if created_offset is not None
+                    else None
+                ),
+            )
+            session.add(pic)
+            session.flush()
+            for tag in spec.get("tags", []):
+                session.add(Tag(picture_id=int(pic.id), tag=tag))
+            picture_ids.append(int(pic.id))
+        session.commit()
+        return picture_ids
+
+    return _run(server, insert)
+
+
+def _member(**kwargs) -> CandidateMember:
+    """A bare :class:`CandidateMember` for the pure-function tests."""
+    defaults = {
+        "id": 1,
+        "width": 4000,
+        "height": 3000,
+        "format": "jpeg",
+        "score": 0,
+        "tag_count": 0,
+    }
+    defaults.update(kwargs)
+    return CandidateMember(**defaults)
+
+
+# ── the tier policy ───────────────────────────────────────────────────────────
+
+
+def test_exact_tier_is_always_on_and_cannot_be_switched_off():
+    assert TierPolicy().tiers == (DedupTier.EXACT,)
+    assert TierPolicy().includes(DedupTier.EXACT)
+    assert not TierPolicy().includes(DedupTier.NEAR)
+
+
+def test_each_looser_tier_requires_the_tier_above_it():
+    assert TierPolicy(near_enabled=True).tiers == (DedupTier.EXACT, DedupTier.NEAR)
+    assert TierPolicy(near_enabled=True, embedding_enabled=True).tiers == (
+        DedupTier.EXACT,
+        DedupTier.NEAR,
+        DedupTier.EMBEDDING,
+    )
+    with pytest.raises(ValueError, match="requires near_enabled"):
+        TierPolicy(embedding_enabled=True)
+
+
+def test_threshold_default_is_090_and_the_floor_is_a_hard_error():
+    assert TierPolicy().threshold == pytest.approx(0.90)
+    # Below the floor is a 400-worthy error, never a silent clamp: a low
+    # threshold produces confident-looking garbage and destroys the count.
+    with pytest.raises(ValueError, match="0.65"):
+        TierPolicy(threshold=0.5)
+    assert TierPolicy(threshold=tiers.MIN_THRESHOLD).threshold == pytest.approx(0.65)
+
+
+def test_group_size_bounds_are_validated():
+    with pytest.raises(ValueError, match="min_group_size"):
+        TierPolicy(min_group_size=1)
+    with pytest.raises(ValueError, match="max_group_size"):
+        TierPolicy(min_group_size=4, max_group_size=3)
+
+
+# ── cover selection ───────────────────────────────────────────────────────────
+
+
+def test_cover_score_is_the_designs_formula():
+    # 12 MP -> 12*4 = 48; 2 tags -> 6; score 3 -> 6; not RAW -> 0.
+    member = _member(width=4000, height=3000, tag_count=2, score=3)
+    assert member.megapixels == pytest.approx(12.0)
+    assert member.cover_score == pytest.approx(48.0 + 6.0 + 6.0)
+
+
+def test_raw_earns_the_cover_bonus_by_format_or_extension():
+    assert _member(format="ARW").is_raw
+    assert _member(format="jpeg", file_path="/shoots/A7R0912.arw").is_raw
+    assert not _member(format="jpeg", file_path="/shoots/x.jpg").is_raw
+    raw = _member(id=1, format="arw", width=1000, height=1000)
+    jpeg = _member(id=2, format="jpeg", width=1000, height=1000)
+    assert raw.cover_score - jpeg.cover_score == pytest.approx(tiers.COVER_RAW_BONUS)
+
+
+def test_cover_prefers_the_highest_score_then_the_oldest_capture():
+    big = _member(id=1, width=6000, height=4000)
+    small = _member(id=2, width=1000, height=1000, tag_count=1)
+    assert tiers.select_cover([small, big]) == 1
+
+    # Identical formula scores: the oldest capture time wins, not the newest.
+    old = _member(id=10, created_at=_BASE_TIME)
+    new = _member(id=11, created_at=_BASE_TIME + timedelta(hours=5))
+    assert old.cover_score == pytest.approx(new.cover_score)
+    assert tiers.select_cover([new, old]) == 10
+
+
+def test_tags_can_outweigh_a_slightly_larger_picture():
+    # 1 MP + 5 tags = 4 + 15 = 19 beats 4 MP with nothing = 16.
+    tagged = _member(id=1, width=1000, height=1000, tag_count=5)
+    bigger = _member(id=2, width=2000, height=2000)
+    assert tiers.select_cover([bigger, tagged]) == 1
+
+
+# ── signature ─────────────────────────────────────────────────────────────────
+
+
+def test_signature_is_order_independent_and_content_derived():
+    assert tiers.group_signature(["b", "a"]) == tiers.group_signature(["a", "b"])
+    assert tiers.group_signature(["a", "b"]) != tiers.group_signature(["a", "c"])
+
+
+def test_signature_falls_back_to_the_picture_id_when_no_hash_exists():
+    hashed = _member(id=7, pixel_sha="deadbeef")
+    unhashed = _member(id=7)
+    assert hashed.content_key == "deadbeef"
+    assert unhashed.content_key == "id:7"
+
+
+# ── evidence ──────────────────────────────────────────────────────────────────
+
+
+def test_group_evidence_reports_both_directions():
+    members = [
+        _member(id=1, width=6000, height=4000, created_at=_BASE_TIME, format="jpeg"),
+        _member(id=2, width=1920, height=1440, created_at=_BASE_TIME, format="webp"),
+    ]
+    pills = tiers.build_group_evidence(DedupTier.NEAR, 0.96, members)
+    texts = {pill["text"]: pill["against"] for pill in pills}
+    assert texts["96% visual match"] is False
+    assert texts["Different resolution"] is True
+    assert texts["Different aspect ratio"] is True
+    assert texts["Different file format"] is True
+    assert texts["Same capture second"] is False
+
+
+def test_exact_evidence_leads_with_the_hash_and_same_dimensions():
+    members = [_member(id=1), _member(id=2)]
+    pills = tiers.build_group_evidence(DedupTier.EXACT, 1.0, members)
+    texts = [pill["text"] for pill in pills]
+    assert texts[0] == "Identical file hash"
+    assert "Same dimensions" in texts
+    assert not any(pill["against"] for pill in pills)
+
+
+def test_candidate_evidence_explains_the_preselection_both_ways():
+    best = _member(id=1, width=6000, height=4000, tag_count=6, score=5)
+    worst = _member(id=2, width=1080, height=1080)
+    members = [best, worst]
+    best_pills = tiers.build_candidate_evidence(best, members, cover_id=1)
+    worst_pills = tiers.build_candidate_evidence(worst, members, cover_id=1)
+    assert any(p["text"] == "Highest resolution" for p in best_pills)
+    assert any(p["text"] == "Preselected as cover" for p in best_pills)
+    assert any(p["against"] and "fewer pixels" in p["text"] for p in worst_pills)
+    assert any(p["against"] and "Fewer tags" in p["text"] for p in worst_pills)
+
+
+def test_reference_folder_pictures_expose_their_path_and_others_do_not():
+    managed = _member(id=1, file_path="/vault/a.png")
+    referenced = _member(id=2, file_path="/photos/a.png", reference_folder_id=3)
+    assert managed.as_dict()["file_path"] is None
+    assert referenced.as_dict()["file_path"] == "/photos/a.png"
+
+
+# ── tier 1: exact ─────────────────────────────────────────────────────────────
+
+
+def test_exact_tier_groups_on_the_indexed_hash(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 4},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "bbb", "size_bytes": 100},
+        ],
+    )
+    groups = _run(server, tiers.find_exact_groups_in_session, None)
+    assert len(groups) == 1
+    group = groups[0]
+    assert sorted(group.picture_ids) == sorted(ids[:2])
+    assert group.confidence == pytest.approx(1.0)
+    assert group.tier is DedupTier.EXACT
+    # The higher human score wins the cover under the formula.
+    assert group.cover_picture_id == ids[0]
+
+
+def test_exact_tier_refuses_to_group_on_a_digest_alone(server):
+    """The sampled-digest guard: same hash, different size is not a match.
+
+    ``pixel_sha`` samples large files rather than hashing every byte, so equal
+    file size is a required co-key. Dropping it would let the queue claim an
+    identity the digest does not actually prove.
+    """
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+        ],
+    )
+    assert _run(server, tiers.find_exact_groups_in_session, None) == []
+
+
+def test_exact_tier_ignores_the_scrapheap_and_unhashed_rows(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100, "deleted": True},
+            {"pixel_sha": None, "size_bytes": 100},
+            {"pixel_sha": None, "size_bytes": 100},
+        ],
+    )
+    assert _run(server, tiers.find_exact_groups_in_session, None) == []
+
+
+def test_exact_tier_narrows_to_a_scope(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 100},
+        ],
+    )
+
+    def add_set(session):
+        picture_set = PictureSet(name="Scope")
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        for picture_id in ids[:2]:
+            session.add(
+                PictureSetMember(set_id=int(picture_set.id), picture_id=picture_id)
+            )
+        session.commit()
+        return int(picture_set.id)
+
+    set_id = _run(server, add_set)
+    scope = DedupScope(scope_type=ScopeType.SET, scope_id=str(set_id))
+    scoped = _run(server, tiers.find_exact_groups_in_session, scope)
+    assert len(scoped) == 1
+    assert sorted(scoped[0].picture_ids) == sorted(ids[:2])
+    assert len(_run(server, tiers.find_exact_groups_in_session, None)) == 2
+
+
+# ── tier 2: bucketed near ─────────────────────────────────────────────────────
+
+
+def test_buckets_come_from_the_precomputed_columns(server):
+    _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_ONE_BIT, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_FAR, "width": 200, "height": 200},
+        ],
+    )
+    buckets = _run(server, tiers.build_near_buckets, None)
+    kinds = {bucket.kind for bucket in buckets}
+    assert "size_bin" in kinds
+    # The 200x200 picture is alone in its size bin, so that bucket is dropped:
+    # a singleton bucket is not work and must not inflate the progress total.
+    size_bins = [b for b in buckets if b.kind == "size_bin"]
+    assert len(size_bins) == 1
+    assert len(size_bins[0].picture_ids) == 2
+
+
+def test_near_pairs_are_only_compared_inside_a_bucket(server):
+    """A picture that shares no bucket is never compared, however similar it is.
+
+    The third picture has a byte-identical perceptual hash but different
+    dimensions *and* a different folder, so it shares no candidate bucket with
+    the pair. Library-wide comparison would have pulled it in; bucketed
+    comparison does not.
+    """
+    ids = _seed(
+        server,
+        [
+            # Same dimensions and folder -> same bucket, 1 bit apart.
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 100,
+                "height": 100,
+                "file_path": "/vault/a/one.png",
+            },
+            {
+                "perceptual_hash": PHASH_ONE_BIT,
+                "width": 100,
+                "height": 100,
+                "file_path": "/vault/a/two.png",
+            },
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 300,
+                "height": 300,
+                "file_path": "/vault/b/three.png",
+            },
+        ],
+    )
+    groups = _run(
+        server, tiers.find_near_groups_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert len(groups) == 1
+    assert sorted(groups[0].picture_ids) == sorted(ids[:2])
+    assert groups[0].confidence == pytest.approx(63 / 64)
+    assert groups[0].tier is DedupTier.NEAR
+
+
+def test_capture_minute_buckets_catch_a_resize(server):
+    """Different dimensions, same capture minute: still one bucket, still found."""
+    ids = _seed(
+        server,
+        [
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 4000,
+                "height": 3000,
+                "created_at": 0,
+            },
+            {
+                "perceptual_hash": PHASH_ONE_BIT,
+                "width": 2000,
+                "height": 1500,
+                "created_at": 5,
+            },
+        ],
+    )
+    groups = _run(
+        server, tiers.find_near_groups_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert len(groups) == 1
+    assert sorted(groups[0].picture_ids) == sorted(ids)
+    assert any(
+        pill["against"] and pill["text"] == "Different resolution"
+        for pill in groups[0].evidence
+    )
+
+
+def test_the_threshold_excludes_a_weaker_near_pair(server):
+    _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_FOUR_BITS, "width": 100, "height": 100},
+        ],
+    )
+    # 4 bits apart is 0.9375: above the 0.90 default, below a 0.99 threshold.
+    loose = _run(
+        server, tiers.find_near_groups_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert len(loose) == 1
+    tight = _run(
+        server,
+        tiers.find_near_groups_in_session,
+        TierPolicy(near_enabled=True, threshold=0.99),
+        None,
+    )
+    assert tight == []
+
+
+def test_a_group_is_judged_by_its_weakest_link(server):
+    """A~B at 1 bit and B~C at 4 bits is one group whose confidence is the 4-bit edge."""
+    ids = _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_ONE_BIT, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_FOUR_BITS, "width": 100, "height": 100},
+        ],
+    )
+    groups = _run(
+        server, tiers.find_near_groups_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert len(groups) == 1
+    assert sorted(groups[0].picture_ids) == sorted(ids)
+    assert groups[0].confidence == pytest.approx(60 / 64)
+
+
+def test_unparseable_perceptual_hashes_are_excluded_not_crashed(server):
+    _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": "not-a-hash-xx", "width": 100, "height": 100},
+            {"perceptual_hash": "abc", "width": 100, "height": 100},
+        ],
+    )
+    assert (
+        _run(
+            server,
+            tiers.find_near_groups_in_session,
+            TierPolicy(near_enabled=True),
+            None,
+        )
+        == []
+    )
+
+
+# ── tier 3: embedding ─────────────────────────────────────────────────────────
+
+
+def test_embedding_tier_reuses_the_shipped_likeness_table(server):
+    ids = _seed(server, [{}, {}, {}])
+
+    def link(session):
+        first, second = PictureLikeness.canon_pair(ids[0], ids[1])
+        session.add(
+            PictureLikeness(
+                picture_id_a=first, picture_id_b=second, likeness=0.97, metric="test"
+            )
+        )
+        session.commit()
+
+    _run(server, link)
+    policy = TierPolicy(near_enabled=True, embedding_enabled=True)
+    groups = _run(server, tiers.find_embedding_groups_in_session, policy, None)
+    assert len(groups) == 1
+    assert sorted(groups[0].picture_ids) == sorted(ids[:2])
+    assert groups[0].tier is DedupTier.EMBEDDING
+    assert groups[0].confidence == pytest.approx(0.97)
+
+
+# ── persistence, the queue and the counts ─────────────────────────────────────
+
+
+def _scan(server, policy=None, scope=None):
+    return _run(server, tiers.run_scan_now_in_session, policy or TierPolicy(), scope)
+
+
+def test_a_rescan_refreshes_groups_instead_of_duplicating_them(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    assert _scan(server)["unresolved_groups"] == 1
+    _scan(server)
+    rows = _run(server, lambda session: session.exec(select(DedupGroup)).all())
+    assert len(rows) == 1
+
+
+def test_the_queue_pages_by_confidence_descending(server):
+    _seed(
+        server,
+        [
+            # An exact pair (confidence 1.0). Separate folders so it does not
+            # also land in a near bucket with the pairs below.
+            {
+                "pixel_sha": "aaa",
+                "size_bytes": 100,
+                "width": 10,
+                "height": 10,
+                "file_path": "/vault/x/1.png",
+            },
+            {
+                "pixel_sha": "aaa",
+                "size_bytes": 100,
+                "width": 10,
+                "height": 10,
+                "file_path": "/vault/x/2.png",
+            },
+            # A 1-bit near pair (0.984).
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 20,
+                "height": 20,
+                "file_path": "/vault/y/1.png",
+            },
+            {
+                "perceptual_hash": PHASH_ONE_BIT,
+                "width": 20,
+                "height": 20,
+                "file_path": "/vault/y/2.png",
+            },
+            # A 4-bit near pair (0.9375), in its own folder so it stays its own
+            # group rather than chaining onto the pair above.
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 30,
+                "height": 30,
+                "file_path": "/vault/z/1.png",
+            },
+            {
+                "perceptual_hash": PHASH_FOUR_BITS,
+                "width": 30,
+                "height": 30,
+                "file_path": "/vault/z/2.png",
+            },
+        ],
+    )
+    policy = TierPolicy(near_enabled=True)
+    _scan(server, policy)
+    page, total = _run(server, tiers.page_queue_in_session, policy, None, 0, 2)
+    assert total == 3
+    assert [round(group["confidence"], 4) for group in page] == [
+        1.0,
+        round(63 / 64, 4),
+    ]
+    assert page[0]["tier"] == "exact"
+    second, _total = _run(server, tiers.page_queue_in_session, policy, None, 2, 2)
+    assert len(second) == 1
+    assert second[0]["confidence"] == pytest.approx(60 / 64)
+
+
+def test_the_queue_carries_the_cover_and_both_evidence_layers(server):
+    ids = _seed(
+        server,
+        [
+            {
+                "pixel_sha": "aaa",
+                "size_bytes": 100,
+                "score": 5,
+                "tags": ["portrait", "outdoor"],
+            },
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    page, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    group = page[0]
+    assert group["cover_picture_id"] == ids[0]
+    assert any(pill["text"] == "Identical file hash" for pill in group["why"])
+    cover = next(c for c in group["candidates"] if c["picture_id"] == ids[0])
+    assert cover["tag_count"] == 2
+    assert any(p["text"] == "Preselected as cover" for p in cover["why"])
+    assert any(p["text"].startswith("Most metadata") for p in cover["why"])
+
+
+def test_the_near_tier_is_hidden_until_it_is_switched_on(server):
+    _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_ONE_BIT, "width": 100, "height": 100},
+        ],
+    )
+    near_policy = TierPolicy(near_enabled=True)
+    _scan(server, near_policy)
+    # Detected and stored, but the default policy shows only tier 1.
+    assert _run(server, tiers.count_unresolved_in_session, TierPolicy(), None) == 0
+    assert _run(server, tiers.count_unresolved_in_session, near_policy, None) == 1
+    # The per-tier counts report the switched-off tier anyway, so the user can
+    # see what enabling it would add.
+    by_tier = _run(server, tiers.count_by_tier_in_session, TierPolicy(), None)
+    assert by_tier["near"] == 1
+    assert by_tier["exact"] == 0
+
+
+def test_a_recorded_verdict_resolves_the_group_on_the_next_scan(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    page, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    signature = page[0]["signature"]
+
+    def record(session):
+        session.add(
+            DedupVerdict(
+                signature=signature,
+                verdict=VERDICT_KEEP_SEPARATE,
+                picture_ids="[]",
+                excluded_picture_ids="[]",
+            )
+        )
+        session.commit()
+
+    _run(server, record)
+    # A rescan re-derives the same signature and never re-asks.
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+    page, total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    assert page == [] and total == 0
+
+
+def test_a_reopened_verdict_puts_the_group_back_in_the_queue(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    page, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    signature = page[0]["signature"]
+
+    def record_and_reopen(session):
+        session.add(
+            DedupVerdict(
+                signature=signature,
+                verdict=VERDICT_KEEP_SEPARATE,
+                picture_ids="[]",
+                excluded_picture_ids="[]",
+                reopened_at=_BASE_TIME,
+            )
+        )
+        session.commit()
+
+    _run(server, record_and_reopen)
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+
+def test_stale_groups_are_pruned_when_their_members_go_to_the_scrapheap(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+    def soft_delete(session):
+        pic = session.get(Picture, ids[1])
+        pic.deleted = True
+        session.add(pic)
+        session.commit()
+
+    _run(server, soft_delete)
+    assert _run(server, tiers.prune_stale_groups_in_session) == 1
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+
+
+def test_scoped_counts_are_reported_per_scope(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+
+    def add_set(session):
+        picture_set = PictureSet(name="Scope")
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        for picture_id in ids[:2]:
+            session.add(
+                PictureSetMember(set_id=int(picture_set.id), picture_id=picture_id)
+            )
+        session.commit()
+        return int(picture_set.id)
+
+    set_id = _run(server, add_set)
+    scopes = [
+        DedupScope(),
+        DedupScope(scope_type=ScopeType.SET, scope_id=str(set_id)),
+    ]
+    counts = _run(server, tiers.scope_counts_in_session, scopes, None)
+    assert counts[0]["key"] == "global"
+    assert counts[0]["unresolved_groups"] == 2
+    assert counts[1]["key"] == f"set:{set_id}"
+    assert counts[1]["unresolved_groups"] == 1
+
+
+def test_a_scope_id_is_required_for_a_non_global_scope():
+    with pytest.raises(ValueError, match="scope_id is required"):
+        DedupScope(scope_type=ScopeType.PROJECT)
+    assert DedupScope(scope_type=ScopeType.GLOBAL, scope_id="ignored").key == "global"
+
+
+# ── scan progress ─────────────────────────────────────────────────────────────
+
+
+def test_requesting_a_scan_creates_one_row_per_scope_and_reuses_it(server):
+    first = _run(server, tiers.request_scan_in_session, TierPolicy(), None)
+    assert first["status"] == "pending"
+    assert first["scope_key"] == "global"
+    second = _run(
+        server, tiers.request_scan_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert second["scan_id"] == first["scan_id"]
+    assert second["tiers"] == ["exact", "near"]
+
+
+def test_scan_progress_for_an_unscanned_scope_is_idle_not_an_error(server):
+    progress = _run(server, tiers.scan_progress_in_session, None)
+    assert progress["status"] == "idle"
+    assert progress["total_pictures"] == 0

--- a/tests/test_dedup_tiers_api.py
+++ b/tests/test_dedup_tiers_api.py
@@ -1,0 +1,505 @@
+"""API tests for the v1.9 tiered duplicate queue.
+
+Every route is declared ``OWNER_ONLY`` in ``pixlstash/authz/registry.py`` and
+enforced by the central authz gate, so these assert **both directions** per the
+CLAUDE.md security review process:
+
+* negative — a resource-scoped READ share token gets 403 on every route, via the
+  ``Authorization`` header and via the ``?token=`` query-parameter path;
+* positive — the owner cookie session reaches every route and gets a complete
+  answer (over-blocking is its own regression).
+
+Plus the contract the frontend reads: the policy is served rather than
+hardcoded, the queue pages by confidence descending with the cover preselection
+and both evidence layers, counts are live and scoped, and the verdict routes are
+non-destructive.
+
+Background workers are disabled and the pictures are inserted directly, so the
+likeness worker cannot write rows underneath the assertions.
+"""
+
+import gc
+import json
+import os
+import tempfile
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models import Picture, PictureSetMember
+from pixlstash.db_models.tag import Tag
+from pixlstash.server import Server
+from pixlstash.services import dedup_tier_service as tiers
+from pixlstash.services.dedup_tier_service import TierPolicy
+from tests.authz_guard import no_spa_fallback  # noqa: F401
+
+API = "/api/v1"
+POLICY_URL = f"{API}/dedup/policy"
+GROUPS_URL = f"{API}/dedup/groups"
+COUNTS_URL = f"{API}/dedup/counts"
+SCAN_URL = f"{API}/dedup/scan"
+STACK_URL = f"{API}/dedup/verdicts/stack"
+KEEP_SEPARATE_URL = f"{API}/dedup/verdicts/keep-separate"
+REOPEN_URL = f"{API}/dedup/verdicts/reopen"
+AUTO_STACK_URL = f"{API}/dedup/auto-stack"
+
+# The SPA catch-all answers unmatched GETs with 200, so a wrong URL could make a
+# positive assertion vacuous. See tests/authz_guard.py.
+pytestmark = pytest.mark.usefixtures("no_spa_fallback")
+
+
+def _run(server, fn, *args):
+    return server.vault.db.run_task(fn, *args, priority=DBPriority.IMMEDIATE)
+
+
+def _insert_pictures(server, specs):
+    def insert(session):
+        picture_ids = []
+        for index, spec in enumerate(specs):
+            pic = Picture(
+                file_path=f"/vault/dedup_{index}.png",
+                format="png",
+                width=spec.get("width", 4000),
+                height=spec.get("height", 3000),
+                size_bytes=spec.get("size_bytes", 1000),
+                score=spec.get("score"),
+                pixel_sha=spec.get("pixel_sha"),
+            )
+            session.add(pic)
+            session.flush()
+            for tag in spec.get("tags", []):
+                session.add(Tag(picture_id=int(pic.id), tag=tag))
+            picture_ids.append(int(pic.id))
+        session.commit()
+        return picture_ids
+
+    return _run(server, insert)
+
+
+def _env():
+    """Owner cookie client, one exact duplicate pair, and a set-scoped READ token.
+
+    Pictures 0 and 1 share a ``pixel_sha`` and a size, so tier 1 finds exactly
+    one group. Picture 2 is unique and never appears.
+    """
+    temp_dir = tempfile.TemporaryDirectory()
+    os.makedirs(os.path.join(temp_dir.name, "images"), exist_ok=True)
+    config_path = os.path.join(temp_dir.name, "server-config.json")
+    with open(config_path, "w") as fh:
+        fh.write(json.dumps({"port": 8000, "disable_background_workers": True}))
+    Server.DEFAULT_FORCE_CPU = True
+    server = Server(config_path)
+    client = TestClient(server.api)
+    assert (
+        client.post(
+            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        ).status_code
+        == 200
+    )
+    picture_ids = _insert_pictures(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5, "tags": ["portrait"]},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 300},
+        ],
+    )
+    set_id = client.post(f"{API}/picture_sets", json={"name": "Set A"}).json()[
+        "picture_set"
+    ]["id"]
+
+    def add_to_set(session):
+        session.add(PictureSetMember(set_id=set_id, picture_id=picture_ids[0]))
+        session.commit()
+
+    _run(server, add_to_set)
+    token = client.post(
+        f"{API}/users/me/token",
+        json={
+            "description": "set A read",
+            "scope": "READ",
+            "resource_type": "picture_set",
+            "resource_id": set_id,
+        },
+    ).json()["token"]
+    _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+    return temp_dir, client, server, picture_ids, token, set_id
+
+
+def _teardown(temp_dir, server):
+    server.vault.close()
+    temp_dir.cleanup()
+    gc.collect()
+
+
+def _signature(client) -> str:
+    body = client.get(GROUPS_URL).json()
+    assert body["groups"], body
+    return body["groups"][0]["signature"]
+
+
+# ── authorization, both directions ────────────────────────────────────────────
+
+
+def test_scoped_read_token_is_denied_on_every_route():
+    temp_dir, client, server, _ids, token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        scoped = TestClient(server.api)
+        headers = {"Authorization": f"Bearer {token}"}
+        assert scoped.get(POLICY_URL, headers=headers).status_code == 403
+        assert scoped.get(GROUPS_URL, headers=headers).status_code == 403
+        assert scoped.post(COUNTS_URL, json={}, headers=headers).status_code == 403
+        assert scoped.post(SCAN_URL, json={}, headers=headers).status_code == 403
+        assert (
+            scoped.post(
+                STACK_URL, json={"signature": signature}, headers=headers
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(
+                KEEP_SEPARATE_URL, json={"signature": signature}, headers=headers
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(
+                REOPEN_URL, json={"signature": signature}, headers=headers
+            ).status_code
+            == 403
+        )
+        assert scoped.post(AUTO_STACK_URL, json={}, headers=headers).status_code == 403
+
+        # Same via the ?token= query-param path (no Authorization header).
+        assert scoped.get(POLICY_URL, params={"token": token}).status_code == 403
+        assert scoped.get(GROUPS_URL, params={"token": token}).status_code == 403
+        assert (
+            scoped.post(COUNTS_URL, params={"token": token}, json={}).status_code == 403
+        )
+        assert (
+            scoped.post(SCAN_URL, params={"token": token}, json={}).status_code == 403
+        )
+        assert (
+            scoped.post(
+                STACK_URL, params={"token": token}, json={"signature": signature}
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(
+                KEEP_SEPARATE_URL,
+                params={"token": token},
+                json={"signature": signature},
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(
+                REOPEN_URL, params={"token": token}, json={"signature": signature}
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(AUTO_STACK_URL, params={"token": token}, json={}).status_code
+            == 403
+        )
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_denied_verdict_route_changed_nothing():
+    """Fail-closed, not fail-late: the 403 happens before any write."""
+    temp_dir, client, server, ids, token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        scoped = TestClient(server.api)
+        headers = {"Authorization": f"Bearer {token}"}
+        assert (
+            scoped.post(
+                STACK_URL, json={"signature": signature}, headers=headers
+            ).status_code
+            == 403
+        )
+        stacked = _run(
+            server,
+            lambda session: [session.get(Picture, pid).stack_id for pid in ids],
+        )
+        assert stacked == [None, None, None]
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_unauthenticated_is_denied():
+    temp_dir, _client, server, _ids, _token, _set_id = _env()
+    try:
+        anonymous = TestClient(server.api)
+        assert anonymous.get(POLICY_URL).status_code in (401, 403)
+        assert anonymous.get(GROUPS_URL).status_code in (401, 403)
+        assert anonymous.post(COUNTS_URL, json={}).status_code in (401, 403)
+        assert anonymous.post(SCAN_URL, json={}).status_code in (401, 403)
+        assert anonymous.post(AUTO_STACK_URL, json={}).status_code in (401, 403)
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── policy ────────────────────────────────────────────────────────────────────
+
+
+def test_owner_reads_the_tier_policy():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        response = client.get(POLICY_URL)
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["defaults"]["threshold"] == pytest.approx(0.90)
+        assert body["defaults"]["near_enabled"] is False
+        assert body["defaults"]["embedding_enabled"] is False
+        bounds = body["bounds"]
+        assert bounds["min_threshold"] == pytest.approx(0.65)
+        assert bounds["tiers"] == ["exact", "near", "embedding"]
+        assert bounds["always_on_tiers"] == ["exact"]
+        assert bounds["tier_requires"] == {
+            "exact": None,
+            "near": "exact",
+            "embedding": "near",
+        }
+        assert set(bounds["verdicts"]) == {"stacked", "keep_separate"}
+        assert "folder" in bounds["scope_types"]
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_threshold_below_the_floor_is_rejected():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        assert client.get(GROUPS_URL, params={"threshold": 0.4}).status_code == 422
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_enabling_the_embedding_tier_alone_is_rejected():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        response = client.get(GROUPS_URL, params={"embedding_enabled": True})
+        assert response.status_code == 400, response.text
+        assert "requires near_enabled" in response.json()["detail"]
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── the queue ─────────────────────────────────────────────────────────────────
+
+
+def test_the_queue_page_carries_cover_evidence_and_progress():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        response = client.get(GROUPS_URL)
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 1
+        assert body["offset"] == 0
+        assert body["policy"]["threshold"] == pytest.approx(0.90)
+        assert body["scope"]["key"] == "global"
+        # No scan row has been written by a route yet, so the banner is idle
+        # rather than an error.
+        assert body["scan"]["status"] == "idle"
+
+        group = body["groups"][0]
+        assert group["tier"] == "exact"
+        assert group["confidence"] == pytest.approx(1.0)
+        assert group["member_count"] == 2
+        assert group["cover_picture_id"] == ids[0]
+        assert any(p["text"] == "Identical file hash" for p in group["why"])
+        assert sorted(c["picture_id"] for c in group["candidates"]) == sorted(ids[:2])
+        cover = next(c for c in group["candidates"] if c["picture_id"] == ids[0])
+        assert cover["tag_count"] == 1
+        assert cover["cover_score"] > 0
+        assert any(p["text"] == "Preselected as cover" for p in cover["why"])
+        # Managed-library pictures hide their path.
+        assert all(c["file_path"] is None for c in group["candidates"])
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_the_queue_page_size_is_honoured():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        body = client.get(GROUPS_URL, params={"limit": 1, "offset": 1}).json()
+        assert body["limit"] == 1
+        assert body["offset"] == 1
+        assert body["groups"] == []
+        assert body["total"] == 1
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── counts ────────────────────────────────────────────────────────────────────
+
+
+def test_counts_report_the_badge_the_tiers_and_the_scopes():
+    temp_dir, client, server, _ids, _token, set_id = _env()
+    try:
+        response = client.post(
+            COUNTS_URL,
+            json={"scopes": [{"scope_type": "set", "scope_id": str(set_id)}]},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["unresolved_groups"] == 1
+        assert body["by_tier"] == {"exact": 1, "near": 0, "embedding": 0}
+        assert len(body["scopes"]) == 1
+        assert body["scopes"][0]["key"] == f"set:{set_id}"
+        assert body["scopes"][0]["unresolved_groups"] == 1
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_scope_without_an_id_is_rejected():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        response = client.post(COUNTS_URL, json={"scopes": [{"scope_type": "project"}]})
+        assert response.status_code == 400, response.text
+        assert "scope_id is required" in response.json()["detail"]
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── scan ──────────────────────────────────────────────────────────────────────
+
+
+def test_requesting_a_scan_returns_immediately_with_progress():
+    temp_dir, client, server, _ids, _token, set_id = _env()
+    try:
+        response = client.post(
+            SCAN_URL,
+            json={
+                "policy": {"near_enabled": True},
+                "scope": {"scope_type": "set", "scope_id": str(set_id)},
+            },
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["status"] == "pending"
+        assert body["scope_key"] == f"set:{set_id}"
+        assert body["tiers"] == ["exact", "near"]
+        # And the queue for that scope now reports the scan rather than idle.
+        queue = client.get(
+            GROUPS_URL, params={"scope_type": "set", "scope_id": str(set_id)}
+        ).json()
+        assert queue["scan"]["scope_key"] == f"set:{set_id}"
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── verdicts ──────────────────────────────────────────────────────────────────
+
+
+def test_stacking_through_the_api_applies_the_union_and_clears_the_badge():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        response = client.post(
+            STACK_URL, json={"signature": signature, "cover_picture_id": ids[0]}
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["verdict"] == "stacked"
+        assert body["cover_picture_id"] == ids[0]
+        assert sorted(body["picture_ids"]) == sorted(ids[:2])
+        assert body["stack_id"] is not None
+        assert body["metadata_union"]["tags_added"] == 1
+        assert body["metadata_union"]["scores_lifted"] == 1
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        # Nothing was deleted: a stack is a grouping row plus a cover pointer.
+        live = _run(
+            server,
+            lambda session: [
+                int(row) for row in session.exec(select(Picture.id)).all()
+            ],
+        )
+        assert sorted(live) == sorted(ids)
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_keep_separate_then_reopen_round_trips_through_the_api():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        kept = client.post(KEEP_SEPARATE_URL, json={"signature": signature})
+        assert kept.status_code == 200, kept.text
+        assert kept.json()["verdict"] == "keep_separate"
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        assert client.get(GROUPS_URL).json()["groups"] == []
+
+        reopened = client.post(REOPEN_URL, json={"signature": signature})
+        assert reopened.status_code == 200, reopened.text
+        assert reopened.json()["previous_verdict"] == "keep_separate"
+        assert reopened.json()["group_returned_to_queue"] is True
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+        # No picture changed in either direction.
+        stacked = _run(
+            server,
+            lambda session: [session.get(Picture, pid).stack_id for pid in ids],
+        )
+        assert stacked == [None, None, None]
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_an_unknown_signature_is_a_400_not_a_500():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        for url in (STACK_URL, KEEP_SEPARATE_URL, REOPEN_URL):
+            response = client.post(url, json={"signature": "0" * 64})
+            assert response.status_code == 400, (url, response.text)
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── bulk auto-stack ───────────────────────────────────────────────────────────
+
+
+def test_auto_stack_defaults_to_a_dry_run():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        response = client.post(AUTO_STACK_URL, json={})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["dry_run"] is True
+        assert body["groups"] == 1
+        assert body["pictures"] == 2
+        assert body["results"] == []
+        stacked = _run(
+            server,
+            lambda session: [session.get(Picture, pid).stack_id for pid in ids],
+        )
+        assert stacked == [None, None, None]
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_auto_stack_applies_under_one_batch_id():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        response = client.post(AUTO_STACK_URL, json={"dry_run": False})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["dry_run"] is False
+        assert body["groups"] == 1
+        assert body["batch_id"]
+        assert body["failures"] == []
+        assert {item["batch_id"] for item in body["results"]} == {body["batch_id"]}
+        stacked = _run(
+            server,
+            lambda session: [session.get(Picture, pid).stack_id for pid in ids],
+        )
+        assert stacked[0] is not None and stacked[0] == stacked[1]
+        assert stacked[2] is None
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+    finally:
+        _teardown(temp_dir, server)

--- a/tests/test_dedup_tiers_api.py
+++ b/tests/test_dedup_tiers_api.py
@@ -29,7 +29,7 @@ from sqlmodel import select
 
 from pixlstash.database import DBPriority
 from pixlstash.db_models import Picture, PictureSet, PictureSetMember
-from pixlstash.db_models.dedup import DedupScan
+from pixlstash.db_models.dedup import DedupScan, DedupVerdict
 from pixlstash.db_models.tag import Tag
 from pixlstash.server import Server
 from pixlstash.services import dedup_tier_service as tiers
@@ -670,5 +670,340 @@ def test_a_partially_blocked_auto_stack_returns_its_batch_id():
             _run(server, lambda session: session.get(Picture, locked_ids[0]).stack_id)
             is None
         )
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── undo reopens the verdict, not only the pictures ───────────────────────────
+
+
+def _add_exact_groups(server, count, members=2, sha_prefix="extra"):
+    """Insert *count* more exact groups of *members* byte-identical pictures."""
+
+    def insert(session):
+        created = []
+        for index in range(count):
+            group = []
+            for member in range(members):
+                pic = Picture(
+                    file_path=f"/vault/{sha_prefix}_{index}_{member}.png",
+                    format="png",
+                    width=100,
+                    height=100,
+                    size_bytes=500 + index,
+                    pixel_sha=f"{sha_prefix}-{index}",
+                )
+                session.add(pic)
+                session.flush()
+                group.append(int(pic.id))
+            created.append(group)
+        session.commit()
+        return created
+
+    return _run(server, insert)
+
+
+def _rescan(server):
+    _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+
+
+def _signatures(client) -> set:
+    return {group["signature"] for group in client.get(GROUPS_URL).json()["groups"]}
+
+
+def _verdict_row(server, signature):
+    return _run(
+        server,
+        lambda session: session.exec(
+            select(DedupVerdict).where(DedupVerdict.signature == signature)
+        ).first(),
+    )
+
+
+def test_undo_returns_the_stacked_group_to_the_queue():
+    """QA blocker 1, single verdict.
+
+    Undo restored every picture facet but left the ``DedupVerdict`` decided and
+    the ``DedupGroup`` resolved, so the group never came back to the queue, was
+    not counted, and survived a rescan (the signature still carried a live
+    verdict). The only way back was a ``POST /dedup/verdicts/reopen`` no user
+    could discover. The post-restore hook now reopens both rows inside the undo's
+    own transaction.
+    """
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+
+        stacked = client.post(STACK_URL, json={"signature": signature})
+        assert stacked.status_code == 200, stacked.text
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        assert _signatures(client) == set()
+
+        undone = client.post(f"{API}/operations/undo", json={})
+        assert undone.status_code == 200, undone.text
+
+        # The pictures are unstacked ...
+        assert _run(
+            server, lambda session: [session.get(Picture, pid).stack_id for pid in ids]
+        ) == [None, None, None]
+        # ... and so is the decision.
+        assert _signatures(client) == {signature}
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+        verdict = _verdict_row(server, signature)
+        assert verdict is not None, "the verdict row is kept, only reopened"
+        assert verdict.reopened_at is not None
+
+        # A rescan does not re-decide it either: it is genuinely back in the queue.
+        _rescan(server)
+        assert _signatures(client) == {signature}
+
+        redone = client.post(f"{API}/operations/redo", json={})
+        assert redone.status_code == 200, redone.text
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        assert _signatures(client) == set()
+        assert _verdict_row(server, signature).reopened_at is None
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_batch_undo_after_auto_stack_returns_every_group():
+    """QA blocker 1, QA's exact repro: bulk auto-stack then batch undo.
+
+    Every duplicate vanished from the queue permanently - one undo click, and the
+    whole vault's worth of duplicate decisions was unrecoverable without
+    hand-reopening each signature.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        _add_exact_groups(server, count=3)
+        _rescan(server)
+        before = _signatures(client)
+        assert len(before) == 4
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 4
+
+        applied = client.post(AUTO_STACK_URL, json={"dry_run": False})
+        assert applied.status_code == 200, applied.text
+        batch_id = applied.json()["batch_id"]
+        assert applied.json()["groups"] == 4
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+
+        undone = client.post(f"{API}/operations/batches/{batch_id}/undo", json={})
+        assert undone.status_code == 200, undone.text
+
+        assert _signatures(client) == before
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 4
+        # And the whole batch is redoable, back to nothing outstanding.
+        assert client.post(f"{API}/operations/redo", json={}).status_code == 200
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_an_undo_does_not_reopen_a_group_it_never_touched():
+    """The hook is scoped to the undone batch, not to every decided group."""
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        _add_exact_groups(server, count=1)
+        _rescan(server)
+        signatures = sorted(_signatures(client))
+        assert len(signatures) == 2
+        kept_separate, stacked = signatures
+
+        keep = client.post(KEEP_SEPARATE_URL, json={"signature": kept_separate})
+        assert keep.status_code == 200, keep.text
+        response = client.post(STACK_URL, json={"signature": stacked})
+        assert response.status_code == 200, response.text
+        assert _signatures(client) == set()
+
+        assert client.post(f"{API}/operations/undo", json={}).status_code == 200
+
+        # Only the stacked group came back; the keep-separate decision stands,
+        # and a rescan does not re-ask it.
+        assert _signatures(client) == {stacked}
+        _rescan(server)
+        assert _signatures(client) == {stacked}
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── keyset paging ─────────────────────────────────────────────────────────────
+
+
+def test_a_verdict_between_pages_makes_offset_skip_and_the_cursor_not():
+    """QA 3: a decided page-1 row shifts every later row's offset by one.
+
+    Both halves are asserted: offset paging demonstrably loses a group (so the
+    test cannot pass vacuously), and the cursor delivers it.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        _add_exact_groups(server, count=3)
+        _rescan(server)
+        everything = _signatures(client)
+        assert len(everything) == 4
+
+        # Offset paging: read page 1, decide it, read page 2 at offset=2.
+        page_one = client.get(GROUPS_URL, params={"limit": 2}).json()
+        delivered = [group["signature"] for group in page_one["groups"]]
+        assert len(delivered) == 2
+        decided = client.post(STACK_URL, json={"signature": delivered[0]})
+        assert decided.status_code == 200, decided.text
+        offset_page = client.get(GROUPS_URL, params={"limit": 2, "offset": 2}).json()
+        seen_by_offset = set(delivered) | {
+            group["signature"] for group in offset_page["groups"]
+        }
+        skipped = everything - seen_by_offset
+        assert skipped, "offset paging is expected to skip after a verdict"
+
+        # Same situation, cursor paging: nothing is skipped.
+        assert page_one["next_cursor"], page_one
+        cursor_page = client.get(
+            GROUPS_URL, params={"limit": 2, "cursor": page_one["next_cursor"]}
+        ).json()
+        seen_by_cursor = set(delivered) | {
+            group["signature"] for group in cursor_page["groups"]
+        }
+        assert skipped <= seen_by_cursor
+        assert seen_by_cursor == everything
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_the_cursor_walks_every_group_when_confidences_tie():
+    """Exact groups all sit at the same confidence, so the tie-break is the id.
+
+    ``confidence < c`` alone would drop the rest of the tied run; ``<=`` would
+    repeat it forever. Walking one row at a time exercises the boundary on every
+    step.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        _add_exact_groups(server, count=4)
+        _rescan(server)
+        everything = _signatures(client)
+        assert len(everything) == 5
+        confidences = {
+            group["confidence"] for group in client.get(GROUPS_URL).json()["groups"]
+        }
+        assert len(confidences) == 1, "the tie-break is what is under test"
+
+        walked = []
+        cursor = None
+        for _ in range(len(everything) + 2):
+            params = {"limit": 1}
+            if cursor:
+                params["cursor"] = cursor
+            body = client.get(GROUPS_URL, params=params).json()
+            walked.extend(group["signature"] for group in body["groups"])
+            cursor = body["next_cursor"]
+            if not cursor:
+                break
+        assert cursor is None, "paging must terminate"
+        assert len(walked) == len(set(walked)), "no group is delivered twice"
+        assert set(walked) == everything
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_cursor_and_offset_together_are_rejected():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        cursor = client.get(GROUPS_URL, params={"limit": 1}).json()["next_cursor"]
+        response = client.get(GROUPS_URL, params={"cursor": cursor or "x", "offset": 0})
+        assert response.status_code == 400, response.text
+        assert "mutually exclusive" in response.text
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_malformed_cursor_is_a_400_not_a_silent_restart():
+    """Silently paging from the top would hand the client page 1 forever."""
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        for bad in ("not-base64!!", "AAAA", "MXwxLjB8"):
+            response = client.get(GROUPS_URL, params={"cursor": bad})
+            assert response.status_code == 400, (bad, response.text)
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── batch id namespacing and folder scope normalisation ───────────────────────
+
+
+def test_a_server_shaped_batch_id_from_a_client_is_rejected():
+    """CSO M1: a verbatim body batch_id let a client impersonate a server batch."""
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        for bad in ("srv-deadbeef", "batch-42", "cli-ab", "cli-" + "a" * 200, ""):
+            response = client.post(
+                STACK_URL, json={"signature": signature, "batch_id": bad}
+            )
+            assert response.status_code == 400, (bad, response.text)
+            assert (
+                client.post(
+                    KEEP_SEPARATE_URL, json={"signature": signature, "batch_id": bad}
+                ).status_code
+                == 400
+            ), bad
+            assert (
+                client.post(
+                    AUTO_STACK_URL, json={"dry_run": False, "batch_id": bad}
+                ).status_code
+                == 400
+            ), bad
+        # Nothing was decided by any of the rejected calls.
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+
+        # A client-namespaced id is accepted and used verbatim.
+        response = client.post(
+            STACK_URL, json={"signature": signature, "batch_id": "cli-gesture-01"}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["batch_id"] == "cli-gesture-01"
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_server_minted_batch_id_is_namespaced():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        response = client.post(STACK_URL, json={"signature": signature})
+        assert response.status_code == 200, response.text
+        assert response.json()["batch_id"].startswith("srv-")
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_folder_scope_that_normalises_to_nothing_is_rejected():
+    """CSO W2: "/" rstripped to "" and became a LIKE of "%" - silently global."""
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        for bad in ("/", "\\", "///", "\\\\", "/\\/"):
+            body = {"scope_type": "folder", "scope_id": bad}
+            assert (
+                client.get(
+                    GROUPS_URL, params={"scope_type": "folder", "scope_id": bad}
+                ).status_code
+                == 400
+            ), bad
+            assert client.post(COUNTS_URL, json={"scopes": [body]}).status_code == 400
+            assert client.post(SCAN_URL, json={"scope": body}).status_code == 400
+            assert client.post(AUTO_STACK_URL, json={"scope": body}).status_code == 400
+        # No poison scan row was persisted by the rejected requests.
+        assert _run(server, lambda session: session.exec(select(DedupScan)).all()) == []
+
+        # A real folder still works, with or without a trailing separator, and
+        # both spellings are the same scope.
+        for spelling in ("/vault", "/vault/"):
+            counts = client.post(
+                COUNTS_URL,
+                json={"scopes": [{"scope_type": "folder", "scope_id": spelling}]},
+            )
+            assert counts.status_code == 200, counts.text
+            assert counts.json()["scopes"][0]["unresolved_groups"] == 1
+            assert counts.json()["scopes"][0]["key"] == "folder:/vault"
     finally:
         _teardown(temp_dir, server)

--- a/tests/test_dedup_tiers_api.py
+++ b/tests/test_dedup_tiers_api.py
@@ -28,11 +28,14 @@ from fastapi.testclient import TestClient
 from sqlmodel import select
 
 from pixlstash.database import DBPriority
-from pixlstash.db_models import Picture, PictureSetMember
+from pixlstash.db_models import Picture, PictureSet, PictureSetMember
+from pixlstash.db_models.dedup import DedupScan
 from pixlstash.db_models.tag import Tag
 from pixlstash.server import Server
 from pixlstash.services import dedup_tier_service as tiers
 from pixlstash.services.dedup_tier_service import TierPolicy
+from pixlstash.routes.dedup import MAX_COUNT_SCOPES
+from pixlstash.utils.image_processing.image_utils import ImageUtils
 from tests.authz_guard import no_spa_fallback  # noqa: F401
 
 API = "/api/v1"
@@ -501,5 +504,171 @@ def test_auto_stack_applies_under_one_batch_id():
         assert stacked[0] is not None and stacked[0] == stacked[1]
         assert stacked[2] is None
         assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── resource hardening ────────────────────────────────────────────────────────
+
+
+def test_a_non_numeric_scope_id_is_a_400_on_every_route():
+    """Regression for the CSO's D4.
+
+    ``picture_predicate()`` calls ``int(scope_id)`` for project / set / character.
+    Leaving that unvalidated turned a bad request into an unhandled 500 on three
+    read routes, and `POST /dedup/scan` returned 200 while **persisting** the
+    unparseable scope — a self-inflicted poison row that made every later
+    `GET /dedup/groups` for that scope 500 too. Validation now happens at the
+    boundary, before any write.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        for scope_type in ("project", "set", "character"):
+            params = {"scope_type": scope_type, "scope_id": "not-an-int"}
+            body = {"scope_type": scope_type, "scope_id": "not-an-int"}
+            assert client.get(GROUPS_URL, params=params).status_code == 400
+            assert client.post(COUNTS_URL, json={"scopes": [body]}).status_code == 400
+            assert client.post(SCAN_URL, json={"scope": body}).status_code == 400
+            assert client.post(AUTO_STACK_URL, json={"scope": body}).status_code == 400
+        # And nothing was persisted by the rejected scan requests.
+        scans = _run(server, lambda session: session.exec(select(DedupScan)).all())
+        assert scans == []
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_folder_scope_does_not_treat_wildcards_as_wildcards():
+    """A "Find duplicates in this folder" entry must not silently mean everywhere.
+
+    The folder predicate is a LIKE prefix match; unescaped, a scope_id of "%"
+    matches every path in the vault.
+    """
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        # The seeded duplicate pair lives under /vault/, so a literal "%" would
+        # match it if the metacharacter were not escaped.
+        wild = client.post(
+            COUNTS_URL, json={"scopes": [{"scope_type": "folder", "scope_id": "%"}]}
+        )
+        assert wild.status_code == 200, wild.text
+        assert wild.json()["scopes"][0]["unresolved_groups"] == 0
+
+        # The real folder still matches.
+        real = client.post(
+            COUNTS_URL,
+            json={"scopes": [{"scope_type": "folder", "scope_id": "/vault"}]},
+        )
+        assert real.json()["scopes"][0]["unresolved_groups"] == 1
+        assert len(ids) == 3
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_the_counts_scope_list_is_capped():
+    """One request must not become thousands of correlated COUNT subqueries."""
+    temp_dir, client, server, _ids, _token, set_id = _env()
+    try:
+        scopes = [{"scope_type": "set", "scope_id": str(set_id)}] * (
+            MAX_COUNT_SCOPES + 1
+        )
+        assert client.post(COUNTS_URL, json={"scopes": scopes}).status_code == 422
+        ok = client.post(COUNTS_URL, json={"scopes": scopes[:MAX_COUNT_SCOPES]})
+        assert ok.status_code == 200, ok.text
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── frontend contract additions ───────────────────────────────────────────────
+
+
+def test_every_candidate_carries_a_thumbnail_cache_token():
+    """The queue must be able to bust a stale thumbnail like the grid does."""
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        candidates = client.get(GROUPS_URL).json()["groups"][0]["candidates"]
+        # Unprocessed pictures report the "0" sentinel rather than omitting it.
+        assert all(c["thumbnail_version"] == "0" for c in candidates)
+
+        def set_thumbnail(session):
+            pic = session.get(Picture, ids[0])
+            pic.thumbnail_width = 320
+            pic.thumbnail_height = 240
+            session.add(pic)
+            session.commit()
+
+        _run(server, set_thumbnail)
+        candidates = client.get(GROUPS_URL).json()["groups"][0]["candidates"]
+        token = next(
+            c["thumbnail_version"] for c in candidates if c["picture_id"] == ids[0]
+        )
+        # Exactly the token the batch-thumbnail endpoint puts in its ?v=.
+        assert token == ImageUtils.thumbnail_cache_token(320, 240) == "320x240"
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_the_auto_stack_dry_run_carries_the_consent_aggregates():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        body = client.post(AUTO_STACK_URL, json={}).json()
+        summary = body["dry_run_summary"]
+        assert summary["groups"] == body["groups"] == 1
+        assert summary["pictures"] == body["pictures"] == 2
+        assert summary["groups_by_tier"] == {"exact": 1, "near": 0, "embedding": 0}
+        # The seeded cover carries the only tag and the only score, so it gains
+        # nothing from the union.
+        assert summary["covers_gaining_metadata"] == 0
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_partially_blocked_auto_stack_returns_its_batch_id():
+    """R2 at the HTTP boundary: a 423 mid-run must not swallow the undo handle."""
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+
+        def add_second_group_and_lock_it(session):
+            created = []
+            for _ in range(2):
+                pic = Picture(
+                    file_path=f"/vault/locked_{len(created)}.png",
+                    format="png",
+                    width=10,
+                    height=10,
+                    size_bytes=42,
+                    pixel_sha="locked",
+                )
+                session.add(pic)
+                session.flush()
+                created.append(int(pic.id))
+            picture_set = PictureSet(name="Frozen", locked=True)
+            session.add(picture_set)
+            session.commit()
+            session.refresh(picture_set)
+            session.add(
+                PictureSetMember(set_id=int(picture_set.id), picture_id=created[0])
+            )
+            session.commit()
+            return created
+
+        locked_ids = _run(server, add_second_group_and_lock_it)
+        _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+
+        response = client.post(AUTO_STACK_URL, json={"dry_run": False})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["batch_id"]
+        assert body["groups"] == 1
+        assert body["blocked"] == 1
+        assert body["failures"][0]["status_code"] == 423
+        # The unlocked group was applied, the locked one was not.
+        assert (
+            _run(server, lambda session: session.get(Picture, ids[0]).stack_id)
+            is not None
+        )
+        assert (
+            _run(server, lambda session: session.get(Picture, locked_ids[0]).stack_id)
+            is None
+        )
     finally:
         _teardown(temp_dir, server)

--- a/tests/test_dedup_verdict_service.py
+++ b/tests/test_dedup_verdict_service.py
@@ -8,6 +8,10 @@ Covers:
 * **reopen** — the group comes back and the decision history is kept;
 * **bulk auto-stack** — exact tier only, one batch id across the whole run, and
   the dry run writes nothing;
+* **the operation log (§21)** — one verdict is exactly one row (no double-record
+  through `routes/stacks.py`), undo reverses the stacking *and* the metadata
+  union, the snapshot covers stack siblings the group never named, and a whole
+  bulk run reverses with a single batch undo;
 * **the non-destructive invariant** — no verdict deletes a picture, ever;
 * **locked sets** — the metadata union is refused rather than half-applied.
 """
@@ -21,16 +25,23 @@ import pytest
 from sqlmodel import select
 
 from pixlstash.database import DBPriority
-from pixlstash.db_models import Picture, PictureSet, PictureSetMember
+from pixlstash.db_models import (
+    Picture,
+    PictureSet,
+    PictureSetMember,
+    PictureStack,
+)
 from pixlstash.db_models.dedup import (
     VERDICT_KEEP_SEPARATE,
     VERDICT_STACKED,
     DedupVerdict,
 )
+from pixlstash.db_models.operation import Operation
 from pixlstash.db_models.tag import Tag
 from pixlstash.server import Server
 from pixlstash.services import dedup_tier_service as tiers
 from pixlstash.services import dedup_verdict_service as verdicts
+from pixlstash.services import operation_log_service
 from pixlstash.services.dedup_tier_service import TierPolicy
 from pixlstash.services.dedup_verdict_service import DedupVerdictError
 
@@ -552,3 +563,567 @@ def test_no_verdict_ever_deletes_a_picture(server):
     )
     assert sorted(live) == sorted(ids)
     assert all(_picture(server, pid).deleted is False for pid in ids)
+
+
+# ── operation log integration (§21) ───────────────────────────────────────────
+
+
+def _operations(server) -> list:
+    return _run(
+        server,
+        lambda session: list(
+            session.exec(select(Operation).order_by(Operation.id)).all()
+        ),
+    )
+
+
+def test_a_stack_verdict_records_exactly_one_operation(server):
+    """One verdict, one row. The verdict path must not double-record.
+
+    ``routes/stacks.py`` wraps itself in ``run_recorded_metadata_task``; this
+    module deliberately stacks in-session instead and records once around the
+    whole verdict, so a second row here would mean two Ctrl+Z presses to undo
+    one decision.
+    """
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    batch_id = verdicts.new_batch_id()
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        batch_id,
+    )
+    rows = _operations(server)
+    assert len(rows) == 1
+    assert rows[0].op_type == verdicts.OP_TYPE_STACK
+    assert rows[0].batch_id == batch_id
+    assert rows[0].undoable is True
+    assert "Stacked 2 duplicates" in (rows[0].summary or "")
+
+
+def test_undoing_a_stack_verdict_reverses_the_stacking(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    assert _picture(server, ids[0]).stack_id is not None
+
+    _run(server, operation_log_service.undo_in_session, None)
+    # The recorded `stack` facet is written back, so both pictures leave the
+    # stack neither of them was in before the verdict.
+    assert _picture(server, ids[0]).stack_id is None
+    assert _picture(server, ids[1]).stack_id is None
+    rows = _operations(server)
+    assert len(rows) == 1 and rows[0].status == "undone"
+
+
+def test_undoing_a_stack_verdict_reverses_the_metadata_union(server):
+    """The union happens inside the snapshot, so undo restores tags and scores."""
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5, "tags": ["portrait"]},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    assert _tags(server, ids[1]) == {"portrait"}
+    assert _picture(server, ids[1]).score == 5
+
+    _run(server, operation_log_service.undo_in_session, None)
+    assert _tags(server, ids[1]) == set()
+    assert _picture(server, ids[1]).score is None
+    # The picture that already carried them keeps them.
+    assert _tags(server, ids[0]) == {"portrait"}
+    assert _picture(server, ids[0]).score == 5
+
+
+def test_the_snapshot_covers_stack_siblings_the_group_never_named(server):
+    """Folding a second stack in must be fully reversible (§21 ``expand_stacks``).
+
+    The duplicate pair is 0 and 1. Picture 0 sits in stack A with sibling 2;
+    picture 1 sits in stack B with sibling 3. The verdict's cover is 0, so stack
+    B is **folded into A** and sibling 3 — which the group never named — is
+    reparented. An undo that snapshotted only the group's own members would
+    leave 3 stranded in A with B gone.
+
+    Verified non-vacuous: with the snapshot narrowed back to ``included``, this
+    test fails on the sibling assertion.
+    """
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "yyy", "size_bytes": 800},
+            {"pixel_sha": "zzz", "size_bytes": 900},
+        ],
+    )
+
+    def pre_stack(session):
+        created = []
+        for name, members in (("A", [ids[0], ids[2]]), ("B", [ids[1], ids[3]])):
+            stack = PictureStack(name=name)
+            session.add(stack)
+            session.commit()
+            session.refresh(stack)
+            for position, picture_id in enumerate(members):
+                pic = session.get(Picture, picture_id)
+                pic.stack_id = int(stack.id)
+                pic.stack_position = position
+                session.add(pic)
+            created.append(int(stack.id))
+        session.commit()
+        return created
+
+    stack_a, stack_b = _run(server, pre_stack)
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        ids[0],
+        [],
+        None,
+    )
+    # Stack B was folded into A: all four pictures, sibling 3 included, now
+    # share one stack, and B is gone.
+    assert {_picture(server, pid).stack_id for pid in ids} == {stack_a}
+    assert _run(server, lambda session: session.get(PictureStack, stack_b)) is None
+
+    _run(server, operation_log_service.undo_in_session, None)
+    assert _picture(server, ids[0]).stack_id == stack_a
+    assert _picture(server, ids[2]).stack_id == stack_a
+    # The sibling the group never named is returned to its own stack, which the
+    # recorded `stack` facet recreates by name.
+    assert _picture(server, ids[1]).stack_id == _picture(server, ids[3]).stack_id
+    assert _picture(server, ids[1]).stack_id != stack_a
+    assert _picture(server, ids[1]).stack_id is not None
+
+
+def test_bulk_auto_stack_reverses_with_one_batch_undo(server):
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    batch_id = report["batch_id"]
+    assert report["groups"] == 2
+    rows = _operations(server)
+    # Two groups, two rows, ONE batch id.
+    assert len(rows) == 2
+    assert {row.batch_id for row in rows} == {batch_id}
+    assert all(_picture(server, pid).stack_id is not None for pid in ids)
+
+    _run(server, operation_log_service.undo_batch_in_session, batch_id)
+    # A single call reversed every stack in the run.
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert {row.status for row in _operations(server)} == {"undone"}
+
+
+def test_undoing_any_member_of_the_batch_reverts_the_whole_run(server):
+    """Batch semantics: a partially-undone bulk action cannot exist."""
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    first_id = _operations(server)[0].id
+
+    _run(server, operation_log_service.undo_in_session, first_id)
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert {row.status for row in _operations(server)} == {"undone"}
+
+
+def test_keep_separate_and_reopen_record_no_operation(server):
+    """Neither changes a reversible picture facet, so neither writes a row.
+
+    A no-op operation row would still consume a Ctrl+Z, which is worse than
+    offering no undo here: the way back from keep-separate is the explicit
+    reopen action the Stacks view shows.
+    """
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    _run(server, verdicts.apply_keep_separate_in_session, signature, None)
+    assert _operations(server) == []
+    _run(server, verdicts.reopen_verdict_in_session, signature)
+    assert _operations(server) == []
+
+
+# ── R2: the bulk path must never lose its undo handle ─────────────────────────
+
+
+def _lock_picture_in_a_set(server, picture_id: int, name: str = "Frozen") -> None:
+    def add_locked_set(session):
+        picture_set = PictureSet(name=name, locked=True)
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        session.add(PictureSetMember(set_id=int(picture_set.id), picture_id=picture_id))
+        session.commit()
+
+    _run(server, add_locked_set)
+
+
+def _seed_three_exact_groups(server):
+    return _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+            {"pixel_sha": "ccc", "size_bytes": 300},
+            {"pixel_sha": "ccc", "size_bytes": 300},
+        ],
+    )
+
+
+def test_a_locked_group_mid_run_does_not_abort_the_bulk_run(server):
+    """Regression for the CSO's B2.
+
+    The locked-set guards raise ``HTTPException(423)``, not
+    ``DedupVerdictError``. Catching only the latter meant a locked group in the
+    middle of a bulk run propagated out **after** earlier groups had already
+    committed — a partially applied bulk mutation whose server-minted batch id
+    the caller never received, i.e. work that happened with no undo handle in the
+    response. The run must instead skip the group, report it, and still return
+    the batch id.
+    """
+    ids = _seed_three_exact_groups(server)
+    _lock_picture_in_a_set(server, ids[2])  # a member of the middle group
+    _scan(server)
+
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+
+    # The run completed rather than raising.
+    assert report["batch_id"]
+    assert report["dry_run"] is False
+    assert report["groups"] == 2
+    assert report["blocked"] == 1
+    assert report["failed"] == 0
+
+    # Every group is accounted for under exactly one outcome.
+    assert {r["outcome"] for r in report["results"]} == {verdicts.BULK_REASON_APPLIED}
+    assert len(report["failures"]) == 1
+    failure = report["failures"][0]
+    assert failure["outcome"] == verdicts.BULK_REASON_BLOCKED
+    assert failure["status_code"] == 423
+    assert failure["error"]["code"] == "set_locked"
+
+    # The locked group is untouched; the other two are stacked.
+    assert _picture(server, ids[2]).stack_id is None
+    assert _picture(server, ids[3]).stack_id is None
+    assert _picture(server, ids[0]).stack_id is not None
+    assert _picture(server, ids[4]).stack_id is not None
+    # ...and the locked group is still in the queue, awaiting its own decision.
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+
+def test_the_returned_batch_id_reverses_exactly_the_applied_groups(server):
+    """The undo handle from a partial run must work, and must not over-reach."""
+    ids = _seed_three_exact_groups(server)
+    _lock_picture_in_a_set(server, ids[2])
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    batch_id = report["batch_id"]
+
+    rows = _operations(server)
+    assert len(rows) == 2
+    assert {row.batch_id for row in rows} == {batch_id}
+
+    _run(server, operation_log_service.undo_batch_in_session, batch_id)
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert {row.status for row in _operations(server)} == {"undone"}
+
+
+def test_a_blocked_group_leaves_no_partial_write_of_its_own(server):
+    """The skipped iteration is rolled back, not carried into the next commit."""
+    ids = _seed_three_exact_groups(server)
+    _lock_picture_in_a_set(server, ids[2])
+    _scan(server)
+    _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+
+    # No stack row was left behind for the blocked group (_stack_members flushes
+    # a PictureStack before the lock guard runs), and no verdict was recorded.
+    stack_ids = {
+        _picture(server, pid).stack_id for pid in ids if _picture(server, pid).stack_id
+    }
+    assert len(stack_ids) == 2
+    stacks = _run(server, lambda session: session.exec(select(PictureStack)).all())
+    assert len(stacks) == 2
+    signatures = _run(
+        server,
+        lambda session: [
+            row.signature for row in session.exec(select(DedupVerdict)).all()
+        ],
+    )
+    assert len(signatures) == 2
+
+
+# ── R3: §21 origin discipline on the recording routes ─────────────────────────
+
+
+def test_a_stack_verdict_records_the_actor_and_origin(server):
+    """The service must carry through what the handler read from the request.
+
+    §21 is explicit that actor / source / origin_client_id come from the request,
+    in the handler, and are passed down — the contextvar is dead on the DB worker
+    thread. Before this, every dedup operation recorded `actor=None,
+    source="external"`, degrading the audit trail for the most far-reaching
+    mutation on the surface.
+    """
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+        "42",
+        "ui",
+        "tab-abc",
+    )
+    row = _operations(server)[0]
+    assert row.actor == "42"
+    assert row.source == "ui"
+    assert row.origin_client_id == "tab-abc"
+
+
+def test_bulk_auto_stack_attributes_every_row_in_the_batch(server):
+    _seed_two_exact_groups(server)
+    _scan(server)
+    _run(
+        server,
+        verdicts.bulk_auto_stack_in_session,
+        None,
+        None,
+        False,
+        None,
+        "42",
+        "ui",
+        "tab-abc",
+    )
+    rows = _operations(server)
+    assert len(rows) == 2
+    assert {row.actor for row in rows} == {"42"}
+    assert {row.source for row in rows} == {"ui"}
+    assert {row.origin_client_id for row in rows} == {"tab-abc"}
+
+
+# ── R7: the scrapheaped-sibling snapshot flag is load-bearing ─────────────────
+
+
+def test_undo_restores_a_scrapheaped_stack_siblings_position(server):
+    """Regression for the CSO's C1 — pins ``include_deleted=True``.
+
+    ``normalize_stack_positions`` renumbers **every** member of an affected
+    stack, soft-deleted ones included (§21.1). If the undo snapshot expanded the
+    stack without ``include_deleted=True``, the scrapheaped sibling's renumbered
+    position would be an unrecorded change that undo could not reverse — and the
+    whole suite stayed green without it.
+    """
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "zzz", "size_bytes": 900},
+        ],
+    )
+
+    def pre_stack(session):
+        stack = PictureStack(name="with-a-scrapheaped-member")
+        session.add(stack)
+        session.commit()
+        session.refresh(stack)
+        live = session.get(Picture, ids[1])
+        live.stack_id = int(stack.id)
+        live.stack_position = 0
+        session.add(live)
+        buried = session.get(Picture, ids[2])
+        buried.stack_id = int(stack.id)
+        buried.stack_position = 5
+        buried.deleted = True
+        session.add(buried)
+        session.commit()
+
+    _run(server, pre_stack)
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    # The verdict renumbered the scrapheaped sibling along with everyone else.
+    assert _picture(server, ids[2]).stack_position != 5
+
+    _run(server, operation_log_service.undo_in_session, None)
+    buried = _picture(server, ids[2])
+    assert buried.stack_position == 5
+    assert buried.deleted is True
+
+
+# ── addendum: the auto-stack dry-run consent aggregates ───────────────────────
+
+
+def test_the_dry_run_summary_counts_covers_that_gain_metadata(server):
+    """The design's consent dialog promises a "covers gaining metadata" row.
+
+    Derived from the planned verdicts in the dry run's own snapshot — the union
+    is never executed, and nothing is written.
+    """
+    ids = _seed(
+        server,
+        [
+            # Group 1: the cover (highest score) gains a tag from its twin.
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["portrait"]},
+            # Group 2: the cover already has everything, so it gains nothing.
+            {"pixel_sha": "bbb", "size_bytes": 200, "score": 5, "tags": ["sunset"]},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+        ],
+    )
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, True, None)
+    summary = report["dry_run_summary"]
+    assert summary["groups"] == 2
+    assert summary["groups_by_tier"] == {"exact": 2, "near": 0, "embedding": 0}
+    assert summary["pictures"] == 4
+    assert summary["covers_gaining_tags"] == 1
+    assert summary["covers_gaining_metadata"] == 1
+    # Aggregates agree with the top-level counts from the same snapshot.
+    assert summary["groups"] == report["groups"]
+    assert summary["pictures"] == report["pictures"]
+    # Still a dry run: nothing written, nothing tagged.
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert _tags(server, ids[0]) == set()
+
+
+def test_the_dry_run_summary_counts_a_score_lift(server):
+    _seed(
+        server,
+        [
+            # The cover is chosen on tags, but a twin outranks it on score, so
+            # the union would lift the cover's score.
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["a", "b", "c", "d"]},
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+        ],
+    )
+    _scan(server)
+    summary = _run(server, verdicts.bulk_auto_stack_in_session, None, None, True, None)[
+        "dry_run_summary"
+    ]
+    assert summary["covers_gaining_score"] == 1
+    assert summary["covers_gaining_metadata"] == 1
+
+
+def test_an_applied_run_carries_no_dry_run_summary(server):
+    _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    assert "dry_run_summary" not in report
+
+
+def test_a_locked_co_member_of_a_folded_stack_is_refused(server):
+    """The lock guard must run BEFORE the fold, and expand through it.
+
+    ``apply_metadata_union_in_session`` only checks the group's own members, so
+    the co-members that ``_stack_members`` drags in when it folds another stack
+    are covered solely by ``enforce_stack_membership_not_locked`` running first
+    and expanding through ``expand_picture_ids_to_stacks``. That ordering is
+    load-bearing: move the lock check after the fold and a locked picture gets
+    silently reparented. Pins the CSO's B6b probe.
+    """
+    from fastapi import HTTPException
+
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "zzz", "size_bytes": 900},
+        ],
+    )
+
+    def pre_stack_and_lock(session):
+        # Picture 2 (a group member) shares a stack with picture 3, which is NOT
+        # in the group and is the one frozen by the locked set.
+        stack = PictureStack(name="folds-in")
+        session.add(stack)
+        session.commit()
+        session.refresh(stack)
+        for position, picture_id in enumerate([ids[1], ids[2]]):
+            pic = session.get(Picture, picture_id)
+            pic.stack_id = int(stack.id)
+            pic.stack_position = position
+            session.add(pic)
+        picture_set = PictureSet(name="Frozen", locked=True)
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        session.add(PictureSetMember(set_id=int(picture_set.id), picture_id=ids[2]))
+        session.commit()
+        return int(stack.id)
+
+    original_stack = _run(server, pre_stack_and_lock)
+    _scan(server)
+    with pytest.raises(HTTPException) as excinfo:
+        _run(
+            server,
+            verdicts.apply_stack_verdict_in_session,
+            _one_signature(server),
+            ids[0],
+            [],
+            None,
+        )
+    assert excinfo.value.status_code == 423
+    # Nothing moved: the group member outside the stack is still unstacked and
+    # the folded stack is intact.
+    assert _picture(server, ids[0]).stack_id is None
+    assert _picture(server, ids[1]).stack_id == original_stack
+    assert _picture(server, ids[2]).stack_id == original_stack
+    assert _operations(server) == []

--- a/tests/test_dedup_verdict_service.py
+++ b/tests/test_dedup_verdict_service.py
@@ -1,0 +1,554 @@
+"""Unit tests for applying and remembering duplicate verdicts.
+
+Covers:
+
+* **stack** — members land in one stack led by the chosen cover, excluded members
+  are untouched, and the metadata union runs (tags, sets, score);
+* **keep separate** — no picture row changes, and the decision survives a rescan;
+* **reopen** — the group comes back and the decision history is kept;
+* **bulk auto-stack** — exact tier only, one batch id across the whole run, and
+  the dry run writes nothing;
+* **the non-destructive invariant** — no verdict deletes a picture, ever;
+* **locked sets** — the metadata union is refused rather than half-applied.
+"""
+
+import gc
+import json
+import os
+import tempfile
+
+import pytest
+from sqlmodel import select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models import Picture, PictureSet, PictureSetMember
+from pixlstash.db_models.dedup import (
+    VERDICT_KEEP_SEPARATE,
+    VERDICT_STACKED,
+    DedupVerdict,
+)
+from pixlstash.db_models.tag import Tag
+from pixlstash.server import Server
+from pixlstash.services import dedup_tier_service as tiers
+from pixlstash.services import dedup_verdict_service as verdicts
+from pixlstash.services.dedup_tier_service import TierPolicy
+from pixlstash.services.dedup_verdict_service import DedupVerdictError
+
+
+@pytest.fixture
+def server():
+    temp_dir = tempfile.TemporaryDirectory()
+    config_path = os.path.join(temp_dir.name, "server-config.json")
+    with open(config_path, "w") as fh:
+        fh.write(json.dumps({"port": 8000, "disable_background_workers": True}))
+    Server.DEFAULT_FORCE_CPU = True
+    srv = Server(config_path)
+    try:
+        yield srv
+    finally:
+        srv.vault.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
+def _run(server, fn, *args):
+    return server.vault.db.run_task(fn, *args, priority=DBPriority.IMMEDIATE)
+
+
+def _seed(server, specs):
+    def insert(session):
+        picture_ids = []
+        for index, spec in enumerate(specs):
+            pic = Picture(
+                file_path=spec.get("file_path", f"/vault/pic_{index}.png"),
+                format="png",
+                width=spec.get("width", 4000),
+                height=spec.get("height", 3000),
+                size_bytes=spec.get("size_bytes", 1000),
+                score=spec.get("score"),
+                pixel_sha=spec.get("pixel_sha"),
+            )
+            session.add(pic)
+            session.flush()
+            for tag in spec.get("tags", []):
+                session.add(Tag(picture_id=int(pic.id), tag=tag))
+            picture_ids.append(int(pic.id))
+        session.commit()
+        return picture_ids
+
+    return _run(server, insert)
+
+
+def _scan(server, policy=None):
+    return _run(server, tiers.run_scan_now_in_session, policy or TierPolicy(), None)
+
+
+def _one_signature(server) -> str:
+    page, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    assert page, "expected at least one unresolved group"
+    return page[0]["signature"]
+
+
+def _picture(server, picture_id: int) -> Picture:
+    return _run(server, lambda session: session.get(Picture, picture_id))
+
+
+def _tags(server, picture_id: int) -> set[str]:
+    return _run(
+        server,
+        lambda session: {
+            str(row)
+            for row in session.exec(
+                select(Tag.tag).where(Tag.picture_id == picture_id)
+            ).all()
+        },
+    )
+
+
+# ── stack ─────────────────────────────────────────────────────────────────────
+
+
+def test_stacking_puts_the_chosen_cover_at_position_zero(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 1},
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    # Override the preselection: the user picks the *lower*-scored picture.
+    result = _run(
+        server, verdicts.apply_stack_verdict_in_session, signature, ids[0], [], None
+    )
+    assert result.verdict == VERDICT_STACKED
+    assert result.cover_picture_id == ids[0]
+    cover = _picture(server, ids[0])
+    other = _picture(server, ids[1])
+    assert cover.stack_id == other.stack_id == result.stack_id
+    assert cover.stack_position == 0
+    assert other.stack_position == 1
+
+
+def test_stacking_defaults_to_the_server_preselection(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 1},
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+        ],
+    )
+    _scan(server)
+    result = _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    # The formula's score term makes the 5-star picture the cover.
+    assert result.cover_picture_id == ids[1]
+
+
+def test_excluded_members_stay_out_and_are_recorded(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    result = _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        signature,
+        None,
+        [ids[2]],
+        None,
+    )
+    assert result.excluded_picture_ids == [ids[2]]
+    assert _picture(server, ids[2]).stack_id is None
+    row = _run(
+        server,
+        lambda session: session.exec(
+            select(DedupVerdict).where(DedupVerdict.signature == signature)
+        ).first(),
+    )
+    assert json.loads(row.excluded_picture_ids) == [ids[2]]
+
+
+def test_excluding_down_to_one_member_is_rejected(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    with pytest.raises(DedupVerdictError, match="at least two"):
+        _run(
+            server,
+            verdicts.apply_stack_verdict_in_session,
+            _one_signature(server),
+            None,
+            [ids[1]],
+            None,
+        )
+
+
+def test_a_cover_outside_the_group_is_rejected(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "bbb", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    with pytest.raises(DedupVerdictError, match="not an included member"):
+        _run(
+            server,
+            verdicts.apply_stack_verdict_in_session,
+            _one_signature(server),
+            ids[2],
+            [],
+            None,
+        )
+
+
+def test_an_unknown_signature_is_rejected(server):
+    with pytest.raises(DedupVerdictError, match="No duplicate group"):
+        _run(server, verdicts.apply_stack_verdict_in_session, "0" * 64, None, [], None)
+
+
+# ── the metadata union ────────────────────────────────────────────────────────
+
+
+def test_stacking_unions_tags_onto_every_member(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["portrait", "outdoor"]},
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["sunset"]},
+        ],
+    )
+    _scan(server)
+    result = _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    assert result.metadata_union["tags_added"] == 3
+    expected = {"portrait", "outdoor", "sunset"}
+    assert _tags(server, ids[0]) == expected
+    assert _tags(server, ids[1]) == expected
+
+
+def test_the_tag_union_skips_pipeline_sentinels(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["portrait"]},
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["__tag:wd14"]},
+        ],
+    )
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    # The sentinel is a "needs retagging" marker, not user metadata: copying it
+    # would re-queue an already-tagged picture for no reason.
+    assert _tags(server, ids[0]) == {"portrait"}
+    assert _tags(server, ids[1]) == {"__tag:wd14", "portrait"}
+
+
+def test_stacking_lifts_every_member_to_the_highest_score(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 1},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    result = _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    assert result.metadata_union["scores_lifted"] == 2
+    assert [_picture(server, pid).score for pid in ids] == [5, 5, 5]
+
+
+def test_stacking_unions_set_membership(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+
+    def add_set(session):
+        picture_set = PictureSet(name="Celebrities")
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        session.add(PictureSetMember(set_id=int(picture_set.id), picture_id=ids[0]))
+        session.commit()
+        return int(picture_set.id)
+
+    set_id = _run(server, add_set)
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    members = _run(
+        server,
+        lambda session: {
+            int(row)
+            for row in session.exec(
+                select(PictureSetMember.picture_id).where(
+                    PictureSetMember.set_id == set_id
+                )
+            ).all()
+        },
+    )
+    # A union can never break an album: the set gained a member, lost none.
+    assert members == set(ids)
+
+
+def test_the_union_is_refused_on_a_locked_set_rather_than_half_applied(server):
+    from fastapi import HTTPException
+
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["portrait"]},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+
+    def add_locked_set(session):
+        picture_set = PictureSet(name="Frozen", locked=True)
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        session.add(PictureSetMember(set_id=int(picture_set.id), picture_id=ids[0]))
+        session.commit()
+
+    _run(server, add_locked_set)
+    _scan(server)
+    with pytest.raises(HTTPException) as excinfo:
+        _run(
+            server,
+            verdicts.apply_stack_verdict_in_session,
+            _one_signature(server),
+            None,
+            [],
+            None,
+        )
+    assert excinfo.value.status_code == 423
+    assert _tags(server, ids[1]) == set()
+
+
+# ── keep separate, and the memory ─────────────────────────────────────────────
+
+
+def test_keep_separate_changes_no_picture_row(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 3},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    result = _run(
+        server, verdicts.apply_keep_separate_in_session, _one_signature(server), None
+    )
+    assert result.verdict == VERDICT_KEEP_SEPARATE
+    assert result.stack_id is None
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert _picture(server, ids[1]).score is None
+
+
+def test_a_verdict_survives_a_rescan(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    _run(server, verdicts.apply_keep_separate_in_session, _one_signature(server), None)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+
+
+def test_reopening_returns_the_group_and_keeps_the_history(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    _run(server, verdicts.apply_keep_separate_in_session, signature, None)
+    reopened = _run(server, verdicts.reopen_verdict_in_session, signature)
+    assert reopened["previous_verdict"] == VERDICT_KEEP_SEPARATE
+    assert reopened["group_returned_to_queue"] is True
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+    # The row is kept and marked, not deleted: the decision history survives.
+    row = _run(
+        server,
+        lambda session: session.exec(
+            select(DedupVerdict).where(DedupVerdict.signature == signature)
+        ).first(),
+    )
+    assert row is not None and row.reopened_at is not None
+    with pytest.raises(DedupVerdictError, match="already reopened"):
+        _run(server, verdicts.reopen_verdict_in_session, signature)
+
+
+def test_reopening_a_stack_verdict_does_not_unstack_anything(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    _run(server, verdicts.apply_stack_verdict_in_session, signature, None, [], None)
+    _run(server, verdicts.reopen_verdict_in_session, signature)
+    assert _picture(server, ids[0]).stack_id is not None
+    assert _picture(server, ids[1]).stack_id is not None
+
+
+def test_reopening_an_unknown_signature_is_rejected(server):
+    with pytest.raises(DedupVerdictError, match="No verdict recorded"):
+        _run(server, verdicts.reopen_verdict_in_session, "0" * 64)
+
+
+# ── bulk auto-stack ───────────────────────────────────────────────────────────
+
+
+def _seed_two_exact_groups(server):
+    return _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+        ],
+    )
+
+
+def test_the_dry_run_counts_and_writes_nothing(server):
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, True, None)
+    assert report["dry_run"] is True
+    assert report["groups"] == 2
+    assert report["pictures"] == 4
+    assert report["results"] == []
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 2
+
+
+def test_auto_stack_shares_one_batch_id_across_every_group(server):
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    assert report["dry_run"] is False
+    assert report["groups"] == 2
+    batch_id = report["batch_id"]
+    assert batch_id
+    assert {item["batch_id"] for item in report["results"]} == {batch_id}
+    rows = _run(server, lambda session: session.exec(select(DedupVerdict)).all())
+    assert {row.batch_id for row in rows} == {batch_id}
+    # Two groups, two stacks, every picture stacked and none deleted.
+    stacks = {_picture(server, pid).stack_id for pid in ids}
+    assert len(stacks) == 2 and None not in stacks
+    assert all(_picture(server, pid).deleted is False for pid in ids)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+
+
+def test_auto_stack_never_touches_the_near_tier(server):
+    """Only tier 1 is bulk-eligible; a near group always goes through the queue."""
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+
+    def add_near_group(session):
+        pictures = session.exec(select(Picture)).all()
+        members = [
+            tiers.CandidateMember(id=int(pic.id), width=10, height=10)
+            for pic in pictures
+        ]
+        group = tiers.assemble_group(tiers.DedupTier.NEAR, 0.95, members)
+        # A distinct signature so it is a second, near-tier group.
+        group.signature = "n" * 64
+        tiers.persist_groups_in_session(session, [group])
+
+    _scan(server)
+    _run(server, add_near_group)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    assert report["groups"] == 1
+    near_policy = TierPolicy(near_enabled=True)
+    assert _run(server, tiers.count_unresolved_in_session, near_policy, None) == 1
+
+
+def test_auto_stack_respects_a_limit(server):
+    _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, 1)
+    assert report["groups"] == 1
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+
+def test_no_verdict_ever_deletes_a_picture(server):
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    live = _run(
+        server,
+        lambda session: [int(row) for row in session.exec(select(Picture.id)).all()],
+    )
+    assert sorted(live) == sorted(ids)
+    assert all(_picture(server, pid).deleted is False for pid in ids)

--- a/tests/test_dedup_verdict_service.py
+++ b/tests/test_dedup_verdict_service.py
@@ -95,7 +95,7 @@ def _scan(server, policy=None):
 
 
 def _one_signature(server) -> str:
-    page, _total = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    page, _total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
     assert page, "expected at least one unresolved group"
     return page[0]["signature"]
 

--- a/tests/test_operation_log.py
+++ b/tests/test_operation_log.py
@@ -24,6 +24,7 @@ import json
 import os
 import tempfile
 
+import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
 from sqlmodel import select
@@ -994,3 +995,124 @@ def test_operations_routes_have_no_inline_authz_check():
             f"{forbidden} is an inline authz check; the AuthzGate owns "
             "authorization for these routes (docs/backend_architecture.md §16.1)"
         )
+
+
+# ── post-restore hooks ────────────────────────────────────────────────────────
+
+
+def _register_recording_hook(op_type):
+    """Register a hook that records its calls, and return the call list.
+
+    The registry is module-global, so the hook is removed again by the caller's
+    ``finally`` to keep tests independent.
+    """
+    calls = []
+
+    def _hook(session, operations, direction):
+        calls.append((direction, sorted(int(op.id) for op in operations)))
+
+    operation_log_service.register_post_restore_hook(op_type, _hook)
+    return calls
+
+
+def test_a_post_restore_hook_runs_once_per_restore_with_its_whole_batch():
+    """The generic seam a feature uses to reopen what an operation also decided.
+
+    An operation can change state the recorded picture facets do not cover (the
+    v1.9 duplicate verdict is the first). Without a hook, undo restored the
+    pictures and left that decision standing. The contract asserted here is what
+    the feature relies on: called once per restore, with **every** operation of
+    its own op_type, with the direction, and never for a foreign op_type.
+    """
+    temp_dir, client, server = _setup()
+    try:
+        calls = _register_recording_hook("test.hooked")
+        other = _register_recording_hook("test.unhooked")
+        ids = [_upload(client) for _ in range(2)]
+        batch_id = operation_log_service.new_batch_id()
+
+        def _tag_one(session, picture_id, tag):
+            session.add(Tag(picture_id=picture_id, tag=tag))
+            session.commit()
+
+        for picture_id in ids:
+            operation_log_service.run_recorded_metadata_task(
+                server.vault,
+                _tag_one,
+                picture_id,
+                "hooked",
+                op_type="test.hooked",
+                picture_ids=[picture_id],
+                batch_id=batch_id,
+                summary="Hooked",
+            )
+        recorded = sorted(op["id"] for op in _operations(server, batch_id=batch_id))
+        assert len(recorded) == 2
+        assert calls == [], "recording must not fire a restore hook"
+
+        assert client.post(f"{API}/operations/undo").status_code == 200
+        assert calls == [("undo", recorded)], calls
+
+        assert client.post(f"{API}/operations/redo").status_code == 200
+        assert calls == [("undo", recorded), ("redo", recorded)], calls
+
+        # A hook registered for a different op_type never saw any of it.
+        assert other == []
+    finally:
+        operation_log_service._POST_RESTORE_HOOKS.pop("test.hooked", None)
+        operation_log_service._POST_RESTORE_HOOKS.pop("test.unhooked", None)
+        _teardown(temp_dir, server)
+
+
+def test_a_failing_post_restore_hook_aborts_the_whole_undo():
+    """The hook runs inside the restore's transaction, so it fails closed.
+
+    A hook that could fail *after* the state was committed would leave the
+    pictures restored and the feature's own state stale — exactly the split the
+    hook exists to prevent.
+    """
+    temp_dir, client, server = _setup()
+    try:
+
+        def _boom(session, operations, direction):
+            raise RuntimeError("hook refused")
+
+        operation_log_service.register_post_restore_hook("test.failing", _boom)
+        picture_id = _upload(client)
+
+        def _tag_one(session, pid, tag):
+            session.add(Tag(picture_id=pid, tag=tag))
+            session.commit()
+
+        operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            _tag_one,
+            picture_id,
+            "kept",
+            op_type="test.failing",
+            picture_ids=[picture_id],
+            summary="Failing",
+        )
+        assert _tags(server, picture_id) == ["kept"]
+
+        # The TestClient re-raises an unhandled server exception rather than
+        # turning it into a 500, so the refusal surfaces here.
+        with pytest.raises(RuntimeError, match="hook refused"):
+            client.post(f"{API}/operations/undo")
+        # Nothing was written: the tag is still there and the operation is still
+        # applied, so the user can retry rather than being left half-undone.
+        assert _tags(server, picture_id) == ["kept"]
+        assert [op["status"] for op in _operations(server, op_type="test.failing")] == [
+            "applied"
+        ]
+    finally:
+        operation_log_service._POST_RESTORE_HOOKS.pop("test.failing", None)
+        _teardown(temp_dir, server)
+
+
+def test_a_server_minted_batch_id_is_namespaced():
+    """M1: an un-namespaced id is indistinguishable from a client-supplied one."""
+    assert operation_log_service.new_batch_id().startswith(
+        operation_log_service.SERVER_BATCH_ID_PREFIX
+    )
+    assert operation_log_service.new_batch_id() != operation_log_service.new_batch_id()


### PR DESCRIPTION
Lane 1A of the Dedup → Stacks feature (design: `design/1.9-dedup/`, committed here). Implements the owner's design contract:

- **Tier 1 exact**: groups on existing indexed `(pixel_sha, size_bytes)` — documented honestly as a sampled digest with the consent-dialog mitigation; `MissingPixelShaFinder` backfills NULLs. **Tier 2**: bucketed dHash XOR/popcount (size-bin / capture-minute / import-batch / folder buckets, sharded at 4000, never dropped), streamed via the task system. **Tier 3**: existing likeness edges, weakest-link confidence.
- `TierPolicy` (exact locked on, opt-in descent, 0.90 default, 0.65 hard floor) + the design's cover formula with why-pills in both directions.
- Verdict memory (`dedupverdict` keyed on group signature) + group cache + scan rows; migration `0088` (chain 0086 → 0087 → 0088, verified linear).
- Verdicts apply the metadata union (tags, set/project membership, score lifted; characters only in the unambiguous single-character case — documented partial) and record ONE op-log operation per verdict; bulk auto-stack = one batch id = one Ctrl+Z, proven by tests. Keep-separate/reopen deliberately record nothing (no reversible facet changed; a no-op row would eat a Ctrl+Z).
- Undo snapshots the stack-expanded set — fixes a real stranded-sibling bug found during integration, pinned by a deliberately de-vacuized two-stack-fold test.

8 new routes, all `owner_only` with content-identity justifications; coverage matrix re-derived to 236 declared / 235 mounted. 190 targeted tests green; ruff clean; new test files registered in the CI gate.

**Merge gated on independent CSO sign-off** (author cannot certify own authz declarations) — running now.

https://claude.ai/code/session_017hrfK6Z1RtdoaXJSZHSc4U