### PR TITLE
Dedup → Stacks (v1.9): tiered detection backend, Duplicates queue frontend, authz sign-off (#156)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,9 @@ jobs:
           tests/test_comfyui_workflow_extraction.py
           tests/test_dedup_sweep_api.py
           tests/test_dedup_sweep_service.py
+          tests/test_dedup_tier_service.py
+          tests/test_dedup_tiers_api.py
+          tests/test_dedup_verdict_service.py
           tests/test_detections_scope.py
           tests/test_facial_features_worker.py
           tests/test_find_orphaned_files.py

--- a/design/1.9-dedup/CONTRACT.md
+++ b/design/1.9-dedup/CONTRACT.md
@@ -1,0 +1,107 @@
+# Dedup → Stacks — implementation contract (v1.9, routed 2026-07-29)
+
+Authority: the owner's "Deduplication → Stacks" card in the PixlStash Design
+System (`ui_kits/app/dedup-stacks.html` + `dedup-stacks.babel.js`; exact copies
+sit next to this file). This lifts the master plan's Loop 1 design gate. Where
+the design and previously shipped backend disagree, **the design wins**; the
+deltas are listed explicitly below. The design's own §7 "Rules" block is the
+handoff checklist — implement it verbatim unless a line below overrides it.
+
+## The feature in one paragraph
+
+Duplicate detection becomes a sidebar **Duplicates** destination with a live
+to-do count. Detection is tiered: exact matches from an indexed hash query
+(~ms, always on), near-dupes from perceptual hashes compared **only within
+candidate buckets** (same dimensions / capture minute / import batch / folder,
+streamed as buckets finish), and embedding similarity as an opt-in background
+tier reusing the existing likeness data. The queue shows group rows (one
+focused, keyboard-driven: Enter stack · S keep separate · C compare · 1–9 set
+cover · X exclude candidate · Ctrl+Z undo, auto-advance). The only verdicts
+are **stack** or **keep separate** — no deletion anywhere in 1.9. Exact
+matches go through a bulk auto-stack dialog (one batch op, one Ctrl+Z).
+Verdicts persist keyed on group signature so rescans never re-ask. The
+"Similarity to …" / Likeness-Groups sort order is removed from the sort menu,
+with a one-time notice pointing at the new sidebar entry.
+
+## Design-over-shipped-backend deltas (backend adapts)
+
+1. **Cover selection formula** replaces the shipped planner's keeper order
+   (score → smart score → recency): `megapixels×4 + tags×3 + userScore×2 +
+   RAW bonus`, ties break to **oldest capture time**. Always a visible
+   preselection the user can override (1–9); never silent. (The pixel term is
+   **megapixels**, not raw pixel count: at raw counts it would dwarf every
+   other term and the formula would be "biggest file wins" with decoration.)
+2. **Policy model** replaces `SweepPolicy`'s auto/review split semantics with
+   tier gating: Tier 1 exact is always included and cannot be switched off;
+   each looser tier is a separate opt-in with its own live count and enabling
+   one requires the tier above it; near-dupe threshold default **0.90**;
+   below **0.65 nothing is suggested at all** (hard floor). The shipped
+   dry-run/report API and non-destructive planner remain the foundation —
+   rework, don't discard.
+3. **Tier 1 (exact hash) and Tier 2 (bucketed perceptual hash) are new.**
+   The shipped planner covers only the embedding tier. Investigate what hash
+   columns exist (e.g. metadata/content hashes) and document which one Tier 1
+   uses; if a new column is needed it follows the conditional-migration rules
+   and backfills via the finder/task system, incrementally on import.
+4. **Verdict memory is a new table**: verdict keyed on a group signature
+   (sorted member content hashes). "Keep separate" is permanent until the
+   user reopens it from the Stacks view. Re-imports and rescans never re-ask.
+   This is what makes the sidebar count trustworthy.
+5. **Metadata union on stacking**: stacking unions tags, characters and set
+   membership onto the stack and takes the highest score. Nothing is
+   overwritten or lost. (Reconcile with existing stack semantics; if current
+   "Stack groups" behaviour differs, the design's union wins.)
+   **Characters carry one carve-out.** A face carries a bbox and an embedding
+   that belong to one specific picture, so a true face-to-character union
+   would mean fabricating `Face` rows. When the group's members between them
+   reference exactly **one** character, members that lack it get
+   `pending_character_id` (the shipped deferred-assignment path). A group
+   spanning **several** characters is left alone and logged — inventing
+   detection data is worse than not unioning. Tags, sets, projects and score
+   union unconditionally.
+
+## Performance rules (design §1, binding)
+
+- Never block on a full pass: the queue opens with whatever has been found,
+  with a "scanned N% of M" banner streaming.
+- Queue is virtual: one group in the DOM, prefetch next group's thumbnails
+  only; group list paged from the DB by confidence descending, never loaded
+  whole. 10 groups and 10,000 must perform identically. Paging is by
+  **keyset cursor**, not offset: the queue is a live list (a verdict removes
+  the row the user just decided, a tier-2 scan commits new groups after every
+  bucket), and an offset re-read skips exactly as many groups as changed
+  underneath it.
+- Scoped scans (project/set/character/folder context menu "Find duplicates
+  in…" with live count) reuse cached hashes and return instantly; queue opens
+  with a dismissible scope pill.
+
+## Undo integration (binding)
+
+Every verdict raises the standard action receipt and lands in the operation
+log (stacking is already a recorded facet). Bulk auto-stack coalesces into a
+single batch id, so N stacks reverse with one Ctrl+Z. The frontend consumes
+the shipped `useOperationStore` / `ActionReceipt` from the undo lane.
+
+## UI inventory (frontend lane)
+
+Sidebar Duplicates row (live count badge, spinner while scanning); scan
+banner; queue rows (focused row = accent bar + caret + tinted bg + filled
+Stack button + "keyboard acts here" label; thumbnails at grid scale carrying
+NO metadata; why-pills: olive check = matching evidence, red × = evidence
+against, e.g. "different resolution", "subject moved"); Compare view (= issue
+#156: every candidate field-by-field, best value highlighted per column, full
+paths, Stack / Keep separate in its footer); auto-stack dialog (dry-run counts,
+the single consent); stacks in the grid (count badge, edge ticks, expansion
+strip with cover marker, grid-view expand-stacks toggle); Filters popover
+gains a Stacks segment row (Any / Stacked / Unstacked / Unresolved
+duplicates) with the choice spelled out and live match count; context-menu
+scoped entry + scope pill; done-state; one-time sort-menu migration notice.
+File paths shown ONLY for reference-folder pictures. Confidence pill per
+group (`exact` styled distinctly). No em-dashes in shipped copy; design
+tokens only; the design's mock CSS maps onto repo tokens.
+
+## Explicitly out of scope for 1.9
+
+Deletion / dehydration (v1.11), auto-at-import policy setting (plan item 6 —
+only if trivially cheap once the finder exists), Immich-style per-group
+mandatory adjudication of exact matches.

--- a/design/1.9-dedup/README.md
+++ b/design/1.9-dedup/README.md
@@ -1,0 +1,11 @@
+Handoff bundle for the v1.9 Dedup → Stacks feature (master plan Loop 1 exit).
+Source of truth: the "Deduplication → Stacks" card in the claude.ai Design
+System project "PixlStash Design System" (ui_kits/app/dedup-stacks.html +
+dedup-stacks.babel.js), fetched 2026-07-29.
+
+- CONTRACT.md — distilled spec + the reconciliation deltas vs the shipped
+  sweep planner (read FIRST; it is the implementation authority ordering).
+- dedup-stacks.babel.js — the exact interaction/visual reference: group data
+  shapes, queue states, keyboard model, dialog, grid-stack treatments, §7
+  rules list. The card's HTML shell only carries mock CSS; the repo's design
+  tokens are the styling authority.

--- a/design/1.9-dedup/dedup-stacks.babel.js
+++ b/design/1.9-dedup/dedup-stacks.babel.js
@@ -1,0 +1,835 @@
+const DS = window.PixlStashDesignSystem_ac544c || {};
+const { Button, Kbd, SectionLabel, Badge, Tag, ScoreStars } = DS;
+const { useState, useEffect, useCallback, useMemo } = React;
+
+const KH = ({ keys }) => <span className="kbdhint">{keys.map((k, i) => <Kbd key={i}>{k}</Kbd>)}</span>;
+
+const GROUPS = [
+  { id:'g1', kind:'exact', conf:1, why:[['Identical file hash'],['Same dimensions'],['Imported 4 min apart']],
+    cands:[
+      { src:'scene-01', res:'6016×4016', px:24.2, size:14.8, date:'12 May 14:22', score:4, tags:2, fmt:'JPEG', path:'/shoots/may/DSC_4417.jpg' },
+      { src:'scene-01', res:'6016×4016', px:24.2, size:14.8, date:'12 May 14:22', score:0, tags:0, fmt:'JPEG', path:'/backup/2024/DSC_4417 (1).jpg', ref:true },
+    ] },
+  { id:'g2', kind:'near', conf:0.96, why:[['96% visual match'],['Same capture second'],['Different resolution', true],['One is a re-export', true]],
+    cands:[
+      { src:'tile-03', res:'4032×3024', px:12.2, size:8.4, date:'03 Jun 09:11', score:3, tags:4, fmt:'JPEG', path:'/shoots/jun/IMG_2201.jpg' },
+      { src:'tile-03', res:'1920×1440', px:2.8, size:1.1, date:'03 Jun 09:11', score:0, tags:0, fmt:'WEBP', path:'/export/web/IMG_2201.webp', ref:true },
+      { src:'tile-03', res:'2048×1536', px:3.1, size:1.6, date:'11 Jun 18:40', score:0, tags:1, fmt:'JPEG', path:'/tmp/upscale/IMG_2201_x2.jpg', ref:true },
+    ] },
+  { id:'g3', kind:'near', conf:0.81, why:[['81% visual match'],['Burst — 0.6s apart'],['Same folder'],['Subject moved between frames', true]],
+    cands:[
+      { src:'tile-08', res:'4032×3024', px:12.2, size:7.9, date:'21 Jun 16:04', score:5, tags:3, fmt:'JPEG', path:'/shoots/jun/burst_0071.jpg' },
+      { src:'tile-08', res:'4032×3024', px:12.2, size:8.1, date:'21 Jun 16:04', score:2, tags:0, fmt:'JPEG', path:'/shoots/jun/burst_0072.jpg' },
+      { src:'tile-08', res:'4032×3024', px:12.2, size:7.6, date:'21 Jun 16:04', score:0, tags:0, fmt:'JPEG', path:'/shoots/jun/burst_0073.jpg' },
+      { src:'tile-08', res:'4032×3024', px:12.2, size:8.3, date:'21 Jun 16:04', score:0, tags:0, fmt:'JPEG', path:'/shoots/jun/burst_0074.jpg' },
+    ] },
+  { id:'g4', kind:'near', conf:0.68, why:[['68% visual match'],['Same scene, different framing', true],['Different subject position', true]],
+    cands:[
+      { src:'scene-03', res:'5472×3648', px:20.0, size:11.2, date:'02 Jul 11:58', score:4, tags:5, fmt:'RAW', path:'/shoots/jul/A7R0912.arw' },
+      { src:'scene-04', res:'5472×3648', px:20.0, size:10.7, date:'02 Jul 11:59', score:3, tags:2, fmt:'RAW', path:'/shoots/jul/A7R0913.arw' },
+    ] },
+  { id:'g5', kind:'exact', conf:1, why:[['Identical file hash'],['Same folder twice']],
+    cands:[
+      { src:'tile-11', res:'3000×2000', px:6.0, size:4.2, date:'18 Apr 08:30', score:3, tags:2, fmt:'JPEG', path:'/shoots/apr/set_a/0031.jpg' },
+      { src:'tile-11', res:'3000×2000', px:6.0, size:4.2, date:'18 Apr 08:30', score:0, tags:0, fmt:'JPEG', path:'/shoots/apr/set_a copy/0031.jpg', ref:true },
+    ] },
+  { id:'g6', kind:'near', conf:0.93, why:[['93% visual match'],['Crop of the same frame'],['Different aspect ratio', true],['Different resolution', true]],
+    cands:[
+      { src:'tile-14', res:'6000×4000', px:24.0, size:13.4, date:'27 Apr 19:02', score:5, tags:6, fmt:'JPEG', path:'/shoots/apr/hero_full.jpg' },
+      { src:'tile-14', res:'2400×2400', px:5.8, size:3.1, date:'27 Apr 19:44', score:2, tags:1, fmt:'JPEG', path:'/shoots/apr/hero_square.jpg' },
+      { src:'tile-14', res:'1080×1080', px:1.2, size:0.6, date:'27 Apr 19:45', score:0, tags:0, fmt:'JPEG', path:'/export/social/hero_ig.jpg', ref:true },
+    ] },
+  { id:'g7', kind:'near', conf:0.87, why:[['87% visual match'],['Burst — 1.1s apart'],['Same folder'],['Eyes closed in one', true]],
+    cands:[
+      { src:'scene-05', res:'4032×3024', px:12.2, size:8.8, date:'09 Jul 07:15', score:4, tags:2, fmt:'JPEG', path:'/shoots/jul/dawn_014.jpg' },
+      { src:'scene-05', res:'4032×3024', px:12.2, size:8.6, date:'09 Jul 07:15', score:0, tags:0, fmt:'JPEG', path:'/shoots/jul/dawn_015.jpg' },
+      { src:'scene-05', res:'4032×3024', px:12.2, size:9.0, date:'09 Jul 07:15', score:0, tags:0, fmt:'JPEG', path:'/shoots/jul/dawn_016.jpg' },
+    ] },
+];
+
+// keeper score — largest pixel count, then metadata richness, then user score
+function pickCover(cands) {
+  let best = 0;
+  cands.forEach((c, i) => {
+    const s = c.px * 4 + c.tags * 3 + c.score * 2 + (c.fmt === 'RAW' ? 8 : 0);
+    const bs = cands[best].px * 4 + cands[best].tags * 3 + cands[best].score * 2 + (cands[best].fmt === 'RAW' ? 8 : 0);
+    if (s > bs) best = i;
+  });
+  return best;
+}
+const bestOf = (cands, key) => Math.max(...cands.map(c => c[key]));
+// keep the filename visible without bidi reordering — truncate the head in JS, not with direction:rtl
+const shortPath = (p) => { const s = p.split('/').filter(Boolean); return s.length > 2 ? '…/' + s.slice(-2).join('/') : p; };
+
+function Shell({ children, active, crumb }) {
+  return (
+    <React.Fragment>
+      <div className="titlebar">
+        <div className="tb-brand"><img src="../../assets/Logo.png" alt="" /><span className="wordmark">Pixl<span className="s">Stash</span></span></div>
+        <nav className="breadcrumb"><span className="sep">›</span><span className="crumb link">Global</span><span className="sep">›</span><span className="crumb">{crumb}</span></nav>
+        <span className="tb-spacer"></span><span className="tb-version">v1.9.0-dev.3</span>
+        <div className="tb-win">
+          <button><span className="mdi mdi-window-minimize"></span></button>
+          <button><span className="mdi mdi-window-maximize"></span></button>
+          <button className="close"><span className="mdi mdi-window-close"></span></button>
+        </div>
+      </div>
+      <div className="fm">
+        <aside className="sidebar">
+          <div className="side-tabs">
+            <button className="side-tab active"><span className="mdi mdi-web"></span> Global</button>
+            <button className="side-tab"><span className="mdi mdi-folder-outline"></span> Projects</button>
+            <button className="side-tab"><span className="mdi mdi-monitor"></span> Folders</button>
+          </div>
+          <div className="side-scroll">
+            <div className={`row ${active === 'all' ? 'active' : ''}`}><span className="lead mdi mdi-image-multiple"></span><span className="label">All Pictures</span><span className="count">128,412</span></div>
+            <div className={`row ${active === 'dupes' ? 'active' : ''}`}><span className="lead mdi mdi-content-duplicate"></span><span className="label">Duplicates</span>{active === 'dupes' ? children.badge : <span className="count">4</span>}</div>
+            <div className="row"><span className="lead mdi mdi-trash-can-outline"></span><span className="label">Scrapheap</span><span className="count">2</span></div>
+            <div className="sec">People<span className="sp"></span><span className="mdi mdi-plus"></span></div>
+            <div className="row"><img className="avatar" src="../../assets/samples/tile-01.webp" alt="" /><span className="label">Angela Merkel</span><span className="count">8</span></div>
+            <div className="row"><img className="avatar" src="../../assets/samples/tile-05.webp" alt="" /><span className="label">Walter</span><span className="count">4</span></div>
+            <div className="sec">Sets<span className="sp"></span><span className="mdi mdi-plus"></span></div>
+            <div className="row"><span className="set-ico mdi mdi-crown" style={{ color:'#00acc1' }}></span><span className="label">Celebrities</span><span className="count">20</span></div>
+          </div>
+        </aside>
+        <main className="main">{children.main}</main>
+      </div>
+    </React.Fragment>
+  );
+}
+
+function Cand({ c, i, cands, isCover, isOut, onCover, onToggle }) {
+  return (
+    <div className={`cand ${isCover ? 'cover' : ''} ${isOut ? 'out' : ''}`}
+      onClick={() => onCover(i)}
+      onContextMenu={(e) => { e.preventDefault(); onToggle(i); }}
+      title={isOut ? 'Right-click to include in the stack' : 'Click to make cover · right-click to leave out of the stack'}>
+      <div className="cthumb">
+        <img src={`../../assets/samples/${c.src}.webp`} alt="" />
+        {isCover && !isOut && <span className="cflag"><span className="mdi mdi-star" style={{ fontSize:12 }}></span>Cover</span>}
+        {isOut && <span className="cflag outf">Not in stack</span>}
+        <span className="cnum">{i + 1}</span>
+      </div>
+      <div className="cmeta">
+        <div className="mline"><span className="mk">Resolution</span><span className={`mv ${c.px === bestOf(cands,'px') ? 'best' : 'dim'}`}>{c.res}</span></div>
+        <div className="mline"><span className="mk">File</span><span className={`mv ${c.size === bestOf(cands,'size') ? 'best' : 'dim'}`}>{c.size} MB · {c.fmt}</span></div>
+        <div className="mline"><span className="mk">Captured</span><span className="mv dim">{c.date}</span></div>
+        <div className="mline"><span className="mk">Score</span><span className={`mv ${c.score && c.score === bestOf(cands,'score') ? 'best' : 'dim'}`}>{c.score ? '★'.repeat(c.score) : '—'}</span></div>
+        <div className="mline"><span className="mk">Metadata</span><span className={`mv ${c.tags && c.tags === bestOf(cands,'tags') ? 'best' : 'dim'}`}>{c.tags ? `${c.tags} tags` : 'none'}</span></div>
+        <div className="mline"><span className="mk">In stack</span>
+          <span className="mv" style={{ display:'flex', alignItems:'center', gap:4 }}>
+            <button className="bbtn bbtn--icon" style={{ height:18, width:18 }} title={isOut ? 'Include in stack' : 'Leave out of stack'}
+              onClick={(e) => { e.stopPropagation(); onToggle(i); }}>
+              <span className={`mdi mdi-${isOut ? 'plus-circle-outline' : 'minus-circle-outline'}`} style={{ fontSize:15 }}></span>
+            </button>
+            <span style={{ color:'var(--text-muted)' }}>{isOut ? 'No' : 'Yes'}</span>
+          </span>
+        </div>
+      </div>
+      {c.ref && (
+        <div className="cfoot">
+          <span className="mdi mdi-folder-eye-outline" title="Reference folder — not managed by PixlStash"></span>
+          <span style={{ flex:1, minWidth:0, whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis' }} title={c.path}>{shortPath(c.path)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GroupRow({ g, n, focused, cover, out, onFocus, onCover, onToggle, onStack, onSeparate, onCompare }) {
+  const inStack = g.cands.length - out.length;
+  return (
+    <div className={`grow ${focused ? 'focus' : ''}`} onClick={onFocus}>
+      <div className="ginfo">
+        {focused && <span className="gcaret mdi mdi-menu-right"></span>}
+        <div className="gn"><b>Group {n}</b><span>{g.cands.length} pictures</span></div>
+        <span className={`conf ${g.kind === 'exact' ? 'exact' : ''}`} style={{ alignSelf:'flex-start' }}>
+          <span className={`mdi mdi-${g.kind === 'exact' ? 'approximately-equal' : 'blur'}`} style={{ fontSize:14 }}></span>
+          {g.kind === 'exact' ? <b>Exact</b> : <React.Fragment><b>{Math.round(g.conf * 100)}%</b> similar</React.Fragment>}
+        </span>
+        {focused
+          ? <span className="gfocusnote"><span className="mdi mdi-keyboard-outline" style={{ fontSize:13 }}></span>Keyboard acts here</span>
+          : <div className="greasons">{[...g.why.filter(w => w[1]), ...g.why.filter(w => !w[1])].slice(0, 2).map(([w, neg], i) => <i key={i} className={neg ? 'neg' : ''}><span className={`mdi mdi-${neg ? 'close' : 'check'}`}></span>{w}</i>)}</div>}
+      </div>
+      <div className="gstrip">
+        {g.cands.map((c, i) => {
+          const isOut = out.includes(i);
+          return (
+            <div key={i} className={`gthumb ${i === cover ? 'iscover' : ''} ${isOut ? 'out' : ''}`}
+              onClick={(e) => { e.stopPropagation(); onFocus(); onCover(i); }}
+              onContextMenu={(e) => { e.preventDefault(); onFocus(); onToggle(i); }}
+              title={isOut ? 'Right-click to include' : 'Click to make cover · right-click to exclude'}>
+              <div className="gt">
+                <img src={`../../assets/samples/${c.src}.webp`} alt="" />
+                <span className="gnum">{i + 1}</span>
+                {i === cover && !isOut && <span className="gcv">COVER</span>}
+                {isOut && <span className="gx mdi mdi-minus-circle-outline"></span>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="gact">
+        <Button variant={focused ? 'accent' : 'secondary'} size="sm" iconLeft="layers-plus" onClick={(e) => { e.stopPropagation(); onStack(); }}>Stack {inStack}{focused && <span className="kin"><Kbd>Enter</Kbd></span>}</Button>
+        <Button variant="ghost" size="sm" iconLeft="call-split" onClick={(e) => { e.stopPropagation(); onSeparate(); }}>Keep separate{focused && <span className="kin"><Kbd>S</Kbd></span>}</Button>
+        <button className="gcompare" onClick={(e) => { e.stopPropagation(); onFocus(); onCompare(); }}>
+          <span className="mdi mdi-compare-horizontal" style={{ fontSize:15 }}></span>Compare all {g.cands.length}{focused && <Kbd>C</Kbd>}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Queue() {
+  const [focus, setFocus] = useState(0);
+  const [covers, setCovers] = useState(() => GROUPS.map(g => pickCover(g.cands)));
+  const [outs, setOuts] = useState(() => GROUPS.map(() => []));
+  const [resolved, setResolved] = useState([]);
+  const [receipt, setReceipt] = useState(null);
+  const [compare, setCompare] = useState(null);
+  const listRef = React.useRef(null);
+  const [scan, setScan] = useState(62);
+  const [tiersOpen, setTiersOpen] = useState(false);
+  const [tiers, setTiers] = useState({ high:true, medium:true, loose:false });
+  const tierLabel = !tiers.high ? 'Exact only' : tiers.loose ? 'Exact + all near' : tiers.medium ? 'Exact + near ≥75%' : 'Exact + near ≥90%';
+  const inTier = (g) => g.kind === 'exact' || (g.conf >= 0.90 ? tiers.high : g.conf >= 0.75 ? tiers.medium : tiers.loose);
+  const open = GROUPS.map((g, i) => i).filter(i => !resolved.some(r => r.i === i) && inTier(GROUPS[i]));
+  const focusIdx = open.includes(focus) ? focus : (open[0] ?? -1);
+
+  useEffect(() => {
+    const t = setInterval(() => setScan(s => (s >= 100 ? 100 : s + 1)), 900);
+    return () => clearInterval(t);
+  }, []);
+
+  const resolve = useCallback((i, verdict) => {
+    const g = GROUPS[i];
+    if (!g) return;
+    const n = g.cands.length - outs[i].length;
+    setResolved(r => [...r, { i, verdict }]);
+    setReceipt({ verdict, n, at: Date.now() });
+    setFocus(f => {
+      const rest = GROUPS.map((_, j) => j).filter(j => j !== i && !resolved.some(r => r.i === j));
+      return rest.find(j => j > i) ?? rest[rest.length - 1] ?? 0;
+    });
+  }, [outs, resolved]);
+
+  useEffect(() => { if (!receipt) return; const t = setTimeout(() => setReceipt(null), 5000); return () => clearTimeout(t); }, [receipt]);
+
+  const undo = useCallback(() => {
+    setResolved(r => {
+      if (!r.length) return r;
+      setFocus(r[r.length - 1].i);
+      setReceipt(null);
+      return r.slice(0, -1);
+    });
+  }, []);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list || focusIdx < 0) return;
+    const row = list.querySelector('.grow.focus');
+    if (!row) return;
+    const top = row.offsetTop, bottom = top + row.offsetHeight;
+    if (top < list.scrollTop) list.scrollTop = top;
+    else if (bottom > list.scrollTop + list.clientHeight) list.scrollTop = bottom - list.clientHeight;
+  }, [focusIdx, resolved.length]);
+
+  const setCover = (i, v) => setCovers(c => c.map((x, j) => j === i ? v : x));
+  const toggleOut = (i, v) => setOuts(o => o.map((x, j) => j === i ? (x.includes(v) ? x.filter(y => y !== v) : [...x, v]) : x));
+
+  useEffect(() => {
+    const h = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') { e.preventDefault(); undo(); return; }
+      if (e.key === 'Escape' && compare !== null) { setCompare(null); return; }
+      if (e.ctrlKey || e.metaKey || focusIdx < 0) return;
+      const k = e.key.toLowerCase();
+      if (compare !== null) {
+        if (k === 'enter') { e.preventDefault(); resolve(compare, 'stacked'); setCompare(null); }
+        else if (k === 's') { e.preventDefault(); resolve(compare, 'separate'); setCompare(null); }
+        return;
+      }
+      if (k === 'enter') { e.preventDefault(); resolve(focusIdx, 'stacked'); }
+      else if (k === 's') { e.preventDefault(); resolve(focusIdx, 'separate'); }
+      else if (k === 'arrowdown' || k === 'j') { e.preventDefault(); const p = open.indexOf(focusIdx); setFocus(open[Math.min(open.length - 1, p + 1)]); }
+      else if (k === 'arrowup' || k === 'k') { e.preventDefault(); const p = open.indexOf(focusIdx); setFocus(open[Math.max(0, p - 1)]); }
+      else if (k === 'c') { e.preventDefault(); setCompare(focusIdx); }
+      else if (/^[1-9]$/.test(k)) { const n = +k - 1; if (n < GROUPS[focusIdx].cands.length) setCover(focusIdx, n); }
+      else if (k === 'x') { toggleOut(focusIdx, covers[focusIdx]); }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [focusIdx, open, covers, compare, resolve, undo]);
+
+  return (
+    <div className="frame">
+      <div className="app" style={{ height:700 }}>
+        <Shell crumb="Duplicates" active="dupes" children={{
+          badge: <span className="badge">{open.length}</span>,
+          main: <React.Fragment>
+            <div className="toolbar">
+              <div className="tb-left">
+                <div className="split">
+                  <button className="bbtn bbtn--icon"><span className="mdi mdi-sort-ascending"></span></button>
+                  <button className="bbtn"><span className="prefix">Sort:</span><span className="mdi mdi-star"></span><span>Confidence</span><span className="mdi mdi-menu-down chev"></span></button>
+                </div>
+                <button className={`bbtn ${tiersOpen ? 'bbtn--open' : ''}`} onClick={() => setTiersOpen(t => !t)}><span className="mdi mdi-filter-outline"></span><span>{tierLabel}</span><span className="mdi mdi-menu-down chev"></span></button>
+                <button className="bbtn"><span className="prefix">Scope:</span><span>Whole library</span><span className="mdi mdi-menu-down chev"></span></button>
+                <div className="sep"></div>
+                <div className="grp">
+                  <button className="bbtn bbtn--icon" onClick={undo} title="Undo" style={{ opacity: resolved.length ? 1 : .35 }}><span className="mdi mdi-undo-variant"></span></button>
+                  <button className="bbtn bbtn--icon" title="Redo" style={{ opacity:.35 }}><span className="mdi mdi-redo-variant"></span></button>
+                </div>
+              </div>
+              <div className="tb-right">
+                <button className="bbtn bbtn--accent"><span className="mdi mdi-flash-outline"></span>Auto-stack 1,204 exact matches</button>
+                <div className="sep"></div>
+                <button className="bbtn bbtn--icon" title="Duplicate detection settings"><span className="mdi mdi-cog-outline"></span></button>
+              </div>
+            </div>
+            {tiersOpen && (
+              <div className="tbm" style={{ width:340, top:42, left:150 }}>
+                <span className="tbm-caret"></span>
+                <div className="tbm-head"><span className="ic mdi mdi-filter"></span><span className="tbm-title">Include</span><span className="tbm-sp" style={{ flex:1 }}></span>
+                  <span className="tbm-count">{open.length} groups</span></div>
+                <div className="tbm-sec">
+                  <div className="tierrow locked">
+                    <span className="cbox"><span className="mdi mdi-check"></span></span>
+                    <span className="tname">Exact matches <span className="trange">hash</span></span>
+                    <span className="tcount">1,204</span>
+                  </div>
+                  <div className={`tierrow ${tiers.high ? 'on' : ''}`} onClick={() => setTiers(t => ({ ...t, high:!t.high, medium:t.high ? false : t.medium, loose:t.high ? false : t.loose }))}>
+                    <span className="cbox">{tiers.high && <span className="mdi mdi-check"></span>}</span>
+                    <span className="tname">Near-identical <span className="trange">≥90%</span></span>
+                    <span className="tcount">96</span>
+                  </div>
+                  <div className={`tierrow ${tiers.medium ? 'on' : ''}`} style={{ opacity: tiers.high ? 1 : .4, pointerEvents: tiers.high ? 'auto' : 'none' }}
+                    onClick={() => setTiers(t => ({ ...t, medium:!t.medium, loose:t.medium ? false : t.loose }))}>
+                    <span className="cbox">{tiers.medium && <span className="mdi mdi-check"></span>}</span>
+                    <span className="tname">Bursts &amp; re-exports <span className="trange">75–90%</span></span>
+                    <span className="tcount">38</span>
+                  </div>
+                  <div className={`tierrow ${tiers.loose ? 'on' : ''}`} style={{ opacity: tiers.medium ? 1 : .4, pointerEvents: tiers.medium ? 'auto' : 'none' }}
+                    onClick={() => setTiers(t => ({ ...t, loose:!t.loose }))}>
+                    <span className="cbox">{tiers.loose && <span className="mdi mdi-check"></span>}</span>
+                    <span className="tname">Same scene <span className="trange">65–75%</span></span>
+                    <span className="tcount">9</span>
+                  </div>
+                  {tiers.loose && (
+                    <div className="tierwarn"><span className="mdi mdi-alert-outline"></span>
+                      Same-scene groups are often genuinely different pictures. Compare before stacking — these are the ones people get wrong.</div>
+                  )}
+                </div>
+              </div>
+            )}
+            {scan < 100 && (
+              <div className="scanbar">
+                <span className="sb-ico mdi mdi-radar"></span>
+                <span className="sb-txt">Still scanning — <b>{(scan * 1284).toLocaleString()}</b> of <b>128,412</b> pictures compared. Groups appear as they're found.</span>
+                <span className="sb-sub">{scan}% · ~{Math.max(1, Math.round((100 - scan) / 7))} min left</span>
+                <div className="sb-track"><div className="sb-fill" style={{ width:`${scan}%` }}></div></div>
+              </div>
+            )}
+            {focusIdx >= 0 ? (
+              <div className="queue">
+                <div className="qhead">
+                  <span className="qtitle">{open.length} groups to review</span>
+                  <span className="qsub">{resolved.length} done</span>
+                  <span className="sp"></span>
+                  <span className="khint" style={{ color:'var(--text)' }}><KH keys={['↑','↓']} /> choose group</span>
+                  <span className="khint"><KH keys={['Enter']} /> stack it</span>
+                  <span className="khint"><KH keys={['S']} /> keep separate</span>
+                  <span className="khint"><KH keys={['C']} /> compare</span>
+                  <span className="khint"><KH keys={['Ctrl','Z']} /> undo</span>
+                </div>
+                <div className="qlist" ref={listRef}>
+                  {open.map(i => (
+                    <GroupRow key={GROUPS[i].id} g={GROUPS[i]} n={i + 1} focused={i === focusIdx}
+                      cover={covers[i]} out={outs[i]} onFocus={() => setFocus(i)}
+                      onCover={(v) => setCover(i, v)} onToggle={(v) => toggleOut(i, v)}
+                      onStack={() => resolve(i, 'stacked')} onSeparate={() => resolve(i, 'separate')}
+                      onCompare={() => setCompare(i)} />
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="qdone">
+                <span className="mdi mdi-check-circle-outline"></span>
+                <h3>Queue clear</h3>
+                <p>{resolved.filter(r => r.verdict === 'stacked').length} groups stacked, {resolved.filter(r => r.verdict === 'separate').length} kept separate. Scanning continues in the background — new groups will appear here as they're found.</p>
+                <Button variant="secondary" size="sm" iconLeft="undo-variant" onClick={undo}>Undo last</Button>
+              </div>
+            )}
+            {compare !== null && GROUPS[compare] && (
+              <div className="scrim" onClick={() => setCompare(null)}>
+                <div className="dlg" style={{ width:'auto', maxWidth:1180 }} onClick={(e) => e.stopPropagation()}>
+                  <div className="dlg-head"><span className="mdi mdi-compare-horizontal"></span><b>Compare group {compare + 1}</b>
+                    <span style={{ flex:1 }}></span>
+                    <span className={`conf ${GROUPS[compare].kind === 'exact' ? 'exact' : ''}`}>
+                      {GROUPS[compare].kind === 'exact' ? <b>Exact match</b> : <React.Fragment><b>{Math.round(GROUPS[compare].conf * 100)}%</b> similar</React.Fragment>}
+                    </span>
+                  </div>
+                  <div className="dlg-body">
+                    <div className="cands" style={{ padding:0 }}>
+                      {GROUPS[compare].cands.map((c, i) => (
+                        <Cand key={i} c={c} i={i} cands={GROUPS[compare].cands} isCover={i === covers[compare]}
+                          isOut={outs[compare].includes(i)} onCover={(v) => setCover(compare, v)} onToggle={(v) => toggleOut(compare, v)} />
+                      ))}
+                    </div>
+                    <div className="why" style={{ padding:0 }}>
+                      {GROUPS[compare].why.map(([w, neg], i) => (
+                        <span key={i} className={`wtag ${neg ? 'wtag--neg' : ''}`}><span className={`mdi mdi-${neg ? 'close' : 'check'}`}></span>{w}</span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="dlg-foot">
+                    <span className="khint" style={{ marginRight:'auto' }}>Click a picture to make it cover · right-click to leave it out</span>
+                    <Button variant="ghost" size="md" onClick={() => setCompare(null)}>Close<span className="kin"><Kbd>Esc</Kbd></span></Button>
+                    <Button variant="secondary" size="md" iconLeft="call-split" onClick={() => { resolve(compare, 'separate'); setCompare(null); }}>Keep separate<span className="kin"><Kbd>S</Kbd></span></Button>
+                    <Button variant="accent" size="md" iconLeft="layers-plus" onClick={() => { resolve(compare, 'stacked'); setCompare(null); }}>Stack {GROUPS[compare].cands.length - outs[compare].length}<span className="kin"><Kbd>Enter</Kbd></span></Button>
+                  </div>
+                </div>
+              </div>
+            )}
+            {receipt && (
+              <div className="receipt">
+                <span className={`r-ico mdi mdi-${receipt.verdict === 'stacked' ? 'layers-plus' : 'call-split'}`}></span>
+                <span className="r-text">{receipt.verdict === 'stacked'
+                  ? <React.Fragment>Stacked <b>{receipt.n} pictures</b> — cover kept, nothing deleted</React.Fragment>
+                  : <React.Fragment>Kept <b>{receipt.n} pictures</b> separate — won't be suggested again</React.Fragment>}</span>
+                <Button variant="ghost" size="sm" iconLeft="undo-variant" onClick={undo}>Undo<span className="kin"><Kbd>Ctrl</Kbd><Kbd>Z</Kbd></span></Button>
+                <span className="r-progress"></span>
+              </div>
+            )}
+          </React.Fragment>
+        }} />
+      </div>
+    </div>
+  );
+}
+
+const GRID = ['tile-06','tile-04','tile-07','tile-09','tile-10','tile-11','tile-12','tile-13','tile-14','tile-15','tile-16','tile-01'];
+const STACK_AT = 2;
+const STACK_MEMBERS = ['tile-08','tile-08','tile-08','tile-08'];
+
+function GridStacks() {
+  const [expanded, setExpanded] = useState(false);
+  const [menu, setMenu] = useState('filter');
+  const [stackFilter, setStackFilter] = useState('all');
+  return (
+    <div className="frame">
+      <div className="app" style={{ height:660 }}>
+        <Shell crumb="All Pictures" active="all" children={{ main: <React.Fragment>
+          <div className="toolbar">
+            <div className="tb-left">
+              <div className="split">
+                <button className="bbtn bbtn--icon"><span className="mdi mdi-sort-ascending"></span></button>
+                <button className="bbtn"><span className="prefix">Sort:</span><span className="mdi mdi-calendar"></span><span>Date Created</span><span className="mdi mdi-menu-down chev"></span></button>
+              </div>
+              <button className={`bbtn ${menu === 'filter' ? 'bbtn--open' : ''}`} onClick={() => setMenu(m => m === 'filter' ? null : 'filter')}><span className="mdi mdi-filter-outline"></span><span className="mdi mdi-menu-down chev"></span></button>
+              <button className={`bbtn ${menu === 'view' ? 'bbtn--open' : ''}`} onClick={() => setMenu(m => m === 'view' ? null : 'view')} title="Grid view"><span className="mdi mdi-view-grid"></span><span className="mdi mdi-menu-down chev"></span></button>
+              <div className="sep"></div>
+              <button className="bbtn bbtn--icon" title="Search (F)"><span className="mdi mdi-magnify"></span></button>
+              <button className="bbtn bbtn--icon" title="Export current grid to zip"><span className="mdi mdi-tray-arrow-down"></span></button>
+              <button className="bbtn bbtn--icon" title="Import photos"><span className="mdi mdi-cloud-upload-outline"></span></button>
+            </div>
+            <div className="tb-right">
+              <button className="bbtn bbtn--icon" title="Review and fix tags"><span className="mdi mdi-tag-check-outline"></span></button>
+              <button className="bbtn bbtn--icon" title="Settings"><span className="mdi mdi-cog-outline"></span></button>
+              <button className="bbtn bbtn--icon" title="Show/Hide stats sidebar"><span className="mdi mdi-chart-bar"></span></button>
+            </div>
+          </div>
+        <div className="grid-scroll">
+          {menu === 'filter' && (
+            <div className="tbm" style={{ width:376, top:6, left:104 }}>
+              <span className="tbm-caret"></span>
+              <div className="rfhead"><span className="ic mdi mdi-filter"></span><span className="t">Filters</span><span className="sp"></span>
+                <span className="cnt">{stackFilter === 'dupes' ? '9' : stackFilter === 'only' ? '61' : '128'} matches</span>
+                <button className="clear"><span className="mdi mdi-close-circle-outline" style={{ fontSize:16 }}></span> Clear</button></div>
+              <div className="rfsec">
+                <div className="rfcheckrow">
+                  <label className="rfcheck"><span className="box"></span>Shared pictures only</label>
+                  <label className="rfcheck"><span className="box"></span>Unassigned only</label>
+                </div>
+              </div>
+              <div className="rfsec">
+                <div style={{ display:'flex', gap:'var(--space-4)' }}>
+                  <div style={{ flex:1 }}>
+                    <span className="rflabel">Media</span>
+                    <div className="bigseg" style={{ marginTop:'var(--space-2)' }}>
+                      <button className="bigbtn bigbtn--on" title="All media"><span className="mdi mdi-image-multiple-outline"></span></button>
+                      <button className="bigbtn" title="Images"><span className="mdi mdi-image-outline"></span></button>
+                      <button className="bigbtn" title="Video"><span className="mdi mdi-video-outline"></span></button>
+                    </div>
+                  </div>
+                  <div style={{ flex:1, display:'flex', flexDirection:'column', alignItems:'flex-end' }}>
+                    <span className="rflabel">Faces</span>
+                    <div className="bigseg" style={{ marginTop:'var(--space-2)' }}>
+                      <button className="bigbtn bigbtn--on" title="Any"><span className="mdi mdi-infinity"></span></button>
+                      <button className="bigbtn" title="Has face"><span className="mdi mdi-face-recognition"></span></button>
+                      <button className="bigbtn" title="No face"><span className="mdi mdi-account-off-outline"></span></button>
+                    </div>
+                  </div>
+                </div>
+                <div style={{ marginTop:'var(--space-3)' }}>
+                  <span className="rflabel">Stacks</span>
+                  <div className="bigseg" style={{ marginTop:'var(--space-2)', alignSelf:'flex-start', width:'fit-content' }}>
+                    {[['all','Any stack state','infinity'],['only','Stacked only','image-multiple'],['unstacked','Unstacked only','image-outline'],['dupes','Unresolved duplicates','content-duplicate']].map(([v, label, ic]) => (
+                      <button key={v} className={`bigbtn ${stackFilter === v ? 'bigbtn--on' : ''}`} title={label} onClick={() => setStackFilter(v)}>
+                        <span className={`mdi mdi-${ic}`}></span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="rfsec">
+                <div style={{ display:'flex', justifyContent:'space-between' }}><span className="rflabel">Min score</span><span className="rflabel">Max score</span></div>
+                <div style={{ display:'flex', justifyContent:'space-between' }}>
+                  <div className="rfstars">{[0,1,2,3,4].map(i => <span key={i} className="mdi mdi-star-outline"></span>)}</div>
+                  <div className="rfstars">{[0,1,2,3,4].map(i => <span key={i} className="mdi mdi-star-outline"></span>)}</div>
+                </div>
+              </div>
+              <div className="rfsec"><div className="rfcollapse"><span className="rflabel">Impossible tags</span><span className="mdi mdi-chevron-down"></span></div></div>
+              <div className="rfsec">
+                <div className="rfcollapse" style={{ cursor:'default' }}><span className="rflabel">Tags</span><span style={{ fontSize:'var(--text-sm)', color:'var(--text-muted)' }}>Clear</span></div>
+                <div className="rfinput"><span className="mdi mdi-magnify" style={{ fontSize:16 }}></span> Filter by tag…</div>
+              </div>
+              <div className="rfsec"><div className="rfcollapse"><span className="rflabel">Tag confidence</span><span className="mdi mdi-chevron-down"></span></div></div>
+              <div className="rfsec"><div className="rfcollapse"><span className="rflabel">ComfyUI</span><span className="mdi mdi-chevron-down"></span></div></div>
+            </div>
+          )}
+          {menu === 'view' && (
+            <div className="tbm" style={{ width:264, top:6, left:150 }}>
+              <span className="tbm-caret"></span>
+              <div className="tbm-head"><span className="ic mdi mdi-view-grid"></span><span className="tbm-title">Grid view</span><span className="tbm-sp"></span>
+                <button className="tbm-ghost"><span className="mdi mdi-view-compact-outline"></span> Compact</button></div>
+              <div className="tbm-sec">
+                <div className="row-between"><span>Size</span><div className="slider"><span className="fill"></span><span className="knob"></span></div><span className="mono">Medium</span></div>
+              </div>
+              <div className="tbm-sec">
+                <span className="tbm-label">Stacks</span>
+                <div className="btngroup">
+                  <button className={`gbtn ${expanded ? 'gbtn--on' : ''}`} onClick={() => setExpanded(true)}><span className="mdi mdi-arrow-expand-vertical"></span>Expand all</button>
+                  <button className={`gbtn ${!expanded ? 'gbtn--on' : ''}`} onClick={() => setExpanded(false)}><span className="mdi mdi-arrow-collapse-vertical"></span>Collapse</button>
+                </div>
+              </div>
+              <div className="tbm-sec">
+                <span className="tbm-label">Overlays</span>
+                <div className="grid3">
+                  <button className="toggle toggle--vert"><span className="mdi mdi-face-recognition"></span>Face boxes</button>
+                  <button className="toggle toggle--vert on"><span className="mdi mdi-shape-outline"></span>Object boxes</button>
+                  <button className="toggle toggle--vert on"><span className="mdi mdi-alert-outline"></span>Problems</button>
+                </div>
+              </div>
+            </div>
+          )}
+          <div className="cgrid">
+            {GRID.slice(0, STACK_AT).map((t, i) => (
+              <div key={i} className="cell"><img src={`../../assets/samples/${t}.webp`} alt="" /></div>
+            ))}
+            <div className="cell stack">
+              <img src="../../assets/samples/tile-08.webp" alt="" />
+              <span className="stackbadge"><span className="mdi mdi-image-multiple"></span>4</span>
+              <span className="score-dot"></span>
+            </div>
+            {expanded && (
+              <div className="exp">
+                <div className="ehead">
+                  <b><span className="mdi mdi-image-multiple"></span>Stack of 4</b>
+                  <span>Burst · 81% similar</span>
+                  <span>21 Jun 16:04</span>
+                </div>
+                <div className="estrip">
+                  {STACK_MEMBERS.map((m, i) => (
+                    <div key={i} className={`eth ${i === 0 ? 'iscover' : ''}`}>
+                      <img src={`../../assets/samples/${m}.webp`} alt="" />
+                      {i === 0 && <span className="cv">Cover</span>}
+                    </div>
+                  ))}
+                  <div style={{ display:'flex', alignItems:'center', paddingLeft:'var(--space-2)', gap:'var(--space-2)' }}>
+                    <Button variant="ghost" size="sm" iconLeft="call-split">Unstack</Button>
+                    <Button variant="ghost" size="sm" iconLeft="star-outline">Set cover</Button>
+                  </div>
+                </div>
+              </div>
+            )}
+            {GRID.slice(STACK_AT).map((t, i) => (
+              <div key={i} className="cell"><img src={`../../assets/samples/${t}.webp`} alt="" /></div>
+            ))}
+          </div>
+        </div>
+        </React.Fragment> }} />
+      </div>
+    </div>
+  );
+}
+
+function AutoStackDialog() {
+  return (
+    <div className="frame" style={{ position:'relative' }}>
+      <div className="app" style={{ height:420 }}>
+        <div className="grid-scroll" style={{ filter:'blur(1px)', opacity:.5 }}>
+          <div className="cgrid">
+            {GRID.map((t, i) => <div key={i} className="cell"><img src={`../../assets/samples/${t}.webp`} alt="" /></div>)}
+          </div>
+        </div>
+        <div className="scrim">
+          <div className="dlg">
+            <div className="dlg-head"><span className="mdi mdi-flash-outline"></span><b>Auto-stack exact matches</b></div>
+            <div className="dlg-body">
+              <p>Byte-identical files need no judgment. This stacks every exact-match group and picks the copy with the richest metadata as cover. Near-duplicates are left for the queue.</p>
+              <div className="dryrun">
+                <div className="dr pos"><span className="mdi mdi-layers-plus"></span><span className="sp">Stacks to create</span><b>1,204</b></div>
+                <div className="dr pos"><span className="mdi mdi-image-multiple-outline"></span><span className="sp">Pictures collapsed into a cover</span><b>2,861</b></div>
+                <div className="dr"><span className="mdi mdi-tag-multiple-outline"></span><span className="sp">Covers gaining metadata from copies</span><b>318</b></div>
+                <div className="dr"><span className="mdi mdi-blur"></span><span className="sp">Near-duplicate groups left in queue</span><b>143</b></div>
+                <div className="dr"><span className="mdi mdi-delete-off-outline"></span><span className="sp">Files deleted</span><b>0</b></div>
+              </div>
+              <p style={{ display:'flex', alignItems:'center', gap:'var(--space-2)' }}><span className="mdi mdi-information-outline" style={{ fontSize:16, color:'var(--accent)' }}></span>Reversible as one step with <Kbd>Ctrl</Kbd><Kbd>Z</Kbd> for the rest of the session.</p>
+            </div>
+            <div className="dlg-foot">
+              <span className="sp"></span>
+              <Button variant="ghost" size="md">Cancel</Button>
+              <Button variant="accent" size="md" iconLeft="layers-plus">Create 1,204 stacks<span className="kin"><Kbd>Enter</Kbd></span></Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ContextEntry() {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="frame">
+      <div className="app" style={{ height:420 }}>
+        <div className="fm">
+          <aside className="sidebar" style={{ position:'relative' }}>
+            <div className="side-tabs">
+              <button className="side-tab active"><span className="mdi mdi-web"></span> Global</button>
+              <button className="side-tab"><span className="mdi mdi-folder-outline"></span> Projects</button>
+              <button className="side-tab"><span className="mdi mdi-monitor"></span> Folders</button>
+            </div>
+            <div className="side-scroll">
+              <div className="row"><span className="lead mdi mdi-image-multiple"></span><span className="label">All Pictures</span><span className="count">128,412</span></div>
+              <div className="row"><span className="lead mdi mdi-content-duplicate"></span><span className="label">Duplicates</span><span className="count">143</span></div>
+              <div className="sec">Sets<span className="sp"></span><span className="mdi mdi-plus"></span></div>              <div className="row"><span className="set-ico mdi mdi-crown" style={{ color:'#00acc1' }}></span><span className="label">Celebrities</span><span className="count">20</span></div>
+              <div className={`row ${open ? 'active' : ''}`} onClick={() => setOpen(o => !o)} style={{ cursor:'context-menu' }}>
+                <span className="set-ico mdi mdi-folder-multiple-image" style={{ color:'#26a69a' }}></span><span className="label">Release Set B</span><span className="count">1,482</span>
+              </div>
+              <div className="row"><span className="set-ico mdi mdi-code-braces" style={{ color:'#e53935' }}></span><span className="label">AI Characters</span><span className="count">101</span></div>
+            </div>
+          </aside>
+          <main className="main" style={{ position:'relative' }}>
+            <div className="toolbar">
+              <div className="tb-left">
+                <div className="split">
+                  <button className="bbtn bbtn--icon"><span className="mdi mdi-sort-ascending"></span></button>
+                  <button className="bbtn"><span className="prefix">Sort:</span><span className="mdi mdi-calendar"></span><span>Date Created</span><span className="mdi mdi-menu-down chev"></span></button>
+                </div>
+                <button className="bbtn"><span className="mdi mdi-filter-outline"></span><span className="mdi mdi-menu-down chev"></span></button>
+                <button className="bbtn"><span className="mdi mdi-view-grid"></span><span className="mdi mdi-menu-down chev"></span></button>
+              </div>
+              <div className="tb-right">
+                <button className="bbtn bbtn--icon" title="Settings"><span className="mdi mdi-cog-outline"></span></button>
+              </div>
+            </div>
+            <div className="grid-scroll">
+              <div className="cgrid">
+                {GRID.slice(0, 12).map((t, i) => <div key={i} className="cell"><img src={`../../assets/samples/${t}.webp`} alt="" /></div>)}
+              </div>
+            </div>
+            {open && (
+              <div className="ctx" style={{ left:-64, top:132 }}>
+                <div className="ctx-label">Release Set B</div>
+                <div className="ctx-item"><span className="mdi mdi-pencil-outline"></span>Edit set…</div>
+                <div className="ctx-item"><span className="mdi mdi-tray-arrow-down"></span>Export to zip</div>
+                <div className="ctx-div"></div>
+                <div className="ctx-item hi"><span className="mdi mdi-content-duplicate"></span><span className="sp">Find duplicates in this set</span><span className="cnt">18</span></div>
+                <div className="ctx-item"><span className="mdi mdi-image-multiple"></span><span className="sp">Filter to stacks in this set</span><span className="cnt">7</span></div>
+                <div className="ctx-div"></div>
+                <div className="ctx-item"><span className="mdi mdi-lock-outline"></span>Lock set</div>
+                <div className="ctx-item danger"><span className="mdi mdi-trash-can-outline"></span>Delete set…</div>
+              </div>
+            )}
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Spec({ title, note, children, wide }) {
+  return (
+    <div className="spec" style={wide ? { gridColumn:'span 2' } : null}>
+      <div className="stage">{children}</div>
+      <div className="cap"><b>{title}</b><span>{note}</span></div>
+    </div>
+  );
+}
+
+function Page() {
+  return (
+    <div className="page">
+      <div className="lede">
+        <div>
+          <h1>Dedup <span className="s">→</span> Stacks</h1>
+          <p>1.9.0. Duplicate detection becomes a destination with a count, and its only verdict is <b>stack</b> or <b>keep separate</b>. Nothing is deleted — that's a later release.</p>
+        </div>
+        <div className="note-card warn">
+          <h3>Why the sort order has to go</h3>
+          <p>“Similarity to …” is a <b>lens</b>, not a task. It never tells you how many duplicates you have, offers no verdict, has no bulk action, and forgets everything the moment you change sort. Users don't discover it, and when they do they can't finish anything with it.</p>
+          <p>It also implies a full-library comparison every time you use it — the thing that makes Immich's dedup unusable at scale.</p>
+        </div>
+        <div className="note-card good">
+          <h3>What replaces it</h3>
+          <p><b>Tiered detection</b> — exact matches come from an indexed hash query in milliseconds; near-dupes are found inside candidate buckets, streamed in, and cached forever.</p>
+          <p><b>A triage queue</b> — one group on screen, cover preselected with reasons shown, one keystroke, auto-advance. Designed for groups-per-minute, not groups-displayed.</p>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>1 · Detection strategy</h2><span>The part that keeps it fast on 128k pictures — and the reason it isn't Immich's model</span></div>
+        <div className="tiers">
+          <div className="tier">
+            <div className="th"><span className="mdi mdi-approximately-equal"></span><b>Tier 1 · Exact</b><span className="cost">~200 ms</span></div>
+            <p>A hash column with an index. <code>GROUP BY hash HAVING count(*) &gt; 1</code>. No ML, no image decode, no GPU.</p>
+            <ul>
+              <li>Typically 60–80% of a real backlog</li>
+              <li>Zero human judgment needed → bulk auto-stack</li>
+              <li>Runs on import, incrementally</li>
+            </ul>
+          </div>
+          <div className="tier">
+            <div className="th"><span className="mdi mdi-view-grid-outline"></span><b>Tier 2 · Bucketed near</b><span className="cost">seconds/bucket</span></div>
+            <p>Perceptual hash compared <b>only within candidate buckets</b> — same dimensions, same capture minute, same import batch, same folder. Never library-wide.</p>
+            <ul>
+              <li>Turns O(n²) into many tiny problems</li>
+              <li>Catches bursts, re-exports, resizes</li>
+              <li>Streams groups as buckets finish</li>
+            </ul>
+          </div>
+          <div className="tier">
+            <div className="th"><span className="mdi mdi-brain"></span><b>Tier 3 · Embedding</b><span className="cost">background, opt-in</span></div>
+            <p>Full ML similarity for cross-folder, differently-framed near-dupes. Expensive, so it's a background job the user opts into — never a prerequisite for seeing results.</p>
+            <ul>
+              <li>Reuses embeddings the app already computes</li>
+              <li>Results append to the same queue</li>
+              <li>Cached; only new assets rescan</li>
+            </ul>
+          </div>
+        </div>
+        <div className="note-card">
+          <h3>Three rules that keep it usable at any size</h3>
+          <p><b>Never block on a full pass.</b> The queue opens with whatever's been found so far and a “scanned 62% of 128,412” banner. Immich's review page waits for everything, then tries to render it all.</p>
+          <p><b>Virtualize the queue, don't paginate a page.</b> One group is in the DOM at a time. 10 groups and 10,000 groups perform identically.</p>
+          <p><b>Persist verdicts.</b> “Keep separate” is remembered per group signature, so a rescan never re-asks. This is what makes the count trustworthy — and what the sort order could never do.</p>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>2 · The review queue, live</h2><span>↑↓ chooses the group the keyboard acts on — the accent bar and caret mark it. Enter stacks it, S keeps it separate, C compares.</span></div>
+        <Queue />
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>3 · Stacks in the grid</h2><span>The result — All Pictures keeps its normal toolbar; the grid-view button expands stacks</span></div>
+        <GridStacks />
+        <div className="board">
+          <Spec title="Collapsed stack" note="Matches the grid's existing badge vocabulary — the same translucent chip and mdi-image-multiple icon the selection bar already uses — plus the count. No new chrome: a stack is a picture first.">
+            <div className="demo-cell">
+              <img src="../../assets/samples/tile-08.webp" alt="" />
+              <span className="stackbadge"><span className="mdi mdi-image-multiple"></span>4</span>
+            </div>
+          </Spec>
+          <Spec title="Suggested, not yet stacked" note="Groups still waiting in the queue use the duplicate icon and a ? in place of a count — never a fake state change. Clicking it jumps to that group in the queue.">
+            <div className="demo-cell">
+              <img src="../../assets/samples/tile-03.webp" alt="" />
+              <span className="stackbadge" style={{ color:'var(--text-muted)' }}><span className="mdi mdi-content-duplicate"></span>3?</span>
+            </div>
+          </Spec>
+          <Spec title="Kept separate" note="No marker at all. The group is remembered as resolved so no rescan re-suggests it, but the grid shows nothing — the user's decision is that these are simply different pictures.">
+            <div className="demo-cell"><img src="../../assets/samples/scene-03.webp" alt="" /></div>
+          </Spec>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>4 · Duplicates in context</h2><span>Right-click any project, set, character or folder — dedup scoped to that data set</span></div>
+        <ContextEntry />
+        <div className="board">
+          <Spec title="Scoped queue header" note="Choosing the context item opens the same queue with a scope pill in place of the whole-library scope. Dismissing the pill widens back to the full library without losing your position.">
+            <div style={{ display:'flex', alignItems:'center', gap:'var(--space-3)', flexWrap:'wrap', justifyContent:'center' }}>
+              <span className="qtitle" style={{ fontSize:'var(--text-md)', fontWeight:'var(--weight-semibold)' }}>Group 1</span>
+              <span className="qsub" style={{ fontSize:'var(--text-sm)', color:'var(--text-muted)' }}>of 18</span>
+              <span className="scopepill"><span className="mdi mdi-folder-multiple-image"></span>Release Set B<button className="mdi mdi-close"></button></span>
+            </div>
+          </Spec>
+          <Spec title="Why it belongs on the row" note="A scoped scan is a fraction of the work of a library scan — usually instant. Putting it on the object the user is already looking at is the difference between “dedup this shoot” being a two-second job and a global chore.">
+            <div style={{ display:'flex', flexDirection:'column', gap:'var(--space-2)', width:'100%', maxWidth:300 }}>
+              <div className="ctx-item hi" style={{ borderRadius:'var(--radius-sm)' }}><span className="mdi mdi-folder-outline"></span><span className="sp">Find duplicates in this folder</span><span className="cnt">4</span></div>
+              <div className="ctx-item hi" style={{ borderRadius:'var(--radius-sm)' }}><span className="mdi mdi-account-box-outline"></span><span className="sp">Find duplicates for Walter</span><span className="cnt">2</span></div>
+              <div className="ctx-item hi" style={{ borderRadius:'var(--radius-sm)' }}><span className="mdi mdi-briefcase-outline"></span><span className="sp">Find duplicates in this project</span><span className="cnt">61</span></div>
+            </div>
+          </Spec>
+          <Spec title="Zero-state" note="When a scoped scan finds nothing, the menu item still appears but reads as resolved rather than vanishing — an absent item reads as a missing feature, a zero reads as an answer.">
+            <div className="ctx-item" style={{ borderRadius:'var(--radius-sm)', opacity:.55 }}><span className="mdi mdi-check"></span><span className="sp">No duplicates in this set</span></div>
+          </Spec>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>5 · Bulk: the fast lane</h2><span>Exact matches never deserve a human</span></div>
+        <AutoStackDialog />
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>6 · Migrating off Similarity Groups</h2><span>What happens to the existing sort order</span></div>
+        <div className="migrate">
+          <div className="mcol old">
+            <h4>1.8 — Sort order</h4>
+            <div style={{ display:'flex', gap:'var(--space-2)', marginBottom:'var(--space-3)' }}>
+              <span className="togglebtn gone"><span className="mdi mdi-account-search-outline"></span>Similarity to …</span>
+            </div>
+            <p>Reorders the grid so lookalikes sit next to each other. No count, no verdict, no memory. Discoverable only by opening the sort menu and reading every option.</p>
+            <p>Removed from the sort menu in 1.9.0.</p>
+          </div>
+          <div className="marrow"><span className="mdi mdi-arrow-right"></span></div>
+          <div className="mcol">
+            <h4>1.9 — Destination + queue</h4>
+            <div style={{ display:'flex', gap:'var(--space-2)', marginBottom:'var(--space-3)', flexWrap:'wrap' }}>
+              <span className="togglebtn on"><span className="mdi mdi-content-duplicate"></span>Duplicates <span style={{ background:'rgba(0,0,0,.25)', borderRadius:99, padding:'0 6px', fontSize:11 }}>143</span></span>
+              <span className="togglebtn"><span className="mdi mdi-filter-outline"></span>Filter › Stacked only</span>
+            </div>
+            <p>A sidebar entry with a live count that goes down as you work, and a queue that produces stacks. Stacked / unstacked becomes a <b>filter</b> rather than a second destination — only the thing with a to-do count earns a sidebar row. The similarity <i>signal</i> survives: it now builds groups instead of shuffling the grid.</p>
+            <p>On first launch after upgrade: a one-line notice in the sort menu's place pointing at the new sidebar entry, shown once.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="sect">
+        <div className="sect-head"><h2>7 · Rules</h2><span>Handoff</span></div>
+        <div className="rulelist">
+          <div className="rule"><span className="rn mdi mdi-star-outline"></span><p><b>Cover selection</b>Score = <code>pixels×4 + tags×3 + userScore×2 + RAW bonus</code>. Highest wins, ties break to oldest capture time. Always shown as a preselection the user can override with 1–9; never silent.</p></div>
+          <div className="rule"><span className="rn mdi mdi-shield-check-outline"></span><p><b>No deletion in 1.9</b>Every member file stays on disk and in the database. A stack is a grouping row plus a cover pointer — dropping it restores the flat grid exactly. This is what makes the whole feature safe to ship without confirmation dialogs.</p></div>
+          <div className="rule"><span className="rn mdi mdi-tag-multiple-outline"></span><p><b>Metadata union</b>Stacking unions tags, characters and Set membership onto the stack, and takes the highest score. Nothing is overwritten or lost — the reason Immich users get burned is albums silently breaking, and a union can't break anything.</p></div>
+          <div className="rule"><span className="rn mdi mdi-view-sequential-outline"></span><p><b>Rows, not one-at-a-time</b>The queue shows as many groups as fit. Exactly one row is focused — accent left bar, caret, tinted background, filled Stack button and a “keyboard acts here” label — so <code>↑↓</code> then <code>Enter</code>/<code>S</code> can never be ambiguous about which group it hits.</p></div>
+          <div className="rule"><span className="rn mdi mdi-image-size-select-actual"></span><p><b>Thumbnails carry no metadata</b>Queue rows show pictures at grid scale, edge to edge, with only the cover label and the index while focused. Resolution, size, date and tag counts live in Compare, in two columns with de-emphasised labels so the values read first and the metadata never squeezes the image.</p></div>
+          <div className="rule"><span className="rn mdi mdi-close-circle-outline"></span><p><b>Signals cut both ways</b>Matching evidence is an olive check pill; anything arguing against a stack — different resolution, different aspect ratio, subject moved, eyes closed — is a red × pill. A group carrying red pills is exactly the one that needs Compare, so the pills do the warning rather than generic "review carefully" copy.</p></div>
+          <div className="rule"><span className="rn mdi mdi-folder-eye-outline"></span><p><b>Paths only where they matter</b>File location shows only for pictures in reference folders, where the user manages the files themselves and needs to know which copy is which. Managed library pictures hide it — there, the path is an implementation detail.</p></div>
+          <div className="rule"><span className="rn mdi mdi-compare-horizontal"></span><p><b>Compare is a button, not a secret</b>Every row carries a <b>Compare all N</b> button showing <code>C</code> on the focused row. It opens the full field-by-field view — every candidate, best value highlighted per column, full paths — with Stack and Keep separate in its footer so the decision is made without a second trip.</p></div>
+          <div className="rule"><span className="rn mdi mdi-filter-outline"></span><p><b>Stacks is a filter, not a place</b>A second row of the same large icon segments, directly under the media-type row — Any / Stacked / Unstacked / Unresolved duplicates — with the current choice spelled out beside it and the header's match count updating live. Only <b>Duplicates</b>, which has a to-do count, earns a sidebar entry.</p></div>
+          <div className="rule"><span className="rn mdi mdi-shield-half-full"></span><p><b>Confidence tiers gate the queue</b>Exact matches are always included and can't be switched off. Each looser tier is a separate opt-in with its own count, and enabling one requires the tier above it — so a user can't land on “same scene” suggestions without having deliberately walked down to them. Turning on the loosest tier states the risk in place.</p></div>
+          <div className="rule"><span className="rn mdi mdi-memory"></span><p><b>Queue is virtual</b>One group in the DOM. Prefetch the next group's thumbnails only. Group list is paged from the database by confidence descending; never loaded whole.</p></div>
+          <div className="rule"><span className="rn mdi mdi-keyboard-outline"></span><p><b>Keyboard</b><code>Enter</code> stack · <code>S</code> keep separate · <code>1–9</code> set cover · <code>X</code> exclude the focused candidate · <code>Ctrl+Z</code> undo. Auto-advance after every verdict; the queue is designed to be worked without a mouse.</p></div>
+          <div className="rule"><span className="rn mdi mdi-undo-variant"></span><p><b>Undo integration</b>Every verdict raises the standard action receipt and lands in the history stack. Bulk auto-stack coalesces into a single step, so 1,204 stacks reverse with one <code>Ctrl+Z</code>.</p></div>
+          <div className="rule"><span className="rn mdi mdi-bookmark-check-outline"></span><p><b>Resolved memory</b>Verdicts are keyed on a group signature (sorted member hashes), so re-imports and rescans never re-ask. “Keep separate” is permanent until the user reopens it from the Stacks view.</p></div>
+          <div className="rule"><span className="rn mdi mdi-crosshairs-gps"></span><p><b>Scoped entry points</b>Every collection object — project, set, character, folder — carries <b>Find duplicates in…</b> in its context menu with a live count. A scoped scan reuses cached hashes, so it returns instantly; the queue opens with a dismissible scope pill.</p></div>
+          <div className="rule"><span className="rn mdi mdi-tune-variant"></span><p><b>Threshold</b>Default 0.90. Exact matches are always shown. Below 0.65 nothing is suggested at all — a low threshold produces confident-looking garbage and destroys trust in the count.</p></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+if (window.__DEDUP_HOST) ReactDOM.createRoot(document.getElementById('root')).render(<Page />);

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -91,7 +91,7 @@ pixlstash/
 │   ├── projects.py                   # Projects
 │   ├── picture_sets.py               # Picture sets + membership
 │   ├── stacks.py                     # Stacks
-│   ├── dedup.py                      # Near-duplicate sweep policy + dry run
+│   ├── dedup.py                      # Duplicate queue, counts, scan, verdicts + sweep dry run
 │   ├── config.py                     # User/server config + progress
 │   ├── reference_folders.py          # Reference folders
 │   ├── import_folders.py             # Watch folders
@@ -149,6 +149,8 @@ pixlstash/
 ├── services/                         # Business-logic extracted from route handlers
 │   ├── config_service.py             # Hardware monitoring + import folder utilities
 │   ├── dedup_sweep_service.py        # Vault-wide near-duplicate sweep planner (read-only)
+│   ├── dedup_tier_service.py         # Tiered detection, tier policy, cover + evidence (§22)
+│   ├── dedup_verdict_service.py      # Stack / keep-separate verdicts + metadata union (§22)
 │   ├── plugin_service.py             # Image plugin orchestration + progress tracking
 │   ├── share_service.py              # Share-token validation + watermark resolution
 │   └── tag_prediction_service.py     # Confirm / reject / reset tag predictions
@@ -354,7 +356,9 @@ Add/remove user tags; bulk clear; confirm or reject model-predicted tags (`TagPr
 Standard CRUD; set/stack membership management; stack reordering.
 
 ### `dedup.py`
-The vault-wide near-duplicate sweep, **dry run only** (v1.9 Lane E). `GET /dedup/sweep/policy` returns the server's default confidence policy plus the bounds and closed vocabularies a client should build its controls from; `POST /dedup/sweep/dry-run` resolves every near-duplicate group in the vault under a supplied policy and returns the plan behind "N groups auto-collapse, M need review". Both are `owner_only` (a vault-wide aggregate cannot be narrowed to a share token's scope without leaking out-of-scope counts — the same reasoning as `tag_health`), and neither writes anything. All logic lives in [services/dedup_sweep_service.py](../pixlstash/services/dedup_sweep_service.py); the handlers only translate the request body into a `SweepPolicy` and serialise the `SweepReport`. Execution (applying a plan), the review queue, and the auto-at-import policy are later work; the dry-run planner already accepts an optional `operation_batch_id` so a future apply step can correlate a plan with the operation-log batch that undoes it.
+The vault-wide near-duplicate sweep, **dry run only** (v1.9 Lane E). `GET /dedup/sweep/policy` returns the server's default confidence policy plus the bounds and closed vocabularies a client should build its controls from; `POST /dedup/sweep/dry-run` resolves every near-duplicate group in the vault under a supplied policy and returns the plan behind "N groups auto-collapse, M need review". Both are `owner_only` (a vault-wide aggregate cannot be narrowed to a share token's scope without leaking out-of-scope counts — the same reasoning as `tag_health`), and neither writes anything. All logic lives in [services/dedup_sweep_service.py](../pixlstash/services/dedup_sweep_service.py); the handlers only translate the request body into a `SweepPolicy` and serialise the `SweepReport`. Execution (applying a plan) and the auto-at-import policy are later work; the dry-run planner already accepts an optional `operation_batch_id` so a future apply step can correlate a plan with the operation-log batch that undoes it.
+
+The same module also serves the **v1.9 tiered Duplicates queue** — `GET /dedup/policy`, `GET /dedup/groups`, `POST /dedup/counts`, `POST /dedup/scan`, `POST /dedup/verdicts/{stack,keep-separate,reopen}` and `POST /dedup/auto-stack`. Every one of them is `owner_only` for the same reasoning plus, for the verdict routes, the fact that they mutate stacks across arbitrary pictures. Detection lives in [services/dedup_tier_service.py](../pixlstash/services/dedup_tier_service.py) and verdicts in [services/dedup_verdict_service.py](../pixlstash/services/dedup_verdict_service.py); the handlers only build a `TierPolicy` / `DedupScope` (a bad one is a 400, never a silent retune) and call a service wrapper. See §22 for the tiers, the hash decision, the bucket design, the cover formula and the verdict memory, and `docs/integration_architecture.md` §19 for the request/response contract.
 
 ### `config.py`
 | Method | Path | Purpose |
@@ -430,8 +434,16 @@ Public guest scoring and shared-link endpoints.
 | GET    | /api/v1/characters/{id}/summary                                               | characters      | Get character category summary                             |
 | GET    | /api/v1/characters/{id}/{field}                                               | characters      | Get character field                                        |
 | GET    | /api/v1/check-session                                                         | auth            | Check Session                                              |
+| POST   | /api/v1/dedup/auto-stack                                                      | dedup           | Bulk auto-stack the exact tier                             |
+| POST   | /api/v1/dedup/counts                                                          | dedup           | Live duplicate counts, global and scoped                   |
+| GET    | /api/v1/dedup/groups                                                          | dedup           | One page of the duplicate queue                            |
+| GET    | /api/v1/dedup/policy                                                          | dedup           | Duplicate detection tier defaults                          |
+| POST   | /api/v1/dedup/scan                                                            | dedup           | Queue a duplicate scan                                     |
 | POST   | /api/v1/dedup/sweep/dry-run                                                   | dedup           | Plan a vault-wide near-duplicate sweep                     |
 | GET    | /api/v1/dedup/sweep/policy                                                    | dedup           | Near-duplicate sweep policy defaults                       |
+| POST   | /api/v1/dedup/verdicts/keep-separate                                          | dedup           | Record that a group is not duplicates                      |
+| POST   | /api/v1/dedup/verdicts/reopen                                                 | dedup           | Return a decided group to the queue                        |
+| POST   | /api/v1/dedup/verdicts/stack                                                  | dedup           | Stack a duplicate group                                    |
 | GET    | /api/v1/login                                                                 | auth            | Check Registration                                         |
 | POST   | /api/v1/login                                                                 | auth            | Login                                                      |
 | POST   | /api/v1/logout                                                                | auth            | Logout                                                     |
@@ -965,7 +977,9 @@ Selected milestones:
 
 | 0087 | `characterprojectmember` / `picturesetprojectmember` join tables — many-to-many characters and picture sets across projects (#125). Additive: the scalar `project_id` FKs stay and stay populated as the primary project, and the migration backfills one join row per existing assignment |
 
-Current head: `0087_add_entity_project_membership`.
+| 0088 | `dedupgroup` / `dedupgroupmember` / `dedupverdict` / `dedupscan` — the tiered Duplicates queue cache, verdict memory and scan progress (§22.6). Additive, and deliberately no `NULL` reset: tier 1 reuses the existing `pixel_sha` column and the runtime `MissingPixelShaFinder` backfills rows where it is `NULL` (§22.1) |
+
+Current head: `0088_add_dedup_tier_tables`.
 
 ---
 
@@ -984,7 +998,7 @@ Current head: `0087_add_entity_project_membership`.
 └── reference-folders/         # If configured
 ```
 
-- `pixel_sha` (SHA-256 of decoded pixels) is used for import deduplication.
+- `pixel_sha` (indexed) is used for import deduplication and for §22's tier-1 exact-duplicate detection. It is a **SHA-256 over the file's bytes** (not over decoded pixels, despite the name), and it is **sampled** above 128 KiB: `ImageUtils._calculate_sha256_digest` digests 8 chunks of 8 KiB spread across the file rather than every byte. Anything comparing on it should pair it with `size_bytes` — see §22.1.
 - Watermarks are rendered on demand and cached in memory.
 
 ### Database
@@ -1690,8 +1704,421 @@ A handler that is a bulk action in its own right (the scrapheap move/restore) pa
 
 **Deliberately NOT recorded in this lane** (decided, not overlooked): `POST /pictures/{id}/tag_predictions/delete`, `POST /pictures/{id}/reset_tags` and `POST /pictures/{id}/reset_description`. All three exist to *trigger re-inference* — they drop machine output and queue the tagger/captioner to regenerate it. Their undo semantics are genuinely different (restoring the old rows would immediately be overwritten by the pass they started, and "undo" would have to mean cancelling a queued job), so they need a design of their own rather than a facet.
 
+### 21.3 Post-restore hooks — reopening what an operation also decided
+
+The recorded before/after state covers the reversible **picture** facets. An
+operation can additionally have decided something that is *not* a picture facet,
+and restoring the pictures without reopening that decision leaves the two halves
+disagreeing. The v1.9 duplicate verdict is the first such case, and QA
+caught it half-working: undoing a stack verdict unstacked the pictures but left the
+`DedupVerdict` decided and the `DedupGroup` resolved, so the group never returned
+to the queue, was not counted, and **survived a rescan** (the signature still
+carried a live verdict). The only way back was a `POST /dedup/verdicts/reopen`
+no user could find.
+
+`register_post_restore_hook(op_type, hook)` is the generic seam. `_restore` — the
+one place both undo and redo write state — dispatches the registered hooks after
+every state has been applied and **before the commit**, so the decision and the
+pictures land in one transaction or not at all; a hook that raises aborts the
+whole restore and the operation stays `applied`.
+
+- The hook is called **once per restore** with *every* operation of its own
+  `op_type` in that restore (`(session, operations, direction)`), so a 2 700-row
+  batch undo is one call, not 2 700.
+- `direction` is `RESTORE_UNDO` / `RESTORE_REDO`.
+- **The op-log core imports no feature module.** Registration lives in the
+  feature that owns the `op_type` — `dedup_verdict_service` registers at import
+  time and is imported by `routes/dedup.py`, which `Server` mounts at startup.
+  An `op_type` with no hook simply has none.
+
+Pinned by `tests/test_operation_log.py::test_a_post_restore_hook_runs_once_per_restore_with_its_whole_batch`
+and `::test_a_failing_post_restore_hook_aborts_the_whole_undo`.
+
+### 21.4 `batch_id` is namespaced
+
+`new_batch_id()` mints `srv-<uuid4hex>` (`SERVER_BATCH_ID_PREFIX`). A batch id can
+also come from a client, and the two must be distinguishable: an un-namespaced id
+makes a client-supplied grouping key indistinguishable from a server-minted one,
+so a client could submit an id that reads as a server batch — or graft its rows
+into an existing batch, where one Ctrl+Z then reverses more than the user did.
+There are two client entry points, one contract (`^cli-[A-Za-z0-9_-]{4,76}$`,
+≤80 chars): the `X-Operation-Batch-Id` **header** (§21.2's gesture coalescing,
+validated in `utils/request_origin.py`) and the dedup verdict **body** field
+(validated in `routes/dedup.py`), refused with a **400** when it does not match.
+Note the deliberate asymmetry between the two: an unusable *header* is dropped
+and ignored because a header is ambient; an unusable *body* field is a refusal,
+because the client named it on purpose and silently ignoring it would mis-group
+its undo.
+
 ---
 
-*Last updated: 2026-07-28. Update this document whenever architectural patterns, module boundaries, or integration contracts change.*
+## 22. Tiered Duplicate Detection (v1.9 Dedup → Stacks)
+
+The Duplicates queue is filled by three tiers of increasing cost and decreasing
+certainty. Detection lives in `pixlstash/services/dedup_tier_service.py`; what
+happens when the user decides lives in `pixlstash/services/dedup_verdict_service.py`.
+The shipped `dedup_sweep_service.py` dry-run planner is unchanged and remains the
+non-destructive foundation the whole feature is built on.
+
+### 22.1 Tier 1 — exact, and the hash decision
+
+Tier 1 is `GROUP BY pixel_sha, size_bytes HAVING count(*) > 1` on the **existing
+indexed `picture.pixel_sha` column**. No new hash column was added.
+
+Be honest about what `pixel_sha` is. `ImageUtils._calculate_sha256_digest` hashes
+the whole file only up to 128 KiB; above that it samples 8 chunks of 8 KiB spread
+across the file. So it is a *sampled* content digest, not a full-file SHA-256, and
+two files could in principle share one while differing in an unsampled region.
+
+Two consequences, both deliberate:
+
+- **`size_bytes` is a co-key, not decoration.** The sample offsets are derived from
+  the file size, so equal size plus equal sampled digest is a far stronger claim
+  than the digest alone. It costs nothing — the `pixel_sha` index already narrows
+  the group.
+- **Exact matches still go through a consent dialog.** `POST /dedup/auto-stack`
+  defaults to `dry_run=true`; the design deliberately does not stack exact matches
+  at import without the user seeing the count first. The worst case of a false
+  exact match is two different pictures in one *stack*, which is reversible with
+  one keystroke and destroys nothing.
+
+A new full-file hash column was considered and rejected: it would mean re-reading
+every byte of every file in the library on upgrade to buy a guarantee this feature
+does not need. `pixel_sha` is already computed incrementally on every import path;
+`MissingPixelShaFinder` / `PixelShaTask` (`TaskType.PIXEL_SHA`) backfill the rows
+that predate it, selecting on `pixel_sha IS NULL` — which is why migration
+`0088` contains no `NULL` reset.
+
+### 22.2 Tier 2 — bucketed near, and what "bucket" reuses
+
+Perceptual hashes are compared **only within candidate buckets**, never
+library-wide. `build_near_buckets()` emits four bucket kinds from columns the
+library already maintains:
+
+| Bucket kind | Column | Catches |
+|---|---|---|
+| `size_bin` | `picture.size_bin_index` (indexed `(w << 32) + h`) | re-saves, re-encodes, burst frames |
+| `capture_minute` | `created_at` truncated to the minute | bursts, re-exports that changed size |
+| `import_folder` | `picture.import_source_folder` (indexed) | one import run |
+| `folder` | parent directory of `file_path` | a duplicated folder |
+
+A picture belongs to several buckets; that is the point. Buckets over
+`MAX_BUCKET_MEMBERS` (4000) are **split into shards**, never dropped, so no
+candidate is silently skipped.
+
+Inside a bucket the comparison is a numpy XOR plus a SWAR popcount over the 64-bit
+dHash in `picture.perceptual_hash`, with
+`similarity = 1 - hamming / 64`. A 4000-member bucket is ~8M popcounts, which is
+milliseconds.
+
+**`LikenessParameter.PHASH_PREFIX` is deliberately not used as a bucket key.**
+Despite the name it stores the *entire* 64-bit dHash linearly normalised into
+`[0, 1]` (`int(phash[:16], 16) / (2**64 - 1)`), so numeric proximity in that slot
+is dominated by the top bit and says nothing about Hamming proximity.
+`LikenessUtils.PHASH_PREFIX_LEN = 3` is dead code with no reader. The reusable
+precomputed bucket key is `size_bin_index`, and that is what tier 2 uses.
+
+**Memory is bounded separately from CPU.** `MAX_BUCKET_MEMBERS` caps the
+comparison *work*; it does not cap the *result*. A bucket whose members are
+mutually near-identical (a burst of near-black frames, a folder of solid-colour
+placeholders, one image copied 4000 times) yields `k*(k-1)/2` pairs — ~8M tuples,
+roughly 580 MB, for a component the union-find only needs a spanning subset of.
+Two further caps, both logged when they bite (never silent):
+
+| Constant | Value | Bounds |
+|---|---|---|
+| `MAX_PAIRS_PER_BUCKET` | 50 000 (~4 MB) | pairs materialised for one bucket |
+| `MAX_TRACKED_PAIRS` | 400 000 (~32 MB) | pairs a whole streaming scan retains across buckets |
+
+**The per-bucket cap can lose membership, and the log says so.** Pairs are
+emitted in increasing member-offset order, so the cap keeps the nearest-offset
+edges and drops every wider one. In a *uniformly* near-identical bucket that is
+harmless — the offset-1 edges alone span the block — and the only loss is
+confidence *resolution*. In a **dense but non-uniform** block it is not: ~700
+mutually matching members exhaust 50 000 pairs well inside the low offsets, so a
+member whose only match sits at a wider offset gets no edge at all and is split
+into its own group or drops out of the queue entirely. An earlier version of this
+paragraph claimed membership was never lost; that was wrong. The warning now
+names the bucket, the offset it stopped at, and that consequence, and states the
+mitigations (resolve the dense block and rescan, narrow the bucket, or raise
+`MAX_PAIRS_PER_BUCKET` for the memory it costs). Hitting the scan-wide cap stops
+cross-bucket chaining growing, so a chain spanning two buckets can be reported as
+two groups. Both log a warning naming the bucket or scan and what was given up.
+
+### 22.3 Tier 3 — embedding
+
+Opt-in, and recomputes nothing: it folds the existing `PictureLikeness` edge table
+into components through the shipped `dedup_sweep_service.stream_likeness_edges` /
+`_LikenessForest`. Its groups append to the same queue.
+
+### 22.4 Policy: tier gating replaces the auto/review split
+
+`TierPolicy` is the queue's policy surface and supersedes `SweepPolicy`'s
+auto/review split *for the queue* (`SweepPolicy` remains the parameter object for
+the dry-run planner, unchanged).
+
+- Tier 1 is always included and **has no switch**.
+- Each looser tier is a separate opt-in, and `embedding_enabled` **requires**
+  `near_enabled`.
+- `threshold` defaults to `0.90`; `MIN_THRESHOLD = 0.65` is a hard floor. It is
+  never silently clamped: a low threshold produces confident-looking garbage and
+  destroys trust in the sidebar count. **The refusal is a 422, not a 400.** The
+  floor is a pydantic `ge=MIN_THRESHOLD` bound on the query parameter and on
+  `TierPolicyModel.threshold`, so FastAPI rejects a low value before any handler
+  runs, on every route. `TierPolicy.__post_init__` keeps its own `ValueError`
+  check because it is the *service-level* invariant — reachable from a task or a
+  test that never went through a request — and the tier-dependency rule it also
+  enforces (`embedding_enabled` requires `near_enabled`) is not expressible as a
+  field bound, so **that** one is the 400 the handlers translate.
+
+### 22.5 Cover selection and evidence
+
+Cover score is `megapixels*4 + tags*3 + score*2 + 8 if RAW`; highest wins, ties
+break to the **oldest capture time**, then to the lowest id. It is always exposed
+as a *preselection* the user overrides, together with:
+
+- **group evidence** — matching pills and evidence-against pills (different
+  resolution / aspect ratio / file format), so a group carrying red pills is
+  visibly the one that needs Compare;
+- **per-candidate evidence** — what each candidate is best at and where it loses,
+  plus its numeric `cover_score`.
+
+The server reports reasons. The user concludes.
+
+### 22.6 Persistence: four tables
+
+`pixlstash/db_models/dedup.py`, migration `0088_add_dedup_tier_tables`:
+
+- **`dedupgroup` / `dedupgroupmember`** — the found-groups cache. Detection
+  *upserts on `signature`*, so a rescan refreshes rows instead of duplicating
+  them, and the queue is paged from `(resolved, confidence DESC)` and never
+  materialised whole. This is what makes 10 groups and 10,000 cost the same.
+
+  **The upsert honours tier precedence** (`TIER_STRENGTH`: exact > near >
+  embedding). Two tiers routinely find the *same* group — a byte-identical pair
+  is also perceptually identical, so every near-enabled scan rediscovers every
+  exact pair under the same signature — and the upsert originally wrote
+  `row.tier` unconditionally. An exact pair silently demoted to `near`
+  disappeared from the exact-only default view **and** from
+  `POST /dedup/auto-stack`, which only ever acts on `exact`. Tier, confidence,
+  evidence and cover move together (they describe one finding); membership is
+  refreshed either way, because the signature pins the member *content keys* and
+  a re-import can give the same content new picture ids. Pinned by
+  `test_a_near_scan_does_not_downgrade_an_exact_group` and
+  `test_the_upsert_takes_the_stronger_tier_in_either_arrival_order`.
+- **`dedupverdict`** — verdict memory keyed on the group **signature**: `sha256`
+  of the sorted member content keys, where a content key is
+  **`<pixel_sha>:<size_bytes>`** (or `id:<n>` for a picture not yet hashed).
+  Because the key is content and not ids, a rescan or a re-import never re-asks.
+  `reopened_at` marks a verdict as no longer live; the row is kept so the
+  decision history survives.
+
+  **The size co-key is not optional.** Identity has to match detection: tier 1
+  groups on `(pixel_sha, size_bytes)` precisely because the digest is sampled
+  above 128 KiB. A signature over the digest alone was not injective over groups
+  — two distinct exact groups differing only in size collapsed onto one
+  signature, and all three consequences were silent: the upsert-on-signature
+  dropped one group from the queue, a `keep_separate` on the survivor resolved
+  both file sets, and a stack verdict's write target depended on scan order
+  rather than on what the user saw. Pinned by
+  `test_two_groups_sharing_a_digest_but_not_a_size_stay_distinct`.
+- **`dedupscan`** — one row per scope key, both the scan *request* (status
+  `pending`) and the "scanned N of M" progress readout.
+
+`prune_stale_groups_in_session()` removes groups whose live membership has
+dropped below two, so the sidebar badge cannot be inflated by scrapheaped
+pictures. Prune only runs on a verdict or a scan, so the counts and the open
+queue additionally filter on the spot (`_live_groups_filter`): a group counts
+only while it still POSES a decision — two or more live members spanning two
+or more stack units (`COALESCE(stack_id, -id)`). The stack-unit half exists
+because the grid's own stack actions never touch `dedupgroup`: an exact pair
+the user stacked by hand stayed "unresolved" and was re-offered forever
+(found in the wild as 21 zombie groups, 2026-07-29). A group where a stack
+would still fold something in — two stacks, or a stack plus a loner — keeps
+counting.
+
+**Scope ids are normalised and validated at construction** (`DedupScope.__post_init__`),
+not at query time. Project / set / character ids must parse as integers. A
+**folder** `scope_id` is stripped of trailing separators and **refused when that
+leaves it empty**: `/`, `\`, `///` all rstripped to `""`, which became a `LIKE`
+pattern of `%` — a "Find duplicates in this folder" request that silently meant
+the whole vault, plus a persisted `dedupscan` row whose `scope_key` claimed
+otherwise. Normalising at construction also collapses `/photos` and `/photos/`
+onto one scope key instead of two scans.
+
+### 22.7 Paging the queue: a keyset cursor, not an offset
+
+`GET /dedup/groups` pages by an **opaque keyset cursor**. The queue is a live
+list: a verdict removes the row the user just decided from `resolved=False`, and
+a tier-2 scan commits new groups after every bucket. Both shift every later row's
+offset, so `offset=limit` on the next request skips exactly as many groups as the
+page's decisions removed — a deterministic, silent skip reproduced with a single
+verdict between two pages.
+
+- **Order is `(confidence DESC, id ASC)`**, and the cursor encodes that pair for
+  the last delivered row. Wire form: unpadded base64url over
+  `"1|<confidence at %.17g>|<group id>"` (`CURSOR_VERSION` is the leading `1`).
+  17 significant digits make the float round-trip exactly, which the tie-break
+  branch depends on.
+- **The tie-break half is load-bearing.** Every exact group sits at the same
+  confidence, so `confidence < c` alone would drop the rest of the tied run and
+  `confidence <= c` would repeat it forever. The predicate is
+  `confidence < c OR (confidence = c AND id > i)`.
+- `next_cursor` is `null` once the page is not full — end-of-found. A full last
+  page hands back a cursor that yields one empty page, which is cheaper than the
+  extra `COUNT` needed to know for certain.
+- **Opaque by intent.** Clients pass it back verbatim. A cursor this server did
+  not mint is a **400**, never a silent restart from the top — silently paging
+  from offset 0 would hand the client page 1 forever.
+- `offset` still works and is **deprecated**; sending both is a **400** rather
+  than a silent preference, because a client that sends both has two different
+  ideas of where it is.
+
+### 22.8 Streaming and the background path
+
+`DedupScanFinder` / `DedupScanTask` (`TaskType.DEDUP_SCAN`) turn a `pending`
+`dedupscan` row into work. Tier 1 runs first and in one shot so the queue is never
+empty; tier 2 then commits **after each bucket**, so a bucket's groups appear in
+the queue the moment that bucket finishes and `scanned_buckets` advances with it;
+tier 3 appends last. Restarting a scan is safe because persistence is an upsert.
+The finder `depends_on` `PIXEL_SHA` and `IMAGE_EMBEDDING` so a scan reports honest
+counts rather than a partially hashed library.
+
+**Only the groups a bucket could have changed are re-persisted.** Pairs are
+retained across buckets so a chain spanning two of them folds into one group, but
+each bucket tracks the picture ids its *new* pairs touched and rewrites only the
+groups containing one of them. The earlier version re-derived and re-wrote **every
+group after every bucket** — `O(buckets × groups)` DELETE+INSERT on the single DB
+writer thread, which every import, tag edit, scrapheap move and verdict then
+queues behind.
+
+**Honest scope of the performance claim.** §22.6's "10 groups and 10,000 perform
+identically" is a statement about the **queue page**, which reads exactly `limit`
+rows. It is *not* a statement about the scan: a scan is inherently proportional to
+the library, it holds the single DB writer while it runs, and its memory is bounded
+by the caps in §22.2 rather than being free.
+
+### 22.9 Verdicts and the metadata union
+
+The only two verdicts are **stack** and **keep separate**. Neither deletes
+anything; there is no destructive route on this surface in 1.9.
+
+Stacking applies the metadata union onto every member:
+
+| What | Behaviour |
+|---|---|
+| project + set membership | union, via the existing `reconcile_stack_membership` |
+| tags | union of every non-sentinel tag; `__tag` / `__tag:<engine>` markers are excluded so an already-tagged picture is not re-queued |
+| score | every member lifted to `max(score)`; never lowered |
+| characters | see below |
+
+**Characters are the one honest limitation.** A face carries a bbox and an
+embedding that belong to one specific picture, so a true face-to-character union
+would mean fabricating `Face` rows. Instead, when the group's members between them
+reference exactly **one** character, members that do not already carry it get
+`Picture.pending_character_id` (the shipped deferred-assignment mechanism the face
+extraction task consumes). A group spanning several characters is left alone and
+logged.
+
+The union writes tags and scores, which are curation state, so it calls
+`enforce_pictures_not_locked` first: a locked-set member makes the whole verdict a
+423 rather than a half-applied union.
+
+**Guard ordering is load-bearing.** `_stack_members` calls
+`enforce_stack_membership_not_locked` **before** it folds any other stack in, and
+that guard expands through `expand_picture_ids_to_stacks` — which is why a locked
+co-member dragged in by the fold is caught even though
+`apply_metadata_union_in_session` only checks the group's own members. Moving the
+lock check after the fold would open that hole. Pinned by
+`test_a_locked_co_member_of_a_folded_stack_is_refused`.
+
+#### Accepted risk A1 — the union widens live share tokens
+
+**This is a change to who can see what, not only to metadata.** Unioning set and
+project membership adds an out-of-scope duplicate to a *shared* set, and every
+live share token for that set immediately reaches it — the picture, its tags, its
+`pixel_sha`, its file. The authz gate is behaving correctly (the picture genuinely
+*is* a set member after the union); the widening is the membership change itself.
+
+- **Not new.** An ordinary `POST /stacks` does exactly the same thing; this is the
+  shipped stack-atomic membership model, not a dedup regression.
+- **What is new is the amplification.** `POST /dedup/auto-stack` with
+  `dry_run=false` applies it to **every exact group in the vault** behind one
+  consent dialog. The dry run reports `groups` / `pictures` and a
+  `dry_run_summary`, but **not** how many shared sets or live tokens would gain
+  members.
+- **Blast radius.** Bounded to the owner's own sharing decisions: only sets and
+  projects that already have an outstanding token, and only pictures the owner has
+  just declared duplicates of something already in that set.
+- **Compensating controls.** `dry_run=true` is the default; the union is additive
+  and reversible through the operation log; tokens are owner-minted and READ-only;
+  a locked set refuses the union outright.
+- **Ruling: accepted** for the single-owner product. **Revisit** at the start of
+  any multi-user work, and immediately if bulk auto-stack is ever wired to run
+  unattended (at import or on a schedule) — unattended bulk membership widening is
+  a different risk and this acceptance does not cover it.
+- **Recommended, not implemented:** a `shared_sets_affected` count in the dry-run
+  summary so the consent dialog can say so out loud.
+
+### 22.10 Operation-log integration (§21)
+
+Every stack verdict records **exactly one** `Operation` row.
+
+- **One verdict, one row.** The verdict path deliberately does *not* call
+  `routes/stacks.py`, whose handlers already wrap themselves in
+  `run_recorded_metadata_task`; going through them would write a second row and
+  "one verdict, one undo" would stop being true. `_stack_members` stacks
+  in-session and `_record_operation` records once around the whole verdict.
+- **Bulk auto-stack shares one `batch_id`** across every group in the run, so
+  `POST /operations/batches/{batch_id}/undo` reverses the lot in one step. The
+  response carries the `batch_id` **even when the run only partially applied**
+  (see below), so work that happened is never left without a way to reverse it.
+- **The snapshot is stack-expanded**, taken over `expand_picture_ids_to_stacks`
+  with `include_deleted=True`: folding a stack reparents co-members the group
+  never named, and `normalize_stack_positions` renumbers soft-deleted members too
+  (§21.1). Both are pinned by non-vacuous tests.
+- **Keep-separate and reopen record nothing.** Neither changes a reversible
+  picture facet, so `record_operation_in_session` would return `None` anyway;
+  writing a no-op row would still consume a Ctrl+Z. The way back from
+  keep-separate is the explicit reopen action.
+- **A stack verdict is always recorded under a `batch_id`**, minted server-side
+  (`srv-…`, §21.3) when the caller supplies none. The batch id is what ties the
+  `Operation` row back to its `DedupVerdict` row, and that correlation is what
+  makes the undo complete — see below.
+- **Undo reopens the verdict, not only the pictures.** `restore_verdicts_in_session`
+  is registered as the §21.2 post-restore hook for `dedup.stack`. On **undo** it
+  stamps `reopened_at` on every verdict in the restored batches (the row is kept
+  — the decision history is worth keeping) and sets its group `resolved=False`;
+  on **redo** it clears `reopened_at` and re-resolves the group. `decided_at` is
+  never re-stamped: it records when the user decided, and "live" is exactly
+  `reopened_at IS NULL`. One query covers a 2 700-group batch undo. Without this
+  the undo was half an undo: the pictures came back unstacked while the group
+  stayed decided, invisible in the queue and in the counts, and it **survived a
+  rescan** because `verdict_signatures_in_session` still saw a live verdict.
+  Pinned at the HTTP level by `test_undo_returns_the_stacked_group_to_the_queue`,
+  `test_batch_undo_after_auto_stack_returns_every_group` (QA's exact repro) and
+  `test_an_undo_does_not_reopen_a_group_it_never_touched`.
+- **A pre-existing row without a batch id cannot be correlated**, and the hook
+  says so with a warning naming the operation ids rather than half-restoring in
+  silence: the pictures are back, the group stays decided until the user reopens
+  it explicitly.
+- **Origin discipline.** `actor` / `source` / `origin_client_id` come from
+  `operation_log_service.request_context(request)`, read in the handler on the
+  request's own task and passed down explicitly — never from the contextvar, which
+  is dead on the DB worker thread. Only the two recording handlers take a
+  `Request`; keep-separate and reopen deliberately do not, since the values would
+  be dead arguments.
+
+**A bulk run is never aborted by one bad group.** The locked-set guards raise
+`HTTPException(423)`, so the loop catches that alongside `DedupVerdictError`,
+rolls back just that iteration, and records the group under an explicit outcome:
+`applied`, `blocked` (a guard refused it) or `failed` (it could not be resolved).
+Catching only `DedupVerdictError` meant a locked group mid-run propagated out
+after earlier groups had already committed — a partially applied mutation whose
+server-minted batch id the caller never saw.
+
+---
+
+*Last updated: 2026-07-29. Update this document whenever architectural patterns, module boundaries, or integration contracts change.*
 
 ### Known drift / cleanup notes

--- a/docs/design/visual-language.md
+++ b/docs/design/visual-language.md
@@ -644,6 +644,20 @@ rules and tokens they collapse onto.
   is the sidebar task/upload badge's pulse-on-landing. Loop the **attention pulse**
   only while work is genuinely live; stop it when idle.
 
+### The outline count pill (a count in a different unit)
+
+A count that is **not pictures** must not wear the filled count pill, or it
+reads as one more picture count sitting in a column of them. The outline
+variant — no fill, a 1px border, tabular numerals, same pill radius and size —
+is the answer when such a count must be shown, with a tooltip naming the unit.
+
+*History:* introduced 2026-07-29 for the Duplicates sidebar count, and retired
+from that spot the same day: the group count moves with the tier gate and the
+threshold, so it read as churn, and the owner replaced it with the plain
+**attention dot** ("there are duplicates to review" — the queue's own header
+carries the numbers). The variant remains available for a stable non-picture
+count.
+
 ### The key-hint badge (`kbd`)
 
 Dialog action buttons wear their keys (owner decision, 2026-07-29; the behavioural

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -58,6 +58,7 @@ frontend/src/
 │   ├── useReviewSessionsStore.js # tag-review sessions, health board, and sticker gamification
 │   ├── useEntityNamesStore.js   # id→name maps for the ImageGrid breadcrumb
 │   ├── useOperationStore.js     # the undo/redo stack + the action receipt (backend §21)
+│   ├── useDedupStore.js         # the duplicate triage queue, its live counts and the tier gate
 │   └── useTasksStore.js         # active background work (workers + ComfyUI runs); app-wide activity light
 │
 ├── composables/                 # Extracted logic composables (Phase 8.1 — complete)
@@ -73,7 +74,9 @@ frontend/src/
 │   ├── useReviewRoute.js        # URL ⇄ tag-review overlay (`?review=…`); mirrors ImageGrid's `?overlay=` mechanics (+ *.test.js)
 │   ├── useActionReceipt.js      # The receipt contract (wording, keycaps, drain, pause, focus) shared by the grid pill and the lightbox's own narration
 │   ├── useVersionCheck.js       # "New version available" check (pixlstash.dev poll); single owner gated by `enabled`
-│   └── useSidebarExpansion.js   # Which sidebar sections / projects / folders are open; localStorage-backed (+ *.test.js)
+│   ├── useSidebarExpansion.js   # Which sidebar sections / projects / folders are open; localStorage-backed (+ *.test.js)
+│   ├── useDedupQueueKeyboard.js # The duplicate queue's key model, as a dependency-injected factory (+ *.test.js)
+│   └── useOneTimeNotice.js      # A notice shown once per browser and then never again; localStorage-backed (+ *.test.js)
 │
 ├── api/                         # Backend resource modules: the only place URL strings live (see §8)
 │   ├── config.js                # Per-user config blob: GET/PATCH /users/me/config
@@ -116,7 +119,7 @@ frontend/src/
 └── components/
     ├── TitleBar.vue             # Desktop-only custom window title bar (Electron): wordmark, breadcrumb, window controls, update alert
     ├── WordmarkLogo.vue         # "PixlStash" brand wordmark in the Tiny5 pixel font (two-tone via --wordmark-accent)
-    ├── views/       # Full-page / full-screen UI surfaces: ImageGrid, ImageOverlay + extracted OverlayTagsPanel/OverlayDescriptionPanel/OverlayMetadataPanel/OverlayFilmstrip, ReviewSessionsOverlay, LoginScreen
+    ├── views/       # Full-page / full-screen UI surfaces: ImageGrid, ImageOverlay + extracted OverlayTagsPanel/OverlayDescriptionPanel/OverlayMetadataPanel/OverlayFilmstrip, ReviewSessionsOverlay, DuplicateQueue, LoginScreen
     ├── panels/      # Large structural panels that form the app shell: SideBar, Toolbar + extracted TbTagPanel/TbComfyPanel/TbExportPanel/TbImportPanel/GbFilterPanel/UndoControl, SelectionBar, SelectionMenu, StatsSidebar, ProjectFiles, …
     ├── reviews/     # Tag-review surfaces (see below)
     │   ├── ReviewSessionView.vue      # One open review session: header, rail, and card queue
@@ -133,7 +136,7 @@ frontend/src/
     ├── editors/     # Entity create / edit / delete dialogs
     ├── settings/    # UserSettingsDialog, its section sub-components (Appearance, Behaviour, SmartScore, Workflows, Account, Snapshots, Compute), and the Settings* layout primitives (SettingsRow, SettingsSection, SettingsChip/ChipGrid, SettingsFieldBlock, SettingsSliderRow, SettingsTwoCol, SettingsInfoCard, SettingsAddTagRow)
     ├── io/          # Import / export / external-service connection, ComfyUiRunner, RemixDialog
-    └── widgets/     # Reusable primitives, including the App* design-system layer (AppButton/AppDialog/AppInput/AppSelect/AppStepper/AppTextarea + FieldLabel) and the two undo receipts (ActionReceipt over the grid, OverlayActionReceipt inside the lightbox)
+    └── widgets/     # Reusable primitives, including the App* design-system layer (AppButton/AppDialog/AppInput/AppSelect/AppStepper/AppTextarea + FieldLabel), the two undo receipts (ActionReceipt over the grid, OverlayActionReceipt inside the lightbox), the Dedup* family (the duplicate queue's row, compare dialog, auto-stack dialog, tier menu, scan banner, scope pill, why-pills and confidence pill), and the Stack* family (badge, edge ticks, expansion strip)
 ```
 
 ---
@@ -146,7 +149,7 @@ frontend/src/
 | UI component library | Vuetify 3 |
 | State management | **Pinia** — 21 domain stores in `src/stores/`; `App.vue` owns only UI-shell state |
 | HTTP client | Axios (singleton `apiClient`) |
-| Routing | **Vue Router 4** (`createWebHistory`). `Root.vue` gates on `isAuthenticated`; all authenticated views (`/`, `/character/:id`, `/set/:id`, `/project/:id`, `/scrapheap`) render `App.vue` via `<RouterView>`. `useViewStore` owns the app's single route watcher and syncs params to Pinia stores (§4.5); `App.vue`'s nav handlers call `router.push()` to update the URL. **The route is the single source of truth for what the grid shows** — only explicit entry clicks push routes; sidebar tab/category switches never do (see Key Design Principles). |
+| Routing | **Vue Router 4** (`createWebHistory`). `Root.vue` gates on `isAuthenticated`; all authenticated views (`/`, `/character/:id`, `/set/:id`, `/project/:id`, `/scrapheap`, `/duplicates`) render `App.vue` via `<RouterView>`. `useViewStore` owns the app's single route watcher and syncs params to Pinia stores (§4.5); `App.vue`'s nav handlers call `router.push()` to update the URL. `/duplicates` is deliberately NOT a grid view: `parseRouteView` returns `null` for it, so the selection stores keep whatever the user was looking at. **The route is the single source of truth for what the grid shows** — only explicit entry clicks push routes; sidebar tab/category switches never do (see Key Design Principles). |
 | Build tool | Vite 5 |
 | Unit tests | Vitest (jsdom environment) — test files co-located as `*.test.js` in `utils/` |
 | End-to-end tests | Playwright (`frontend/e2e/`) — drives the real SPA against a backend booted on a throwaway copy of the `test-data/` fixture. See `frontend/e2e/README.md`. |
@@ -222,6 +225,7 @@ All state consumed by more than one component lives in a Pinia store. The stores
 | `useGenStackPrefsStore` | `useGenStackPrefsStore.js` | Remembered client prefs for whether newly generated / filtered images stack with their source: `stackI2IOutputs` (ComfyUI image-to-image) and `stackFilterOutputs` (plugin "Filters" runs), both default ON and persisted to `localStorage`. |
 | `useEntityNamesStore` | `useEntityNamesStore.js` | `characterNames`, `setNames`, `projectNames`, `refFolderLabels`, `importFolderLabels` (id→name maps). One-directional id→name only (names aren't unique). `SideBar` publishes via `merge*` setters after each fetch; `ImageGrid`'s breadcrumb consumes them to label the route's IDs. |
 | `useOperationStore` | `useOperationStore.js` | The undo/redo stack, mirrored from the backend's append-only operation log (`backend_architecture.md` §21): `operations` (newest 50, newest first), `canUndo`/`canRedo`/`nextUndo`/`nextRedo` from `GET /operations/undo-state`, and the single live `receipt` that narrates what just happened. Computeds `past` (applied steps), `future` (undone, redoable), `historyCount`, `nextUndoIsExternal`. Owns the receipt's dwell timer (5s, 8s destructive, paused on hover/focus/hidden tab) and the multi-step `undoTo` walk. Refreshed on a debounced WS picture/tag/character/description event; the receipt narrates THIS client's operations only (origin read from the event `data`), so another tab's work updates the stack silently. |
+| `useDedupStore` | `useDedupStore.js` | The duplicate triage queue. `openCount` (the sidebar badge), `byTier` (the per-tier split, including tiers that are switched off), `scopeCounts` (the per-object counts the context menus read, cached and de-duplicated while in flight), `scan` (normalised from the server's picture and bucket counters; the percentage is derived here because the server publishes none), `groups` + `total` + `hasMore` (offset-paged by confidence descending, never loaded whole), `focusIndex`, the per-group `coverChoices` / `exclusions` keyed on signature, and the tier gate (`nearEnabled`, `embeddingEnabled`, `threshold`) whose bounds all come from `GET /dedup/policy`. Owns the verdicts and the auto-advance: resolving a group removes its row and the focus lands on the next open group. A **stack** verdict is recorded server-side like any other change, so its receipt and `Ctrl+Z` come from `useOperationStore` with nothing bespoke here; a **keep-separate** records no operation by design; its narration is a transient notice pointing at the **Decided page** (owner call, 2026-07-29 — this replaced the sticky Reopen notice). `showingDecided` / `toggleDecided` flip the queue to `GET /dedup/groups?decided=true`: resolved groups with their live verdict, each row swapping its verdict buttons for a verdict label and a **Clear decision** action (`POST /dedup/verdicts/reopen` — never touches pictures; a reopened stacked group stays stacked until unstacked from the Stacks view). Verdicts and multi-select are inert on the decided page, and its empty state carries its own way back since the header toggle unmounts with the list. **Multi-select (owner request, 2026-07-29):** Ctrl/Cmd+click toggles a group in and out of a selection, Shift+click ranges from the anchor, plain click clears — the grid's own conventions. A verdict on any selected group applies to the whole selection (`verdictTargets`); a bulk stack shares ONE `cli-` batch id so a single Ctrl+Z reverses the gesture, and a bulk keep-separate's sticky notice reopens every group it covered. The bulk scope is stated twice — a header chip ("N groups selected — Stack and Keep separate apply to all") and the verdict buttons themselves rename ("Stack N groups" / "Keep N separate") — because a bulk action must never look like a single one. Escape clears the selection without costing the focus; a reload (scope, tier, rescan) clears it too, since it would silently point at different rows. **`openQueue` is the scan trigger**: the group cache only fills when a scan runs, so opening the queue queues one (`POST /dedup/scan`) and the queue opens over whatever exists while the banner streams — without this the queue reads an empty cache forever, whatever the tier gate says. Loosening the policy (enabling a tier, lowering the threshold) rescans too; narrowing only re-queries. While a scan is `pending`/`running` the store polls counts every 2s and reloads the group list **only while it is empty**, so the first finds surface on their own and a triage in progress is never yanked to the top. |
 | `useTasksStore` | `useTasksStore.js` | `workerSnapshots`, `series` (per-worker throughput history), `systemUsage` (CPU/RAM/VRAM), `comfyuiRuns` (frontend-driven run progress keyed by run id); computeds `activeEntries` (backend workers + ComfyUI runs, merged), `hasActiveTasks`, `activeCount`. The **single poller** of `GET /workers/progress` (adaptive cadence — see §4.4) and the single source of truth for the app-wide "is the app working" indicators. |
 
 Components import stores directly (`import { useFilterStore } from '../../stores/useFilterStore'`) — no prop drilling required.
@@ -504,6 +508,8 @@ Actual file upload engine. Props: `backendUrl`, `selectedCharacterId`, `allPictu
 #### App* design-system layer (`widgets/`)
 The house-styled form/control primitives that wrap Vuetify with the PixlStash tokens (`styles/design-tokens.css`), so new UI composes from one consistent kit instead of raw Vuetify: `AppButton.vue` (~140 lines), `AppDialog.vue` (~165 lines), `AppInput.vue` (~95 lines), `AppSelect.vue` (~95 lines), `AppStepper.vue` (~125 lines), `AppTextarea.vue` (~60 lines), plus `FieldLabel.vue` (~15 lines) for consistent field labelling. Presentational; each takes `v-model` / props and emits the matching update events.
 
+**`AppDialog fullscreen`** (2026-07-29): a near-viewport dialog (min(1800px, 96vw) × 94vh, flexing body) for working surfaces where the content is the point — first user: the dedup Compare dialog, per the owner's "take the full space of the grid view". Ordinary forms keep the fixed `width`.
+
 **The dialog keyboard contract (owner decision, 2026-07-29).** Every dialog dismisses on **Escape** and accepts on plain **Enter**, and the buttons wear the keys. `AppDialog` implements both on its own subtree so no page-level Escape owner is consulted first: Escape emits `close` (suppressed while `persistent`), Enter emits `accept`. Enter is deliberately inert where the key already has a meaning — multiline fields, buttons and links (native activation wins, so Enter on a focused Cancel cancels), selects, `<summary>`, ARIA text boxes, and any element that already handled the event (`defaultPrevented`). To adopt: wire the primary action to `@accept`, give the accept/confirm button `AppButton key-hint="enter"` (an ↵ badge, plus `aria-keyshortcuts`) and the cancel/abort button `key-hint="esc"`, and let the disabled state of the button — not the handler — be what gates the keypress (the `accept` handler must check the same `canSubmit` the button uses). New dialogs must follow this; existing dialogs adopt it as they are touched. First adopter: `RemixDialog`.
 
 #### `ActionReceipt.vue` (465 lines, `widgets/`)
@@ -580,6 +586,7 @@ Load-bearing behaviours, each of which is a deliberate decision rather than an i
 - **It closes on submit and hands progress to `ComfyUiRunner`**, rather than hosting its own bar. Abort is global (`POST /comfyui/abort` clears the entire ComfyUI queue), so a modal-local control next to it would be a mislabel. A submit *failure* is treated as a form error: the dialog stays open with every input intact and the message in a `role="alert"`.
 - **Scope is disclosed, not silently applied.** The action always targets the right-clicked picture; with a wider selection live the dialog says so and offers a one-click route to the shipped batch path (`open-comfyui-panel`).
 - **Three seed modes in recipe mode, two in template mode.** Random draws fresh. **Incremented** (recipe mode only — templates have no original to increment from) applies a signed delta (default +1, session-sticky) to the original seed read from the recipe response (`seed`, falling back to the first `seed_inputs` value) and shows the resulting value live; it submits as `seed_mode: "fixed"` with the computed seed, so the API surface is unchanged. **Fixed** defaults to the original seed and carries a small warning-toned "same as original" note until edited, because replaying the identical seed re-creates the identical image, which the importer dedupes into silence — flagged, not forbidden. A sticky `incremented` preference falls back to random where it cannot be honoured.
+- **Compare is fullscreen, image-first, with the design system's blink compare.** The dialog takes the grid's full space (`AppDialog fullscreen`); candidate cards grow into the width and preview **down-scaled originals** (browser-decodable formats; RAW/video fall back to the server thumbnail) with the metadata compacted into the design system's two-column label-over-value grid. The **zoom** (per the design-system update, 2026-07-29) is a full-screen blink compare teleported above the modal: one candidate at a time flipped in place (←/→ wrap, 1–9 jump) so differences read as motion; **Fit** keeps every candidate registered in one box, **Actual pixels** (P) is 1:1 with drag-to-pan; click picks the cover, right-click excludes, Enter/S give the verdict from inside. The zoom's *state* lives in the dialog (exposed as `isZoomOpen/openZoom/closeZoom/flipZoom/zoomTo/toggleZoomPixels`) but its *keys* live in the queue's one keyboard model, which Escape-peels one layer at a time: zoom → Compare → queue. In the zoom, digits flip — they never silently re-pick the cover.
 - **First adopter of the dialog keyboard contract** (see "App* design-system layer"): Escape dismisses, plain Enter accepts via `AppDialog`'s `accept`, and the footer buttons wear the ↵ / Esc badges. The prompt textarea and seed field stop propagation of ordinary typing so grid shortcuts stay quiet, but deliberately let Escape and Enter through to the dialog — and handle Ctrl/Meta+Enter themselves, since the root-level shortcut cannot hear a stopped event.
 
 **Recipe mode is a consent surface** (review finding R3, CWE-829). The replayed graph is file metadata: whoever made the image authored it, and it runs on the owner's ComfyUI bounded only by their installed node packs. The confirm step's reading order *is* the argument — what came from outside, what could not be checked, what it would run, I accept, run:
@@ -910,6 +917,7 @@ For `<img :src="...">` bindings and similar direct browser requests that bypass 
 | `api/pictureImport.js` | the streaming-staging import session (`/pictures/import/staging/*`) |
 | `api/operations.js` | `/operations`: the append-only change log, `undo-state`, and undo / redo / per-operation undo / batch undo (all OWNER_ONLY — callers guard on `isReadOnly`) |
 | `api/stacks.js` | `/stacks`: grouping, ordering, dissolving |
+| `api/dedup.js` | `/dedup`: the triage queue, the live counts, the scoped scan, the three verdicts, the bulk auto-stack |
 | `api/pictures.js` | `/pictures`, the largest resource: reads, count, stream, the searches, stats |
 
 Modules are seeded as their first call site migrates, so a module can legitimately expose one function today and a dozen once the components that use the rest of its resource move over.
@@ -1006,6 +1014,85 @@ While the lightbox overlay is open, the user's own in-overlay edits (and any oth
 `grid.isOverlayOpen` / `grid.markOverlayDeferredRefresh` are exposed by `ImageGrid` (Tier-3 imperative API) and forwarded to `useGridRealtimeSync` through `App.vue`'s `gridApi`. Tested in `useGridRealtimeSync.test.js` (both directions: deferred while open, pill still raised when closed).
 
 ---
+
+### 9.2 The Duplicates destination
+
+Duplicate detection is a **destination with a to-do count**, not a sort order or
+a filter. `/duplicates` mounts `DuplicateQueue.vue` in place of `ImageGrid`
+(`App.vue`, `isDuplicatesView`), so the grid is unmounted and its fetches and
+WebSocket reconciliation go quiet while the queue is open. The route branch in
+`applyRouteToStores` deliberately leaves the selection stores untouched: the
+queue shows no pictures, so it has no selection to express, and navigating back
+out of it lands the user on the view they left.
+
+Three rules from the design are load-bearing and are easy to break by accident:
+
+- **Never block on a full pass.** `listQueue` returns whatever has been found
+  plus the scan's progress, so the view renders a partial queue with a streaming
+  banner. There is no state in which a user waits on a complete scan.
+- **Never render the queue whole.** Groups are paged by confidence descending,
+  the row list is windowed around the focus, and only the focused row and the
+  one after it decode real thumbnails (the next group is prefetched into the
+  browser cache and nothing further). Ten groups and ten thousand cost the same
+  to render. Paging **prefers the keyset cursor**: a response carrying
+  `next_cursor` puts `loadMore` on the cursor path and the offset is never sent
+  alongside it, which is what removes the re-serve/skip hazard an offset has over
+  a table a scan is still inserting into. A server that publishes no cursor falls
+  back to the offset path with its mitigations intact — dedupe by signature,
+  advance by the page's *served* length — and either path can hand over to the
+  other mid-queue. See `integration_architecture.md` 2.1.
+- **Auto-advance.** A verdict removes its row and the focus lands on the next
+  open group, so a run of `Enter` presses works the queue with no extra
+  keystrokes.
+- **A stack needs two members.** `useDedupStore.toggleExcluded` refuses an `X`
+  that would leave a single included candidate and returns `false`, so a
+  two-candidate group accepts no exclusion at all and the Stack button the row is
+  still offering can never be a guaranteed 400. `DuplicateQueue` narrates the
+  refusal into the live region rather than letting a one-key action read as a
+  dead key, and a verdict that *is* refused by the server surfaces the server's
+  own `detail` instead of a generic sentence.
+
+**Undo is not reimplemented for a stack verdict.** It is recorded server-side
+like any other change; `useOperationStore` notices the resulting event and
+raises the standard receipt. A **keep-separate** is the exception, and
+deliberately so: it changes no reversible picture facet, the backend records no
+operation for it, and an empty operation row would still consume a `Ctrl+Z`. No
+receipt will ever arrive for it, so `DuplicateQueue` raises its own sticky notice
+carrying a **Reopen** action, which is the only way back from that verdict.
+The queue's only other undo-specific job is to *claim* `Ctrl+Z`
+(`preventDefault` **and** `stopPropagation`, see `useDedupQueueKeyboard.js`) so
+the app shell's global handler does not also fire and undo twice. Any new view
+that owns keys the shell also owns has the same obligation.
+
+**The sidebar badge is reconciled from the server, never inferred from
+WebSocket traffic.** A keep-separate mutates no picture row, so it raises no
+event and `App.refreshSidebar` never fires for it: the optimistic decrement in
+`useDedupStore` would be corrected by nothing, would already be wrong in a second
+tab, and would drift further with every verdict. Every verdict therefore refetches
+`POST /dedup/counts` behind its optimistic tick (unawaited, so auto-advance is
+not held up), and `syncQueueToRoute` refreshes the counts on queue open even when
+the requested scope is already showing.
+
+**Scope travels in the URL**, not in a store: `/duplicates?scope=set&scope_id=12`.
+That makes a scoped queue reloadable and keeps a back-navigation meaningful.
+`useViewStore.parseRouteView` returns `null` for `/duplicates` (it drives no
+grid, so the selection stores keep whatever the user was looking at), which is
+why `DuplicateQueue` reads the scope off the route itself rather than receiving
+it from the route sync. The
+`Find duplicates in…` context-menu entries in `SideBar.vue` warm the per-scope
+count through `useDedupStore.fetchScopeCount` when the menu opens, then emit
+`select-duplicates` after `closeSidebarCtxMenu()` on the next tick, so the menu's
+teardown cannot race the navigation for focus.
+
+**Stacked / unstacked is a filter, not a place.** `filterStore.stackStateFilter`
+(`all` / `stacked` / `unstacked` / `unresolved`) serialises to `stack_state` in
+both grid query builders. Only Duplicates, which has a to-do count, earns a
+sidebar row.
+
+**The Likeness Groups sort order is gone from the menu** (`Toolbar.vue`,
+`filteredSortOptions`). The backend still serves the mechanism, so a saved
+preference naming it keeps working; the menu simply shows a one-time migration
+notice in its place, persisted through `useOneTimeNotice`.
 
 ## 10. Naming and Coding Conventions
 

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -26,6 +26,7 @@
 16. [Versioning](#16-versioning)
 17. [Integration Pitfalls](#17-integration-pitfalls)
 18. [Integration Diagrams](#18-integration-diagrams)
+19. [Duplicates Queue API (v1.9)](#19-duplicates-queue-api-v19)
 
 ---
 
@@ -53,6 +54,147 @@ PixlStash is designed to be served from **one origin**: the FastAPI server hosts
 **Contract rule**: every new backend router must be mounted with `prefix=API_V1_PREFIX`. Every new frontend call must use a relative URL (the client adds the prefix).
 
 ---
+
+### 2.1 The `/dedup` contract (v1.9)
+
+The duplicate queue was built by two lanes at once, so the agreement is written
+down rather than inferred from either side. The client half lives in
+[`api/dedup.js`](../frontend/src/api/dedup.js); this is the integration-side
+copy, reconciled against `routes/dedup.py` as shipped (2026-07-29).
+
+| Route | Purpose | Response |
+|---|---|---|
+| `GET /dedup/policy` | tier defaults, bounds and closed vocabularies | `{ defaults, bounds }` |
+| `GET /dedup/groups` | one page of the queue, confidence descending | `{ groups, total, offset, limit, next_cursor, policy, scope, scan }` |
+| `POST /dedup/counts` | the sidebar badge, the per-tier split, and N scoped counts | `{ unresolved_groups, by_tier, scopes, policy, scan }` |
+| `POST /dedup/scan` | queue a scan for one scope | `ScanProgressModel` |
+| `POST /dedup/verdicts/stack` | the "same picture" verdict | `VerdictResponse` |
+| `POST /dedup/verdicts/keep-separate` | the "different pictures" verdict | `VerdictResponse` |
+| `POST /dedup/verdicts/reopen` | un-resolve a group | `{ signature, previous_verdict, reopened_at, group_returned_to_queue }` |
+| `POST /dedup/auto-stack` | bulk-stack the exact tier, `dry_run` first | `{ batch_id, dry_run, groups, pictures, scope, dry_run_summary, results, failures }` |
+
+Shapes and rules the frontend depends on:
+
+- **A group is `{ signature, tier, confidence, member_count, cover_picture_id,
+  why, created_at, candidates }`.** `signature` is a hash of the sorted member
+  content hashes and is the id every verdict route takes, **in the request
+  body**, never in a path. `tier` is `exact | near | embedding`; the exact tier
+  is rendered as a different kind of claim, never as "100% similar".
+- **A candidate is `{ picture_id, width, height, megapixels, size_bytes, format,
+  is_raw, score, tag_count, created_at, imported_at, stack_id,
+  reference_folder_id, file_path, cover_score, why }`.** `file_path` is
+  populated **only** for a reference-folder picture and is null for a managed
+  one, which is exactly the design's "paths only where they matter" rule
+  enforced server-side rather than trusted to the client.
+- **A why-pill is `{ text, against }`.** `against: true` is counter-evidence and
+  renders as the red x; the client orders counter-evidence first, because a
+  collapsed row only has room for two pills and the warning is the half that
+  matters.
+- **`scan` is `{ status, scanned_pictures, total_pictures, scanned_buckets,
+  total_buckets, groups_found, error }`** and rides on the queue, the counts and
+  the scan trigger, so any of the three can feed the progress banner. `status`
+  is `idle | pending | running | complete | failed`. There is **no percentage
+  and no time estimate**: the client derives the percentage from pictures, or
+  from buckets when no picture total is known yet, and deliberately shows no
+  "N min left" rather than inventing one.
+- **Scope is `(scope_type, scope_id)`** with `scope_type` one of
+  `global | project | set | character | folder`, published in
+  `bounds.scope_types`. The whole vault is `global` and takes no id; every other
+  type requires one, and a folder's id is its absolute path. `ScopeRequestModel`
+  **forbids extra fields**, so a scope label or glyph is a 422: those are client
+  presentation state and live in the URL query instead.
+- **The tier gate is two booleans plus a threshold**, not a list of tier names:
+  `near_enabled`, then `embedding_enabled` which requires it. `bounds` carries
+  `tiers` (strongest first), `always_on_tiers`, `tier_requires`,
+  `min_threshold`, `max_threshold` and `max_page_size`, so no bound is stated
+  twice. A threshold below the floor is a **400, never a silent clamp**.
+- **Counts take a LIST of scopes and always return the global badge**, so a
+  context menu labelling three entries refreshes the sidebar in the same
+  request and the two can never disagree. `by_tier` deliberately includes tiers
+  that are switched off, so the tier menu can show what enabling one would add.
+- **`batch_id`** is what makes a bulk auto-stack reverse with one `Ctrl+Z`, so
+  it has to reach the client on the real run. `failures` names groups the run
+  skipped: one unstackable group never aborts it, so a partial result is
+  reported rather than hidden.
+
+**Keep-separate records no operation, deliberately.** It changes no reversible
+picture facet, so there is nothing for undo to restore, and an empty operation
+row would still consume a `Ctrl+Z`. The frontend therefore must **not** wait for
+a receipt on this verdict: `DuplicateQueue` raises its own sticky notice with a
+**Reopen** action, which is the documented way back. Stack verdicts do record one
+operation each (bulk auto-stack shares one batch id) and flow through the
+standard `ActionReceipt` with nothing dedup-specific.
+
+**Paging is a keyset cursor; `offset` is the deprecated fallback.** The queue is
+ordered by confidence descending while a scan is still inserting rows, so an
+offset can re-serve a group the client already holds or skip one. `next_cursor`
+over `(confidence DESC, signature)` removes that hazard instead of mitigating
+it, so it is the **primary path**:
+
+- A first page is always `offset=0`. A cursor is a position inside one ordering,
+  and the policy, the threshold or the scope may have changed under it, so
+  `useDedupStore.loadFirstPage` never reuses one.
+- A response carrying a non-empty `next_cursor` puts that queue on the cursor
+  path: `loadMore` sends `cursor` and **never sends `offset` alongside it**,
+  because a server free to choose between the two could silently keep the weaker
+  one. `next_cursor: null` (or absent) ends the cursor path.
+- A cursor outranks the offset arithmetic in both directions. `total` is a live
+  count under a running scan, so a served cursor means "more" even when the
+  offset says the page was the last, and an **empty page ends the queue whatever
+  the cursor says**, or a server that kept minting cursors past the end would
+  loop the read-ahead.
+- A cursor needs no correction when a verdict removes a row: it names a position
+  in the ordering, not a count of rows before it. Only the offset is decremented
+  in `removeGroup`.
+- **The offset fallback stays seamless and keeps its mitigations.** A server that
+  publishes no `next_cursor` is paged exactly as before, and either path can hand
+  over to the other mid-queue. `loadMore` dedupes by signature on **both** paths
+  and drops a re-seen group (a duplicated row could be resolved twice, and the
+  second verdict would 400), and the offset still advances by the page's
+  **served** length rather than its kept length.
+
+**The sidebar badge is reconciled from the server after every verdict.** A
+keep-separate mutates no picture row, so it raises no WebSocket event and
+`App.refreshSidebar` never runs for it: an optimistic decrement would never be
+corrected, would be wrong in a second tab from the first verdict, and would drift
+further with each one. `useDedupStore` therefore keeps the optimistic tick for
+immediacy and fires `POST /dedup/counts` behind it (one scope, one COUNT, not
+awaited so auto-advance is not held up), and `DuplicateQueue` refreshes the
+counts on queue open even when it is already showing the requested scope. **Do
+not treat a WebSocket event as the source of truth for a dedup count.**
+
+**The auto-stack consent dialog reads `dry_run_summary`, not the envelope.** The
+server derives `{ groups, groups_by_tier, pictures, covers_gaining_tags,
+covers_gaining_score, covers_gaining_metadata }` from one read of one group list,
+so the dialog's rows cannot disagree with each other across a landing scan. The
+design's "covers gaining metadata from copies" row is
+`covers_gaining_metadata`, and "Stacks to create" sums `groups_by_tier`. The
+top-level `groups` / `pictures` are used only as a fallback for a server that
+predates the summary. **`groups_by_tier` counts only what the run would act on**
+(exact-only today, zero-filled for the rest), so it is *not* the queue's
+remainder: the dialog's "Groups left in the queue to review" row stays on
+`POST /dedup/counts` -> `by_tier`, which is the only call that knows it. Those
+two rows therefore still come from different calls, deliberately, and could
+disagree across a race.
+
+**Punch-list for the backend lane** (fields a designed UI state wants and the
+shipped surface does not provide; none is worked around silently):
+
+1. **No thumbnail version on a candidate.** The grid busts its thumbnail cache
+   with `?v=<version>`; a dedup candidate carries none, so the queue's
+   thumbnails load without one. A thumbnail regenerated mid-triage therefore
+   shows stale until a reload. Non-blocking, and a wrong decision is not
+   possible from it.
+2. ~~**No "covers gaining metadata" count on the auto-stack dry run.**~~
+   **Resolved:** `dry_run_summary.covers_gaining_metadata`, and the row is back
+   in the dialog.
+3. **The queue remainder and the run's counts still come from two calls.**
+   `dry_run_summary.groups_by_tier` covers the run, not the queue, so the
+   "groups left in the queue" row is fed from `POST /dedup/counts` -> `by_tier`.
+   Noted so the two are known to be able to disagree across a race.
+
+---
+
 
 ## 3. API Client ([apiClient.js](../frontend/src/utils/apiClient.js))
 
@@ -564,4 +706,255 @@ flowchart TB
 
 ---
 
-*Last updated: 2026-07-19. Update this document whenever any integration contract (URL prefix, event names, auth mode, build output path, CORS policy, share-token mechanism, settings field names) changes.*
+## 19. Duplicates Queue API (v1.9)
+
+The contract behind the sidebar **Duplicates** destination. Every route is
+`owner_only`; a share token gets 403 on all of them. Backend design is
+`docs/backend_architecture.md` §22.
+
+**Two rules the client must hold to.** The queue is *paged*, never fetched whole
+(`GET /dedup/groups` returns `total` so a scrollbar can be sized without a second
+request), and a group is addressed by its **`signature`**, never by an id. The
+signature is a hash of the group's member content hashes, so it survives a rescan
+and a re-import; a numeric id would not.
+
+### `GET /dedup/policy`
+
+No parameters. Renders the tier switches and the threshold slider so 0.90 and the
+0.65 floor are never hardcoded twice.
+
+```jsonc
+{
+  "defaults": { "near_enabled": false, "embedding_enabled": false,
+                "threshold": 0.9, "min_group_size": 2, "max_group_size": 24 },
+  "bounds": {
+    "min_threshold": 0.65, "max_threshold": 0.99999,
+    "tiers": ["exact", "near", "embedding"],
+    "always_on_tiers": ["exact"],
+    "tier_requires": { "exact": null, "near": "exact", "embedding": "near" },
+    "scope_types": ["global", "project", "set", "character", "folder"],
+    "verdicts": ["stacked", "keep_separate"],
+    "max_page_size": 200
+  }
+}
+```
+
+`always_on_tiers` is why the exact switch renders disabled; `tier_requires` is why
+enabling *embedding* must first enable *near*. Sending `embedding_enabled=true`
+without `near_enabled` is a **400**, and a `threshold` below `min_threshold` is a
+**422** — neither is silently corrected.
+
+### `GET /dedup/groups`
+
+Query: `near_enabled`, `embedding_enabled`, `threshold`, `scope_type`,
+`scope_id`, `cursor`, `limit` (≤ 200), the deprecated `offset`, and
+`decided` (default `false`). With `decided=true` the same shape pages the
+**resolved** groups instead — each row additionally carrying its live
+`verdict` (`stacked` | `keep_separate`) and `decided_at` — so a decision can
+be reviewed and cleared via `POST /dedup/verdicts/reopen`. The decided page
+deliberately ignores the tier gate and the threshold: a decision made under
+yesterday's policy must not be hidden by today's. On the open queue both
+fields are `null`.
+
+```jsonc
+{
+  "groups": [{
+    "signature": "9f2c…",           // the id every verdict route takes
+    "tier": "exact",                 // exact | near | embedding
+    "confidence": 1.0,               // 1.0 for exact; else the WEAKEST pairwise link
+    "member_count": 2,
+    "cover_picture_id": 41,          // a preselection, never a silent decision
+    "why": [                         // group evidence, BOTH directions
+      { "text": "Identical file hash", "against": false },
+      { "text": "Different resolution", "against": true }
+    ],
+    "created_at": "2026-07-29T09:00:00",
+    "candidates": [{
+      "picture_id": 41, "width": 6016, "height": 4016, "megapixels": 24.16,
+      "size_bytes": 14800000, "format": "jpeg", "is_raw": false,
+      "score": 4, "tag_count": 2,
+      "created_at": "2026-05-12T14:22:00", "imported_at": "2026-05-13T08:00:00",
+      "stack_id": null, "reference_folder_id": null,
+      "file_path": null,             // non-null ONLY for reference-folder pictures
+      "thumbnail_version": "320x240",// append as ?v= — same token the grid uses
+      "cover_score": 108.64,         // megapixels*4 + tags*3 + score*2 + 8 if RAW
+      "why": [{ "text": "Highest resolution", "against": false }]
+    }]
+  }],
+  "total": 128, "offset": 0, "limit": 20,
+  "cursor": null,                    // echo of the cursor this page was read from
+  "next_cursor": "MXwxfDQy",         // pass back as ?cursor=; null at end-of-found
+  "policy": { … }, "scope": { "scope_type": "global", "scope_id": null, "key": "global" },
+  "scan": { "status": "running", "scanned_pictures": 79412, "total_pictures": 128412,
+            "scanned_buckets": 210, "total_buckets": 940, "groups_found": 128,
+            "error": null }
+}
+```
+
+**Page with `cursor`, not `offset`.** Send the previous page's `next_cursor`
+back verbatim and stop when it is `null`. The queue is a live list: deciding a
+verdict removes the group the user just decided, and a tier-2 scan commits new
+groups after every bucket, so an `offset` re-read skips exactly as many groups as
+changed underneath it — reproducibly, with a single verdict between two pages.
+The cursor is **opaque**: never construct, parse or edit one. A cursor the server
+did not mint is a **400** (not a silent restart from page 1), `offset` is
+deprecated but still works, and sending **both** is a **400**.
+
+`scan` is the banner. `status` is `idle` when the scope has never been scanned —
+that is not an error, the queue still shows what an earlier global scan found.
+`file_path` is populated **only** for reference-folder pictures, where the user
+manages the files; for a managed-library picture the path is an implementation
+detail and the API returns `null`.
+
+Render the `why` pills as reasons, not conclusions: `against: false` is the olive
+check, `against: true` the red x. A group carrying red pills is the one that needs
+Compare.
+
+**`thumbnail_version` must be appended as `?v=`** to every thumbnail URL the queue
+builds — `/api/v1/pictures/thumbnails/{picture_id}.webp?v={thumbnail_version}` —
+exactly as the batch-thumbnail endpoint does (both come from the same server-side
+helper, so they cannot drift). Without it a thumbnail regenerated mid-triage keeps
+painting the stale cached bitmap, because the queue's URL never changes. The value
+is `"0"` until the picture has been processed.
+
+**Scope validation.** `scope_id` must be an integer for `project` / `set` /
+`character`; anything else is a **400** at the boundary on every route that takes a
+scope, including `POST /dedup/scan` (which writes nothing on a rejected scope). For
+`folder`, `%` and `_` are escaped rather than treated as wildcards, so a folder
+scope always means the folder it names.
+
+### `POST /dedup/counts`
+
+Read-only despite the verb (a scope list does not fit a URL). Body:
+`{ "policy": {…}, "scopes": [{ "scope_type": "set", "scope_id": "9" }] }`.
+
+```jsonc
+{
+  "unresolved_groups": 128,                              // the sidebar badge
+  "by_tier": { "exact": 96, "near": 30, "embedding": 2 },// INCLUDING disabled tiers
+  "scopes": [{ "scope_type": "set", "scope_id": "9", "key": "set:9",
+               "unresolved_groups": 4 }],
+  "policy": { … }, "scan": { … }
+}
+```
+
+`by_tier` deliberately reports tiers that are switched off, so a tier switch can
+be labelled with what enabling it would add. A non-global scope without a
+`scope_id` is a **400**, and the `scopes` list is capped at **200** entries (each
+is a separate correlated `COUNT`) — over that is a **422**.
+
+### `POST /dedup/scan`
+
+Body: `{ "policy": {…}, "scope": { "scope_type": "project", "scope_id": "3" } }`.
+Returns the scan progress row **immediately** — the queue is opened while the
+scan runs. Hashes are cached (computed on import), so a scoped scan only reads and
+compares them. Tier 1 lands in milliseconds; tier 2 groups appear as each
+candidate bucket finishes, so poll `GET /dedup/groups` and watch
+`scan.scanned_buckets` rather than waiting for `status: "complete"`.
+
+### Verdict routes
+
+All three take `{ "signature": "9f2c…", "batch_id": "…" }`; `POST
+/dedup/verdicts/stack` additionally takes `cover_picture_id` and
+`excluded_picture_ids`. An unknown signature, a cover outside the group, or
+excluding down to fewer than two members is a **400**. A member frozen by a locked
+picture set is a **423** with the usual `pictures_locked` detail.
+
+**`batch_id` is namespaced.** Omit it and the server mints its own `srv-…`;
+supply one only to make several calls reverse as one undo, and then it must match
+`cli-<4–76 chars of A-Z a-z 0-9 _ ->` (≤ 80). Any other shape — including a
+`srv-…` id — is a **400**, so a client cannot mint what reads as a server batch
+or graft its rows into an existing one.
+
+| Route | Effect |
+|---|---|
+| `POST /dedup/verdicts/stack` | Stacks the included members behind the cover and applies the metadata union. |
+| `POST /dedup/verdicts/keep-separate` | Records that the group is not duplicates. Changes **no** picture row. |
+| `POST /dedup/verdicts/reopen` | Returns a decided group to the queue. Does **not** unstack anything. |
+
+**Undoing a stack verdict also returns its group to the queue.** `POST
+/operations/undo` and `POST /operations/batches/{batch_id}/undo` unstack the
+pictures *and* reopen the verdict, so after an undo the group is back in `GET
+/dedup/groups` and back in the sidebar count with no extra call — do not follow an
+undo with a `reopen`. Redo re-decides it. `reopen` stays the explicit way back
+from a **keep-separate**, which records no operation and therefore has no undo.
+
+`stack` and `keep-separate` return:
+
+```jsonc
+{ "signature": "9f2c…", "verdict": "stacked", "stack_id": 77,
+  "cover_picture_id": 41, "picture_ids": [41, 42], "excluded_picture_ids": [],
+  "batch_id": "a1b2…",
+  "metadata_union": { "tags_added": 3, "scores_lifted": 1,
+                      "characters_pending": 0, "membership_changed": true,
+                      "best_score": 5 } }
+```
+
+`metadata_union` is what the action receipt should say. Stacking **unions** tags,
+project membership and set membership onto every member and lifts every member to
+the highest score; nothing is overwritten and nothing is deleted.
+
+> **The union is also a visibility change.** Adding an out-of-scope duplicate to a
+> *shared* set means every live share token for that set now reaches it. That is
+> the shipped stack-atomic membership model (ordinary `POST /stacks` does the
+> same), but auto-stack applies it in bulk — worth saying out loud in the consent
+> copy. See backend §22.9 accepted risk A1.
+
+### `POST /dedup/auto-stack`
+
+Body: `{ "scope": {…}, "dry_run": true, "batch_id": null, "limit": null }`.
+**Defaults to `dry_run: true`**, which returns the counts the consent dialog shows
+and writes nothing. Send `dry_run: false` to apply.
+
+Dry run:
+
+```jsonc
+{ "batch_id": null, "dry_run": true, "groups": 1204, "pictures": 2611,
+  "scope": { … }, "results": [],
+  "dry_run_summary": {
+    "groups": 1204,
+    "groups_by_tier": { "exact": 1204, "near": 0, "embedding": 0 },
+    "pictures": 2611,
+    "covers_gaining_tags": 310,
+    "covers_gaining_score": 88,
+    "covers_gaining_metadata": 361   // the dialog's "covers gaining metadata" row
+  } }
+```
+
+`dry_run_summary` is derived from the **same** snapshot as the top-level counts in
+a single read, so the dialog's figures can never disagree with each other. The
+union is not executed to produce them and nothing is written; a cover "gains" a
+facet when some other member of its group carries something it does not.
+
+Applied (including a partially applied run):
+
+```jsonc
+{ "batch_id": "a1b2…", "dry_run": false, "groups": 1203, "pictures": 2609,
+  "scope": { … },
+  "results":  [ { …verdict…, "outcome": "applied" } ],
+  "failures": [ { "signature": "…", "outcome": "blocked", "status_code": 423,
+                  "error": { "code": "set_locked", … } } ],
+  "blocked": 1, "failed": 0 }
+```
+
+Only the **exact** tier is eligible; near and embedding groups always go through
+the queue no matter how confident they look. Every group in the run shares one
+`batch_id`, so N stacks reverse with a single `POST
+/operations/batches/{batch_id}/undo`.
+
+**Every group is accounted for under exactly one `outcome`** — `applied`,
+`blocked` (a guard refused it, in practice a locked picture set at 423) or
+`failed` (it could not be resolved at all). One bad group never aborts the run,
+and **the `batch_id` is returned even on a partially applied run**, so work that
+did happen always comes back with its undo handle. Show `blocked` groups to the
+user: they are still in the queue awaiting an individual decision.
+
+### Not in this API
+
+There is **no deletion route** anywhere in v1.9. A stack is a grouping row plus a
+cover pointer; dropping it restores the flat grid exactly. Any UI copy implying
+files are removed would be wrong.
+
+---
+
+*Last updated: 2026-07-29. Update this document whenever any integration contract (URL prefix, event names, auth mode, build output path, CORS policy, share-token mechanism, settings field names) changes.*

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -32,7 +32,7 @@ the other two test layers:
 | Frontend units | Vitest | pure utils / pure logic |
 | **End-to-end** | **Playwright** | **the built SPA + a live backend, one origin** |
 
-There are **21 specs** today, all green locally. Each spec maps to a section of
+There are **22 specs** today, all green locally. Each spec maps to a section of
 [`docs/release-test-plan.md`](release-test-plan.md), so the manual release
 checklist shrinks as e2e coverage grows.
 
@@ -58,6 +58,8 @@ checklist shrinks as e2e coverage grows.
 | §19 Grid live-update | [`grid-own-change-no-pill.spec.js`](../frontend/e2e/specs/grid-own-change-no-pill.spec.js), [`grid-external-change-pill.spec.js`](../frontend/e2e/specs/grid-external-change-pill.spec.js), [`grid-injection.spec.js`](../frontend/e2e/specs/grid-injection.spec.js), [`grid-overlay-deferral.spec.js`](../frontend/e2e/specs/grid-overlay-deferral.spec.js) | WebSocket refresh: own change raises no pill, external raises the right pill, injection origin-suppression, flood coalescing, overlay deferral |
 | §20 Review Sessions | [`review-board.spec.js`](../frontend/e2e/specs/review-board.spec.js) | Tag-health board (9 cases): open, render columns, rebuild control, Why column, filter, sort, anomalies toggle, Start-review row (drives the real `tag_health` cache) |
 | §20 Review Sessions | [`review-session.spec.js`](../frontend/e2e/specs/review-session.spec.js) | Session loop (7 cases): create, binary Yes/No mapping + tally + backend receipt, and Escape-close run green (**BUG-RS-1 render crash resolved**); four further cases — Undo, Skip, keyboard, queue completion/archive — stay `test.fixme`'d for reasons unrelated to BUG-RS-1 (see docs/regular-tests.md §Review Sessions) |
+
+| §21 Duplicates | [`dedup.spec.js`](../frontend/e2e/specs/dedup.spec.js) | Keyboard triage (6 cases): arrow navigation and focus clamping, the `X` exclusion floor and its refusal, `C` opens Compare and Escape closes it, `Enter` stacks (asserted against the server's stack) with auto-advance and a moving sidebar badge, `S` keeps separate, and the done state. **Requires the `/dedup` backend branch**; seeds its own duplicates (see below) |
 
 Still manual (candidates for future specs): §14 Tag predictions, §15 Export,
 and the Selection ▾ ↔ context-menu parity comparison (#403).
@@ -106,6 +108,33 @@ gitignored `.auth/` dir for the duration of the run.
 > (`disable_rate_limit` / `rate_limit_max_requests` / `rate_limit_window_seconds`),
 > whose defaults are unchanged for production.
 
+### The duplicates seed
+
+The fixture holds no byte-identical duplicates, and the harness cannot create
+any through the product: `POST /pictures/import` refuses without the
+face-extraction worker, a reference folder's initial scan is planner-driven, and
+a `DedupGroup` row is only ever written by `DedupScanTask` — all three ride on
+the work planner, which `disable_background_workers: true` switches off.
+Enabling the workers for the whole suite would start face extraction, quality
+scoring and captioning over the entire fixture on every run.
+
+[`seed_dedup_fixture.py`](../frontend/e2e/seed_dedup_fixture.py) does exactly
+what those disabled workers would have done and nothing else: it copies fixture
+images to new files, inserts a `picture` row per copy (same bytes, therefore the
+same `pixel_sha`, which is what tier 1 groups on) and then runs the **real**
+`DedupScanTask.run_scan_in_session`, so the groups, covers and evidence the spec
+drives are production output rather than fabricated rows. It touches only the
+throwaway work directory, never the committed `test-data/`.
+
+`dedup.spec.js` runs it in `beforeAll` and runs it again with `--cleanup` in
+`afterAll`. **That cleanup is not optional.** The suite shares one mutable
+backend and these are the only cases that add pictures and create stacks; the
+stack verdict's metadata union pulls the copies into the source picture's sets,
+and a set left counting copies that are then deleted is what makes the export
+and tag-health specs downstream fail. The cleanup removes the seeded pictures
+and every row hanging off them, unstacks and drops the stacks the verdicts
+created, and clears the dedup tables.
+
 ### Layout
 
 ```
@@ -118,6 +147,8 @@ e2e/
   specs/             one file per release-test-plan section
   global-setup.js    registers admin, mints token, saves session state
   serve_e2e_backend.py  the throwaway-backend launcher
+  seed_dedup_fixture.py seeds byte-identical duplicates and runs the real
+                        dedup scan; --cleanup undoes both (see above)
 ```
 
 ## 4. Running Locally

--- a/docs/reviews/authz-coverage-matrix.md
+++ b/docs/reviews/authz-coverage-matrix.md
@@ -258,6 +258,35 @@ covered in both directions by `tests/test_dedup_sweep_api.py`
 | GET | `/api/v1/dedup/sweep/policy` | owner_only |  | Sweep policy defaults/bounds; operator surface, returns no per-object data |
 | POST | `/api/v1/dedup/sweep/dry-run` | owner_only |  | Vault-wide near-duplicate plan (counts + picture ids across the whole library); cannot be narrowed to a share token's scope without leaking out-of-scope counts, same reasoning as tag_health. POST also blocked for READ tokens |
 
+The eight routes below were added 2026-07-29 with the v1.9 tiered Duplicates queue
+(Lane 1A). All are new, none carries inline authz code (the gate is the sole
+enforcement, §16.1), and all eight are covered **in both directions** by
+`tests/test_dedup_tiers_api.py` — negative via `Authorization: Bearer` *and* via
+the `?token=` query-parameter path
+(`test_scoped_read_token_is_denied_on_every_route`), plus
+`test_a_denied_verdict_route_changed_nothing` (the 403 is fail-closed: no write
+happened) and `test_unauthenticated_is_denied`; positive on every route via the
+owner cookie session across the policy, queue, counts, scan, verdict and
+auto-stack tests.
+
+Two rationales apply. **Read routes:** a duplicate group is defined by *content
+identity*, not by collection membership, so it routinely spans a share token's
+scope boundary; narrowing it would leak that out-of-scope copies exist, which is
+the tag_health reasoning. **Write routes:** a verdict is addressed by a content
+signature that can name any picture in the vault and mutates stack membership,
+tags, project/set membership and scores, so there is no coherent scoped form of it.
+
+| Method | Effective path | Policy | id_param / body_ids | Rationale (current enforcement) |
+|---|---|---|---|---|
+| GET | `/api/v1/dedup/policy` | owner_only |  | Tier defaults/bounds; operator surface, returns no per-object data |
+| GET | `/api/v1/dedup/groups` | owner_only |  | Returns duplicate groups with picture ids, dimensions and (for reference-folder pictures) file paths from anywhere in the vault; content-identity grouping crosses any token scope |
+| POST | `/api/v1/dedup/counts` | owner_only |  | Vault-wide and per-scope duplicate counts. Read-only but POST because the scope list does not fit a URL; POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/scan` | owner_only |  | Queues a background scan over the vault or a chosen scope; owner-only maintenance trigger. POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/verdicts/stack` | owner_only |  | Mutates stack membership, tags, project/set membership and scores across pictures named only by a content signature. POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/verdicts/keep-separate` | owner_only |  | Writes a permanent verdict about an arbitrary set of vault pictures. POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/verdicts/reopen` | owner_only |  | Reverses a stored verdict about an arbitrary set of vault pictures. POST also blocked for READ tokens |
+| POST | `/api/v1/dedup/auto-stack` | owner_only |  | Bulk stacking across the whole vault under one undo batch; the most far-reaching mutation on this surface. POST also blocked for READ tokens |
+
 ### characters.py
 
 | Method | Effective path | Policy | id_param / body_ids | Rationale (current enforcement) |

--- a/docs/reviews/dedup-tiers-authz-signoff.md
+++ b/docs/reviews/dedup-tiers-authz-signoff.md
@@ -1,0 +1,688 @@
+# `feature/dedup-tiers` (PR #638) — independent adversarial authz sign-off
+
+- **Reviewer:** CSO persona, independent of the authors. Did not write any code on this branch.
+- **Branch under review:** `origin/feature/dedup-tiers` @ `21b07e64` (merge of `develop-1.9`), diffed against `origin/develop-1.9` @ `9f9cd566`.
+- **Diff size:** 25 files, +7647 / −25. New surface: 8 routes, 3 services, 4 tables, 1 migration, 2 finders/tasks.
+- **Date:** 2026-07-29.
+- **Mandate:** refute the branch's safety claims. Reproduce every finding with a concrete request or test before reporting it. Coverage matrix, not a findings list.
+
+---
+
+## Verdict
+
+# **APPROVE-WITH-REQUIRED-CHANGES**
+
+The **authorization** work is correct and I could not break it. All eight routes are
+`OWNER_ONLY`, enforced solely by the central gate, verified 403 in both transports
+against two token shapes and 200 for the owner on every route. The coverage-matrix
+arithmetic reproduces exactly. The locked-set fail-closed contract holds on a
+partial-lock batch, including the folded-stack co-member case the authors did not
+test. The stack-expanded undo snapshot is genuinely non-vacuous.
+
+The required changes are **not** authorization holes. They are: one write-path
+identity defect that makes a verdict address the wrong picture set (R1), one
+fail-closed gap in the bulk path that leaves a partially-applied mutation whose
+undo handle is never returned (R2), and one §21 compliance omission on the most
+far-reaching mutation on the surface (R3). R1 and R2 are both reproduced below with
+concrete state dumps.
+
+| # | Severity | What | Status |
+|---|---|---|---|
+| **R1** | **MEDIUM** | Group signature omits the `size_bytes` co-key → two distinct duplicate groups collide on one signature; one is silently dropped from the queue and a verdict about one silently resolves the other | **REQUIRED** |
+| **R2** | **MEDIUM** | `bulk_auto_stack` catches only `DedupVerdictError`; a `423` mid-run aborts after committing earlier groups, and the server-minted `batch_id` is never returned — a partially-applied bulk mutation with no undo handle in the response | **REQUIRED** |
+| **R3** | **LOW-MED** | The verdict routes are the only operation-log recording routes on the branch that omit `request_context(request)`; every dedup stack is recorded `actor=None, source="external"` | **REQUIRED** |
+| R4 | LOW | Non-numeric `scope_id` for project/set/character → unhandled `ValueError` → **500** on `/dedup/groups`, `/dedup/counts`, `/dedup/auto-stack`; `POST /dedup/scan` **persists** the poison row | Hardening |
+| R5 | LOW | `MAX_BUCKET_MEMBERS` bounds tier-2 CPU but **not** memory: the pair list is O(k²) and `DedupScanTask` accumulates it across all buckets, re-deriving and re-persisting every group after every bucket, on the single DB writer thread | Hardening |
+| R6 | LOW | No cap or coalescing on distinct scan scopes (301 pending rows from 301 requests) and no cap on the `POST /dedup/counts` scope list (5000 accepted) | Hardening |
+| R7 | LOW | `include_deleted=True` on the undo snapshot is load-bearing and **correct** but untested — removing it leaves all 28 verdict tests green | Test gap |
+| A1 | Accepted | A stack verdict widens live share tokens via the set/project membership union; `/dedup/auto-stack` amplifies this to a one-click vault-wide bulk operation | Accepted risk |
+| A2 | Accepted | Caller-supplied `batch_id` is taken verbatim; unrelated verdicts can be grafted into one undo unit | Accepted risk |
+| D1 | Doc | §22.9 describes a lazy import and "the operation log is not on this branch" — stale after the merge; the import is module-level | Doc fix |
+
+---
+
+## 1. Coverage matrix — recounted from `ROUTE_POLICIES`, not from prose
+
+The authors claim **236 declared / 235 mounted / 1 conditional**. Re-derived
+independently against the live route inventory (probe `test_A1`):
+
+```
+[A1] mounted (api_endpoint_set)  = 235
+[A1] declared (ROUTE_POLICIES)   = 236
+[A1] conditional waiver          = 1 [('POST', '/api/v1/test-hooks/ws-event')]
+[A1] declared - conditional      = 235
+[A1] undeclared mounted routes   = []
+[A1] dead declarations           = []
+[A1] mounted dedup paths         = 10 [.../auto-stack, .../counts, .../groups, .../policy,
+     .../scan, .../sweep/dry-run, .../sweep/policy, .../verdicts/keep-separate,
+     .../verdicts/reopen, .../verdicts/stack]
+```
+
+`235 == 236 − 1`. **Arithmetic confirmed.** Policy distribution recounted:
+`owner_only` 92 → **100** (+8, exactly the new dedup routes); no other class moved
+(`public` 13, `any_token` 16, `picture_scoped` 35, `scoped_list` 39, `set_scoped` 4,
+`character_scoped` 5, `project_scoped` 6, `local_owner_only` 13,
+`loopback_owner_only` 5). The matrix document's updated numbers match.
+
+**Note on my first attempt:** a naive `app.routes` walk returned **14** routes, not
+235 — the documented FastAPI `_IncludedRouter` trap that `pixlstash/route_inventory.py`
+exists to defeat. That trap is real and the guard in `route_inventory.py` is
+load-bearing; anyone re-deriving this count by hand will silently under-count.
+
+### 1.1 The 8 new routes — both directions, both transports
+
+Probe `test_A2` / `test_A2b`, one fresh `TestClient` per request:
+
+| Method | Path | Policy | set-scoped READ (hdr / `?token=`) | unscoped READ (hdr / `?token=`) | owner cookie |
+|---|---|---|---|---|---|
+| GET | `/dedup/policy` | `OWNER_ONLY` | 403 / 403 | 403 / 403 | 200 |
+| GET | `/dedup/groups` | `OWNER_ONLY` | 403 / 403 | 403 / 403 | 200 |
+| POST | `/dedup/counts` | `OWNER_ONLY` | 403 / 403 | 403 / 403 | 200 |
+| POST | `/dedup/scan` | `OWNER_ONLY` | 403 / 403 | 403 / 403 | 200 |
+| POST | `/dedup/verdicts/stack` | `OWNER_ONLY` | 403 / 403 | 403 / 403 | 200 |
+| POST | `/dedup/verdicts/keep-separate` | `OWNER_ONLY` | 403 / 403 | 403 / 403 | 200 |
+| POST | `/dedup/verdicts/reopen` | `OWNER_ONLY` | 403 / 403 | 403 / 403 | 200 (with a prior verdict) |
+| POST | `/dedup/auto-stack` | `OWNER_ONLY` | 403 / 403 | 403 / 403 | 200 |
+
+**The authors' tests only cover the resource-scoped READ token.** I added the
+**unscoped READ** token shape — a legitimately mintable whole-library read-only
+share token, and the shape that `require_unscoped_owner` distinguishes with a
+*different* branch (`token_scope is not None` rather than
+`matched_token.resource_type is not None`). It is denied on all eight, both
+transports. That sibling vector is now verified but is **not** pinned by a durable
+test; see R7-adjacent recommendation in §6.
+
+Handlers contain **no** inline authz code (verified by reading
+`pixlstash/routes/dedup.py` end to end — the only guards are `_policy` / `_scope`
+400-translators). §16.1 satisfied: the gate is the sole enforcement.
+
+### 1.2 Sibling hunt — can a scoped-reachable route leak dedup-derived facts?
+
+I checked every scoped-reachable route the verdict path touches, before and after a
+verdict (probe `test_A3`).
+
+| Route | Scoped token, before verdict | After verdict | Leak? |
+|---|---|---|---|
+| `GET /pictures` | `[1]` | `[1, 2]` | Not a leak — see A1 |
+| `GET /pictures?fields=grid` | `[1]` | `[1]` (collapsed) | No |
+| `GET /pictures/{out_of_scope}` | 403 | 200 | Not a leak — see A1 |
+| `GET /pictures/{out}/pixel_sha` | **403** | 200 | Not a leak — see A1 |
+| `GET /pictures/{out}/tags` | **403** | 200 | Not a leak — see A1 |
+| `GET /stacks/{stack_id}/pictures` | n/a | 200 | Consistent with membership |
+| `GET /picture_sets/{id}/members` | 200 (1 member) | 200 (2 members) | Consistent |
+
+**No route exposes a dedup-derived fact** — no signature, no group id, no group
+membership, no confidence, no scan progress reaches a scoped token. `pixel_sha` is
+reachable only through `GET /pictures/{id}/{field}`, which is `PICTURE_SCOPED` and
+returned **403** for an out-of-scope picture (verified). The widening in the table
+above is a *membership* change, not a scope-check failure — see A1.
+
+---
+
+## 2. R1 (REQUIRED) — the group signature is not injective over groups
+
+**Severity:** MEDIUM (write-path target ambiguity + silent data loss from the queue).
+Not a confidentiality issue. **Location:** `pixlstash/services/dedup_tier_service.py`
+`CandidateMember.content_key` (line ~415) and `group_signature` (line ~485).
+
+`§22.1` states, as the branch's own central design claim:
+
+> **`size_bytes` is a co-key, not decoration.** The sample offsets are derived from
+> the file size, so equal size plus equal sampled digest is a far stronger claim
+> than the digest alone.
+
+Tier 1 honours this in **detection** (`GROUP BY pixel_sha, size_bytes`) and drops it
+in **identity**:
+
+```python
+@property
+def content_key(self) -> str:
+    return self.pixel_sha or f"id:{self.id}"      # no size_bytes
+```
+
+`signature = sha256("\x1f".join(sorted(content_keys)))`. Two distinct tier-1 groups
+that differ only by `size_bytes` therefore produce the **same** signature — and
+`dedupgroup.signature` / `dedupverdict.signature` are both `unique=True`.
+
+### Reproduction (probe `test_E1`)
+
+Four pictures: `{1,2}` at `pixel_sha='aaa', size=100`; `{3,4}` at `pixel_sha='aaa', size=999`.
+
+```
+[E1] tier 1 detected 2 distinct group(s): [[1, 2], [3, 4]]
+[E1] their signatures = ['731037cc1fb26ece2ede462c36719f53cb4a00bb51d2876b05ec2a062f923c4c']
+[E1] >>> distinct groups: 2, distinct signatures: 1
+[E1] persisted dedupgroup rows = [('731037cc1fb2', 'exact', [3, 4], False)]
+[E1] >>> 2 detected groups collapsed to 1 stored row(s) — the upsert-on-signature dropped one
+[E1] after keep-separate on the surviving group: [('731037cc1fb2', 'exact', [3, 4], True)]
+[E1] after a rescan:                             [('731037cc1fb2', 'exact', [3, 4], True)]
+[E1] verdict rows = [('731037cc1fb2', 'keep_separate', '[3, 4]')]
+[E1] >>> a decision about one file-set silently resolves the other
+```
+
+**Three consequences, all reproduced:**
+
+1. **A real duplicate group vanishes from the queue.** Pictures 1 and 2 are exact
+   duplicates and the user is never shown them. The sidebar badge under-counts, and
+   no log line says anything was dropped — `persist_groups_in_session` treats the
+   second group as a refresh of the first.
+2. **A `keep_separate` verdict silences both file-sets permanently.**
+   `verdict_signatures_in_session` marks any future re-detection `resolved=True`,
+   and the design's whole point is that this decision survives rescans and
+   re-imports. The user consented to one thing and got two.
+3. **A `stack` verdict's write target depends on scan ordering, not on what the
+   user saw.** `_load_group(signature)` returns whichever member set survived the
+   upsert. A UI showing group A can send a confirmed cover and the server stacks
+   group B. This is the one place on the surface where "the signature bounds the
+   write" — the justification in `ROUTE_POLICIES` — is not true.
+
+**Likelihood.** A *natural* same-sha-different-size pair is unlikely: below 128 KiB
+`pixel_sha` is a full-file digest, and above it the sample offsets are size-derived.
+But the branch's own §22.1 raises this exact case as the reason the co-key exists,
+the failure is **silent**, the blast radius is a permanent verdict on files the user
+never reviewed, and it is trivially reachable in fixtures and in any future path
+that writes `pixel_sha` without a size (e.g. a sidecar/metadata import).
+
+**Fix (one line):**
+
+```python
+@property
+def content_key(self) -> str:
+    if self.pixel_sha:
+        return f"{self.pixel_sha}:{self.size_bytes}"
+    return f"id:{self.id}"
+```
+
+Changing the signature invalidates stored verdict rows — free on an unreleased
+feature branch, so do it now rather than after 1.9 ships. Add a regression test
+asserting two same-sha/different-size groups produce **two** signatures and **two**
+persisted rows.
+
+---
+
+## 3. R2 (REQUIRED) — the bulk path is not fail-closed and loses its undo handle
+
+**Severity:** MEDIUM. **Location:** `pixlstash/services/dedup_verdict_service.py`
+`bulk_auto_stack_in_session`, the `except DedupVerdictError` at line ~711.
+
+`POST /dedup/auto-stack`'s own API description states:
+
+> A single unstackable group never aborts the run, so a partial result is reported
+> honestly rather than hidden.
+
+That is **false for the locked-set case**, which is the most likely cause of an
+unstackable group. `enforce_stack_membership_not_locked` / `enforce_pictures_not_locked`
+raise `HTTPException(423)`, not `DedupVerdictError`, so the loop does not catch it —
+and each successful iteration has *already* `session.commit()`ed.
+
+### Reproduction (probe `test_B2`)
+
+Three exact groups; one member of the second group is frozen by a locked set.
+
+```
+[B2] raised HTTPException 423: {'code': 'set_locked', 'action': 'stack duplicates together', ...}
+[B2] pictures before  = [(1,None,None,..), (2,None,None,..), (3,None,None,..), (4,..), (5,..), (6,..)]
+[B2] pictures after   = [(1, 1, 0, ..),    (2, 1, 1, ..),    (3,None,None,..), (4,..), (5,..), (6,..)]
+[B2] stacks before/after = [] / [1]
+[B2] verdicts after   = [('731037cc…', 'stacked')]
+[B2] operations after = [('dedup.stack', '8b4f2a48aa704be6bc076b382e907e5e', 'applied')]
+[B2] >>> PARTIAL WRITE after a 423: True
+[B2] >>> batch ids committed but NEVER returned to caller: {'8b4f2a48aa704be6bc076b382e907e5e'}
+```
+
+The caller receives a `423` whose body is the lock detail. The `batch_id` was minted
+**server-side** (`batch_id = batch_id or new_batch_id()`) and is only ever returned
+in the success response. So the user has a partially-applied bulk stack and the
+`POST /operations/batches/{batch_id}/undo` handle for it exists **only** in the
+`operation` table — recoverable via `GET /operations`, but not from the response,
+and not from the toast the frontend would show.
+
+Contrast with the single-verdict path, which **is** correctly fail-closed (§4 below).
+The bulk path breaks the same contract its siblings honour.
+
+**Fix — either is acceptable, pick one and state it:**
+
+- **(a) Make it match the docstring.** Catch `HTTPException` alongside
+  `DedupVerdictError` and record it in `failures` with the status code, so a locked
+  group is skipped and reported instead of aborting. This is the behaviour the API
+  description already promises.
+- **(b) Make it genuinely atomic.** Do not commit per group; commit once at the end.
+  Then a 423 rolls the whole run back (the DB worker already rolls back on exception —
+  `database.py:885`) and "nothing was written" is true.
+
+Whichever is chosen, **the response must carry the `batch_id` on the failure path
+too** if any group committed. Add a regression test with a partial-lock bulk run
+asserting both the surviving state and the returned handle.
+
+---
+
+## 4. What I could **not** break
+
+These were attacked and held. Recording them so the next reviewer does not re-spend
+the effort, and so a regression is visible.
+
+### 4.1 The single-verdict locked path is genuinely fail-closed (probe `test_B1`)
+
+Three-member exact group, **one** member frozen by a locked set. I snapshotted seven
+independent state dimensions before and after:
+
+```
+[B1] status = 423
+[B1] detail = {'code': 'set_locked', 'action': 'stack duplicates together', 'sets': [{'id': 1, 'name': 'Frozen'}]}
+[B1] pictures         unchanged=True
+[B1] stacks           unchanged=True
+[B1] tags             unchanged=True
+[B1] verdicts         unchanged=True
+[B1] operations       unchanged=True
+[B1] set_members      unchanged=True
+[B1] groups_resolved  unchanged=True
+```
+
+Nothing written, including the `PictureStack` row that `_stack_members` `flush()`es
+*before* the lock check — the per-task `session.rollback()` in
+`database.py:_task_worker_loop` covers it. **The claim holds.** The authors' own test
+only asserts the tag facet; mine asserts all seven.
+
+### 4.2 A locked co-member of a *folded* stack is also caught (probe `test_B6b`)
+
+This is the case I expected to break, because `apply_metadata_union_in_session` calls
+`enforce_pictures_not_locked` over `included` only — **not** over the co-members that
+`_stack_members` drags in when it folds another stack. It holds anyway:
+`enforce_stack_membership_not_locked` runs first and expands through
+`expand_picture_ids_to_stacks`, so the folded co-member is inside the checked set.
+
+```
+[B6b] locked set 1 freezes co-member 3 only  (group = {1,2}; 2 and 3 share a pre-existing stack)
+[B6b] -> 423: {'code': 'set_locked', 'action': 'stack duplicates together', 'sets': [{'id': 1, 'name': 'Frozen'}]}
+[B6b] world changed = False
+```
+
+The ordering that makes this safe is load-bearing and undocumented. If anyone ever
+moves `enforce_stack_membership_not_locked` after the fold, this opens. Worth a
+comment and a durable test.
+
+### 4.3 Signature, cover and exclusion abuse (probes `test_B3`, `test_B4`, `test_B5`)
+
+`_load_group` requires an existing `dedupgroup` row, so a signature cannot name an
+arbitrary picture set — it can only name a *detected* group.
+
+```
+[B3] stack(empty     ) -> DedupVerdictError (400)
+[B3] stack(random hex) -> DedupVerdictError (400)
+[B3] stack(sql-ish   ) -> DedupVerdictError (400)   "' OR 1=1 --"  (parameterised; no injection)
+[B3] stack(huge      ) -> DedupVerdictError (400)   100 000 chars
+[B3] stack(weird     ) -> DedupVerdictError (400)   RTL-override chars
+[B3] stale sig (1 of 2 scrapheaped) -> DedupVerdictError: "…has 1 member(s) left after exclusions"
+[B3] world changed: False
+```
+
+Scrapheaped members are filtered by `_load_group`'s `Picture.deleted.is_(False)` join,
+and the surviving group then fails the `len(included) < 2` gate. Nothing written.
+
+```
+[B4] cover=outsider     -> rejected (400)   cover=nonexistent/negative/0 -> rejected (400)
+[B4] excl=outsider      -> rejected (400)   excl=nonexistent -> rejected (400)
+[B4] excl=all           -> rejected (400)   excl=2of3        -> rejected (400)
+[B4] excl=dupes         -> ACCEPTED [1, 3] cover=1           (correctly de-duplicated)
+[B5] reopen(never-decided) -> rejected      reopen(forged) -> rejected
+[B5] double reopen         -> rejected: "Verdict for '…' is already reopened"
+```
+
+Every abuse case rejected with a 400 and no state change. No SQL injection —
+`scope_id` and `signature` reach SQLAlchemy as bound parameters throughout.
+
+### 4.4 Bounds validation (probe `test_D6`)
+
+`limit>MAX_PAGE_SIZE`, `limit<=0`, `offset<0`, `threshold` outside
+`[MIN_THRESHOLD, MAX_THRESHOLD]` → 422 from FastAPI `Query` constraints;
+`embedding_enabled` without `near_enabled` → 400 with the tier-gating message.
+No silent clamping, exactly as §22.4 promises.
+
+### 4.5 The undo integration (probes `test_C1`, `test_C3`, plus a reverted-fix run)
+
+**The stack-expanded snapshot fix is genuinely non-vacuous.** I reverted it myself:
+
+```python
+def _undo_targets(session, picture_ids):
+    return list(picture_ids)   # CSO NON-VACUITY PROBE: fix reverted
+```
+
+```
+FAILED tests/test_dedup_verdict_service.py::test_the_snapshot_covers_stack_siblings_the_group_never_named
+E       assert 2 == 1
+E        +  where 2 = _picture(server, 2).stack_id
+E        +  and   1 = _picture(server, 4).stack_id
+1 failed, 5 passed, 22 deselected
+```
+
+The sibling the group never named is stranded on the merged stack — exactly the
+symptom the fix exists to prevent. **The two-stack-fold test is real.**
+
+Batch undo of an auto-stack reverses **all** its stacks:
+
+```
+[C3] auto-stack groups=5 batch=f13f7d4ec9454ebe9ac57b1ad667e129
+[C3] undo_batch reverted 5
+[C3] >>> fully reversed: True
+[C3] leftover stack rows after undo = [1, 2, 3, 4, 5]     ← 5 orphaned empty PictureStack rows
+```
+
+The orphaned empty stack rows are DB hygiene, not a correctness or security issue
+(no picture points at them and they are invisible in the UI). Worth a cleanup pass.
+
+**Undo cannot cross a scope boundary.** All 7 `operations.py` routes are
+`OWNER_ONLY` (verified in the recount). The only caller-supplied-`batch_id` readers
+in the whole tree are `GET /operations?batch_id=` and
+`POST /operations/batches/{batch_id}/undo`, both owner-only; the two other
+`batch_id` sites (`routes/pictures/_crud.py`) mint their own. A `batch_id` is
+therefore never a capability reachable by a scoped principal.
+
+---
+
+## 5. R3–R7 (required change R3; the rest is hardening)
+
+### R3 (REQUIRED) — the verdict routes skip `request_context(request)`
+
+**Location:** `pixlstash/routes/dedup.py` — none of the four verdict/auto-stack
+handlers takes a `request: Request` parameter; `_record_operation` therefore always
+runs with its defaults `actor=None, source="external", origin_client_id=None`.
+
+§21 *Origin discipline* is explicit that these are read **from the request, in the
+handler**. Every other operation-log recording site on the branch complies
+(`routes/tags.py` ×4, `routes/picture_sets.py`, `routes/pictures/_crud.py`, …).
+The dedup verdict routes are the only exceptions, and they cover the *most
+far-reaching* mutation on the surface — a bulk auto-stack can rewrite thousands of
+pictures under one operation row with no actor recorded.
+
+Consequences: the operation log's audit-trail purpose (§21: "the undo/redo stack
+today and the audit log / Studio activity feed later") is degraded for exactly the
+bulk action that most needs attribution; and `source` is always `"external"`, so the
+frontend cannot tell its own click apart from a scripted call.
+
+**Fix:** add `request: Request` to the four handlers and thread
+`**operation_log_service.request_context(request)` through
+`apply_stack_verdict` / `bulk_auto_stack` into `_record_operation`. Mirror
+`routes/tags.py`. Pin it with the AST-style check already used for the contextvar
+rule.
+
+### R4 (hardening) — non-numeric `scope_id` is a 500 and a persisted poison row
+
+`DedupScope.picture_predicate()` calls `int(self.scope_id)` for
+`project` / `set` / `character`, but `DedupScope.__post_init__` never validates it.
+`_scope()` in the route only catches the `ValueError` raised at construction time,
+not the one raised later at query time (probe `test_D4`):
+
+```
+[D4] project    scan=200 groups=500 counts=500 auto-stack=500
+[D4] set        scan=200 groups=500 counts=500 auto-stack=500
+[D4] character  scan=200 groups=500 counts=500 auto-stack=500
+[D4] persisted dedupscan rows = [(1, 'project:not-an-int', 'pending'),
+                                 (2, 'set:not-an-int',     'pending'),
+                                 (3, 'character:not-an-int','pending')]
+```
+
+`POST /dedup/scan` returns **200** and writes a `dedupscan` row with an unparseable
+`scope_id`. The background `DedupScanTask` then fails on it (handled — `_mark_failed`
+sets `status=failed`), but every subsequent `GET /dedup/groups` for that scope 500s.
+Owner-only, so no disclosure; still an unhandled-exception surface and a self-inflicted
+poison pill. **Fix:** validate/coerce `scope_id` in `DedupScope.__post_init__`
+(int for project/set/character) so it is a 400 at the boundary.
+
+Related, lower: `folder` scopes build `Picture.file_path.like(f"{prefix}%")` without
+escaping LIKE metacharacters, so `scope_id="%"` or `"_"` is accepted and matches
+more than the caller named (probe `test_D5`). Owner-only and read-only, but escape
+it — a "Find duplicates in this folder" entry should not silently mean "everywhere".
+
+### R5 (hardening) — the bucket cap bounds CPU, not memory; the scan is quadratic
+
+The direct question asked: **does the bucket sharding cap actually bound tier-2
+memory? No.** `MAX_BUCKET_MEMBERS = 4000` bounds the *popcount work* per bucket. The
+materialised pair list is O(k²) and unbounded (probe `test_D2`):
+
+```
+[D2] MAX_BUCKET_MEMBERS = 4000
+[D2] k=400 identical hashes -> 79800 pairs in 0.06s, ~5.8 MB
+[D2] >>> extrapolated at k=MAX_BUCKET_MEMBERS: 7,980,000 pairs ~582 MB in ONE bucket
+```
+
+400 identical perceptual hashes (a plausible real case: a burst of near-black frames,
+a folder of solid-colour placeholders, an import of one image copied 4000 times) give
+79 800 pairs. At the cap that is ~8M tuples, ~580 MB, in a single bucket.
+
+Worse, `DedupScanTask.run_scan_in_session` keeps a `pair_cache` across **all**
+buckets and re-derives + re-persists **every group from every pair seen so far**
+after **each** bucket (probe `test_D3` prints the loop verbatim):
+
+```python
+for index, bucket in enumerate(buckets, start=1):
+    for a, b, similarity in near_pairs_in_bucket(session, bucket, policy.threshold):
+        ...pair_cache[key] = similarity
+    groups = groups_from_pairs(session, [(a, b, sim) for (a, b), sim in pair_cache.items()], ...)
+    persist_groups_in_session(session, groups, scan_id)   # deletes + reinserts ALL members
+    session.commit()
+```
+
+That is O(buckets × total_pairs) work and O(buckets) full re-persists. And the whole
+scan runs inside **one** `self._db.run_task(...)` — `database.py:661` shows a single
+`_task_worker` thread — so a vault-wide near-scan holds the only DB writer for its
+entire duration. Every import, tag edit, scrapheap move and verdict queues behind it.
+
+The comment justifies the re-derivation ("a chain that spans two buckets becomes one
+group"), which is a real requirement — but it can be satisfied by deriving groups
+once at the end and streaming only the *new* components per bucket, or by capping
+`pair_cache`. **Not a release blocker** (owner-only, self-inflicted, and the tier is
+opt-in), but §22.7's "10 groups and 10,000 cost the same" claim is true of the
+*queue page* and false of the *scan*, and the doc should not imply otherwise.
+
+### R6 (hardening) — scan and counts amplification
+
+Probe `test_D1`:
+
+```
+[D1a] 50x global scan -> 1 dedupscan row(s): [(1, 'global', 'pending')]     ← coalescing works
+[D1b] +300 distinct folder scopes -> 301 row(s) in 0.6s
+[D1b] >>> pending scan rows queued for the background worker: 301
+```
+
+Same-scope requests **do** coalesce (upsert on `scope_key`) — good. Distinct scopes
+do not, and `scope_id` is an unvalidated free-text string, so there is no bound on
+how many `dedupscan` rows a client can create. `DedupScanFinder.max_inflight_tasks()
+== 1` means they run one at a time rather than in parallel, but the queue itself is
+unbounded and each one is a full scan of its scope.
+
+Probe `test_D7`: `POST /dedup/counts` accepts an uncapped `scopes` list — 5000
+entries → 5000 separate correlated `COUNT` subqueries, accepted with a 200. One
+request, 5000 queries.
+
+Both are owner-only, so this is availability of the owner's own server rather than a
+multi-tenant DoS. **Fix:** cap the `scopes` list (a `max_length` on the Pydantic
+field), and cap or age out `dedupscan` rows.
+
+### R7 (test gap) — `include_deleted=True` is load-bearing but untested
+
+I verified the behaviour is **correct** (probe `test_C1`): a scrapheaped stack
+sibling at `stack_position=5` is renumbered to `2` by the verdict and restored to
+`5` by undo.
+
+```
+[C1] before verdict = [(1, None, None, False), (2, 1, 0, False), (3, 1, 5, True)]
+[C1] after verdict  = [(1, 1, 0, False),       (2, 1, 1, False), (3, 1, 2, True)]
+[C1] after undo     = [(1, None, None, False), (2, 1, 0, False), (3, 1, 5, True)]
+[C1] >>> scrapheaped sibling reversed: True
+```
+
+But it is **not pinned**. Dropping only the flag:
+
+```python
+return expand_picture_ids_to_stacks(session, picture_ids)   # include_deleted dropped
+```
+
+leaves the suite green: `28 passed`. §21.1 requires the flag precisely because
+`normalize_stack_positions` renumbers soft-deleted members too. Promote my `test_C1`
+into `tests/test_dedup_verdict_service.py`.
+
+---
+
+## 6. Accepted risks (per the CLAUDE.md accepted-risk rule)
+
+### A1 — a stack verdict widens live share tokens; auto-stack does it in bulk
+
+- **Risk.** `apply_metadata_union_in_session` calls `reconcile_stack_membership`,
+  which unions set/project membership across the stack (§22.8, intentional). An
+  out-of-scope duplicate is thereby **added to a shared set**, and every live share
+  token for that set immediately reaches it — pictures, tags, `pixel_sha`, files.
+- **Reproduced** (probe `test_A3`), owner performs one `POST /dedup/verdicts/stack`:
+
+  ```
+  [A3] set 1 members BEFORE = [1]
+  [A3] BEFORE verdict   visible=[1] GET pictures/2/pixel_sha=403 GET pictures/2/tags=403
+  [A3] owner POST /dedup/verdicts/stack -> {... "picture_ids": [1, 2],
+                                            "metadata_union": {..., "membership_changed": true}}
+  [A3] set 1 members AFTER  = [1, 2]
+  [A3] AFTER verdict    visible=[1, 2] GET pictures/2/pixel_sha=200 GET pictures/2/tags=200
+  [A3]   out-of-scope tag body = {"id":2,"tags":[{"id":6,"tag":"secret-tag-0"},{"id":2,"tag":"secret-tag-1"}]}
+  ```
+- **Control — is it new?** No. Ordinary `POST /stacks` does the same (probe `test_A3b`):
+  `scoped-token visible before=[1] after=[1, 3]`. This is the shipped stack-atomic
+  membership model, not a dedup regression, and the authz gate is behaving exactly
+  as designed (picture 2 *is* a set member after the union).
+- **What is new** is the amplification: `POST /dedup/auto-stack` with `dry_run=false`
+  applies it to **every exact group in the vault** behind one consent dialog
+  (probe `test_A3c`: 2 groups, 4 pictures, one click; at scale, thousands). The
+  dry-run response reports `groups` and `pictures` and says nothing about how many
+  **shared sets or live tokens** would gain members.
+- **Blast radius.** Bounded to the owner's own sharing decisions; only affects sets/
+  projects that already have an outstanding share token, and only adds pictures the
+  owner has just declared to be duplicates of a picture already in that set.
+- **Compensating controls.** `dry_run=true` default; the union is additive and
+  reversible via the operation log; share tokens are minted only by the owner and
+  only as `READ`; locked sets refuse the union outright (§4.1).
+- **Ruling.** **Accepted** for the single-owner product, with one required
+  documentation change: **§22.8 must state the share-token consequence** — that the
+  membership union is a change to *who can see what*, and that auto-stack applies it
+  in bulk. It currently documents the union as a metadata operation only, and the
+  coverage matrix does not mention it at all. Recommended (not blocking): surface a
+  `shared_sets_affected` count in the auto-stack dry-run response so the consent
+  dialog can say so.
+- **Owner:** backend / auth maintainer. **Revisit:** mandatory at the start of
+  multi-user work, and immediately if bulk auto-stack is ever wired to run
+  unattended (at import, or on a schedule) — unattended bulk membership widening is
+  a different risk and this acceptance does not cover it.
+
+### A2 — caller-supplied `batch_id` is taken verbatim
+
+- **Risk.** `StackVerdictRequestModel.batch_id` / `SignatureRequestModel.batch_id` /
+  `AutoStackRequestModel.batch_id` are stored with no uniqueness, ownership or
+  op-type check. Two unrelated verdicts sent with the same id become one undo unit;
+  supplying an id that belongs to a *foreign* batch (a scrapheap bulk move, say)
+  grafts a dedup stack into it, so one Ctrl+Z reverses both.
+- **Reproduced** (probe `test_C2`): two independent verdicts sent with
+  `batch_id="shared-batch"` produce two `applied` rows in one batch; a single
+  `undo_batch` reverses both, unstacking four pictures across two stacks.
+- **Blast radius.** Owner-only, client-driven, fully reversible (redo restores).
+  It is a usability footgun (one undo does more than the user expects), not a
+  privilege issue.
+- **Compensating control.** All operation routes are `OWNER_ONLY`; the log is
+  append-only, so the mis-grouping is visible in `GET /operations`.
+- **Ruling.** **Accepted.** Cheap hardening if you want it: reject a `batch_id`
+  that already carries a different `op_type`.
+- **Owner:** backend maintainer. **Revisit:** when the operation log becomes a
+  user-visible activity feed (§21 / DAM 4.3), where a mis-grouped batch becomes a
+  misleading audit entry.
+
+### D1 — §22.9 is stale after the merge
+
+`docs/backend_architecture.md` §22.9 says:
+
+> The operation log ships on `feature/operation-log` and is **not on this branch**,
+> so `dedup_verdict_service._record_operation` imports it lazily and logs a warning
+> naming the missing module…
+
+Both halves are now false: `develop-1.9` was merged into this branch, and
+`dedup_verdict_service.py:89` imports `operation_log_service` at module level. There
+is no lazy import and no warning path. A security-review document that describes a
+mechanism the code does not have is a liability — fix the paragraph to describe what
+ships (one operation row per verdict, one shared `batch_id` per bulk run, no row for
+keep-separate/reopen), and fold in the R3 fix and the A1 consequence.
+
+---
+
+## 7. Release blockers, and what is not one
+
+**Release blockers for PR #638 (all must land before merge):**
+
+1. **R1** — signature must include the `size_bytes` co-key, with a regression test
+   proving two same-sha/different-size groups stay distinct.
+2. **R2** — `bulk_auto_stack` must either skip-and-report a `423` (matching its own
+   API description) or become atomic; either way the response must carry the
+   `batch_id` when anything committed. Regression test with a partial-lock bulk run.
+3. **R3** — thread `request_context(request)` through the four verdict handlers.
+4. **A1 doc** — §22.8 must record the share-token consequence of the membership
+   union and that auto-stack applies it in bulk.
+5. **D1 doc** — correct §22.9.
+
+**Explicitly NOT blockers.** The authorization design is sound and I could not find a
+scope hole: all eight routes deny every scoped token shape in both transports, no
+sibling route leaks a dedup-derived fact, the coverage matrix is arithmetically
+complete against an independent recount, the locked-set contract is fail-closed on
+the single-verdict path including the folded-stack case, the stack-expanded undo
+snapshot is non-vacuous, and there is no injection, no traversal, and no destructive
+route on this surface. R4–R7 are hardening and a test gap; they can follow.
+
+**Independence.** This sign-off was produced by a reviewer who wrote none of the
+branch. Per the CLAUDE.md review process, the authors must **not** self-certify the
+R1/R2/R3 fixes: re-run this document's reproductions and have a second party confirm
+before merge.
+
+---
+
+## 8. Reproductions — how to re-run
+
+Probes were written by this reviewer, run against a live `TestClient`/`Server`, and
+**deleted** rather than committed (durable tests belong to the authors — R7 and the
+R1/R2 regressions above name the ones that should be promoted).
+
+```
+PYTHONPATH=<worktree> /home/glindkvist/Projects/pixlstash/.venv/bin/python \
+    -m pytest -s --fast-captions --force-cpu <paths>
+```
+
+| Probe | Covers | Result |
+|---|---|---|
+| `test_A1` | registry vs `api_endpoint_set` recount | 235 / 236 / 1 confirmed |
+| `test_A2`, `test_A2b` | 8 routes × 2 token shapes × 2 transports, + owner 200 | all 403 / all 200 |
+| `test_A3`, `test_A3b`, `test_A3c` | share-token widening + pre-existing control + bulk | A1 |
+| `test_B1` | partial-lock, 7 state dimensions | fail-closed ✅ |
+| `test_B2` | bulk auto-stack, locked group mid-run | **R2** |
+| `test_B3`, `test_B4`, `test_B5` | signature / cover / exclusion / reopen abuse | all rejected ✅ |
+| `test_B6`, `test_B6b` | folded-stack co-member: union coverage + lock | lock ✅; union gap noted |
+| `test_C1` | scrapheaped sibling reversibility | correct, untested → **R7** |
+| `test_C2` | batch-id grafting | A2 |
+| `test_C3` | auto-stack batch undo | fully reversed ✅ |
+| `test_D1`, `test_D4`–`test_D7` | scan spam, bad scopes, bounds, counts fan-out | **R4**, **R6** |
+| `test_D2`, `test_D3` | tier-2 memory and scan complexity | **R5** |
+| `test_E1`, `test_E2` | signature injectivity | **R1** |
+| *(reverted-fix run)* | `_undo_targets` non-vacuity | fix is real ✅ |
+
+**Author suites re-run on this branch:**
+
+- `tests/test_architecture_guardrails.py` — **19 passed**
+- `tests/test_dedup_verdict_service.py` — **28 passed**
+- `tests/test_dedup_tier_service.py`, `tests/test_dedup_tiers_api.py`,
+  `tests/test_dedup_verdict_service.py`, `tests/test_architecture_guardrails.py`,
+  `tests/test_operation_log.py` — see §8.1
+- `ruff check pixlstash` — **All checks passed!**
+
+### 8.1 Combined suite
+
+```
+$ PYTHONPATH=<worktree> .venv/bin/python -m pytest -q --fast-captions --force-cpu \
+    tests/test_dedup_tier_service.py tests/test_dedup_tiers_api.py \
+    tests/test_dedup_verdict_service.py tests/test_architecture_guardrails.py \
+    tests/test_operation_log.py
+
+131 passed, 1 warning in 215.61s (0:03:35)
+```
+
+The branch is green as authored. Every finding above is a gap in what the tests
+*assert*, not a test the authors broke — which is the point of an adversarial pass.

--- a/frontend/e2e/fixtures/test.js
+++ b/frontend/e2e/fixtures/test.js
@@ -9,6 +9,7 @@ import { SideBar } from '../pages/SideBar.js'
 import { ShareDialog } from '../pages/ShareDialog.js'
 import { ReviewSessions } from '../pages/ReviewSessions.js'
 import { NoticeHost } from '../pages/NoticeHost.js'
+import { DuplicateQueuePage } from '../pages/DuplicateQueuePage.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const TOKEN_PATH = resolve(__dirname, '../.auth/token.json')
@@ -166,6 +167,12 @@ export const test = base.extend({
   },
   reviews: async ({ page }, use) => {
     await use(new ReviewSessions(page))
+  },
+  // The Duplicates destination (§21). Its own page object rather than an
+  // extension of GridPage: the queue replaces the grid rather than layering
+  // over it, and shares none of its selectors.
+  duplicates: async ({ page }, use) => {
+    await use(new DuplicateQueuePage(page))
   },
   // The notice surface (NoticeHost.vue). Call `notices.installHooks()` BEFORE
   // the first navigation — the store seam is an addInitScript.

--- a/frontend/e2e/pages/DuplicateQueuePage.js
+++ b/frontend/e2e/pages/DuplicateQueuePage.js
@@ -1,0 +1,86 @@
+import { expect } from '@playwright/test'
+
+/**
+ * The Duplicates destination (DuplicateQueue.vue + DedupGroupRow.vue).
+ *
+ * The queue is a keyboard surface first: exactly one row is focused, and the
+ * keys act on that row rather than on whatever the pointer last touched. This
+ * object therefore exposes the focused row as a first-class locator, and every
+ * key it sends goes to the queue root, which is the element that owns the
+ * keydown handler.
+ *
+ * Selectors verified in source: `.dq` / `[data-testid="duplicate-queue"]` (the
+ * root), `.grow` (a group row) with `.grow--focus` on the focused one and
+ * `data-testid="dedup-group-<signature>"` carrying the group's server id,
+ * `.gthumb` (a candidate) with `--cover` / `--out` modifiers, `.gbtn--stack`,
+ * `.gcompare`, `.dc-dialog` fields inside Compare, and `.sidebar-list-item`
+ * carrying "Duplicates" plus its `.sidebar-dedup-dot` badge.
+ */
+export class DuplicateQueuePage {
+  constructor(page) {
+    this.page = page
+    this.root = page.getByTestId('duplicate-queue')
+    this.rows = page.locator('.grow')
+    this.focusedRow = page.locator('.grow--focus')
+    this.doneState = page.locator('.qdone')
+    this.header = page.locator('.qtitle')
+    this.compareDialog = page.locator('.dc-strip')
+    this.compareCards = page.locator('.dc-card')
+    // The live region the queue narrates verdicts and refusals into. It is
+    // outside the row branches on purpose, so it survives the verdict that
+    // empties the queue.
+    this.announcement = page.getByTestId('dedup-announcement')
+    // The sidebar's Duplicates destination row and its PRESENCE dot: the
+    // count was retired (it moved with the tier gate, so it read as churn) —
+    // the dot only says there is work here.
+    this.sidebarRow = page
+      .locator('.sidebar-list-item', { hasText: 'Duplicates' })
+      .first()
+    this.sidebarDot = this.sidebarRow.locator('.sidebar-dedup-dot')
+  }
+
+  /** Open the queue by route and wait for a group (or the done state). */
+  async goto() {
+    await this.page.goto('/duplicates')
+    await expect(this.root).toBeVisible()
+    await this.page
+      .locator('.grow, .qdone')
+      .first()
+      .waitFor({ state: 'visible' })
+  }
+
+  /**
+   * Send a key to the queue root.
+   *
+   * Deliberately not `page.keyboard.press`: the handler is bound to `.dq`, and
+   * a key pressed at the document with the focus elsewhere proves nothing about
+   * the queue's model.
+   */
+  async pressKey(key) {
+    await this.root.press(key)
+  }
+
+  /** The signature of the focused group, read off its test id. */
+  async focusedSignature() {
+    const id = await this.focusedRow.getAttribute('data-testid')
+    return id ? id.replace('dedup-group-', '') : null
+  }
+
+  /** A row by group signature. */
+  row(signature) {
+    return this.page.getByTestId(`dedup-group-${signature}`)
+  }
+
+  /** The candidate thumbnails of the focused row. */
+  focusedCandidates() {
+    return this.focusedRow.locator('.gthumb')
+  }
+
+  /** How many candidates the focused row's Stack button would collect. */
+  async focusedStackSize() {
+    const text = await this.focusedRow.locator('.gbtn--stack').innerText()
+    const match = text.match(/\d+/)
+    return match ? Number(match[0]) : null
+  }
+
+}

--- a/frontend/e2e/seed_dedup_fixture.py
+++ b/frontend/e2e/seed_dedup_fixture.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Seed byte-identical duplicates into the e2e vault and detect them.
+
+The duplicate queue is the one e2e surface the harness cannot reach through the
+UI or the API, for two reasons that are both properties of the test backend
+rather than of the feature:
+
+1. **Neither import path can add a duplicate.** ``POST /pictures/import``
+   refuses outright without the face-extraction worker, and a reference folder's
+   initial scan is driven by the work planner. Both are off, because
+   ``serve_e2e_backend.py`` boots with ``disable_background_workers: true``.
+2. **A duplicate group only exists after a scan.** ``GET /dedup/groups`` reads
+   persisted ``DedupGroup`` rows; the rows are written by ``DedupScanTask``,
+   which the same disabled work planner never runs. ``POST /dedup/scan`` writes
+   a ``pending`` row and nothing ever picks it up.
+
+Enabling the workers for the whole suite is not the answer: they would start
+face extraction, quality scoring and captioning over the entire fixture on every
+e2e run. So this script does the two things the disabled workers would have
+done, and nothing else:
+
+* copies a handful of fixture images to new files and inserts ``picture`` rows
+  for them, which is exactly what makes them byte-identical duplicates (the
+  ``pixel_sha`` is a hash of the bytes, and tier 1 groups on
+  ``(pixel_sha, size_bytes)``);
+* runs the **real** ``DedupScanTask.run_scan_in_session`` against the same
+  database, so the groups, signatures, covers and evidence the spec then drives
+  are produced by production code rather than fabricated here.
+
+It writes only to the throwaway work directory ``serve_e2e_backend.py`` creates,
+never to the committed ``test-data/`` fixture, and it prints a JSON summary on
+stdout for the spec to read.
+
+The suite shares one mutable backend, so the same script also **undoes** its own
+work: ``--cleanup`` removes the seeded pictures and every row that hangs off
+them, unstacks and drops the stacks the verdicts created, and clears the dedup
+tables. The spec runs it after its last case, because a set left counting a
+picture that no longer exists is how a duplicate run breaks the export and
+tag-health specs that come after it.
+
+Usage::
+
+    python seed_dedup_fixture.py [--groups 3] [--copies 2]
+    python seed_dedup_fixture.py --cleanup
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DATA = Path(os.environ.get("PIXLSTASH_E2E_DATA") or (REPO_ROOT / "test-data"))
+# Mirrors serve_e2e_backend.WORK_DIR exactly; the two must not drift.
+WORK_DIR = Path(tempfile.gettempdir()) / f"pixlstash-e2e-{SRC_DATA.name}"
+IMAGE_ROOT = WORK_DIR / "images"
+DB_PATH = IMAGE_ROOT / "vault.db"
+
+# The marker every seeded row carries, so a re-run replaces its own rows instead
+# of stacking a second set of duplicates on top of the first.
+SEED_PREFIX = "e2e-dedup-seed-"
+
+
+def _source_pictures(conn: sqlite3.Connection, wanted: int) -> list[sqlite3.Row]:
+    """Pick fixture pictures that can carry a duplicate.
+
+    Only unstacked, undeleted rows with a hash and a file that is actually on
+    disk: a group whose members do not resolve to real images would render as
+    broken thumbnails and the spec would be asserting on a placeholder.
+    """
+    rows = conn.execute(
+        "SELECT * FROM picture "
+        "WHERE deleted = 0 AND stack_id IS NULL AND pixel_sha IS NOT NULL "
+        "AND file_path IS NOT NULL AND file_path NOT LIKE ? "
+        "ORDER BY id",
+        (f"%{SEED_PREFIX}%",),
+    ).fetchall()
+    picked = []
+    for row in rows:
+        if _on_disk(row["file_path"]).is_file():
+            picked.append(row)
+        if len(picked) >= wanted:
+            break
+    return picked
+
+
+def _on_disk(file_path: str) -> Path:
+    """Resolve a stored ``picture.file_path`` to a real file.
+
+    Managed pictures store a bare file name relative to the image root; a
+    reference-folder picture stores an absolute path. Both have to resolve, or
+    the seed silently skips every managed row in the fixture.
+    """
+    path = Path(file_path)
+    return path if path.is_absolute() else IMAGE_ROOT / path
+
+
+# Every table that hangs off a picture. A seeded row acquires children the
+# moment a verdict runs the metadata union (tags and set / project membership
+# are copied onto every member), so removing the picture without these would
+# leave a set counting a picture that no longer exists - which is exactly how a
+# dedup run breaks the export and tag-health specs that run after it.
+_PICTURE_CHILD_TABLES = (
+    "dedupgroupmember",
+    "detection",
+    "face",
+    "guest_score",
+    "picturelikenessqueue",
+    "pictureprojectmember",
+    "picturesetmember",
+    "quality",
+    "tag",
+    "tag_prediction",
+    "tag_suggestion",
+)
+
+# The dedup state a run leaves behind. Cleared wholesale: verdict memory is
+# permanent by design, so a leftover row would leave the next run's queue empty.
+_DEDUP_TABLES = ("dedupgroupmember", "dedupgroup", "dedupverdict", "dedupscan")
+
+
+def _clear_previous_seed(conn: sqlite3.Connection) -> int:
+    """Remove every trace of an earlier run and return how many pictures went.
+
+    The suite shares one mutable backend, so this is not merely a convenience
+    for re-running the seed: it is what keeps the duplicate queue's specs
+    reversible for the specs that run after them. It restores the pictures the
+    verdicts stacked, drops the stack rows those verdicts created, and clears
+    the dedup tables.
+    """
+    seeded = conn.execute(
+        "SELECT id, file_path, stack_id FROM picture WHERE file_path LIKE ?",
+        (f"%{SEED_PREFIX}%",),
+    ).fetchall()
+    for table in _DEDUP_TABLES:
+        try:
+            conn.execute(f"DELETE FROM {table}")
+        except sqlite3.OperationalError as exc:
+            print(f"[seed-dedup] skip clearing {table}: {exc}", file=sys.stderr)
+    if not seeded:
+        conn.commit()
+        return 0
+
+    ids = [int(row["id"]) for row in seeded]
+    stack_ids = {int(row["stack_id"]) for row in seeded if row["stack_id"]}
+    placeholders = ",".join("?" * len(ids))
+    for table in _PICTURE_CHILD_TABLES:
+        try:
+            conn.execute(
+                f"DELETE FROM {table} WHERE picture_id IN ({placeholders})", ids
+            )
+        except sqlite3.OperationalError as exc:
+            # A table the fixture does not carry is not an error worth aborting
+            # a cleanup for, but it must not pass unremarked either.
+            print(f"[seed-dedup] skip cleaning {table}: {exc}", file=sys.stderr)
+    conn.execute(f"DELETE FROM picture WHERE id IN ({placeholders})", ids)
+    for row in seeded:
+        path = _on_disk(row["file_path"])
+        if path.is_file():
+            path.unlink()
+
+    # A stack a verdict created held nothing but seeded copies and the fixture
+    # picture they were cloned from, and that picture was unstacked when the
+    # seed picked it. Unstack it again and drop the stack row, or the stacks
+    # spec finds a stack the fixture never had.
+    if stack_ids:
+        stack_places = ",".join("?" * len(stack_ids))
+        conn.execute(
+            "UPDATE picture SET stack_id = NULL, stack_position = NULL "
+            f"WHERE stack_id IN ({stack_places})",
+            list(stack_ids),
+        )
+        try:
+            conn.execute(
+                f"DELETE FROM picturestack WHERE id IN ({stack_places})",
+                list(stack_ids),
+            )
+        except sqlite3.OperationalError as exc:
+            print(f"[seed-dedup] skip deleting stacks: {exc}", file=sys.stderr)
+    conn.commit()
+    return len(ids)
+
+
+def _insert_copies(
+    conn: sqlite3.Connection, source: sqlite3.Row, copies: int, index: int
+) -> list[int]:
+    """Copy one picture's file `copies` times and insert a row per copy.
+
+    Every column is carried over from the source except the identity ones, so
+    the copy is byte-identical **and** row-identical where it matters: the same
+    ``pixel_sha`` and ``size_bytes`` are what tier 1 groups on.
+    """
+    columns = [row[1] for row in conn.execute("PRAGMA table_info(picture)")]
+    carried = [c for c in columns if c not in {"id", "file_path", "stack_id"}]
+    source_path = _on_disk(source["file_path"])
+    stored_absolute = Path(source["file_path"]).is_absolute()
+    new_ids: list[int] = []
+    for copy_index in range(copies):
+        name = f"{SEED_PREFIX}{index}-{copy_index}{source_path.suffix}"
+        target = source_path.with_name(name)
+        shutil.copyfile(source_path, target)
+        # Store the path the same way the source did, or the server resolves it
+        # against the image root twice and serves a 404 for every thumbnail.
+        stored = str(target) if stored_absolute else name
+        values = [source[c] for c in carried]
+        cursor = conn.execute(
+            f"INSERT INTO picture (file_path, {', '.join(carried)}) "
+            f"VALUES ({', '.join('?' * (len(carried) + 1))})",
+            [stored, *values],
+        )
+        new_ids.append(int(cursor.lastrowid))
+    conn.commit()
+    return new_ids
+
+
+def _run_scan() -> dict:
+    """Run the real scan task against the seeded database.
+
+    Imported lazily and only here: this is the one part of the script that needs
+    the backend package, and a caller that only wants the rows should not pay for
+    importing half the server to get them.
+    """
+    from sqlmodel import Session, create_engine, select
+
+    from pixlstash.db_models.dedup import SCAN_PENDING, DedupGroup, DedupScan
+    from pixlstash.services.dedup_tier_service import DedupScope, TierPolicy
+    from pixlstash.tasks.dedup_scan_task import DedupScanTask
+
+    policy = TierPolicy()
+    scope = DedupScope()
+    engine = create_engine(f"sqlite:///{DB_PATH}")
+    with Session(engine) as session:
+        row = session.exec(
+            select(DedupScan).where(DedupScan.scope_key == scope.key)
+        ).first()
+        if row is None:
+            row = DedupScan(scope_key=scope.key)
+        row.scope_type = scope.scope_type.value
+        row.scope_id = scope.scope_id
+        row.tiers = json.dumps([tier.value for tier in policy.tiers])
+        row.threshold = float(policy.threshold)
+        row.status = SCAN_PENDING
+        row.error = None
+        session.add(row)
+        session.commit()
+        session.refresh(row)
+        summary = DedupScanTask.run_scan_in_session(session, int(row.id))
+        signatures = session.exec(
+            select(DedupGroup.signature)
+            .where(DedupGroup.resolved.is_(False))
+            .order_by(DedupGroup.confidence.desc(), DedupGroup.id.asc())
+        ).all()
+    return {"scan": summary, "signatures": [str(s) for s in signatures]}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--groups", type=int, default=3, help="How many duplicate groups to seed."
+    )
+    parser.add_argument(
+        "--copies",
+        type=int,
+        default=2,
+        help="Extra copies per group. 2 gives a three-member group.",
+    )
+    parser.add_argument(
+        "--cleanup",
+        action="store_true",
+        help=(
+            "Remove the seeded pictures, the stacks the verdicts created and "
+            "all dedup state, then exit. The spec runs this after its last "
+            "case so the shared backend is handed on unchanged."
+        ),
+    )
+    args = parser.parse_args()
+
+    if not DB_PATH.exists():
+        print(
+            f"[seed-dedup] ERROR: no e2e vault at {DB_PATH}. "
+            "Start the e2e backend first (Playwright's webServer does).",
+            file=sys.stderr,
+        )
+        return 1
+
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.row_factory = sqlite3.Row
+    try:
+        removed = _clear_previous_seed(conn)
+        if args.cleanup:
+            print(json.dumps({"removed_pictures": removed}))
+            return 0
+        sources = _source_pictures(conn, args.groups)
+        if len(sources) < args.groups:
+            print(
+                f"[seed-dedup] ERROR: only {len(sources)} usable fixture pictures "
+                f"for {args.groups} groups.",
+                file=sys.stderr,
+            )
+            return 1
+        seeded = []
+        for index, source in enumerate(sources):
+            copies = _insert_copies(conn, source, args.copies, index)
+            seeded.append(
+                {"source_picture_id": int(source["id"]), "copy_picture_ids": copies}
+            )
+    finally:
+        conn.close()
+
+    result = _run_scan()
+    result["seeded"] = seeded
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/frontend/e2e/specs/dedup.spec.js
+++ b/frontend/e2e/specs/dedup.spec.js
@@ -1,0 +1,258 @@
+// Release plan §21 — the Duplicates destination, driven by the keyboard.
+//
+// REQUIRES THE BACKEND BRANCH. The `/dedup` routes ship on
+// `feature/dedup-tiers`; this spec lives on the frontend branch and will fail
+// with 404s until the two are merged. That is deliberate: the spec is the
+// frontend lane's half of the contract and is committed with it rather than
+// held back.
+//
+// The queue is a keyboard surface before it is a pointer one, so every case
+// here sends real keypresses at the queue root (the element that actually owns
+// the keydown handler) rather than clicking the buttons that duplicate them.
+// Clicking would exercise the emits and prove nothing about the model that
+// makes the feature worth having.
+//
+// The fixture is seeded by `e2e/seed_dedup_fixture.py`, which copies fixture
+// images to new files, inserts a `picture` row per copy and then runs the real
+// `DedupScanTask`. It exists because the e2e backend boots with
+// `disable_background_workers: true`: `POST /pictures/import` refuses without
+// the face worker, a reference folder's initial scan is planner-driven, and a
+// `DedupGroup` row is only ever written by the scan task the same disabled
+// planner never runs. See that script's own docstring for the full reasoning.
+
+import { execFileSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test, expect } from '../fixtures/test.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SEED_SCRIPT = resolve(__dirname, '../seed_dedup_fixture.py')
+const REPO_ROOT = resolve(__dirname, '../../..')
+
+// Three groups of three: three is the smallest size that can prove both halves
+// of the exclusion floor, because it accepts exactly one exclusion and then
+// refuses the next.
+const SEED_GROUPS = 3
+const SEED_COPIES = 2
+
+/** Run the seed script and parse its JSON report. */
+function runSeedScript(args) {
+  const python = process.env.PIXLSTASH_PYTHON || 'python'
+  const stdout = execFileSync(python, [SEED_SCRIPT, ...args], {
+    // The backend is launched from `frontend/`, so the repo is not on
+    // `sys.path` there. The seed imports the same pixlstash the server runs.
+    env: { ...process.env, PYTHONPATH: REPO_ROOT },
+    encoding: 'utf8',
+  })
+  return JSON.parse(stdout)
+}
+
+/** Seed the duplicates and detect them, returning the scan's own report. */
+function seedDuplicates() {
+  return runSeedScript([
+    '--groups',
+    String(SEED_GROUPS),
+    '--copies',
+    String(SEED_COPIES),
+  ])
+}
+
+/** The unresolved-group count the sidebar badge is rendered from. */
+async function unresolvedGroups(apiContext) {
+  const res = await apiContext.post('/api/v1/dedup/counts', { data: {} })
+  expect(res.ok()).toBeTruthy()
+  return (await res.json()).unresolved_groups
+}
+
+/** The signatures the queue would serve right now, confidence descending. */
+async function queuedSignatures(apiContext) {
+  const res = await apiContext.get('/api/v1/dedup/groups?limit=50')
+  expect(res.ok()).toBeTruthy()
+  const body = await res.json()
+  return body.groups.map((g) => g.signature)
+}
+
+// One shared, mutable backend and verdicts that are remembered for good, so the
+// cases run in order and each one starts from the state the last left.
+test.describe.serial('duplicates queue (§21)', () => {
+  let seeded
+
+  test.beforeAll(() => {
+    seeded = seedDuplicates()
+    expect(seeded.scan.groups_found).toBe(SEED_GROUPS)
+    expect(seeded.signatures).toHaveLength(SEED_GROUPS)
+  })
+
+  // The suite shares one mutable backend, and these cases are the only ones
+  // that add pictures and create stacks. Handing that on would leave a picture
+  // set counting copies that later specs then fail to export or tag-health, so
+  // the seed is undone here rather than left for the next file to survive.
+  test.afterAll(() => {
+    runSeedScript(['--cleanup'])
+  })
+
+  test('opens with the first group focused and walks it with the arrows', async ({
+    duplicates,
+  }) => {
+    await duplicates.goto()
+    await expect(duplicates.rows).toHaveCount(SEED_GROUPS)
+
+    // Exactly one row is focused, and it is the first: "which row does Enter
+    // hit" is the question the whole focused-row treatment exists to answer.
+    await expect(duplicates.focusedRow).toHaveCount(1)
+    const first = await duplicates.focusedSignature()
+    expect(first).toBe(seeded.signatures[0])
+
+    await duplicates.pressKey('ArrowDown')
+    await expect(duplicates.row(seeded.signatures[1])).toHaveClass(
+      /grow--focus/,
+    )
+    await duplicates.pressKey('ArrowDown')
+    await expect(duplicates.row(seeded.signatures[2])).toHaveClass(
+      /grow--focus/,
+    )
+
+    // The focus is clamped, not wrapped: an arrow key that jumped from the last
+    // row back to the first would move the cursor a screen away from where the
+    // user is looking.
+    await duplicates.pressKey('ArrowDown')
+    await expect(duplicates.row(seeded.signatures[2])).toHaveClass(
+      /grow--focus/,
+    )
+
+    await duplicates.pressKey('ArrowUp')
+    await expect(duplicates.row(seeded.signatures[1])).toHaveClass(
+      /grow--focus/,
+    )
+  })
+
+  // The QA finding this spec was written for: the floor is two INCLUDED
+  // members, not one. A group that fell to a single member would still offer a
+  // Stack button, and pressing it would be a guaranteed 400 from a server that
+  // refuses a one-member stack.
+  test('X excludes down to two members and then refuses', async ({
+    duplicates,
+  }) => {
+    await duplicates.goto()
+    await expect(duplicates.focusedCandidates()).toHaveCount(SEED_COPIES + 1)
+    expect(await duplicates.focusedStackSize()).toBe(SEED_COPIES + 1)
+
+    // The first exclusion is allowed: three members can spare one.
+    await duplicates.pressKey('x')
+    await expect(duplicates.focusedRow.locator('.gthumb--out')).toHaveCount(1)
+    expect(await duplicates.focusedStackSize()).toBe(SEED_COPIES)
+
+    // The second is refused, and said out loud rather than dropped silently.
+    await duplicates.pressKey('x')
+    await expect(duplicates.focusedRow.locator('.gthumb--out')).toHaveCount(1)
+    expect(await duplicates.focusedStackSize()).toBe(SEED_COPIES)
+    await expect(duplicates.announcement).toContainText(
+      'A stack needs at least two pictures',
+    )
+  })
+
+  test('C opens Compare on the focused group and Escape closes it', async ({
+    duplicates,
+  }) => {
+    await duplicates.goto()
+    await duplicates.pressKey('c')
+    await expect(duplicates.compareDialog).toBeVisible()
+    // Compare shows every candidate field by field; the row deliberately shows
+    // none of those fields, which is why the second view exists at all.
+    await expect(duplicates.compareCards).toHaveCount(SEED_COPIES + 1)
+
+    await duplicates.page.keyboard.press('Escape')
+    await expect(duplicates.compareDialog).toBeHidden()
+  })
+
+  test('Enter stacks the focused group, auto-advances and moves the badge', async ({
+    duplicates,
+    apiContext,
+  }) => {
+    const target = seeded.signatures[0]
+    const before = await unresolvedGroups(apiContext)
+    await duplicates.goto()
+    // The sidebar shows PRESENCE, not a number: the count moved with the tier
+    // gate, so it was retired for a dot. The numbers live in the queue header.
+    await expect(duplicates.sidebarDot).toBeVisible()
+
+    const memberIds = await duplicates
+      .focusedCandidates()
+      .evaluateAll((nodes) =>
+        nodes
+          .map((n) => n.querySelector('img')?.getAttribute('src') || '')
+          .map((src) => Number((src.match(/thumbnails\/(\d+)/) || [])[1]))
+          .filter(Boolean),
+      )
+    expect(memberIds.length).toBe(SEED_COPIES + 1)
+
+    await duplicates.pressKey('Enter')
+
+    // Auto-advance: the row is gone and the cursor has landed on the next open
+    // group without a further keystroke.
+    await expect(duplicates.row(target)).toHaveCount(0)
+    await expect(duplicates.rows).toHaveCount(SEED_GROUPS - 1)
+    await expect(duplicates.row(seeded.signatures[1])).toHaveClass(
+      /grow--focus/,
+    )
+
+    // Server truth, not just a row that vanished: every member now sits in one
+    // stack, and the group is out of the queue for good. An unstacked picture
+    // answers `{ stack_id: null, picture_ids: [] }` here, so a real stack is
+    // the one shape that can satisfy this.
+    const stackRes = await apiContext.get(
+      `/api/v1/pictures/${memberIds[0]}/stack`,
+    )
+    expect(stackRes.ok()).toBeTruthy()
+    const stack = await stackRes.json()
+    expect(stack.id).toBeTruthy()
+    expect(stack.picture_ids).toEqual(expect.arrayContaining(memberIds))
+    expect(await queuedSignatures(apiContext)).not.toContain(target)
+
+    // The counts are reconciled from POST /dedup/counts after the verdict, not
+    // inferred from a WebSocket event; groups remain, so the dot stays.
+    expect(await unresolvedGroups(apiContext)).toBe(before - 1)
+    await expect(duplicates.sidebarDot).toBeVisible()
+  })
+
+  test('S keeps the focused group separate and it stops being offered', async ({
+    duplicates,
+    apiContext,
+  }) => {
+    const target = seeded.signatures[1]
+    const before = await unresolvedGroups(apiContext)
+    await duplicates.goto()
+    await expect(duplicates.row(target)).toHaveClass(/grow--focus/)
+
+    await duplicates.pressKey('s')
+
+    await expect(duplicates.row(target)).toHaveCount(0)
+    await expect(duplicates.row(seeded.signatures[2])).toHaveClass(
+      /grow--focus/,
+    )
+    expect(await queuedSignatures(apiContext)).not.toContain(target)
+
+    // A keep-separate mutates no picture row, so it raises no WebSocket event.
+    // The dot can only be right here because the verdict refetches the counts
+    // itself — this is the assertion that pins that fix.
+    expect(await unresolvedGroups(apiContext)).toBe(before - 1)
+    await expect(duplicates.sidebarDot).toBeVisible()
+  })
+
+  test('working the last group through lands on the done state', async ({
+    duplicates,
+  }) => {
+    await duplicates.goto()
+    await expect(duplicates.rows).toHaveCount(1)
+    await duplicates.pressKey('Enter')
+    await expect(duplicates.doneState).toBeVisible()
+    await expect(duplicates.doneState).toContainText('Queue clear')
+    // The done state has to be true when it is shown: no picture is deleted, so
+    // it says so rather than implying the copies went somewhere.
+    await expect(duplicates.doneState).toContainText(
+      'Every picture is still in your library',
+    )
+    // Nothing left to review in ANY tier, so the presence dot goes with it.
+    await expect(duplicates.sidebarDot).toHaveCount(0)
+  })
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1060,6 +1060,18 @@ function handleSelectDuplicates(scope = {}) {
 // writes live in useViewStore; App.vue keeps only the route PUSHING above.
 viewStore.startRouteSync(route, { watch });
 
+// A navigation retires the live undo receipt (owner decision, 2026-07-29):
+// the pill narrates something that happened on the view being left, and a
+// receipt carried into the next view reads as a fresh event there. Ctrl+Z
+// keeps working everywhere regardless — the receipt is narration, not the
+// undo affordance itself.
+watch(
+  () => route.fullPath,
+  (next, prev) => {
+    if (prev !== undefined && next !== prev) operationStore.dismissReceipt();
+  },
+);
+
 // Stateless sidebar tabs: switching the Global ↔ Project mode (or the
 // project picker) must not navigate or change the grid — the route is the
 // single source of truth. These handlers therefore only mirror the value
@@ -1479,6 +1491,22 @@ function handleGlobalKeydown(e) {
   // The review overlay is modal and owns its own keyboard handler; don't
   // run the app/grid shortcuts (scroll, search, help) behind it.
   if (reviewSessionsStore.overlayOpen) return;
+  // The LIGHTBOX owns the keyboard too, with its own undo binding and its own
+  // receipt. This used to be enforced implicitly by listener order — the
+  // overlay mounted before App, ran first, and stopImmediatePropagation()
+  // silenced this handler — but the Duplicates view unmounts and remounts the
+  // grid (and the overlay inside it), which re-registers their listeners
+  // AFTER this one and silently flips that order. The result was one Ctrl+Z
+  // running TWO undos: this handler's, then the overlay's, which the
+  // operation store's busy-queue happily executed as a queued second step.
+  // Ownership is therefore stated here explicitly, on the same DOM signal the
+  // overlay renders (`.image-overlay` is v-if'd on open), not on ordering.
+  if (
+    typeof document !== "undefined" &&
+    document.querySelector(".image-overlay") != null
+  ) {
+    return;
+  }
   // Match the strictness the grid and the lightbox already use: a SELECT and an
   // ARIA textbox are typing surfaces too, and the event target matters as much
   // as `document.activeElement` (a Vuetify combobox moves focus around).
@@ -1523,11 +1551,11 @@ function handleGlobalKeydown(e) {
   //
   // The lightbox is NOT covered by that last guard and never was:
   // `isModalOverlayOpen()` looks for a Vuetify scrim, and `.image-overlay`
-  // renders its own. What actually stops this handler there is ImageOverlay's
-  // `stopImmediatePropagation()` on a listener registered before this one (a
-  // child mounts first). Undo works in the lightbox, and it is the lightbox's
-  // own key handler plus `OverlayActionReceipt` that do it, fitted to that
-  // surface's GUI per the owner's ruling.
+  // renders its own. The lightbox is excluded by the explicit `.image-overlay`
+  // check at the top of this handler (listener ORDER used to do it, until the
+  // Duplicates view's grid remount flipped it — see that comment). Undo works
+  // in the lightbox through its own key handler plus `OverlayActionReceipt`,
+  // fitted to that surface's GUI per the owner's ruling.
   if (
     (e.ctrlKey || e.metaKey) &&
     !e.altKey &&

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,6 +33,7 @@ import { useSnapshotsStore } from "./stores/useSnapshotsStore";
 import { useTasksStore } from "./stores/useTasksStore";
 import { useLockedSetsStore } from "./stores/useLockedSetsStore";
 import { useOperationStore } from "./stores/useOperationStore";
+import { useDedupStore } from "./stores/useDedupStore";
 import {
   ALL_PICTURES_ID,
   SCRAPHEAP_PICTURES_ID,
@@ -47,6 +48,7 @@ import TitleBar from "./components/TitleBar.vue";
 import PhotosImportDialog from "./components/io/PhotosImportDialog.vue";
 import RestoreConfirmDialog from "./components/widgets/RestoreConfirmDialog.vue";
 import ImageGrid from "./components/views/ImageGrid.vue";
+import DuplicateQueue from "./components/views/DuplicateQueue.vue";
 import ReviewSessionsOverlay from "./components/views/ReviewSessionsOverlay.vue";
 import StatsSidebar from "./components/panels/StatsSidebar.vue";
 import ThumbnailUpgradeBanner from "./components/panels/ThumbnailUpgradeBanner.vue";
@@ -77,6 +79,7 @@ const snapshotsStore = useSnapshotsStore();
 const tasksStore = useTasksStore();
 const lockedSetsStore = useLockedSetsStore();
 const operationStore = useOperationStore();
+const dedupStore = useDedupStore();
 // Owns route → view resolution (the app's single route watcher). Route pushing
 // stays here in App.vue; see stores/useViewStore.js.
 const viewStore = useViewStore();
@@ -528,6 +531,14 @@ function refreshSidebar(options = {}) {
   // which also fires on a lock/unlock PATCH's CHANGED_PICTURES event). The store
   // coalesces overlapping fetches, so calling it here on every refresh is cheap.
   lockedSetsStore.fetch();
+  // The duplicates badge rides the same triggers: an import, a stack or a
+  // verdict all move the count, and every one of them already causes a sidebar
+  // refresh. The per-scope cache goes with it, since a context menu opened
+  // afterwards must not quote a pre-change number.
+  if (!isReadOnly.value) {
+    dedupStore.invalidateScopeCounts();
+    dedupStore.refreshCounts();
+  }
 }
 
 function refreshSidebarDebounced() {
@@ -1014,6 +1025,34 @@ function pushRouteForCurrentSelection() {
     params: { id: String(sel.selectedCharacter) },
     query,
   });
+}
+
+// The Duplicates destination is addressed by route name, not by a sentinel in
+// the selection store: it shows no pictures, so it has no selection to express.
+const isDuplicatesView = computed(() => route.name === "duplicates");
+
+/**
+ * Open the duplicate triage queue, optionally scoped to one collection object.
+ *
+ * The scope travels in the query rather than in a store, so a scoped queue is a
+ * link the user can bookmark and reload, and a back-navigation out of one lands
+ * somewhere that still makes sense.
+ *
+ * @param {Object} [scope]
+ * @param {string} [scope.type] - "project", "set", "character" or "folder".
+ * @param {number|string} [scope.id]
+ * @param {string} [scope.label] - what the scope pill reads.
+ * @param {string} [scope.icon] - the pill's mdi glyph.
+ */
+function handleSelectDuplicates(scope = {}) {
+  const query = {};
+  if (scope.type && scope.type !== "library") {
+    query.scope = scope.type;
+    if (scope.id !== undefined && scope.id !== null) query.scope_id = scope.id;
+    if (scope.label) query.scope_label = scope.label;
+    if (scope.icon) query.scope_icon = scope.icon;
+  }
+  pushAppRoute({ name: "duplicates", query });
 }
 
 // Route -> stores: install the app's single route watcher (immediately on
@@ -2061,6 +2100,8 @@ defineExpose({
             @update:selected-project-id="handleUpdateSelectedProjectId"
             @view-project="handleViewProject"
             @select-character="handleSelectCharacter"
+            :isDuplicatesView="isDuplicatesView"
+            @select-duplicates="handleSelectDuplicates"
             @select-set="handleSelectSet"
             @select-folder="handleSelectFolder"
             @update:folder-scanning="folderScanning = $event"
@@ -2160,7 +2201,13 @@ defineExpose({
                 overflow: hidden;
               "
             >
+              <!-- Duplicates is a destination, not a filter, so it replaces
+                   the grid rather than floating over it. The grid stays
+                   unmounted while the queue is open, which is also what keeps
+                   its fetches and its WebSocket reconciliation quiet. -->
+              <DuplicateQueue v-if="isDuplicatesView" />
               <ImageGrid
+                v-else
                 ref="gridContainer"
                 :thumbnailSize="gridStore.thumbnailSize"
                 :sidebarVisible="sidebarStore.sidebarVisible"
@@ -2200,6 +2247,7 @@ defineExpose({
                 :tagConfidenceBelowFilter="filterStore.tagConfidenceBelowFilter"
                 :faceBboxFilter="filterStore.faceBboxFilter"
                 :impossibleSources="filterStore.impossibleSources"
+                :stackStateFilter="filterStore.stackStateFilter"
                 :sharedOnlyFilter="filterStore.sharedOnlyFilter"
                 :unassignedOnlyFilter="filterStore.unassignedOnlyFilter"
                 :showFaceBboxes="gridStore.showFaceBboxes"
@@ -2279,6 +2327,7 @@ defineExpose({
                 "
                 @update:match-count="gridStore.matchCount = $event"
                 @update:overlay-open="lightboxOpen = $event"
+                @open-duplicates="handleSelectDuplicates({})"
                 @open-settings="openSettingsDialog"
                 @open-import="openImportDialog"
                 @local-import="handleLocalImport"

--- a/frontend/src/api/dedup.js
+++ b/frontend/src/api/dedup.js
@@ -1,0 +1,401 @@
+// Dedup resource: /dedup.
+//
+// Duplicate detection is a destination with a to-do count, not a sort order.
+// This module is the whole contract behind it: the tier policy the controls are
+// built from, the paged triage queue, the live counts the sidebar and the
+// context menus read, the scan trigger, the three verdicts (stack / keep
+// separate / reopen) and the bulk auto-stack of the exact tier.
+//
+// Two invariants shape every route here:
+//
+//   * **Nothing is deleted.** The only verdicts are "stack" and "keep separate".
+//     A stack is a grouping row plus a cover pointer, so a verdict is reversible
+//     and there is no destructive route on this surface at all.
+//   * **Nothing blocks on a full pass.** The queue returns whatever has been
+//     found so far together with the scan's progress, so the UI opens
+//     immediately and streams the rest in.
+//
+// ## Contract notes (reconciled with the backend lane, 2026-07-29)
+//
+// This module was first written against a speculative contract while the
+// backend was built in parallel. It now matches `routes/dedup.py` as shipped.
+// The parts worth knowing, because they shape the callers:
+//
+//   1. **A group is addressed by its `signature`**, a hash of the sorted member
+//      content hashes, and the signature travels in the request BODY on every
+//      verdict route. It is never interpolated into a path, so no encoding
+//      question arises.
+//   2. **Paging is a keyset cursor, with offset as the fallback.** The queue is
+//      ordered by confidence descending while a scan is still inserting rows, so
+//      an offset can re-serve or skip a group as the table grows. The cursor
+//      removes that hazard rather than mitigating it, so it is the primary path:
+//      a response carrying `next_cursor` is paged with {@link listGroups}'s
+//      `cursor` and the offset is never sent again for that queue. A server that
+//      returns no `next_cursor` is paged by `offset` exactly as before, with the
+//      dedupe-by-signature mitigation still in force. `useDedupStore.loadMore`
+//      picks between the two per page, so both work without a feature flag.
+//   3. **Counts are a POST that takes a LIST of scopes.** Read-only despite the
+//      verb: a context menu asks for its own scopes and gets the global sidebar
+//      badge in the same response, so the badge and the menu can never disagree.
+//   4. **Tier selection is two booleans plus a threshold**, not a list of tier
+//      names: `near_enabled`, then `embedding_enabled` which requires it. The
+//      thresholds, the tier order, the prerequisites and the scope vocabulary
+//      all come from `GET /dedup/policy`, so no bound is hardcoded twice.
+//   5. **The whole-vault scope is `"global"`**, and `scope_id` is required for
+//      every other scope type. `ScopeRequestModel` forbids extra fields, so a
+//      caller must not send a scope label or glyph here; those are the client's
+//      own presentation state and live in the URL.
+//   6. **`autoStackExact` defaults to `dry_run: true`.** The dry run returns the
+//      counts the consent dialog shows and writes nothing; the real run returns
+//      the single `batch_id` that makes N stacks reverse with one undo.
+//   7. **Keep-separate records no operation.** It changes no reversible picture
+//      facet, so there is nothing for undo to restore and the backend
+//      deliberately writes no operation row. Callers must not wait for a receipt
+//      that will never arrive; the way back is {@link reopenGroup}.
+//
+// Every route is owner-scoped on the backend. Guarding a read-only session is
+// the caller's job; this module is pure transport.
+
+import { apiClient } from "../utils/apiClient";
+
+/** The whole-vault scope. Every other scope type requires a `scope_id`. */
+export const GLOBAL_SCOPE = "global";
+
+/**
+ * Build a dedup route, optionally under an explicit backend base.
+ * @param {string} [path=""] - the route below `/dedup`.
+ * @param {string} [baseUrl=""] - explicit backend base.
+ * @returns {string}
+ */
+function dedupUrl(path = "", baseUrl = "") {
+  return `${baseUrl}/dedup${path}`;
+}
+
+/**
+ * Build a `ScopeRequestModel` body fragment.
+ *
+ * The model forbids extra fields, so this deliberately emits only the two the
+ * server accepts: a scope label or glyph is the client's own presentation state
+ * and would come back a 422.
+ *
+ * @param {string} [scopeType=GLOBAL_SCOPE] - `global`, `project`, `set`,
+ *   `character` or `folder`, from `GET /dedup/policy` -> `bounds.scope_types`.
+ * @param {number|string} [scopeId] - the collection's id, or the absolute path
+ *   for `folder`. Required unless the scope is global.
+ * @returns {Object}
+ */
+export function scopeBody(scopeType = GLOBAL_SCOPE, scopeId = null) {
+  const body = { scope_type: scopeType || GLOBAL_SCOPE };
+  if (
+    body.scope_type !== GLOBAL_SCOPE &&
+    scopeId !== undefined &&
+    scopeId !== null
+  ) {
+    body.scope_id = String(scopeId);
+  }
+  return body;
+}
+
+/**
+ * Build a `TierPolicyModel` body fragment from the client's gate.
+ *
+ * Omits every field the caller did not set, so the server's own defaults apply
+ * rather than the client re-stating them. The model forbids extra fields.
+ *
+ * @param {Object} [policy]
+ * @param {boolean} [policy.nearEnabled]
+ * @param {boolean} [policy.embeddingEnabled]
+ * @param {number} [policy.threshold]
+ * @param {number} [policy.minGroupSize]
+ * @param {number} [policy.maxGroupSize]
+ * @returns {Object}
+ */
+export function policyBody({
+  nearEnabled,
+  embeddingEnabled,
+  threshold,
+  minGroupSize,
+  maxGroupSize,
+} = {}) {
+  const body = {};
+  if (typeof nearEnabled === "boolean") body.near_enabled = nearEnabled;
+  if (typeof embeddingEnabled === "boolean") {
+    body.embedding_enabled = embeddingEnabled;
+  }
+  if (Number.isFinite(threshold)) body.threshold = threshold;
+  if (Number.isFinite(minGroupSize)) body.min_group_size = minGroupSize;
+  if (Number.isFinite(maxGroupSize)) body.max_group_size = maxGroupSize;
+  return body;
+}
+
+/**
+ * Read the tier defaults, bounds and closed vocabularies.
+ *
+ * The single reason no threshold, tier id, prerequisite or scope type is
+ * hardcoded in the client. Fetch this before rendering the tier controls.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.baseUrl=""]
+ * @returns {Promise<Object>} the response body: `{ defaults, bounds }`, where
+ *   `bounds` carries `min_threshold`, `max_threshold`, `tiers` (strongest
+ *   first), `always_on_tiers`, `tier_requires`, `scope_types`, `verdicts` and
+ *   `max_page_size`.
+ */
+export async function getPolicy({ baseUrl = "" } = {}) {
+  const res = await apiClient.get(dedupUrl("/policy", baseUrl));
+  return res.data;
+}
+
+/**
+ * Read one page of the queue, confidence descending.
+ *
+ * Returns whatever has been found so far plus this scope's scan progress, so
+ * the queue can open on a partial result and stream the rest in. Groups already
+ * resolved are never returned again: the verdict memory is keyed on the group
+ * signature, so a rescan does not re-ask.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.nearEnabled=false] - include tier 2.
+ * @param {boolean} [options.embeddingEnabled=false] - include tier 3. The
+ *   server rejects this without `nearEnabled`.
+ * @param {number} [options.threshold] - minimum similarity. Omitted means the
+ *   server's default; below its floor is a 400, never a silent clamp.
+ * @param {string} [options.scopeType=GLOBAL_SCOPE]
+ * @param {number|string} [options.scopeId]
+ * @param {string} [options.cursor] - the opaque `next_cursor` from the previous
+ *   page. The primary paging path: a keyset cursor cannot re-serve or skip a
+ *   group while a scan inserts rows, which an offset over the same ordering can.
+ *   Supplying it suppresses `offset` entirely, since sending both would let a
+ *   server pick the weaker one.
+ * @param {number} [options.offset=0] - **deprecated**, and only used when no
+ *   cursor is held: the first page of a queue, or a server that publishes no
+ *   `next_cursor`.
+ * @param {number} [options.limit=20] - clamped server-side to
+ *   `bounds.max_page_size`; the response echoes the effective value.
+ * @param {string} [options.baseUrl=""]
+ * @returns {Promise<Object>} the response body:
+ *   `{ groups, total, offset, limit, policy, scope, scan }`, plus `next_cursor`
+ *   from a cursor-paging server: an opaque string while more pages remain and
+ *   null (or absent) at the end. A group is
+ *   `{ signature, tier, confidence, member_count, cover_picture_id, why,
+ *   created_at, candidates }`.
+ */
+export async function listGroups({
+  nearEnabled = false,
+  embeddingEnabled = false,
+  threshold,
+  scopeType = GLOBAL_SCOPE,
+  scopeId = null,
+  cursor = null,
+  offset = 0,
+  limit = 20,
+  decided = false,
+  baseUrl = "",
+} = {}) {
+  const params = {
+    near_enabled: nearEnabled,
+    embedding_enabled: embeddingEnabled,
+    limit,
+  };
+  // The decided page: resolved groups with their live verdict, so a decision
+  // can be reviewed and cleared. Omitted entirely for the open queue.
+  if (decided) params.decided = true;
+  // Never both: a cursor and an offset describe the same position two ways, and
+  // a server free to choose between them could silently keep the weaker one.
+  if (typeof cursor === "string" && cursor) params.cursor = cursor;
+  else params.offset = offset;
+  if (Number.isFinite(threshold)) params.threshold = threshold;
+  Object.assign(params, scopeBody(scopeType, scopeId));
+  const res = await apiClient.get(dedupUrl("/groups", baseUrl), { params });
+  return res.data;
+}
+
+/**
+ * Read the live counts: the sidebar badge, the per-tier split, and any number
+ * of scoped counts in one request.
+ *
+ * The global count comes back whether or not a scope was asked for, so a
+ * context menu labelling three of its entries also refreshes the badge for
+ * free, and the two can never disagree. The per-tier split deliberately
+ * includes tiers that are switched off, so the tier menu can show what enabling
+ * one would add before the user enables it.
+ *
+ * @param {Object} [options]
+ * @param {Object} [options.policy] - see {@link policyBody}.
+ * @param {Array<{scopeType: string, scopeId: (number|string|null)}>}
+ *   [options.scopes=[]] - extra scopes to count.
+ * @param {string} [options.baseUrl=""]
+ * @returns {Promise<Object>} the response body:
+ *   `{ unresolved_groups, by_tier, scopes, policy, scan }`, where each entry of
+ *   `scopes` is `{ scope_type, scope_id, key, unresolved_groups }`.
+ */
+export async function getCounts({ policy, scopes = [], baseUrl = "" } = {}) {
+  const body = { scopes: scopes.map((s) => scopeBody(s.scopeType, s.scopeId)) };
+  const policyFragment = policyBody(policy);
+  if (Object.keys(policyFragment).length) body.policy = policyFragment;
+  const res = await apiClient.post(dedupUrl("/counts", baseUrl), body);
+  return res.data;
+}
+
+/**
+ * Queue a scan for one scope.
+ *
+ * Returns the progress row immediately; the queue can be opened while it runs.
+ * Cached hashes are reused, so a scoped scan only reads and compares them and
+ * usually returns already-complete progress rather than starting real work.
+ *
+ * @param {Object} [options]
+ * @param {Object} [options.policy] - see {@link policyBody}.
+ * @param {string} [options.scopeType=GLOBAL_SCOPE]
+ * @param {number|string} [options.scopeId]
+ * @param {string} [options.baseUrl=""]
+ * @returns {Promise<Object>} the response body:
+ *   `{ status, scanned_pictures, total_pictures, scanned_buckets,
+ *   total_buckets, groups_found, error }`.
+ */
+export async function startScan({
+  policy,
+  scopeType = GLOBAL_SCOPE,
+  scopeId = null,
+  baseUrl = "",
+} = {}) {
+  const body = { scope: scopeBody(scopeType, scopeId) };
+  const policyFragment = policyBody(policy);
+  if (Object.keys(policyFragment).length) body.policy = policyFragment;
+  const res = await apiClient.post(dedupUrl("/scan", baseUrl), body);
+  return res.data;
+}
+
+/**
+ * Stack one group: the "yes, these are the same picture" verdict.
+ *
+ * Stacking unions tags, project and set membership onto every member and lifts
+ * every member to the highest score, so nothing is overwritten and nothing is
+ * lost. Every member file stays on disk. Answers 423 when a locked picture set
+ * freezes a member, in which case the whole verdict is refused rather than
+ * half-applied.
+ *
+ * @param {string} signature - the group signature from {@link listGroups}.
+ * @param {Object} [options]
+ * @param {number} [options.coverPictureId] - the cover the user chose. Omitted
+ *   means the server's preselection stands.
+ * @param {Array<number>} [options.excludedPictureIds=[]] - members the user
+ *   left out. They are untouched, and the exclusion is recorded so a rescan
+ *   does not treat it as an unfinished decision.
+ * @param {string} [options.batchId] - operation-log batch to record under, so
+ *   several verdicts can reverse as one undo.
+ * @param {string} [options.baseUrl=""]
+ * @returns {Promise<Object>} the response body:
+ *   `{ signature, verdict, stack_id, cover_picture_id, picture_ids,
+ *   excluded_picture_ids, batch_id, metadata_union }`.
+ */
+export async function stackGroup(
+  signature,
+  { coverPictureId, excludedPictureIds = [], batchId, baseUrl = "" } = {},
+) {
+  const body = { signature };
+  if (coverPictureId !== undefined && coverPictureId !== null) {
+    body.cover_picture_id = coverPictureId;
+  }
+  if (excludedPictureIds.length) {
+    body.excluded_picture_ids = excludedPictureIds;
+  }
+  if (batchId) body.batch_id = batchId;
+  const res = await apiClient.post(dedupUrl("/verdicts/stack", baseUrl), body);
+  return res.data;
+}
+
+/**
+ * Keep one group separate: the "no, these are different pictures" verdict.
+ *
+ * No picture row changes, which is exactly why the backend records **no
+ * operation** for it: there is nothing for undo to restore, and an empty
+ * operation row would still consume a Ctrl+Z. Callers must therefore narrate
+ * this verdict themselves and offer {@link reopenGroup} as the way back, rather
+ * than waiting for a receipt that will never arrive.
+ *
+ * @param {string} signature - the group signature.
+ * @param {Object} [options]
+ * @param {string} [options.batchId]
+ * @param {string} [options.baseUrl=""]
+ * @returns {Promise<Object>} the response body, the same `VerdictResponse`
+ *   shape as {@link stackGroup} with `verdict: "keep_separate"`.
+ */
+export async function keepGroupSeparate(
+  signature,
+  { batchId, baseUrl = "" } = {},
+) {
+  const body = { signature };
+  if (batchId) body.batch_id = batchId;
+  const res = await apiClient.post(
+    dedupUrl("/verdicts/keep-separate", baseUrl),
+    body,
+  );
+  return res.data;
+}
+
+/**
+ * Reopen a decided group so it is offered again.
+ *
+ * The pictures are untouched: reopening a `stacked` verdict does not unstack
+ * anything, because unstacking is the Stacks view's own action. This is the
+ * documented way back from a keep-separate, which has no undo of its own.
+ *
+ * @param {string} signature - the group signature.
+ * @param {Object} [options]
+ * @param {string} [options.baseUrl=""]
+ * @returns {Promise<Object>} the response body:
+ *   `{ signature, previous_verdict, reopened_at, group_returned_to_queue }`.
+ *   `group_returned_to_queue` is false when the group has not been re-detected
+ *   yet, in which case the next scan brings it back.
+ */
+export async function reopenGroup(signature, { baseUrl = "" } = {}) {
+  const res = await apiClient.post(dedupUrl("/verdicts/reopen", baseUrl), {
+    signature,
+  });
+  return res.data;
+}
+
+/**
+ * Auto-stack the exact tier, as a preview or for real.
+ *
+ * Byte-identical files are the one tier with no human judgment left in them, so
+ * they get a single consent dialog instead of per-group adjudication. The dry
+ * run and the real run are the same endpoint precisely so the preview cannot
+ * disagree with what the confirmation then does.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.dryRun=true] - preview only. Defaults to the safe
+ *   direction, so a caller that forgets the flag counts rather than writes.
+ * @param {string} [options.scopeType=GLOBAL_SCOPE]
+ * @param {number|string} [options.scopeId]
+ * @param {string} [options.batchId] - omit to have the server mint one.
+ * @param {number} [options.limit] - cap the groups acted on, for a paged run.
+ * @param {string} [options.baseUrl=""]
+ * @returns {Promise<Object>} the response body:
+ *   `{ batch_id, dry_run, groups, pictures, scope, dry_run_summary, results,
+ *   failures }`. `dry_run_summary` is present on a dry run only and carries
+ *   `{ groups, groups_by_tier, pictures, covers_gaining_tags,
+ *   covers_gaining_score, covers_gaining_metadata }`, every figure derived from
+ *   the same read of the same groups so the consent dialog's rows cannot
+ *   disagree with each other. `groups_by_tier` counts only what **this run**
+ *   would act on (exact-only today, zero-filled for the rest), so it is not the
+ *   queue's remainder; that comes from {@link getCounts}. `results` is empty for
+ *   a dry run. `failures` names groups the run skipped and why: one unstackable
+ *   group never aborts the run, so a partial result is reported rather than
+ *   hidden.
+ */
+export async function autoStackExact({
+  dryRun = true,
+  scopeType = GLOBAL_SCOPE,
+  scopeId = null,
+  batchId,
+  limit,
+  baseUrl = "",
+} = {}) {
+  const body = { scope: scopeBody(scopeType, scopeId), dry_run: dryRun };
+  if (batchId) body.batch_id = batchId;
+  if (Number.isFinite(limit)) body.limit = limit;
+  const res = await apiClient.post(dedupUrl("/auto-stack", baseUrl), body);
+  return res.data;
+}

--- a/frontend/src/api/dedup.test.js
+++ b/frontend/src/api/dedup.test.js
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../utils/apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+import { apiClient } from "../utils/apiClient";
+import {
+  getPolicy,
+  listGroups,
+  getCounts,
+  startScan,
+  stackGroup,
+  keepGroupSeparate,
+  reopenGroup,
+  autoStackExact,
+  scopeBody,
+  policyBody,
+  GLOBAL_SCOPE,
+} from "./dedup";
+
+beforeEach(() => {
+  apiClient.get.mockReset();
+  apiClient.post.mockReset();
+  apiClient.patch.mockReset();
+  apiClient.delete.mockReset();
+});
+
+describe("api/dedup — scope and policy fragments", () => {
+  // ScopeRequestModel forbids extra fields, so a label or a glyph here is a 422.
+  it("scopeBody emits only the two fields the server accepts", () => {
+    expect(scopeBody("set", 12)).toEqual({ scope_type: "set", scope_id: "12" });
+  });
+
+  it("scopeBody omits scope_id for the global scope", () => {
+    expect(scopeBody()).toEqual({ scope_type: GLOBAL_SCOPE });
+    expect(scopeBody(GLOBAL_SCOPE, 5)).toEqual({ scope_type: GLOBAL_SCOPE });
+  });
+
+  // A scope id may be a numeric collection id or an absolute folder path, so it
+  // is always sent as a string.
+  it("scopeBody stringifies the id", () => {
+    expect(scopeBody("folder", "/mnt/photos").scope_id).toBe("/mnt/photos");
+    expect(scopeBody("project", 7).scope_id).toBe("7");
+  });
+
+  // An omitted field means "use the server default", which is not the same as
+  // the client re-stating the default it happens to know.
+  it("policyBody omits everything the caller did not set", () => {
+    expect(policyBody()).toEqual({});
+    expect(policyBody({ nearEnabled: false })).toEqual({ near_enabled: false });
+    expect(policyBody({ threshold: 0.9, embeddingEnabled: true })).toEqual({
+      threshold: 0.9,
+      embedding_enabled: true,
+    });
+  });
+});
+
+describe("api/dedup — the policy endpoint", () => {
+  it("getPolicy reads the defaults and bounds", async () => {
+    apiClient.get.mockResolvedValue({
+      data: { defaults: { threshold: 0.9 }, bounds: { min_threshold: 0.65 } },
+    });
+    const result = await getPolicy();
+    expect(apiClient.get).toHaveBeenCalledWith("/dedup/policy");
+    expect(result.bounds.min_threshold).toBe(0.65);
+  });
+});
+
+describe("api/dedup — the queue", () => {
+  it("listGroups reads the first page with the tier gate off", async () => {
+    apiClient.get.mockResolvedValue({ data: { groups: [], scan: {} } });
+    await listGroups();
+    expect(apiClient.get).toHaveBeenCalledWith("/dedup/groups", {
+      params: {
+        near_enabled: false,
+        embedding_enabled: false,
+        offset: 0,
+        limit: 20,
+        scope_type: GLOBAL_SCOPE,
+      },
+    });
+  });
+
+  it("listGroups pages by offset", async () => {
+    apiClient.get.mockResolvedValue({ data: { groups: [] } });
+    await listGroups({ offset: 40, limit: 20 });
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/dedup/groups",
+      expect.objectContaining({
+        params: expect.objectContaining({ offset: 40, limit: 20 }),
+      }),
+    );
+  });
+
+  // The cursor is the primary path: a keyset position cannot re-serve or skip a
+  // group while a scan inserts rows, which an offset over the same ordering can.
+  it("listGroups pages by cursor when it holds one", async () => {
+    apiClient.get.mockResolvedValue({ data: { groups: [] } });
+    await listGroups({ cursor: "eyJjIjowfQ", offset: 40 });
+    const params = apiClient.get.mock.calls[0][1].params;
+    expect(params.cursor).toBe("eyJjIjowfQ");
+    // Never both: a server free to choose between them could silently keep the
+    // weaker one.
+    expect(params.offset).toBeUndefined();
+  });
+
+  it("listGroups ignores an empty cursor and pages by offset", async () => {
+    apiClient.get.mockResolvedValue({ data: { groups: [] } });
+    await listGroups({ cursor: "", offset: 20 });
+    const params = apiClient.get.mock.calls[0][1].params;
+    expect(params.offset).toBe(20);
+    expect(params.cursor).toBeUndefined();
+  });
+
+  it("listGroups sends the tier gate as two booleans", async () => {
+    apiClient.get.mockResolvedValue({ data: { groups: [] } });
+    await listGroups({ nearEnabled: true, embeddingEnabled: true });
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/dedup/groups",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          near_enabled: true,
+          embedding_enabled: true,
+        }),
+      }),
+    );
+  });
+
+  // The threshold's floor is server policy. Omitting it means "use the server
+  // default"; re-stating a value the client guessed would duplicate the bound.
+  it("listGroups omits an unset threshold", async () => {
+    apiClient.get.mockResolvedValue({ data: { groups: [] } });
+    await listGroups();
+    expect(apiClient.get.mock.calls[0][1].params.threshold).toBeUndefined();
+    await listGroups({ threshold: 0.75 });
+    expect(apiClient.get.mock.calls[1][1].params.threshold).toBe(0.75);
+  });
+
+  it("listGroups sends a scoped queue as a type/id pair", async () => {
+    apiClient.get.mockResolvedValue({ data: { groups: [] } });
+    await listGroups({ scopeType: "set", scopeId: 12 });
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/dedup/groups",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          scope_type: "set",
+          scope_id: "12",
+        }),
+      }),
+    );
+  });
+
+  it("listGroups returns the body, not the axios envelope", async () => {
+    apiClient.get.mockResolvedValue({
+      data: { groups: [{ signature: "sig-1" }], total: 143 },
+    });
+    const result = await listGroups();
+    expect(result.total).toBe(143);
+    expect(result.groups[0].signature).toBe("sig-1");
+  });
+});
+
+describe("api/dedup — counts", () => {
+  // The global badge comes back whether or not a scope was asked for, which is
+  // what stops the sidebar and a context menu quoting different numbers.
+  it("getCounts posts an empty scope list for the badge alone", async () => {
+    apiClient.post.mockResolvedValue({ data: { unresolved_groups: 143 } });
+    const result = await getCounts();
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/counts", {
+      scopes: [],
+    });
+    expect(result.unresolved_groups).toBe(143);
+  });
+
+  it("getCounts asks for several scopes in one request", async () => {
+    apiClient.post.mockResolvedValue({ data: { scopes: [] } });
+    await getCounts({
+      scopes: [
+        { scopeType: "set", scopeId: 12 },
+        { scopeType: "project", scopeId: 7 },
+      ],
+    });
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/counts", {
+      scopes: [
+        { scope_type: "set", scope_id: "12" },
+        { scope_type: "project", scope_id: "7" },
+      ],
+    });
+  });
+
+  it("getCounts forwards the tier policy so the counts match the queue", async () => {
+    apiClient.post.mockResolvedValue({ data: {} });
+    await getCounts({ policy: { nearEnabled: true } });
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/counts", {
+      scopes: [],
+      policy: { near_enabled: true },
+    });
+  });
+});
+
+describe("api/dedup — scans", () => {
+  it("startScan nests the scope in the body", async () => {
+    apiClient.post.mockResolvedValue({ data: { status: "running" } });
+    await startScan({ scopeType: "folder", scopeId: "/mnt/a" });
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/scan", {
+      scope: { scope_type: "folder", scope_id: "/mnt/a" },
+    });
+  });
+
+  it("startScan scans the whole vault by default", async () => {
+    apiClient.post.mockResolvedValue({ data: {} });
+    await startScan();
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/scan", {
+      scope: { scope_type: GLOBAL_SCOPE },
+    });
+  });
+});
+
+describe("api/dedup — verdicts", () => {
+  // The signature rides in the body, so it never has to survive a path.
+  it("stackGroup posts the signature, cover and exclusions", async () => {
+    apiClient.post.mockResolvedValue({ data: { stack_id: 5 } });
+    await stackGroup("sig-1", {
+      coverPictureId: 42,
+      excludedPictureIds: [43],
+    });
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/verdicts/stack", {
+      signature: "sig-1",
+      cover_picture_id: 42,
+      excluded_picture_ids: [43],
+    });
+  });
+
+  // An omitted cover means "the server's preselection stands", which is not the
+  // same as sending null.
+  it("stackGroup omits an absent cover and an empty exclusion list", async () => {
+    apiClient.post.mockResolvedValue({ data: {} });
+    await stackGroup("sig-1");
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/verdicts/stack", {
+      signature: "sig-1",
+    });
+  });
+
+  it("stackGroup carries a batch id so several verdicts reverse as one", async () => {
+    apiClient.post.mockResolvedValue({ data: {} });
+    await stackGroup("sig-1", { batchId: "b-1" });
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/verdicts/stack", {
+      signature: "sig-1",
+      batch_id: "b-1",
+    });
+  });
+
+  it("keepGroupSeparate posts to its own verdict route", async () => {
+    apiClient.post.mockResolvedValue({ data: { verdict: "keep_separate" } });
+    const result = await keepGroupSeparate("sig-2");
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/dedup/verdicts/keep-separate",
+      { signature: "sig-2" },
+    );
+    expect(result.verdict).toBe("keep_separate");
+  });
+
+  it("reopenGroup posts the signature alone", async () => {
+    apiClient.post.mockResolvedValue({ data: { previous_verdict: "stacked" } });
+    await reopenGroup("sig-3", { baseUrl: "/be" });
+    expect(apiClient.post).toHaveBeenCalledWith("/be/dedup/verdicts/reopen", {
+      signature: "sig-3",
+    });
+  });
+});
+
+describe("api/dedup — bulk auto-stack", () => {
+  // The safe direction is the default: a caller that forgets the flag counts
+  // rather than writes.
+  it("autoStackExact defaults to a dry run", async () => {
+    apiClient.post.mockResolvedValue({ data: { groups: 1204 } });
+    const result = await autoStackExact();
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/auto-stack", {
+      scope: { scope_type: GLOBAL_SCOPE },
+      dry_run: true,
+    });
+    expect(result.groups).toBe(1204);
+  });
+
+  it("autoStackExact commits with dry_run false and returns the batch id", async () => {
+    apiClient.post.mockResolvedValue({ data: { batch_id: "b-1" } });
+    const result = await autoStackExact({ dryRun: false });
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/auto-stack", {
+      scope: { scope_type: GLOBAL_SCOPE },
+      dry_run: false,
+    });
+    expect(result.batch_id).toBe("b-1");
+  });
+
+  it("autoStackExact scopes and caps a paged run", async () => {
+    apiClient.post.mockResolvedValue({ data: {} });
+    await autoStackExact({
+      dryRun: false,
+      scopeType: "character",
+      scopeId: 2,
+      limit: 500,
+    });
+    expect(apiClient.post).toHaveBeenCalledWith("/dedup/auto-stack", {
+      scope: { scope_type: "character", scope_id: "2" },
+      dry_run: false,
+      limit: 500,
+    });
+  });
+});

--- a/frontend/src/api/pictures.js
+++ b/frontend/src/api/pictures.js
@@ -4,7 +4,30 @@
 // have already migrated; the counts, scores, thumbnails, and export endpoints
 // join it as the grid and overlay move over.
 
-import { apiClient } from "../utils/apiClient";
+import { apiClient, appendShareToken } from "../utils/apiClient";
+
+/**
+ * The URL a browser loads a picture's thumbnail from.
+ *
+ * Not a request function: an `<img src>` bypasses Axios entirely, so the share
+ * token has to be appended by hand. It still belongs in this module, because
+ * the path is part of the pictures contract and a second spelling of it
+ * elsewhere is exactly the drift the api layer exists to prevent.
+ *
+ * @param {number|string} id
+ * @param {Object} [options]
+ * @param {number|string} [options.version] - cache-buster, bumped when the
+ *   thumbnail is regenerated.
+ * @param {string} [options.baseUrl=""]
+ * @returns {string}
+ */
+export function pictureThumbnailUrl(id, { version, baseUrl = "" } = {}) {
+  const query =
+    version === undefined || version === null
+      ? ""
+      : `?v=${encodeURIComponent(version)}`;
+  return appendShareToken(`${baseUrl}/pictures/thumbnails/${id}.webp${query}`);
+}
 
 /**
  * Count the pictures matching a filter scope.

--- a/frontend/src/components/panels/GbFilterPanel.vue
+++ b/frontend/src/components/panels/GbFilterPanel.vue
@@ -84,6 +84,30 @@
             </button>
           </div>
         </div>
+        <!-- Stacks. A second segment row under the media-type row, and a
+             filter rather than a destination: stacked and unstacked carry no
+             to-do count, so neither earns a sidebar entry. The choice is
+             spelled out beside the segments because an icon alone cannot
+             distinguish "unstacked" from "unresolved". -->
+        <div class="gb-stack-row">
+          <span class="tbm-label">Stacks</span>
+          <div class="tbm-seg" role="group" aria-label="Stack state filter">
+            <button
+              v-for="opt in gbStackStateOptions"
+              :key="opt.value"
+              class="tbm-seg-btn"
+              :class="{ 'tbm-seg-btn--on': gbStackStateFilter === opt.value }"
+              type="button"
+              :title="opt.title"
+              :aria-pressed="gbStackStateFilter === opt.value"
+              @click="gbStackStateFilter = opt.value"
+            >
+              <v-icon size="16">{{ opt.icon }}</v-icon>
+              <span class="gb-stack-label">{{ opt.label }}</span>
+            </button>
+          </div>
+          <span class="gb-stack-choice">{{ gbStackStateChoiceLabel }}</span>
+        </div>
       </div>
 
       <!-- Score range -->
@@ -588,6 +612,18 @@ const gbMaxScoreFilter = computed({
     filterStore.maxScoreFilter = v ?? null;
   },
 });
+const gbStackStateFilter = computed({
+  get: () => filterStore.stackStateFilter,
+  set: (v) => {
+    filterStore.stackStateFilter = v || "all";
+  },
+});
+const gbStackStateChoiceLabel = computed(() => {
+  const chosen = gbStackStateOptions.find(
+    (opt) => opt.value === gbStackStateFilter.value,
+  );
+  return chosen ? chosen.choice : "";
+});
 const gbFaceBboxFilter = computed({
   get: () => filterStore.faceBboxFilter,
   set: (v) => {
@@ -706,6 +742,39 @@ const gbMediaTypeOptions = [
     icon: "mdi-video-outline",
     label: "Video",
     title: "Show videos only",
+  },
+];
+
+// The choice is spelled out beside the row, so each option carries the sentence
+// it stands for as well as its short label.
+const gbStackStateOptions = [
+  {
+    value: "all",
+    icon: "mdi-all-inclusive",
+    label: "Any",
+    title: "Every picture, stacked or not",
+    choice: "Showing every picture",
+  },
+  {
+    value: "stacked",
+    icon: "mdi-image-multiple",
+    label: "Stacked",
+    title: "Only pictures that belong to a stack",
+    choice: "Showing pictures that are in a stack",
+  },
+  {
+    value: "unstacked",
+    icon: "mdi-image-outline",
+    label: "Unstacked",
+    title: "Only pictures that do not belong to a stack",
+    choice: "Showing pictures that are not in a stack",
+  },
+  {
+    value: "unresolved",
+    icon: "mdi-content-duplicate",
+    label: "Unresolved",
+    title: "Pictures in a duplicate group nobody has ruled on yet",
+    choice: "Showing duplicates still waiting for a decision",
   },
 ];
 
@@ -985,6 +1054,27 @@ watch(
 }
 
 /* ── Media + Face: two icon-only groups sharing one row ───────────────────── */
+/* The stack row wraps rather than compressing its segments: the spelled-out
+   choice is the half that makes the row readable, so it keeps its own line on a
+   narrow panel instead of being truncated away. */
+.gb-stack-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-top: var(--space-4);
+}
+
+.gb-stack-label {
+  margin-left: var(--space-2);
+}
+
+.gb-stack-choice {
+  flex-basis: 100%;
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
 .gb-media-face-row {
   display: flex;
   align-items: center;

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -73,6 +73,7 @@ import { useLockedSetsStore } from "../../stores/useLockedSetsStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
 import { useVersionCheck } from "../../composables/useVersionCheck";
 import { useSidebarExpansion } from "../../composables/useSidebarExpansion";
+import { useDedupStore, scopeKey } from "../../stores/useDedupStore";
 
 // Publishes id → name maps for the ImageGrid breadcrumb. The sidebar is the
 // authoritative name source (it fetches these lists); see useEntityNamesStore.
@@ -95,12 +96,17 @@ function noticeDetail(e) {
 // bar, so the sidebar copies below are gated on !isDesktop.
 const isDesktop = typeof window !== "undefined" && !!window.pixlstashDesktop;
 
+const dedupStore = useDedupStore();
+
 const props = defineProps({
   docked: { type: Boolean, default: false },
   selectedCharacter: { type: [String, Number, null], default: null },
   allPicturesId: { type: String, required: true },
   unassignedPicturesId: { type: String, required: true },
   scrapheapPicturesId: { type: String, required: true },
+  // The Duplicates destination is addressed by route, not by a selection
+  // sentinel, so its active state arrives as its own flag.
+  isDuplicatesView: { type: Boolean, default: false },
   selectedSet: { type: [Number, null], default: null },
   selectedSetIds: { type: Array, default: () => [] },
   selectedCharacterIds: { type: Array, default: () => [] },
@@ -127,6 +133,7 @@ const props = defineProps({
 });
 
 const emit = defineEmits([
+  "select-duplicates",
   "select-character",
   "update:selected-sort",
   "update:search-query",
@@ -1473,7 +1480,7 @@ const setsCollapsed = computed(() => {
   const charCount = visibleCharacters.value.length;
   const setCount = visibleSets.value.length;
   if (!setCount || dockedScrollHeight.value === 0) return false;
-  const fixedH = 2 * h + _DOCK_DIV; // allPictures + scrapheap + divider after allPictures
+  const fixedH = 3 * h + _DOCK_DIV; // allPictures + duplicates + scrapheap + divider after allPictures
   const charH = (charCount + _addBtn.value) * h; // always include [+] row when editable
   const setDividerH = _DOCK_DIV;
   const allSetsH = (setCount + _addBtn.value) * h;
@@ -1486,7 +1493,7 @@ const charsCollapsed = computed(() => {
   const charCount = visibleCharacters.value.length;
   const setCount = visibleSets.value.length;
   if (!charCount || dockedScrollHeight.value === 0) return false;
-  const fixedH = 2 * h + _DOCK_DIV;
+  const fixedH = 3 * h + _DOCK_DIV; // allPictures + duplicates + scrapheap + divider
   const charH = (charCount + _addBtn.value) * h;
   const setDividerH = setCount > 0 ? _DOCK_DIV : 0;
   const collapsedSetH = setCount > 0 ? h : 0; // sets become 1 button
@@ -1987,9 +1994,75 @@ async function deleteImportFolderById(id) {
   }
 }
 
+/** Context-menu target types that can be scoped for a duplicate scan. */
+const DEDUP_SCOPE_TYPES = {
+  character: { scope: "character", icon: "mdi-account-box-outline", noun: "for" },
+  set: { scope: "set", icon: "mdi-folder-multiple-image", noun: "in this set" },
+  project: { scope: "project", icon: "mdi-briefcase-outline", noun: "in this project" },
+  folder: { scope: "folder", icon: "mdi-folder-outline", noun: "in this folder" },
+};
+
+/**
+ * Fetch the duplicate count for the object a context menu just opened on.
+ *
+ * Fire and forget: the row renders a placeholder until the number lands, which
+ * is the honest state, and a failed read leaves the row reading "Find
+ * duplicates" without a count rather than a wrong zero.
+ *
+ * @param {string} type - the context-menu target type.
+ * @param {Object} item - the target object.
+ */
+function primeDuplicateCount(type, item) {
+  if (isReadOnly.value) return;
+  const spec = DEDUP_SCOPE_TYPES[type];
+  if (!spec || !item?.id) return;
+  dedupStore.fetchScopeCount(spec.scope, item.id);
+}
+
+/**
+ * The known duplicate count for one scope, or null while it is still unknown.
+ * @param {string} type
+ * @param {Object} item
+ * @returns {number|null}
+ */
+function duplicateCountFor(type, item) {
+  const spec = DEDUP_SCOPE_TYPES[type];
+  if (!spec || !item?.id) return null;
+  const value = dedupStore.scopeCounts[scopeKey(spec.scope, item.id)];
+  return value === undefined ? null : value;
+}
+
+/**
+ * Open the duplicate queue scoped to the object the menu was opened on.
+ *
+ * Closes the menu first and acts afterwards, so the menu's own teardown cannot
+ * race the navigation for focus.
+ *
+ * @param {string} type
+ * @param {Object} item
+ */
+function findDuplicatesIn(type, item) {
+  const spec = DEDUP_SCOPE_TYPES[type];
+  if (!spec || !item?.id) return;
+  closeSidebarCtxMenu();
+  nextTick(() => {
+    emit("select-duplicates", {
+      type: spec.scope,
+      id: item.id,
+      label: item.name || item.label || "",
+      icon: spec.icon,
+    });
+  });
+}
+
 function openSidebarCtxMenu(type, item, event) {
   if (isReadOnly.value && (type === "folder" || type === "import-folder"))
     return;
+  // Warm the duplicate count for the object under the cursor, so the menu's
+  // "Find duplicates in..." row can carry a number rather than open a queue
+  // that turns out to be empty. A scoped count reuses cached hashes and is
+  // cheap; the store also de-duplicates repeat opens on the same object.
+  primeDuplicateCount(type, item);
   // Reset here rather than in every branch: only the scrapheap branch turns it
   // on, so a single top-level reset keeps the per-type blocks below untouched.
   sidebarCtxScrapheap.value = false;
@@ -2323,8 +2396,20 @@ function isCountSelected(id) {
   return props.selectedCharacter === id;
 }
 
+/**
+ * Whether a selection-driven row may render as active at all. The Duplicates
+ * view is addressed by ROUTE, not by the selection system, so while it is open
+ * the underlying selection (kept so back-navigation restores it) must yield
+ * the highlight — otherwise the sidebar shows two active destinations. A live
+ * folder filter suppresses the same rows for the same reason, so the two
+ * guards travel together.
+ */
+const selectionOwnsHighlight = computed(
+  () => !props.hasFolderFilter && !props.isDuplicatesView,
+);
+
 const isAllPicturesRowActive = computed(() => {
-  if (props.hasFolderFilter) return false;
+  if (!selectionOwnsHighlight.value) return false;
   if (props.selectedCharacter !== props.allPicturesId) return false;
   if (selectedSetIdSet.value.size > 0) return false;
   return true;
@@ -4063,7 +4148,8 @@ defineExpose({
               :class="{
                 active:
                   sidebarPrimaryTab === 'folders' &&
-                  selectedFolderKey === 'rf-' + rf.id,
+                  selectedFolderKey === 'rf-' + rf.id &&
+                  !props.isDuplicatesView,
               }"
               @click="
                 selectFoldersTab();
@@ -4094,7 +4180,8 @@ defineExpose({
               :class="{
                 active:
                   sidebarPrimaryTab === 'folders' &&
-                  selectedFolderKey === 'if-' + imf.id,
+                  selectedFolderKey === 'if-' + imf.id &&
+                  !props.isDuplicatesView,
               }"
               @click="
                 selectFoldersTab();
@@ -4214,7 +4301,7 @@ defineExpose({
                 {
                   active:
                     props.selectedCharacter === char.id &&
-                    !props.hasFolderFilter,
+                    selectionOwnsHighlight,
                 },
               ]"
             >
@@ -4224,7 +4311,7 @@ defineExpose({
                   {
                     active:
                       props.selectedCharacter === char.id &&
-                      !props.hasFolderFilter,
+                      selectionOwnsHighlight,
                   },
                 ]"
                 :title="`${char.name || 'Character'} (Ctrl/Cmd + click to multi-select)`"
@@ -4294,7 +4381,7 @@ defineExpose({
               'sidebar-collapsed-row--has-flyout',
               {
                 active:
-                  selectedCharacterIdSet.size > 0 && !props.hasFolderFilter,
+                  selectedCharacterIdSet.size > 0 && selectionOwnsHighlight,
               },
             ]"
           >
@@ -4304,7 +4391,7 @@ defineExpose({
                 'sidebar-collapsed-item--has-flyout',
                 {
                   active:
-                    selectedCharacterIdSet.size > 0 && !props.hasFolderFilter,
+                    selectedCharacterIdSet.size > 0 && selectionOwnsHighlight,
                 },
               ]"
               :title="
@@ -4365,7 +4452,7 @@ defineExpose({
                     {
                       active:
                         props.selectedCharacter === char.id &&
-                        !props.hasFolderFilter,
+                        selectionOwnsHighlight,
                     },
                   ]"
                   @click="
@@ -4433,7 +4520,7 @@ defineExpose({
                 'sidebar-collapsed-row',
                 {
                   active:
-                    selectedSetIdSet.has(pset.id) && !props.hasFolderFilter,
+                    selectedSetIdSet.has(pset.id) && selectionOwnsHighlight,
                 },
               ]"
             >
@@ -4442,7 +4529,7 @@ defineExpose({
                   'sidebar-collapsed-item',
                   {
                     active:
-                      selectedSetIdSet.has(pset.id) && !props.hasFolderFilter,
+                      selectedSetIdSet.has(pset.id) && selectionOwnsHighlight,
                   },
                 ]"
                 :title="pset.name || 'Picture Set'"
@@ -4529,7 +4616,7 @@ defineExpose({
             :class="[
               'sidebar-collapsed-row',
               'sidebar-collapsed-row--has-flyout',
-              { active: selectedSetIdSet.size > 0 && !props.hasFolderFilter },
+              { active: selectedSetIdSet.size > 0 && selectionOwnsHighlight },
             ]"
           >
             <div
@@ -4537,7 +4624,7 @@ defineExpose({
                 'sidebar-collapsed-item',
                 'sidebar-collapsed-item--has-flyout',
                 {
-                  active: selectedSetIdSet.size > 0 && !props.hasFolderFilter,
+                  active: selectedSetIdSet.size > 0 && selectionOwnsHighlight,
                 },
               ]"
               :title="selectedSetObj ? selectedSetObj.name : 'Picture Sets'"
@@ -4619,7 +4706,7 @@ defineExpose({
                     'sidebar-collapsed-flyout-item',
                     {
                       active:
-                        selectedSetIdSet.has(pset.id) && !props.hasFolderFilter,
+                        selectedSetIdSet.has(pset.id) && selectionOwnsHighlight,
                     },
                   ]"
                   @click="
@@ -4685,6 +4772,30 @@ defineExpose({
             </div>
           </Teleport>
 
+          <!-- Duplicates keeps its dock row so the count stays reachable when
+               the sidebar is narrow; the badge is the only thing here that
+               reports pending work. -->
+          <div
+            v-if="!isReadOnly"
+            :class="['sidebar-collapsed-row', { active: props.isDuplicatesView }]"
+          >
+            <div
+              :class="[
+                'sidebar-collapsed-item',
+                { active: props.isDuplicatesView },
+              ]"
+              title="Duplicates"
+              @click="emit('select-duplicates', {})"
+            >
+              <v-icon>mdi-content-duplicate</v-icon>
+              <span
+                v-if="dedupStore.hasDuplicates"
+                class="sidebar-collapsed-dedup-badge"
+                title="There are duplicates to review"
+              ></span>
+            </div>
+          </div>
+
           <!-- Scrap Heap at bottom of dock. The flex spacer above it fills most
                of the dock's blank space; its right-clicks bubble to the list's
                catch-all handler, so it needs no handler of its own. -->
@@ -4696,7 +4807,7 @@ defineExpose({
               {
                 active:
                   props.selectedCharacter === props.scrapheapPicturesId &&
-                  !props.hasFolderFilter,
+                  selectionOwnsHighlight,
               },
             ]"
           >
@@ -4707,7 +4818,7 @@ defineExpose({
                 {
                   active:
                     props.selectedCharacter === props.scrapheapPicturesId &&
-                    !props.hasFolderFilter,
+                    selectionOwnsHighlight,
                 },
               ]"
               title="Scrapheap"
@@ -5096,6 +5207,42 @@ defineExpose({
               </div>
             </div>
 
+            <!-- Duplicates earns a sidebar row because it is the one thing
+                 here with a to-do count: the number goes down as the user
+                 works, which is what a destination is for. Stacked and
+                 unstacked stay a filter. -->
+            <div v-if="!isReadOnly" class="sidebar-all-pictures-row">
+              <div
+                :class="[
+                  'sidebar-list-item',
+                  { active: props.isDuplicatesView },
+                ]"
+                @click="emit('select-duplicates', {})"
+              >
+                <span class="sidebar-list-icon sidebar-list-icon--toplevel"
+                  ><v-icon size="18">mdi-content-duplicate</v-icon></span
+                >
+                <span class="sidebar-list-label">Duplicates</span>
+                <span
+                  v-if="dedupStore.isScanning"
+                  class="sidebar-dedup-scanning"
+                  title="Still looking for duplicates. Groups appear as they are found."
+                >
+                  <v-progress-circular indeterminate size="10" width="1.5" />
+                </span>
+                <!-- A presence DOT, not a count (owner call, 2026-07-29): the
+                     group count moves with the tier gate and the threshold,
+                     so it read as churn. The dot only says "there are
+                     duplicates to review"; the queue's own header carries the
+                     numbers. -->
+                <span
+                  v-if="dedupStore.hasDuplicates"
+                  class="sidebar-dedup-dot"
+                  title="There are duplicates to review"
+                ></span>
+              </div>
+            </div>
+
             <div v-if="!isReadOnly" class="sidebar-all-pictures-row">
               <div
                 :class="[
@@ -5103,7 +5250,7 @@ defineExpose({
                   {
                     active:
                       props.selectedCharacter === props.scrapheapPicturesId &&
-                      !props.hasFolderFilter,
+                      selectionOwnsHighlight,
                   },
                 ]"
                 @click="selectCharacter(props.scrapheapPicturesId, 'Scrapheap')"
@@ -5225,7 +5372,7 @@ defineExpose({
                           (selectedCharacterIdSet.size > 0
                             ? selectedCharacterIdSet.has(char.id)
                             : selectedCharacter === char.id) &&
-                          !props.hasFolderFilter,
+                          selectionOwnsHighlight,
                         droppable: dragOverCharacter === char.id,
                       },
                     ]"
@@ -5372,7 +5519,7 @@ defineExpose({
                       {
                         active:
                           selectedSetIdSet.has(pset.id) &&
-                          !props.hasFolderFilter,
+                          selectionOwnsHighlight,
                         droppable: dragOverSet === pset.id,
                       },
                     ]"
@@ -5504,7 +5651,7 @@ defineExpose({
                         props.externalSelectedProjectId === p.id &&
                         props.selectedCharacter === props.allPicturesId &&
                         selectedSetIdSet.size === 0 &&
-                        !props.hasFolderFilter,
+                        selectionOwnsHighlight,
                       droppable: dragOverProjectId === p.id,
                       'project-move-target': moveDragOverProjectId === p.id,
                     },
@@ -5701,7 +5848,7 @@ defineExpose({
                               (selectedCharacterIdSet.size > 0
                                 ? selectedCharacterIdSet.has(char.id)
                                 : selectedCharacter === char.id) &&
-                              !props.hasFolderFilter,
+                              selectionOwnsHighlight,
                             droppable: dragOverCharacter === char.id,
                           },
                         ]"
@@ -5908,7 +6055,7 @@ defineExpose({
                           {
                             active:
                               selectedSetIdSet.has(pset.id) &&
-                              !props.hasFolderFilter,
+                              selectionOwnsHighlight,
                             droppable: dragOverSet === pset.id,
                           },
                         ]"
@@ -6097,6 +6244,29 @@ defineExpose({
       </template>
       <template v-if="sidebarCtxCharacter">
         <button
+          v-if="!isReadOnly"
+          class="sidebar-ctx-item"
+          :disabled="duplicateCountFor('character', sidebarCtxCharacter) === 0"
+          @click="findDuplicatesIn('character', sidebarCtxCharacter)"
+        >
+          <v-icon size="15" class="sidebar-ctx-icon">{{
+            duplicateCountFor('character', sidebarCtxCharacter) === 0
+              ? "mdi-check"
+              : "mdi-content-duplicate"
+          }}</v-icon>
+          <span class="sidebar-ctx-label">{{
+            duplicateCountFor('character', sidebarCtxCharacter) === 0
+              ? "No duplicates for this person"
+              : "Find duplicates for this person"
+          }}</span>
+          <span
+            v-if="duplicateCountFor('character', sidebarCtxCharacter)"
+            class="sidebar-ctx-count"
+            >{{ duplicateCountFor('character', sidebarCtxCharacter) }}</span
+          >
+        </button>
+        <div v-if="!isReadOnly" class="sidebar-ctx-divider"></div>
+        <button
           class="sidebar-ctx-item"
           :disabled="isReadOnly"
           @click="
@@ -6166,6 +6336,29 @@ defineExpose({
         </button>
       </template>
       <template v-if="sidebarCtxSet">
+        <button
+          v-if="!isReadOnly"
+          class="sidebar-ctx-item"
+          :disabled="duplicateCountFor('set', sidebarCtxSet) === 0"
+          @click="findDuplicatesIn('set', sidebarCtxSet)"
+        >
+          <v-icon size="15" class="sidebar-ctx-icon">{{
+            duplicateCountFor('set', sidebarCtxSet) === 0
+              ? "mdi-check"
+              : "mdi-content-duplicate"
+          }}</v-icon>
+          <span class="sidebar-ctx-label">{{
+            duplicateCountFor('set', sidebarCtxSet) === 0
+              ? "No duplicates in this set"
+              : "Find duplicates in this set"
+          }}</span>
+          <span
+            v-if="duplicateCountFor('set', sidebarCtxSet)"
+            class="sidebar-ctx-count"
+            >{{ duplicateCountFor('set', sidebarCtxSet) }}</span
+          >
+        </button>
+        <div v-if="!isReadOnly" class="sidebar-ctx-divider"></div>
         <button
           class="sidebar-ctx-item"
           :disabled="isReadOnly"
@@ -6366,6 +6559,29 @@ defineExpose({
       </template>
       <template v-if="sidebarCtxProject">
         <button
+          v-if="!isReadOnly"
+          class="sidebar-ctx-item"
+          :disabled="duplicateCountFor('project', sidebarCtxProject) === 0"
+          @click="findDuplicatesIn('project', sidebarCtxProject)"
+        >
+          <v-icon size="15" class="sidebar-ctx-icon">{{
+            duplicateCountFor('project', sidebarCtxProject) === 0
+              ? "mdi-check"
+              : "mdi-content-duplicate"
+          }}</v-icon>
+          <span class="sidebar-ctx-label">{{
+            duplicateCountFor('project', sidebarCtxProject) === 0
+              ? "No duplicates in this project"
+              : "Find duplicates in this project"
+          }}</span>
+          <span
+            v-if="duplicateCountFor('project', sidebarCtxProject)"
+            class="sidebar-ctx-count"
+            >{{ duplicateCountFor('project', sidebarCtxProject) }}</span
+          >
+        </button>
+        <div v-if="!isReadOnly" class="sidebar-ctx-divider"></div>
+        <button
           class="sidebar-ctx-item"
           :disabled="isReadOnly"
           @click="
@@ -6437,6 +6653,29 @@ defineExpose({
         </button>
       </template>
       <template v-if="sidebarCtxFolder && !isReadOnly">
+        <button
+          v-if="!isReadOnly && !sidebarCtxFolderScopePath"
+          class="sidebar-ctx-item"
+          :disabled="duplicateCountFor('folder', sidebarCtxFolder) === 0"
+          @click="findDuplicatesIn('folder', sidebarCtxFolder)"
+        >
+          <v-icon size="15" class="sidebar-ctx-icon">{{
+            duplicateCountFor('folder', sidebarCtxFolder) === 0
+              ? "mdi-check"
+              : "mdi-content-duplicate"
+          }}</v-icon>
+          <span class="sidebar-ctx-label">{{
+            duplicateCountFor('folder', sidebarCtxFolder) === 0
+              ? "No duplicates in this folder"
+              : "Find duplicates in this folder"
+          }}</span>
+          <span
+            v-if="duplicateCountFor('folder', sidebarCtxFolder)"
+            class="sidebar-ctx-count"
+            >{{ duplicateCountFor('folder', sidebarCtxFolder) }}</span
+          >
+        </button>
+        <div v-if="!isReadOnly && !sidebarCtxFolderScopePath" class="sidebar-ctx-divider"></div>
         <button
           v-if="!inDocker && !sidebarCtxFolderScopePath"
           class="sidebar-ctx-item"
@@ -8417,6 +8656,56 @@ defineExpose({
   word-break: break-word;
 }
 
+/* The scan spinner sits between the label and the count so the count never
+   moves when a scan starts: a number that jumps is a number people stop
+   trusting. */
+/* Separates the duplicate entry from the object's own actions. It is a
+   different kind of thing: everything above edits or shares the object, this
+   opens a task about it. */
+.sidebar-ctx-divider {
+  height: 1px;
+  margin: var(--space-2) var(--space-3);
+  background: rgb(var(--v-theme-divider));
+}
+
+/* The count on a context-menu row. Not a badge: it sits in the row's flow
+   rather than overlaying a host, so it takes the row's own quiet foreground. */
+.sidebar-ctx-count {
+  margin-left: auto;
+  padding-left: var(--space-3);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--v-theme-sidebar-text), 0.6);
+}
+
+.sidebar-dedup-scanning {
+  display: inline-flex;
+  align-items: center;
+  margin-right: var(--space-2);
+  opacity: 0.7;
+}
+
+/* The docked rail has no room for a label, so the count becomes a real badge.
+   `primary`, not accent: a count is information and reads on the workhorse
+   fill (visual-language.md section 12). */
+.sidebar-collapsed-item {
+  /* The dock badge overlays its host without shifting it, so the host has to be
+     the badge's containing block. */
+  position: relative;
+}
+
+.sidebar-collapsed-dedup-badge {
+  position: absolute;
+  top: var(--space-1);
+  right: var(--space-1);
+  /* The attention dot (visual-language §12): presence, not a count. */
+  width: var(--badge-size-dot);
+  height: var(--badge-size-dot);
+  border-radius: var(--radius-pill);
+  background: rgb(var(--v-theme-accent));
+  pointer-events: none;
+}
+
 .sidebar-list-count {
   font-size: var(--text-xs);
   color: rgb(var(--v-theme-sidebar-text));
@@ -8428,6 +8717,17 @@ defineExpose({
   align-self: center;
   display: inline-flex;
   justify-content: flex-end;
+}
+
+/* The Duplicates PRESENCE dot (visual-language §12, attention dot): there is
+   work here, without a number that would move with the tier gate. */
+.sidebar-dedup-dot {
+  width: var(--badge-size-dot);
+  height: var(--badge-size-dot);
+  flex-shrink: 0;
+  align-self: center;
+  border-radius: var(--radius-pill);
+  background: rgb(var(--v-theme-accent));
 }
 
 .sidebar-new-tag {

--- a/frontend/src/components/panels/Toolbar.vue
+++ b/frontend/src/components/panels/Toolbar.vue
@@ -74,6 +74,36 @@
               Search relevance (fixed)
             </div>
 
+            <!-- Shown once, in the slot the removed sort order used to occupy.
+                 A user who reached for "Likeness Groups" here needs one line
+                 telling them where the capability went, not a changelog. -->
+            <div
+              v-if="dedupMigrationNotice.visible.value"
+              class="tbm-section gb-sort-migration-note"
+              data-testid="sort-migration-notice"
+            >
+              <v-icon size="16">mdi-content-duplicate</v-icon>
+              <span class="gb-sort-migration-text">
+                Looking for Likeness Groups? Duplicates now has its own place in
+                the sidebar, with a count and a one-key review queue.
+              </span>
+              <button
+                type="button"
+                class="gb-sort-migration-open"
+                @click="openDuplicatesFromNotice"
+              >
+                Open Duplicates
+              </button>
+              <button
+                type="button"
+                class="gb-sort-migration-dismiss"
+                aria-label="Hide this notice"
+                @click="dedupMigrationNotice.dismiss()"
+              >
+                <v-icon size="16">mdi-close</v-icon>
+              </button>
+            </div>
+
             <div class="tbm-section">
               <div class="tbm-grid-2">
                 <button
@@ -536,7 +566,6 @@ import { computed, nextTick, ref, watch } from "vue";
 import { isReadOnly } from "../../utils/apiClient";
 import { useFilterStore } from "../../stores/useFilterStore";
 import { useSortStore } from "../../stores/useSortStore";
-import { useSelectionStore } from "../../stores/useSelectionStore";
 import { useGridStore } from "../../stores/useGridStore";
 import { useExportStore } from "../../stores/useExportStore";
 import { useSidebarStore } from "../../stores/useSidebarStore";
@@ -554,6 +583,7 @@ import TbComfyPanel from "./TbComfyPanel.vue";
 import TbExportPanel from "./TbExportPanel.vue";
 import TbImportPanel from "./TbImportPanel.vue";
 import UndoControl from "./UndoControl.vue";
+import { useOneTimeNotice } from "../../composables/useOneTimeNotice";
 const props = defineProps({
   selectedCount: Number,
   selectedCharacter: String,
@@ -572,27 +602,46 @@ const emit = defineEmits([
   "open-import",
   "local-import",
   "open-settings",
+  "open-duplicates",
 ]);
 
 const tbImportMenuOpen = ref(false);
 
-const LIKENESS_GROUPS_SORT_KEY = "LIKENESS_GROUPS";
-const SCRAPHEAP_PICTURES_ID = "SCRAPHEAP";
+// Shown once per browser and then never again. A migration nudge that came back
+// after a reload would be an ad, so the flag is persisted rather than held in
+// the transient notice store.
+const dedupMigrationNotice = useOneTimeNotice("dedup-sort-migration");
 
-const filteredSortOptions = computed(() => {
-  const options = sortStore.sortOptions ?? [];
-  if (selectionStore.selectedCharacter === SCRAPHEAP_PICTURES_ID) {
-    return options.filter((opt) => opt.value !== LIKENESS_GROUPS_SORT_KEY);
-  }
-  return options;
-});
+/** Dismiss the notice and take the user to where the capability moved. */
+function openDuplicatesFromNotice() {
+  dedupMigrationNotice.dismiss();
+  gbSortMenuOpen.value = false;
+  emit("open-duplicates");
+}
+
+const LIKENESS_GROUPS_SORT_KEY = "LIKENESS_GROUPS";
+
+// The Likeness Groups sort order is gone from the menu in 1.9. It was a lens,
+// not a task: it never told you how many duplicates you had, offered no verdict,
+// had no bulk action, and forgot everything the moment you changed sort. It also
+// implied a whole-library comparison every time it was used. The signal survives
+// in the Duplicates destination, which builds groups you can act on instead of
+// shuffling the grid.
+//
+// The backend still serves the mechanism, so a deep link or a saved preference
+// that names it keeps working; it simply has no menu row any more, and the
+// migration notice below points at where it went.
+const filteredSortOptions = computed(() =>
+  (sortStore.sortOptions ?? []).filter(
+    (opt) => opt.value !== LIKENESS_GROUPS_SORT_KEY,
+  ),
+);
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Pinia stores (replaces gridBarState and toolbarState provide/inject)
 // ═══════════════════════════════════════════════════════════════════════════════
 const filterStore = useFilterStore();
 const sortStore = useSortStore();
-const selectionStore = useSelectionStore();
 const gridStore = useGridStore();
 const exportStore = useExportStore();
 const sidebarStore = useSidebarStore();
@@ -1248,6 +1297,64 @@ const gbCollapseAllStacksDisabled = computed(
 .gb-sort-panel {
   width: 320px;
   max-width: 92vw;
+}
+
+/* The migration notice occupies the row the removed sort order used to hold, so
+   it is a menu section rather than a floating card: the user is already looking
+   here, which is the whole reason it works as a pointer. */
+.gb-sort-migration-note {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  border-radius: var(--radius-md);
+  background: rgba(var(--v-theme-accent), 0.12);
+  border: 1px solid rgba(var(--v-theme-accent), 0.35);
+  font-size: var(--text-xs);
+  line-height: var(--leading-body);
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.gb-sort-migration-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.gb-sort-migration-open {
+  border: none;
+  background: transparent;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  color: rgb(var(--v-theme-on-surface));
+  font-family: inherit;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.gb-sort-migration-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  padding: var(--space-1);
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  cursor: pointer;
+}
+
+.gb-sort-migration-open:hover,
+.gb-sort-migration-dismiss:hover {
+  background: var(--hover-wash);
+}
+
+.gb-sort-migration-open:focus-visible,
+.gb-sort-migration-dismiss:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
 }
 
 .gb-sort-search-note {

--- a/frontend/src/components/views/DuplicateQueue.test.js
+++ b/frontend/src/components/views/DuplicateQueue.test.js
@@ -1,0 +1,618 @@
+// The duplicate triage queue.
+//
+// These tests cover the parts of the destination that are invisible in a
+// screenshot and expensive to get wrong: the live region has to outlive the row
+// that emptied the queue, the tier popover has to be dismissible without a
+// mouse, a failed verdict has to be reported rather than swallowed, and a
+// read-only session must not be shown a verdict it can never give.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+
+vi.mock("../../api/dedup", () => ({
+  getPolicy: vi.fn(),
+  listGroups: vi.fn(),
+  getCounts: vi.fn(),
+  startScan: vi.fn(),
+  stackGroup: vi.fn(),
+  keepGroupSeparate: vi.fn(),
+  reopenGroup: vi.fn(),
+  autoStackExact: vi.fn(),
+  GLOBAL_SCOPE: "global",
+}));
+
+// The queue opens itself from the URL's scope, so it needs a route.
+const routeMock = { name: "duplicates", query: {} };
+const routerReplace = vi.fn();
+vi.mock("vue-router", () => ({
+  useRoute: () => routeMock,
+  useRouter: () => ({ replace: (...a) => routerReplace(...a) }),
+}));
+
+vi.mock("../../api/pictures", () => ({
+  pictureThumbnailUrl: (id) => `/pictures/thumbnails/${id}.webp`,
+}));
+
+// The read-only flag is a module-level computed over the session; the tests
+// drive it directly rather than faking a whole session. The factories are
+// hoisted above every top-level binding, so the shared refs and spies are built
+// inside them and read back through the mocked modules.
+let batchCounter = 0;
+vi.mock("../../utils/apiClient", async () => {
+  const { ref: makeRef } = await import("vue");
+  return {
+    isReadOnly: makeRef(false),
+    API_BASE_URL: "http://backend.test/api/v1",
+    newOperationBatchId: () => `cli-test-${(batchCounter += 1)}`,
+  };
+});
+
+vi.mock("../../stores/useOperationStore", () => {
+  const undo = vi.fn();
+  return { useOperationStore: () => ({ undo }) };
+});
+
+vi.mock("../../stores/useNoticeStore", () => {
+  const error = vi.fn();
+  const info = vi.fn();
+  const warning = vi.fn();
+  return { useNoticeStore: () => ({ error, info, warning }) };
+});
+
+import {
+  getPolicy,
+  listGroups,
+  getCounts,
+  stackGroup,
+  keepGroupSeparate,
+  reopenGroup,
+} from "../../api/dedup";
+import { isReadOnly as readOnlyRef } from "../../utils/apiClient";
+import { useNoticeStore } from "../../stores/useNoticeStore";
+import DuplicateQueue from "./DuplicateQueue.vue";
+import { useDedupStore } from "../../stores/useDedupStore";
+
+/** A queue group in the backend's shape, with `n` candidates. */
+function group(signature, n = 2) {
+  const base = Number(signature.replace(/\D/g, "")) * 100;
+  return {
+    signature,
+    tier: "near",
+    confidence: 0.93,
+    member_count: n,
+    cover_picture_id: null,
+    why: [],
+    candidates: Array.from({ length: n }, (_, i) => ({
+      picture_id: base + i,
+      width: 4000,
+      height: 3000,
+      megapixels: 12,
+    })),
+  };
+}
+
+/** The bounds `GET /dedup/policy` publishes. */
+const BOUNDS = {
+  min_threshold: 0.65,
+  max_threshold: 0.99999,
+  tiers: ["exact", "near", "embedding"],
+  always_on_tiers: ["exact"],
+  tier_requires: { exact: null, near: "exact", embedding: "near" },
+  scope_types: ["global", "project", "set", "character", "folder"],
+  verdicts: ["stacked", "keep_separate"],
+  max_page_size: 200,
+};
+
+const globalOpts = {
+  global: {
+    stubs: {
+      "v-icon": true,
+      "v-progress-circular": true,
+      DedupCompareDialog: true,
+      DedupAutoStackDialog: true,
+      ActionReceipt: true,
+    },
+  },
+};
+
+/** Mount the queue over one served page and let the first load settle. */
+async function mountQueue(groups, { byTier = {} } = {}) {
+  getPolicy.mockResolvedValue({
+    defaults: { near_enabled: false, embedding_enabled: false, threshold: 0.9 },
+    bounds: BOUNDS,
+  });
+  listGroups.mockResolvedValue({
+    groups,
+    total: groups.length,
+    offset: 0,
+    limit: 20,
+    scan: { status: "complete", scanned_pictures: 1, total_pictures: 1 },
+  });
+  getCounts.mockResolvedValue({
+    unresolved_groups: groups.length,
+    by_tier: byTier,
+    scopes: [],
+    scan: { status: "complete" },
+  });
+  const store = useDedupStore();
+  await store.loadPolicy();
+  await store.refreshCounts();
+  await store.loadFirstPage();
+  const wrapper = mount(DuplicateQueue, {
+    ...globalOpts,
+    attachTo: document.body,
+  });
+  await wrapper.vm.$nextTick();
+  return { wrapper, store };
+}
+
+let errorSpy;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  readOnlyRef.value = false;
+  routeMock.name = "duplicates";
+  routeMock.query = {};
+  routerReplace.mockReset();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  const notices = useNoticeStore();
+  errorSpy = notices.error;
+  for (const fn of [
+    getPolicy,
+    listGroups,
+    getCounts,
+    stackGroup,
+    keepGroupSeparate,
+    reopenGroup,
+    errorSpy,
+    notices.info,
+    notices.warning,
+  ]) {
+    fn.mockReset();
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("DuplicateQueue — what a screen reader hears", () => {
+  // A live region that unmounts with the last row takes the verdict that
+  // emptied the queue down with it, so the one announcement a user most needs
+  // is the one they would never hear.
+  it("keeps the live region alive once the queue empties", async () => {
+    const { wrapper, store } = await mountQueue([group("g1")]);
+    stackGroup.mockResolvedValue({ ok: true });
+
+    expect(wrapper.find('[role="status"][aria-live="polite"]').exists()).toBe(
+      true,
+    );
+    await wrapper.vm.$nextTick();
+
+    await store.stack(store.groups[0]);
+    await wrapper.vm.$nextTick();
+
+    expect(store.hasGroups).toBe(false);
+    expect(wrapper.find('[role="status"][aria-live="polite"]').exists()).toBe(
+      true,
+    );
+    wrapper.unmount();
+  });
+
+  // The visible hint strip is a row of glyphs hidden from assistive tech, so
+  // the full model has to be stated somewhere it can be read, including the two
+  // keys the strip has no room for.
+  it("describes the whole keyboard model, including X and the digits", async () => {
+    const { wrapper } = await mountQueue([group("g1")]);
+    const help = wrapper.find("#dq-key-help");
+    expect(wrapper.attributes("aria-describedby")).toBe("dq-key-help");
+    const text = help.text();
+    for (const phrase of ["1 to 9", "X leaves", "Escape", "ever deleted"]) {
+      expect(text).toContain(phrase);
+    }
+    wrapper.unmount();
+  });
+});
+
+describe("DuplicateQueue — the tier popover", () => {
+  const TIERS = [{ key: "near", label: "Near duplicates", count: 4 }];
+
+  it("closes on Escape and gives the focus back to its button", async () => {
+    const { wrapper } = await mountQueue([group("g1")], { tiers: TIERS });
+    const button = wrapper.find(".dq-tier-wrap .dq-btn");
+
+    await button.trigger("click");
+    expect(wrapper.findComponent({ name: "DedupTierMenu" }).exists()).toBe(
+      true,
+    );
+    expect(button.attributes("aria-expanded")).toBe("true");
+
+    await wrapper.find(".dq").trigger("keydown", { key: "Escape" });
+    expect(wrapper.findComponent({ name: "DedupTierMenu" }).exists()).toBe(
+      false,
+    );
+    expect(document.activeElement).toBe(button.element);
+    wrapper.unmount();
+  });
+
+  it("closes on a pointer press outside itself", async () => {
+    const { wrapper } = await mountQueue([group("g1")], { tiers: TIERS });
+    await wrapper.find(".dq-tier-wrap .dq-btn").trigger("click");
+    expect(wrapper.findComponent({ name: "DedupTierMenu" }).exists()).toBe(
+      true,
+    );
+
+    document.dispatchEvent(
+      new window.MouseEvent("mousedown", { bubbles: true }),
+    );
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findComponent({ name: "DedupTierMenu" }).exists()).toBe(
+      false,
+    );
+    wrapper.unmount();
+  });
+
+  it("leaves the popover alone for a press inside it", async () => {
+    const { wrapper } = await mountQueue([group("g1")], { tiers: TIERS });
+    const wrap = wrapper.find(".dq-tier-wrap");
+    await wrap.find(".dq-btn").trigger("click");
+
+    wrap.element.dispatchEvent(
+      new window.MouseEvent("mousedown", { bubbles: true }),
+    );
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findComponent({ name: "DedupTierMenu" }).exists()).toBe(
+      true,
+    );
+    wrapper.unmount();
+  });
+});
+
+describe("DuplicateQueue — when a verdict does not land", () => {
+  // A failed verdict leaves the row where it was, which on a queue whose whole
+  // promise is auto-advance reads as a dead keypress.
+  it("raises a notice rather than swallowing the failure", async () => {
+    const { wrapper, store } = await mountQueue([group("g1")]);
+    stackGroup.mockRejectedValue(new Error("nope"));
+
+    wrapper.findComponent({ name: "DedupGroupRow" }).vm.$emit("stack");
+    await flushPromises();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain("still in the queue");
+    expect(store.hasGroups).toBe(true);
+    wrapper.unmount();
+  });
+});
+
+describe("DuplicateQueue — keeping a group separate", () => {
+  // The backend deliberately records NO operation for this verdict, so no
+  // receipt will come. The narration is transient and points at the Decided
+  // page, which is the standing way back (it replaced the sticky notice).
+  it("narrates transiently and points at Decided, with no action attached", async () => {
+    const { wrapper } = await mountQueue([group("g1", 3)]);
+    keepGroupSeparate.mockResolvedValue({ verdict: "keep_separate" });
+    const info = useNoticeStore().info;
+
+    wrapper.findComponent({ name: "DedupGroupRow" }).vm.$emit("keep-separate");
+    await flushPromises();
+
+    expect(info).toHaveBeenCalledTimes(1);
+    const [text, opts] = info.mock.calls[0];
+    expect(text).toContain("under Decided");
+    expect(opts?.action).toBeUndefined();
+    wrapper.unmount();
+  });
+});
+
+describe("DuplicateQueue — the Decided page", () => {
+  it("lists decided groups with their verdict and clears one on demand", async () => {
+    const { wrapper, store } = await mountQueue([group("g1")]);
+    listGroups.mockResolvedValue({
+      groups: [
+        { ...group("g9"), verdict: "keep_separate", decided_at: "2026-07-29" },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 20,
+      scan: { status: "complete", scanned_pictures: 1, total_pictures: 1 },
+    });
+
+    await store.toggleDecided();
+    await wrapper.vm.$nextTick();
+
+    // The decided request is explicit, so the two pages can never blur.
+    expect(listGroups).toHaveBeenLastCalledWith(
+      expect.objectContaining({ decided: true }),
+    );
+    const row = wrapper.findComponent({ name: "DedupGroupRow" });
+    expect(row.text()).toContain("Kept separate");
+    expect(row.text()).toContain("Clear decision");
+    // A decided row gives no verdicts: Enter must be inert here.
+    stackGroup.mockResolvedValue({});
+    await store.stack(store.groups[0]);
+    expect(stackGroup).not.toHaveBeenCalled();
+
+    reopenGroup.mockResolvedValue({
+      signature: "g9",
+      previous_verdict: "keep_separate",
+      group_returned_to_queue: true,
+    });
+    row.vm.$emit("clear-decision");
+    await flushPromises();
+    expect(reopenGroup).toHaveBeenCalledWith("g9");
+    wrapper.unmount();
+  });
+
+  it("multi-selects decided groups and clears every selected decision", async () => {
+    const { wrapper, store } = await mountQueue([group("g1")]);
+    listGroups.mockResolvedValue({
+      groups: [
+        { ...group("g8"), verdict: "keep_separate", decided_at: "2026-07-29" },
+        { ...group("g9"), verdict: "stacked", decided_at: "2026-07-29" },
+      ],
+      total: 2,
+      offset: 0,
+      limit: 20,
+      scan: { status: "complete", scanned_pictures: 1, total_pictures: 1 },
+    });
+    await store.toggleDecided();
+    await wrapper.vm.$nextTick();
+
+    const rows = wrapper.findAll(".grow");
+    await rows[0].trigger("click", { ctrlKey: true });
+    await rows[1].trigger("click", { ctrlKey: true });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".qselchip").text()).toContain("Clear decision applies");
+
+    reopenGroup.mockResolvedValue({ group_returned_to_queue: true });
+    const clearButtons = wrapper.findAll(".gbtn");
+    const bulkClear = clearButtons.find((b) => b.text().includes("Clear 2 decisions"));
+    expect(bulkClear).toBeTruthy();
+    await bulkClear.trigger("click");
+    await flushPromises();
+    expect(reopenGroup).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
+});
+
+describe("DuplicateQueue — filters in the URL", () => {
+  it("restores near, threshold and the Decided view from the query", async () => {
+    // A full refresh lands here with only the URL; the selection must come
+    // back exactly, clamped by the same rules the tier menu enforces.
+    routeMock.query = {
+      near: "1",
+      embedding: "0",
+      threshold: "0.8",
+      view: "decided",
+    };
+    getPolicy.mockResolvedValue({
+      defaults: { near_enabled: false, embedding_enabled: false, threshold: 0.9 },
+      bounds: BOUNDS,
+    });
+    listGroups.mockResolvedValue({
+      groups: [],
+      total: 0,
+      offset: 0,
+      limit: 20,
+      scan: { status: "complete", scanned_pictures: 1, total_pictures: 1 },
+    });
+    getCounts.mockResolvedValue({
+      unresolved_groups: 0,
+      by_tier: {},
+      scopes: [],
+      scan: { status: "complete" },
+    });
+    const store = useDedupStore();
+    const wrapper = mount(DuplicateQueue, {
+      ...globalOpts,
+      attachTo: document.body,
+    });
+    await flushPromises();
+
+    expect(store.nearEnabled).toBe(true);
+    expect(store.embeddingEnabled).toBe(false);
+    expect(store.threshold).toBe(0.8);
+    expect(store.showingDecided).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("mirrors a filter change into the URL with replace, not push", async () => {
+    const { wrapper, store } = await mountQueue([group("g1")]);
+    routerReplace.mockReset();
+
+    await store.setTierEnabled("near", true);
+    await wrapper.vm.$nextTick();
+
+    const { query } = routerReplace.mock.calls.at(-1)[0];
+    expect(query.near).toBe("1");
+    expect(query.embedding).toBe("0");
+    wrapper.unmount();
+  });
+
+  it("drops the filter params when the selection returns to the defaults", async () => {
+    const { wrapper, store } = await mountQueue([group("g1")]);
+    await store.setTierEnabled("near", true);
+    await wrapper.vm.$nextTick();
+    routeMock.query = routerReplace.mock.calls.at(-1)[0].query;
+    routerReplace.mockReset();
+
+    await store.setTierEnabled("near", false);
+    await wrapper.vm.$nextTick();
+
+    const { query } = routerReplace.mock.calls.at(-1)[0];
+    expect(query.near).toBeUndefined();
+    expect(query.threshold).toBeUndefined();
+    wrapper.unmount();
+  });
+});
+
+describe("DuplicateQueue — multi-select", () => {
+  it("ctrl+click selects, the buttons rename, and one verdict takes all", async () => {
+    const { wrapper } = await mountQueue([
+      group("g1"),
+      group("g2"),
+      group("g3"),
+    ]);
+    const rows = wrapper.findAll(".grow");
+    await rows[0].trigger("click", { ctrlKey: true });
+    await rows[1].trigger("click", { ctrlKey: true });
+    await wrapper.vm.$nextTick();
+
+    // The bulk scope is stated twice: once in the header, once on the very
+    // buttons that will act.
+    expect(wrapper.find(".qselchip").text()).toContain("2 groups selected");
+    const stackBtn = wrapper.findAll(".grow")[0].find(".gbtn--stack");
+    expect(stackBtn.text()).toContain("Stack 2 groups");
+
+    stackGroup.mockResolvedValue({});
+    await stackBtn.trigger("click");
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(stackGroup).toHaveBeenCalledTimes(2);
+    const batchIds = stackGroup.mock.calls.map((call) => call[1].batchId);
+    // One gesture, one Ctrl+Z: both verdicts share one client batch id.
+    expect(batchIds[0]).toMatch(/^cli-/);
+    expect(batchIds[1]).toBe(batchIds[0]);
+  });
+
+  it("shift+click selects the range from the focus, Escape clears it", async () => {
+    const { wrapper, store } = await mountQueue([
+      group("g1"),
+      group("g2"),
+      group("g3"),
+    ]);
+    const rows = wrapper.findAll(".grow");
+    await rows[0].trigger("click");
+    await rows[2].trigger("click", { shiftKey: true });
+    expect(store.selectionCount).toBe(3);
+
+    await wrapper.trigger("keydown", { key: "Escape" });
+    expect(store.selectionCount).toBe(0);
+    // Clearing the selection must not cost the user their place.
+    expect(store.focusIndex).toBe(2);
+  });
+
+  it("every selected row wears the Enter/S chips; C stays on the focus", async () => {
+    const { wrapper } = await mountQueue([
+      group("g1"),
+      group("g2"),
+      group("g3"),
+    ]);
+    const rows = wrapper.findAll(".grow");
+    await rows[0].trigger("click", { ctrlKey: true });
+    await rows[1].trigger("click", { ctrlKey: true });
+    await wrapper.vm.$nextTick();
+
+    const fresh = wrapper.findAll(".grow");
+    // Both selected rows say where Enter acts, because it acts on both.
+    expect(fresh[0].find(".gbtn--stack kbd").exists()).toBe(true);
+    expect(fresh[1].find(".gbtn--stack kbd").exists()).toBe(true);
+    expect(fresh[2].find(".gbtn--stack kbd").exists()).toBe(false);
+    // Compare opens ONE group, so its chip stays with the keyboard cursor.
+    expect(fresh[0].find(".gcompare kbd").exists()).toBe(false);
+    expect(fresh[1].find(".gcompare kbd").exists()).toBe(true);
+    // The old explicit label is gone.
+    expect(wrapper.text()).not.toContain("Keyboard acts here");
+  });
+
+  it("a verdict on an unselected group stays single", async () => {
+    const { wrapper, store } = await mountQueue([
+      group("g1"),
+      group("g2"),
+      group("g3"),
+    ]);
+    const rows = wrapper.findAll(".grow");
+    await rows[0].trigger("click", { ctrlKey: true });
+    await rows[1].trigger("click", { ctrlKey: true });
+
+    stackGroup.mockResolvedValue({});
+    // The third row is OUTSIDE the selection: its button must say and do the
+    // single-group thing.
+    const outsideBtn = wrapper.findAll(".grow")[2].find(".gbtn--stack");
+    expect(outsideBtn.text()).not.toContain("groups");
+    await outsideBtn.trigger("click");
+    await wrapper.vm.$nextTick();
+    expect(stackGroup).toHaveBeenCalledTimes(1);
+    expect(store.selectionCount).toBe(2);
+  });
+});
+
+describe("DuplicateQueue — the render window", () => {
+  it("follows the scroll, not just the keyboard focus", async () => {
+    // The regression this pins: the window was anchored to focusIndex alone,
+    // so a mouse user scrolling a 327-group queue saw ~9 rows and then blank
+    // spacer for the rest.
+    const many = Array.from({ length: 20 }, (_, i) => group(`g${i + 1}`));
+    const { wrapper } = await mountQueue(many);
+    const before = wrapper.vm.windowedGroups.map((e) => e.index);
+    expect(before).not.toContain(19);
+
+    const list = wrapper.find(".qlist");
+    // ~row 15 at the estimate pitch (happy-dom never refines the measure).
+    list.element.scrollTop = 15 * 148;
+    await list.trigger("scroll");
+    await wrapper.vm.$nextTick();
+    const after = wrapper.vm.windowedGroups.map((e) => e.index);
+    expect(after).toContain(19);
+    // Scroll-anchored, not a union with the focus window: the mounted count
+    // must stay a constant, so the head of the queue unmounts behind us.
+    expect(after).not.toContain(0);
+  });
+
+  it("every mounted row may decode thumbnails", async () => {
+    const { wrapper } = await mountQueue([group("g1"), group("g2"), group("g3")]);
+    for (const entry of wrapper.vm.windowedGroups) {
+      expect(entry.loadThumbnails).toBe(true);
+    }
+  });
+});
+
+describe("DuplicateQueue — the tier gate", () => {
+  // Nothing about the ladder is hardcoded: the ids, the prerequisites and which
+  // tier cannot be switched off all arrive from GET /dedup/policy.
+  it("renders the tiers the server published, with tier 1 locked", async () => {
+    const { wrapper } = await mountQueue([group("g1")], {
+      byTier: { exact: 1204, near: 96, embedding: 9 },
+    });
+    wrapper.find(".dq-btn").trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const rows = wrapper.findAll(".tierrow");
+    expect(rows).toHaveLength(3);
+    expect(rows[0].text()).toContain("always included");
+    // Tier 3 is unreachable until tier 2 is on, so it must not be pressable.
+    expect(rows[2].attributes("disabled")).toBeDefined();
+    wrapper.unmount();
+  });
+});
+
+describe("DuplicateQueue — a read-only session", () => {
+  // Navigation stays live because reading the queue is not a verdict; the bulk
+  // action is a verdict, so it goes.
+  it("hides the bulk auto-stack button", async () => {
+    getCounts.mockResolvedValue({
+      unresolved_groups: 1,
+      by_tier: { exact: 12 },
+      tiers: [],
+      scan: { state: "idle" },
+    });
+    readOnlyRef.value = true;
+    const { wrapper, store } = await mountQueue([group("g1")]);
+    store.exactCount = 12;
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".dq-btn--accent").exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("tells Compare that the session cannot act", async () => {
+    readOnlyRef.value = true;
+    const { wrapper } = await mountQueue([group("g1")]);
+    expect(
+      wrapper.findComponent({ name: "DedupCompareDialog" }).props("readOnly"),
+    ).toBe(true);
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/views/DuplicateQueue.vue
+++ b/frontend/src/components/views/DuplicateQueue.vue
@@ -1,0 +1,1275 @@
+<template>
+  <div
+    ref="rootEl"
+    class="dq"
+    tabindex="-1"
+    aria-label="Duplicate review queue"
+    aria-describedby="dq-key-help"
+    data-testid="duplicate-queue"
+    @keydown="onKeydown"
+  >
+    <!-- The visible hint strip is a row of glyphs, so it is hidden from
+         assistive tech and this sentence carries the model instead. It also
+         carries the two keys the strip has no room for, and the one fact that
+         makes the whole queue safe to work fast. -->
+    <p id="dq-key-help" class="visually-hidden">
+      Up and Down arrows choose a group. Enter stacks it. S keeps it separate. C
+      compares every copy field by field. The number keys 1 to 9 choose the
+      cover. X leaves the picture under the cursor out of the stack. Control Z
+      undoes the last verdict. Escape returns here from a control. No picture is
+      ever deleted, and a stack can be undone.
+    </p>
+
+    <div class="dq-toolbar">
+      <div class="dq-tb-left">
+        <div ref="tierWrapEl" class="dq-tier-wrap">
+          <button
+            ref="tierButtonEl"
+            type="button"
+            class="dq-btn"
+            :aria-expanded="tierMenuOpen"
+            aria-haspopup="true"
+            @click="toggleTierMenu"
+          >
+            <v-icon size="16">mdi-filter-outline</v-icon>
+            <span>{{ tierLabel }}</span>
+            <v-icon size="16">mdi-menu-down</v-icon>
+          </button>
+          <DedupTierMenu
+            v-if="tierMenuOpen"
+            class="dq-tier-menu"
+            :tiers="store.tierRows"
+            :group-count="store.openCount"
+            :threshold="store.threshold"
+            :min-threshold="store.bounds?.min_threshold ?? null"
+            :max-threshold="store.bounds?.max_threshold ?? null"
+            @threshold="onThresholdChange"
+            @toggle="onTierToggle"
+          />
+        </div>
+
+        <DedupScopePill
+          v-if="store.isScoped"
+          :label="store.scopeLabel || 'This collection'"
+          :icon="store.scopeIcon || 'mdi-folder-multiple-image'"
+          @dismiss="onDismissScope"
+        />
+      </div>
+
+      <div class="dq-tb-right">
+        <button
+          v-if="store.exactCount > 0 && !readOnly"
+          type="button"
+          class="dq-btn dq-btn--accent"
+          @click="openAutoStack"
+        >
+          <v-icon size="16">mdi-flash-outline</v-icon>
+          <span
+            >Auto-stack {{ store.exactCount.toLocaleString() }} exact
+            {{ store.exactCount === 1 ? "match" : "matches" }}</span
+          >
+        </button>
+      </div>
+    </div>
+
+    <DedupScanBanner :scan="store.scan" />
+
+    <!-- One live region for the whole destination, and deliberately OUTSIDE the
+         branches below: a region that unmounts with the last row takes the
+         verdict that emptied the queue down with it, so the one announcement a
+         user most needs is the one they would never hear. -->
+    <span
+      class="visually-hidden"
+      role="status"
+      aria-live="polite"
+      data-testid="dedup-announcement"
+      >{{ announcement }}</span
+    >
+
+    <div v-if="store.loading" class="dq-state" role="status">
+      Looking for duplicates.
+    </div>
+
+    <div v-else-if="store.hasGroups" class="queue">
+      <div class="qhead">
+        <span class="qtitle">{{
+          store.showingDecided
+            ? `${store.total.toLocaleString()} decided ${store.total === 1 ? "group" : "groups"}`
+            : `${store.openCount.toLocaleString()} ${store.openCount === 1 ? "group" : "groups"} to review`
+        }}</span>
+        <!-- SESSION tally, and says so: the durable record is the Decided
+             page, which spans every session. -->
+        <span v-if="store.doneCount && !store.showingDecided" class="qsub"
+          >{{ store.doneCount.toLocaleString() }} done this session</span
+        >
+        <!-- The flip side of the queue: review what was already decided and
+             clear a decision — this is the way back that used to hide in a
+             transient notice. -->
+        <button
+          type="button"
+          class="qdecided"
+          :class="{ 'qdecided--on': store.showingDecided }"
+          :aria-pressed="store.showingDecided ? 'true' : 'false'"
+          @click="store.toggleDecided()"
+        >
+          <v-icon size="15">{{
+            store.showingDecided ? "mdi-arrow-left" : "mdi-history"
+          }}</v-icon>
+          {{ store.showingDecided ? "Back to review" : "Decided" }}
+        </button>
+        <!-- The bulk-scope statement: while ≥2 groups are selected, a verdict
+             on any of them takes all of them, and this is where that is said
+             once, above the rows that each also say it on their buttons. -->
+        <span v-if="store.selectionCount > 1" class="qselchip" role="status">
+          <v-icon size="14">mdi-checkbox-multiple-marked-outline</v-icon>
+          {{ store.selectionCount }} groups selected —
+          {{
+            store.showingDecided
+              ? "Clear decision applies to all"
+              : "Stack and Keep separate apply to all"
+          }}
+          <button
+            type="button"
+            class="qselclear"
+            title="Clear the selection (Esc)"
+            @click="store.clearSelection()"
+          >
+            Clear
+          </button>
+        </span>
+        <span class="qsp"></span>
+        <span
+          v-for="hint in KEY_HINTS"
+          :key="hint.label"
+          class="khint"
+          aria-hidden="true"
+        >
+          <kbd v-for="k in hint.keys" :key="k">{{ k }}</kbd>
+          {{ hint.label }}
+        </span>
+      </div>
+
+      <div ref="listEl" class="qlist" @scroll.passive="onListScroll">
+        <div
+          v-if="topSpacer"
+          class="qspacer"
+          :style="{ height: `${topSpacer}px` }"
+          aria-hidden="true"
+        ></div>
+        <DedupGroupRow
+          v-for="entry in windowedGroups"
+          :key="entry.group.signature"
+          :group="entry.group"
+          :index="entry.index"
+          :focused="entry.index === store.focusIndex"
+          :selected="store.isSelected(entry.group.signature)"
+          :selection-count="store.selectionCount"
+          :bulk-keys="bulkKeysActive"
+          :verdict="store.showingDecided ? entry.group.verdict || '' : ''"
+          :decided-at="entry.group.decided_at || ''"
+          :cover-id="store.coverIdFor(entry.group)"
+          :excluded-ids="store.excludedFor(entry.group.signature)"
+          :load-thumbnails="entry.loadThumbnails"
+          :busy="store.busy"
+          :read-only="readOnly"
+          @focus="onRowFocus(entry.index, $event)"
+          @stack="onStack(entry.group)"
+          @keep-separate="onKeepSeparate(entry.group)"
+          @compare="onCompare(entry.index)"
+          @set-cover="store.setCover(entry.group.signature, $event)"
+          @toggle-excluded="onToggleExcluded(entry.group, $event)"
+          @clear-decision="onClearDecision(entry.group)"
+        />
+        <div
+          v-if="bottomSpacer"
+          class="qspacer"
+          :style="{ height: `${bottomSpacer}px` }"
+          aria-hidden="true"
+        ></div>
+      </div>
+    </div>
+
+    <!-- "Queue clear" has to be true when it is shown. A page can be emptied
+         faster than the read-ahead refills it, and claiming the work is done
+         while the next page is in flight is how the count stops being
+         trusted. -->
+    <div v-else-if="store.loadingMore" class="dq-state" role="status">
+      Loading the next groups.
+    </div>
+
+    <!-- The empty DECIDED page keeps its own copy and, crucially, its own way
+         back: the header toggle lives on the list, which is not rendered here. -->
+    <div v-else-if="store.showingDecided" class="qdone">
+      <v-icon size="48">mdi-history</v-icon>
+      <h3>No decided groups</h3>
+      <p>
+        Groups you stack or keep separate land here — from any session, not
+        just this one — and every decision can be reviewed and cleared until
+        you do.
+      </p>
+      <button type="button" class="qdecided" @click="store.toggleDecided()">
+        <v-icon size="15">mdi-arrow-left</v-icon>
+        Back to review
+      </button>
+    </div>
+
+    <div v-else class="qdone">
+      <v-icon size="48">mdi-check-circle-outline</v-icon>
+      <h3>Queue clear</h3>
+      <p>
+        {{ store.stackedCount.toLocaleString() }}
+        {{ store.stackedCount === 1 ? "group" : "groups" }} stacked,
+        {{ store.separatedCount.toLocaleString() }} kept separate. Every picture
+        is still in your library. Scanning continues in the background, and new
+        groups appear here as they are found.
+      </p>
+      <!-- Always offered: decisions are SERVER state, remembered across
+           sessions, so the way to them must not depend on this session's
+           tally. An empty Decided page explains itself. -->
+      <button type="button" class="qdecided" @click="store.toggleDecided()">
+        <v-icon size="15">mdi-history</v-icon>
+        Review decided groups
+      </button>
+    </div>
+
+    <DedupCompareDialog
+      ref="compareRef"
+      :open="compareOpen"
+      :group="store.focusedGroup"
+      :cover-id="
+        store.focusedGroup ? store.coverIdFor(store.focusedGroup) : null
+      "
+      :excluded-ids="
+        store.focusedGroup
+          ? store.excludedFor(store.focusedGroup.signature)
+          : []
+      "
+      :busy="store.busy"
+      :read-only="readOnly"
+      @close="closeCompare"
+      @set-cover="
+        store.focusedGroup &&
+        store.setCover(store.focusedGroup.signature, $event)
+      "
+      @toggle-excluded="
+        store.focusedGroup && onToggleExcluded(store.focusedGroup, $event)
+      "
+      @stack="onCompareStack"
+      @keep-separate="onCompareKeepSeparate"
+    />
+
+    <DedupAutoStackDialog
+      :open="autoStackOpen"
+      :preview="autoStackPreview"
+      :loading="autoStackLoading"
+      :preview-failed="autoStackPreviewFailed"
+      :busy="store.busy"
+      :queue-remaining="store.queueOnlyCount"
+      @close="autoStackOpen = false"
+      @confirm="confirmAutoStack"
+    />
+
+    <ActionReceipt v-if="!readOnly" />
+  </div>
+</template>
+
+<script setup>
+// The duplicate triage queue: the whole "Duplicates" destination.
+//
+// It replaces the grid rather than floating over it, because duplicates are a
+// task with a to-do count rather than a lens on the library. Three design rules
+// are load-bearing here and are worth stating where they are implemented:
+//
+//   * **Never block on a full pass.** The view renders whatever the first page
+//     returned and lets `DedupScanBanner` narrate the rest. There is no state in
+//     which the user waits on a complete scan before seeing a group.
+//   * **Keep one group's worth of pictures in the DOM.** The row list is
+//     windowed around the focus, and only the focused row and the one after it
+//     decode real thumbnails. Ten groups and ten thousand groups therefore cost
+//     the same to render, which is the difference between this and a review
+//     page that renders everything and dies.
+//   * **Auto-advance.** Every verdict removes its row and the focus lands on
+//     the next open group, so a run of `Enter` presses works the queue without
+//     a single extra keystroke.
+//
+// Undo is not reimplemented here. A verdict is recorded server-side like any
+// other change, the operation store notices the resulting event and raises the
+// standard receipt, and `Ctrl+Z` walks the same shared stack. The queue's only
+// undo-specific job is to claim the chord so the app shell does not also
+// handle it and undo twice.
+
+import {
+  ref,
+  computed,
+  watch,
+  onMounted,
+  onBeforeUnmount,
+  nextTick,
+} from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useDedupStore } from "../../stores/useDedupStore";
+import { useOperationStore } from "../../stores/useOperationStore";
+import { useNoticeStore } from "../../stores/useNoticeStore";
+import { API_BASE_URL, isReadOnly } from "../../utils/apiClient";
+import { candidateId } from "../../utils/dedup";
+import { createDedupKeyHandler } from "../../composables/useDedupQueueKeyboard";
+import { pictureThumbnailUrl } from "../../api/pictures";
+import DedupGroupRow from "../widgets/DedupGroupRow.vue";
+import DedupTierMenu from "../widgets/DedupTierMenu.vue";
+import DedupScanBanner from "../widgets/DedupScanBanner.vue";
+import DedupScopePill from "../widgets/DedupScopePill.vue";
+import DedupCompareDialog from "../widgets/DedupCompareDialog.vue";
+import DedupAutoStackDialog from "../widgets/DedupAutoStackDialog.vue";
+import ActionReceipt from "../widgets/ActionReceipt.vue";
+
+/**
+ * How many rows beyond the anchors stay mounted.
+ *
+ * The window is anchored to BOTH the keyboard focus and the scroll position:
+ * anchoring to the focus alone renders a fixed dozen rows and leaves a mouse
+ * user scrolling into blank spacer — a 327-group queue that appears to hold 9.
+ * Enough margin that neither a page of arrow presses nor a flick of the wheel
+ * lands on an empty viewport; small enough that the mounted row count stays a
+ * constant rather than a function of the queue's length.
+ */
+const WINDOW_BEFORE = 4;
+const WINDOW_AFTER = 8;
+
+/**
+ * The spacer height a windowed-out row stands in for, refined to the real row
+ * pitch once two rows have rendered. It only has to keep the scrollbar honest,
+ * not pixel-accurate.
+ */
+const ROW_ESTIMATE_PX = 148;
+
+/**
+ * What the queue says when `X` is refused at the stack floor.
+ *
+ * One string for both routes into the refusal (the row's right-click and the
+ * key handler), because a rule stated two ways is a rule that drifts.
+ */
+const STACK_FLOOR_NOTICE =
+  "A stack needs at least two pictures, so this one has to stay in. Keep the group separate instead.";
+
+const KEY_HINTS = [
+  { keys: ["↑", "↓"], label: "choose group" },
+  { keys: ["Enter"], label: "stack it" },
+  { keys: ["S"], label: "keep separate" },
+  { keys: ["C"], label: "compare" },
+  { keys: ["Ctrl", "Z"], label: "undo" },
+  { keys: ["Ctrl", "⇧", "click"], label: "select many" },
+];
+
+const route = useRoute();
+const router = useRouter();
+const store = useDedupStore();
+const operationStore = useOperationStore();
+const noticeStore = useNoticeStore();
+
+const rootEl = ref(null);
+const listEl = ref(null);
+const tierWrapEl = ref(null);
+const tierButtonEl = ref(null);
+const tierMenuOpen = ref(false);
+const compareOpen = ref(false);
+const autoStackOpen = ref(false);
+const autoStackLoading = ref(false);
+const autoStackPreview = ref(null);
+const autoStackPreviewFailed = ref(false);
+const announcement = ref("");
+
+const readOnly = computed(() => Boolean(isReadOnly.value));
+
+/** The real row pitch, measured once two rows exist; the estimate until then. */
+const rowPitchPx = ref(ROW_ESTIMATE_PX);
+/** First row index the scroll position implies, and how many rows fit. */
+const scrollIndex = ref(0);
+const viewportRows = ref(WINDOW_AFTER);
+
+function measureRowPitch() {
+  const list = listEl.value;
+  if (!list) return;
+  const rows = list.querySelectorAll(".grow");
+  if (rows.length >= 2) {
+    const pitch = rows[1].offsetTop - rows[0].offsetTop;
+    if (pitch > 0) rowPitchPx.value = pitch;
+  }
+  if (list.clientHeight > 0) {
+    viewportRows.value = Math.ceil(list.clientHeight / rowPitchPx.value) + 1;
+  }
+}
+
+function onListScroll() {
+  const list = listEl.value;
+  if (!list) return;
+  scrollIndex.value = Math.max(0, Math.floor(list.scrollTop / rowPitchPx.value));
+  // Mouse-wheel users reach the tail without ever moving the keyboard focus,
+  // so the scroll position must drive loadMore exactly as the focus does.
+  if (
+    store.hasMore &&
+    scrollIndex.value + viewportRows.value + WINDOW_AFTER >= store.groups.length
+  ) {
+    store.loadMore();
+  }
+}
+
+const focusAnchor = computed(() => (store.focusIndex < 0 ? 0 : store.focusIndex));
+
+/**
+ * Whether Enter/S would genuinely take the whole selection: two or more
+ * groups selected AND the keyboard cursor inside it. Only then may every
+ * selected row wear the Enter/S chips — a chip on a row the key will not hit
+ * is a lie.
+ */
+const bulkKeysActive = computed(() => {
+  const focusedGroup = store.focusedGroup;
+  return Boolean(
+    focusedGroup &&
+      store.selectionCount > 1 &&
+      store.isSelected(focusedGroup.signature),
+  );
+});
+
+// Anchored to the SCROLL alone, so the mounted count stays a constant: a
+// union with the focus window would mount the whole span between the keyboard
+// cursor and a far-away scrollbar. Keyboard moves stay covered because
+// scrollFocusIntoView drags the scroll (and thus this window) to the cursor.
+const renderStart = computed(() =>
+  Math.max(0, scrollIndex.value - WINDOW_BEFORE),
+);
+const renderEnd = computed(() =>
+  Math.min(
+    store.groups.length,
+    scrollIndex.value + viewportRows.value + WINDOW_AFTER,
+  ),
+);
+const topSpacer = computed(() => renderStart.value * rowPitchPx.value);
+const bottomSpacer = computed(
+  () => (store.groups.length - renderEnd.value) * rowPitchPx.value,
+);
+
+/**
+ * The rows that are actually mounted, each carrying its true index. Every
+ * mounted row may decode thumbnails: the window itself is the budget, and the
+ * imgs are `loading="lazy"`, so off-viewport rows inside it cost a request
+ * only as they approach.
+ */
+const windowedGroups = computed(() =>
+  store.groups.slice(renderStart.value, renderEnd.value).map((group, i) => {
+    const index = renderStart.value + i;
+    return {
+      group,
+      index,
+      loadThumbnails: true,
+    };
+  }),
+);
+
+watch(
+  () => store.groups.length,
+  async () => {
+    await nextTick();
+    measureRowPitch();
+  },
+);
+
+/**
+ * What the tier button says the queue is currently showing.
+ *
+ * Named after the loosest tier that is on, because that is the one that decides
+ * how speculative the list is. Built from the server's tier rows, so a tier the
+ * server adds later names itself here rather than falling through to a wrong
+ * label.
+ */
+const tierLabel = computed(() => {
+  const on = store.tierRows.filter((tier) => tier.enabled);
+  const loosest = on[on.length - 1];
+  if (!loosest || loosest.locked) return "Exact only";
+  return `Exact and ${loosest.label.toLowerCase()}`;
+});
+
+/**
+ * Warm the browser cache for the group after the focused one.
+ *
+ * Only one group ahead: prefetching further turns the "one group in the DOM"
+ * rule back into "load the whole queue", slowly.
+ */
+function prefetchNextGroup() {
+  const next = store.groups[store.focusIndex + 1];
+  if (!next || typeof Image === "undefined") return;
+  for (const candidate of next.candidates ?? []) {
+    const img = new Image();
+    // candidateId, not .id — the server calls the field picture_id — and the
+    // backend origin, or the warmed URL is not the one the row will render.
+    img.src = pictureThumbnailUrl(candidateId(candidate), {
+      version: candidate.thumbnail_version,
+      baseUrl: API_BASE_URL,
+    });
+  }
+}
+
+/** Keep the focused row inside the scroll viewport. */
+async function scrollFocusIntoView() {
+  await nextTick();
+  const list = listEl.value;
+  if (!list) return;
+  const row = list.querySelector(".grow--focus");
+  if (!row || typeof row.offsetTop !== "number") {
+    // The cursor left the mounted window (a verdict advanced it while the
+    // user was scrolled elsewhere). Jump the scroll to its estimated pitch;
+    // the scroll event remounts the row and the next pass fine-tunes.
+    list.scrollTop = Math.max(0, focusAnchor.value * rowPitchPx.value);
+    onListScroll();
+    return;
+  }
+  const top = row.offsetTop;
+  const bottom = top + row.offsetHeight;
+  if (top < list.scrollTop) list.scrollTop = top;
+  else if (bottom > list.scrollTop + list.clientHeight) {
+    list.scrollTop = bottom - list.clientHeight;
+  }
+}
+
+/**
+ * Take the DOM focus back off a row control when the keyboard cursor moves.
+ *
+ * A user who tabs onto a row's Compare button and then presses ArrowDown ends
+ * up with the focus ring on one row and the "Keyboard acts here" label on
+ * another, which is exactly the ambiguity the focused-row treatment exists to
+ * prevent. The cursor wins; the ring comes back to the queue.
+ */
+function reclaimFocusFromRow() {
+  if (typeof document === "undefined") return;
+  const list = listEl.value;
+  const active = document.activeElement;
+  if (!list || !active || active === rootEl.value) return;
+  if (list.contains(active)) rootEl.value?.focus?.();
+}
+
+watch(
+  () => store.focusIndex,
+  () => {
+    reclaimFocusFromRow();
+    scrollFocusIntoView();
+    prefetchNextGroup();
+  },
+);
+
+watch(
+  () => store.focusedGroup,
+  (group) => {
+    if (!group) return;
+    const n = group.candidates?.length ?? 0;
+    announcement.value = `Group ${store.focusIndex + 1} of ${store.groups.length}, ${n} pictures.`;
+  },
+);
+
+/** Open Compare on a row, focusing it first so the two can never disagree. */
+function onCompare(index) {
+  store.setFocus(index);
+  compareOpen.value = true;
+}
+
+function closeCompare() {
+  compareOpen.value = false;
+  rootEl.value?.focus?.();
+}
+
+/**
+ * Give a verdict and narrate it for assistive tech.
+ *
+ * The visible receipt is the operation store's; this line exists because the
+ * receipt is a floating pill a screen reader would otherwise have to find.
+ */
+async function onStack(group) {
+  const targets = store.verdictTargets(group);
+  if (targets.length > 1) {
+    const pictures = targets.reduce((n, g) => n + store.stackSizeFor(g), 0);
+    const result = await store.stack(group);
+    if (result) {
+      announcement.value = `Stacked ${targets.length} groups (${pictures} pictures). One undo reverses them all.`;
+      return;
+    }
+    reportVerdictFailure("stack those groups", store.error);
+    return;
+  }
+  const size = store.stackSizeFor(group);
+  const result = await store.stack(group);
+  if (result) {
+    announcement.value = `Stacked ${size} pictures. The cover is kept and nothing is deleted.`;
+    return;
+  }
+  reportVerdictFailure("stack that group", store.error);
+}
+
+/**
+ * Say when `X` was refused rather than letting it read as a dead key.
+ *
+ * The store holds a stack at two members because the server refuses a
+ * one-member stack outright, and a group of two therefore accepts no exclusion
+ * at all. Without this the row simply does not change and the user presses the
+ * key again; with it the queue names the rule and the way past it.
+ *
+ * @param {Object} group
+ * @param {number} pictureId
+ */
+function onToggleExcluded(group, pictureId) {
+  if (store.toggleExcluded(group, pictureId) !== false) return;
+  announcement.value = STACK_FLOOR_NOTICE;
+}
+
+/**
+ * Keep a group separate, and offer the only way back.
+ *
+ * This verdict changes no picture row, so the backend deliberately records no
+ * operation for it: there is nothing for undo to restore, and an empty
+ * operation row would still consume a Ctrl+Z. No receipt will ever appear for
+ * it, so the narration and the escape hatch have to be raised here instead.
+ */
+async function onKeepSeparate(group) {
+  const targets = store.verdictTargets(group);
+  const size = targets.reduce((n, g) => n + (g.candidates?.length ?? 0), 0);
+  const result = await store.keepSeparate(group);
+  if (!result) {
+    reportVerdictFailure("record that decision", store.error);
+    return;
+  }
+  const sentence =
+    targets.length > 1
+      ? `Kept ${targets.length} groups (${size} pictures) separate. Change your mind under Decided.`
+      : `Kept ${size} pictures separate. Change your mind under Decided.`;
+  // No sticky notice any more (owner call, 2026-07-29): the Decided page is
+  // the standing way back, so the narration can be transient.
+  announcement.value = sentence;
+  noticeStore.info(sentence);
+}
+
+/**
+ * Clear one decided group's verdict from the Decided page.
+ *
+ * Never touches pictures: a reopened "stacked" group stays stacked until it
+ * is unstacked from the Stacks view; the group simply returns to the queue.
+ *
+ * @param {Object} group
+ */
+async function onClearDecision(group) {
+  const targets = store.verdictTargets(group);
+  const signatures = targets.map((g) => g.signature);
+  const { cleared, returned } = await store.reopenMany(signatures);
+  if (!cleared) {
+    noticeStore.error("Could not clear that decision. Nothing changed.");
+    return;
+  }
+  if (cleared < signatures.length) {
+    noticeStore.error(
+      `Cleared ${cleared} of ${signatures.length} decisions; the rest kept theirs.`,
+    );
+  }
+  if (signatures.length > 1) {
+    announcement.value = returned
+      ? `Cleared ${cleared} decisions; ${returned} ${returned === 1 ? "group is" : "groups are"} back in the review queue.`
+      : `Cleared ${cleared} decisions. The groups return to the queue after the next scan.`;
+    return;
+  }
+  announcement.value = returned
+    ? "Decision cleared. The group is back in the review queue."
+    : "Decision cleared. The group returns to the queue after the next scan.";
+}
+
+/**
+ * The server's own explanation for a refusal, when it gave one.
+ *
+ * A dedup verdict is refused for reasons the user can act on ("a stack needs at
+ * least two pictures", a locked set), and a generic "could not stack that
+ * group" hides every one of them behind the same sentence. FastAPI puts the
+ * reason in `detail`; anything else is not a message worth quoting.
+ *
+ * @param {*} err - the rejection the store recorded.
+ * @returns {string} the server's sentence, or the empty string.
+ */
+function serverDetail(err) {
+  const detail = err?.response?.data?.detail;
+  if (typeof detail !== "string") return "";
+  const text = detail.trim();
+  if (!text) return "";
+  return /[.!?]$/.test(text) ? text : `${text}.`;
+}
+
+/**
+ * Say so when a verdict did not land.
+ *
+ * A failed verdict leaves the row exactly where it was, which on a queue whose
+ * whole promise is auto-advance reads as a dead keypress. It has to be a
+ * notice, not just a live-region line: the user is looking at the row, not
+ * listening. When the server said why, that sentence is carried through
+ * verbatim rather than being flattened into this function's generic one.
+ *
+ * @param {string} what - the attempt, phrased to follow "could not".
+ * @param {*} [err] - the rejection, for its `detail`.
+ */
+function reportVerdictFailure(what, err) {
+  const detail = serverDetail(err);
+  const because = detail ? ` ${detail}` : "";
+  announcement.value = `Could not ${what}.${because} The group is still in the queue, so nothing was lost.`;
+  noticeStore.error(
+    `Could not ${what}.${because} The group is still in the queue, so you can try again.`,
+  );
+}
+
+function onCompareStack() {
+  const group = store.focusedGroup;
+  compareOpen.value = false;
+  if (group) onStack(group);
+}
+
+function onCompareKeepSeparate() {
+  const group = store.focusedGroup;
+  compareOpen.value = false;
+  if (group) onKeepSeparate(group);
+}
+
+/**
+ * Drop the scope and say so.
+ *
+ * The list underneath is replaced wholesale, so silence here would leave a
+ * screen-reader user with a cursor on a group they were never told about.
+ */
+async function onDismissScope() {
+  await store.clearScope();
+  announcement.value =
+    "Showing duplicates from the whole library, starting at the first group.";
+  rootEl.value?.focus?.();
+}
+
+function toggleTierMenu() {
+  tierMenuOpen.value ? closeTierMenu() : (tierMenuOpen.value = true);
+}
+
+/**
+ * Dismiss the tier popover and put the focus back on the control that opened
+ * it, so the keyboard never has to hunt for where it went.
+ */
+function closeTierMenu() {
+  if (!tierMenuOpen.value) return;
+  tierMenuOpen.value = false;
+  tierButtonEl.value?.focus?.();
+}
+
+/** A pointer press anywhere outside the popover dismisses it. */
+function onDocumentPointerDown(event) {
+  if (!tierMenuOpen.value) return;
+  if (tierWrapEl.value?.contains?.(event.target)) return;
+  tierMenuOpen.value = false;
+}
+
+/**
+ * What `Escape` means in the queue.
+ *
+ * A popover first, because that is the thing on top. Otherwise it hands the
+ * DOM focus back to the queue itself, which is the way out of a row's buttons
+ * without tabbing through the rest of them.
+ */
+function onEscape() {
+  if (tierMenuOpen.value) {
+    closeTierMenu();
+    return;
+  }
+  // The selection is the next thing "on top": clearing it must not also cost
+  // the user their place, so the focus stays where it is.
+  if (store.selectionCount > 0) {
+    store.clearSelection();
+    return;
+  }
+  rootEl.value?.focus?.();
+}
+
+/**
+ * A row click chooses; a modified row click SELECTS.
+ *
+ * Ctrl (or Cmd) toggles the group in and out of the multi-selection,
+ * Shift extends the range from the anchor, and a plain click focuses the row
+ * and drops any selection — exactly the grid's own conventions, so nothing
+ * new has to be learned here.
+ *
+ * @param {number} index
+ * @param {MouseEvent} [event] - absent when a row control re-emits focus.
+ */
+function onRowFocus(index, event) {
+  // A row control re-emitting focus (a cover click, an exclusion toggle)
+  // carries no event: it must move the cursor without costing the selection.
+  if (!event) {
+    store.setFocus(index);
+    return;
+  }
+  if (event.shiftKey) {
+    store.selectRange(index);
+    return;
+  }
+  if (event.ctrlKey || event.metaKey) {
+    store.toggleSelected(index);
+    return;
+  }
+  store.setFocus(index);
+  store.clearSelection();
+}
+
+/**
+ * Move the tier gate. The store reloads the queue, so the menu closes: leaving
+ * it open over a list that just changed underneath reads as a glitch.
+ */
+async function onTierToggle(id, on) {
+  closeTierMenu();
+  await store.setTierEnabled(id, on);
+}
+
+/**
+ * Move the similarity threshold.
+ *
+ * The popover stays open: a threshold is a value the user tunes and re-reads
+ * against the count next to it, unlike a tier switch, which is a decision they
+ * make once and then want to see the result of.
+ */
+async function onThresholdChange(value) {
+  await store.setThreshold(value);
+}
+
+/** Open the bulk dialog on its dry run, so the preview is never stale. */
+async function openAutoStack() {
+  autoStackOpen.value = true;
+  autoStackLoading.value = true;
+  autoStackPreviewFailed.value = false;
+  const preview = await store.previewAutoStack();
+  autoStackPreview.value = preview;
+  // A failed dry run must not render as a confident row of zeroes: that reads
+  // as "there is nothing to stack" when the truth is "nobody asked".
+  autoStackPreviewFailed.value = !preview;
+  autoStackLoading.value = false;
+}
+
+async function confirmAutoStack() {
+  const result = await store.runAutoStack();
+  autoStackOpen.value = false;
+  if (result?.batch_id) {
+    const made = Number(result.groups ?? 0).toLocaleString();
+    announcement.value = `Created ${made} stacks. Undo reverses the whole run in one step.`;
+    // One unstackable group never aborts the run, so a partial result has to be
+    // reported rather than hidden behind a success message.
+    const skipped = result.failures?.length ?? 0;
+    if (skipped) {
+      noticeStore.warning(
+        `Created ${made} stacks. ${skipped} ${skipped === 1 ? "group was" : "groups were"} skipped and stayed in the queue.`,
+      );
+    }
+  } else {
+    reportVerdictFailure("create those stacks", store.error);
+  }
+  rootEl.value?.focus?.();
+}
+
+const compareRef = ref(null);
+
+const onKeydown = createDedupKeyHandler({
+  store,
+  isCompareOpen: () => compareOpen.value,
+  openCompare: () => {
+    if (store.focusedGroup) compareOpen.value = true;
+  },
+  closeCompare,
+  undo: () => operationStore.undo(),
+  isReadOnly: () => readOnly.value,
+  isBlocked: () => autoStackOpen.value || tierMenuOpen.value,
+  onEscape,
+  onExclusionRefused: () => {
+    announcement.value = STACK_FLOOR_NOTICE;
+  },
+  // The blink compare's state lives in the dialog; its KEYS live in the one
+  // keyboard model, driven through the dialog's exposed surface.
+  zoom: {
+    isOpen: () => Boolean(compareRef.value?.isZoomOpen?.()),
+    open: () => compareRef.value?.openZoom?.(),
+    close: () => compareRef.value?.closeZoom?.(),
+    flip: (delta) => compareRef.value?.flipZoom?.(delta),
+    to: (index) => compareRef.value?.zoomTo?.(index),
+    togglePixels: () => compareRef.value?.toggleZoomPixels?.(),
+  },
+});
+
+// Compare renders through the shared dialog, which teleports out of this
+// subtree and moves the focus into itself. Its keys therefore never bubble back
+// to the queue root, so the model's Compare branch is bound at the document for
+// exactly as long as the dialog is up. Keys the root handler claims stop
+// propagating there, so nothing is handled twice.
+watch(compareOpen, (open) => {
+  if (typeof document === "undefined") return;
+  if (open) document.addEventListener("keydown", onKeydown);
+  else document.removeEventListener("keydown", onKeydown);
+});
+
+/**
+ * Read the scope out of the URL.
+ *
+ * The scope lives in the query rather than in a store so a scoped queue is a
+ * link that survives a reload. `useViewStore.parseRouteView` deliberately
+ * returns `null` for this route (it drives no grid), so opening the queue is
+ * this component's own job rather than something the route sync does for it.
+ *
+ * @returns {Object} the `openQueue` scope argument.
+ */
+function scopeFromRoute() {
+  const query = route.query ?? {};
+  return {
+    type: query.scope ? String(query.scope) : "global",
+    id: query.scope_id ?? null,
+    label: query.scope_label ? String(query.scope_label) : "",
+    icon: query.scope_icon ? String(query.scope_icon) : "",
+  };
+}
+
+/**
+ * The filter selection the URL carries, or null when it carries none.
+ *
+ * Each key is applied only when present, so a bare /duplicates URL keeps the
+ * server's defaults rather than forcing everything off.
+ *
+ * @returns {Object|null}
+ */
+function filtersFromRoute() {
+  const query = route.query ?? {};
+  const filters = {};
+  if (query.near !== undefined) {
+    filters.near = query.near === "1" || query.near === "true";
+  }
+  if (query.embedding !== undefined) {
+    filters.embedding = query.embedding === "1" || query.embedding === "true";
+  }
+  const parsed = Number(query.threshold);
+  if (Number.isFinite(parsed)) filters.threshold = parsed;
+  if (query.view !== undefined) filters.decided = query.view === "decided";
+  return Object.keys(filters).length ? filters : null;
+}
+
+// The filter selection is part of the ADDRESS: a full refresh (or a shared
+// link) must restore it. Mirrored with replace(), never push() — tuning the
+// tier gate is not a history step the Back button should have to unwind.
+// Non-default tier/threshold values are written explicitly (near=0 included):
+// "absent" always means "the server's default", never "whatever it was".
+const FILTER_QUERY_KEYS = ["near", "embedding", "threshold", "view"];
+
+watch(
+  () => [
+    store.nearEnabled,
+    store.embeddingEnabled,
+    store.threshold,
+    store.showingDecided,
+    store.policyLoaded,
+  ],
+  () => {
+    if (route.name !== "duplicates" || !store.policyLoaded) return;
+    const defaults = store.policyDefaults ?? {};
+    const next = { ...route.query };
+    for (const key of FILTER_QUERY_KEYS) delete next[key];
+    const isDefault =
+      store.nearEnabled === Boolean(defaults.near_enabled) &&
+      store.embeddingEnabled === Boolean(defaults.embedding_enabled) &&
+      (!Number.isFinite(store.threshold) ||
+        store.threshold === Number(defaults.threshold));
+    if (!isDefault) {
+      next.near = store.nearEnabled ? "1" : "0";
+      next.embedding = store.embeddingEnabled ? "1" : "0";
+      if (Number.isFinite(store.threshold)) {
+        next.threshold = String(store.threshold);
+      }
+    }
+    if (store.showingDecided) next.view = "decided";
+    const current = route.query ?? {};
+    const same = FILTER_QUERY_KEYS.every(
+      (key) => (next[key] ?? null) === (current[key] ?? null),
+    );
+    if (!same) router.replace({ query: next });
+  },
+);
+
+/**
+ * Open the queue for the URL's scope, unless it is already showing it.
+ *
+ * The already-showing path still refreshes the counts. The badge is the one
+ * piece of state that outlives this view, a keep-separate raises no WebSocket
+ * event to correct it, and arriving at the destination is exactly the moment
+ * its number has to be true.
+ */
+function syncQueueToRoute() {
+  const scope = scopeFromRoute();
+  const alreadyShowing =
+    String(store.scopeType) === scope.type &&
+    String(store.scopeId ?? "") === String(scope.id ?? "");
+  if (alreadyShowing && store.groups.length) {
+    store.refreshCounts();
+    return;
+  }
+  store.openQueue({ ...scope, filters: filtersFromRoute() });
+}
+
+// A scope change is a navigation, not a remount: the component stays mounted
+// when the user picks "Find duplicates in..." on a second collection.
+watch(() => [route.query.scope, route.query.scope_id], syncQueueToRoute);
+
+onMounted(() => {
+  syncQueueToRoute();
+  // The queue is a keyboard surface. Taking focus on mount is what makes the
+  // first Enter work without the user hunting for a click target first.
+  rootEl.value?.focus?.();
+  nextTick(measureRowPitch);
+  prefetchNextGroup();
+  if (typeof document !== "undefined") {
+    document.addEventListener("mousedown", onDocumentPointerDown);
+  }
+});
+
+onBeforeUnmount(() => {
+  if (typeof document === "undefined") return;
+  document.removeEventListener("mousedown", onDocumentPointerDown);
+  document.removeEventListener("keydown", onKeydown);
+});
+
+defineExpose({ windowedGroups, tierLabel });
+</script>
+
+<style scoped>
+.dq {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  position: relative;
+  background: rgb(var(--v-theme-background));
+  color: rgb(var(--v-theme-on-background));
+  outline: none;
+}
+
+.dq-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: var(--bar-height);
+  padding: var(--space-2) var(--space-5);
+  background: rgb(var(--v-theme-toolbar));
+  color: rgb(var(--v-theme-toolbar-text));
+  border-bottom: 1px solid rgb(var(--v-theme-divider));
+}
+
+.dq-tb-left,
+.dq-tb-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.dq-tb-right {
+  margin-left: auto;
+}
+
+.dq-tier-wrap {
+  position: relative;
+}
+
+.dq-tier-menu {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  left: 0;
+  z-index: var(--z-dropdown);
+}
+
+.dq-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  height: 27px;
+  padding: 0 var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid rgb(var(--v-theme-border));
+  background: transparent;
+  color: inherit;
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: background var(--dur-1) var(--ease-standard);
+}
+
+.dq-btn:hover {
+  background: var(--hover-wash);
+}
+
+.dq-btn:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+.dq-btn--accent {
+  background: rgb(var(--v-theme-accent));
+  border-color: rgb(var(--v-theme-accent));
+  color: rgb(var(--v-theme-on-accent));
+}
+
+.queue {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+.qhead {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  padding: var(--space-3) var(--space-5);
+}
+
+.qtitle {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+}
+
+.qsub,
+.khint {
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-background), 0.6);
+}
+
+.qsp {
+  flex: 1;
+}
+
+/* The Decided toggle: same chrome as the toolbar buttons, pressed state
+   while the flip side is showing. */
+.qdecided {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid rgb(var(--v-theme-border));
+  border-radius: var(--radius-md);
+  background: transparent;
+  font-size: var(--text-xs);
+  font-family: var(--font-ui);
+  color: rgba(var(--v-theme-on-background), 0.75);
+  cursor: pointer;
+  transition: background var(--dur-1) var(--ease-standard);
+}
+
+.qdecided:hover {
+  background: var(--hover-wash);
+}
+
+.qdecided:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.qdecided--on {
+  background: var(--active-wash);
+  border-color: rgba(var(--v-theme-accent), 0.5);
+  color: rgb(var(--v-theme-on-surface));
+}
+
+/* The bulk-scope chip: accent-washed so it reads as state, not decoration —
+   while it shows, a verdict on any selected row takes the whole selection. */
+.qselchip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid rgba(var(--v-theme-accent), 0.5);
+  border-radius: var(--radius-pill);
+  background: var(--active-wash);
+  font-size: var(--text-xs);
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.qselclear {
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  font-weight: var(--weight-semibold);
+  color: rgb(var(--v-theme-accent));
+  cursor: pointer;
+}
+
+.qselclear:focus-visible {
+  outline: none;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--focus-ring);
+}
+
+.khint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+kbd {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(var(--v-theme-on-background), 0.3);
+}
+
+.qlist {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: 0 var(--space-5) var(--space-6);
+  overflow-y: auto;
+  min-height: 0;
+  flex: 1;
+  scrollbar-gutter: stable;
+}
+
+.qspacer {
+  flex: 0 0 auto;
+}
+
+.dq-state {
+  padding: var(--space-6) var(--space-5);
+  font-size: var(--text-sm);
+  color: rgba(var(--v-theme-on-background), 0.6);
+}
+
+.qdone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  flex: 1;
+  padding: var(--space-9) var(--space-6);
+  text-align: center;
+  color: rgba(var(--v-theme-on-background), 0.75);
+}
+
+.qdone h3 {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: rgb(var(--v-theme-on-background));
+}
+
+.qdone p {
+  margin: 0;
+  max-width: 52ch;
+  font-size: var(--text-sm);
+  line-height: var(--leading-body);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+</style>

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -58,6 +58,7 @@
       @comfyui-run-grid="runComfyuiOnGridImages"
       @expand-all-stacks="expandAllStacks"
       @collapse-all-stacks="collapseAllStacks"
+      @open-duplicates="emit('open-duplicates')"
       @open-settings="emit('open-settings')"
       @open-import="emit('open-import')"
       @local-import="emit('local-import', $event)"
@@ -817,7 +818,32 @@
                 class="stack-band-overlay"
                 :style="getStackBandStyle(img)"
               ></div>
-              <!-- Top-right hover badges: stars + stack indicator -->
+              <!-- The stack count and the deck edges are permanent, not
+                   hover-only: how many pictures a tile stands for is a fact
+                   about the tile, and hiding it until hover is what made stacks
+                   invisible while browsing. -->
+              <StackEdgeTicks
+                v-if="shouldShowStackBadge(img)"
+                :count="getStackBadgeCount(img)"
+              />
+              <!-- Once a stack is expanded its members look like any other
+                   picture, so the one that the collapsed tile stands for has to
+                   say so. Without this, expanding a stack loses the answer to
+                   "which of these is the keeper". -->
+              <span
+                v-if="isExpandedStackCover(img)"
+                class="stack-cover-flag"
+                title="This picture is the stack's cover"
+                >Cover</span
+              >
+              <!-- Top-right badge column — the shared home for corner
+                   indicators (stars above, stack count below, right-aligned,
+                   2px gap). The stars are hover-only; the stack count is
+                   PERMANENT — how many pictures a tile stands for is a fact
+                   about the tile, and hiding it until hover is what made
+                   stacks invisible while browsing. The hover behaviour
+                   therefore lives on the container's other children, not the
+                   container. -->
               <div
                 v-if="isThumbnailReady(img.id) && img.thumbnail"
                 class="thumbnail-top-right-badges"
@@ -833,19 +859,12 @@
                   :compact="true"
                   @set-score="setScore(img, $event)"
                 />
-                <div
+                <StackBadge
                   v-if="shouldShowStackBadge(img)"
-                  class="stack-indicator"
-                  :title="stackBadgeTitle(img)"
-                  @click.stop="toggleStackExpand(img)"
+                  :count="getStackBadgeCount(img)"
+                  @activate="toggleStackExpand(img)"
                   @mouseenter.stop="prefetchStackMembers(img)"
-                >
-                  <v-icon
-                    :size="badgeIconSizes.stack"
-                    :style="getStackBadgeIconStyle(img)"
-                    >mdi-layers-outline</v-icon
-                  >
-                </div>
+                />
               </div>
             </div>
           </div>
@@ -1086,6 +1105,8 @@ import ActionReceipt from "../widgets/ActionReceipt.vue";
 import ImageGridContextMenu from "../widgets/ImageGridContextMenu.vue";
 import SearchResultBar from "../widgets/SearchResultBar.vue";
 import StarRatingOverlay from "../widgets/StarRatingOverlay.vue";
+import StackBadge from "../widgets/StackBadge.vue";
+import StackEdgeTicks from "../widgets/StackEdgeTicks.vue";
 import ComfyUiRunner from "../io/ComfyUiRunner.vue";
 import RemixDialog from "../io/RemixDialog.vue";
 import ProgressOverlay from "../widgets/ProgressOverlay.vue";
@@ -1155,7 +1176,6 @@ import {
   getStackPositionValue,
   selectNewestStackMember,
   shouldShowStackBadge,
-  stackBadgeTitle,
 } from "../../utils/stack.js";
 import { useVirtualScroll } from "../../composables/useVirtualScroll.js";
 import {
@@ -1190,6 +1210,7 @@ const emit = defineEmits([
   "load-sort-changed",
   "flag-sort-changed",
   "open-settings",
+  "open-duplicates",
   "open-import",
   "local-import",
   "confirm-export-zip",
@@ -1264,6 +1285,8 @@ const props = defineProps({
   tagConfidenceBelowFilter: { type: Array, default: () => [] },
   faceBboxFilter: { type: String, default: null },
   impossibleSources: { type: Array, default: () => [] },
+  // "all" | "stacked" | "unstacked" | "unresolved"
+  stackStateFilter: { type: String, default: "all" },
   sharedOnlyFilter: { type: Boolean, default: false },
   unassignedOnlyFilter: { type: Boolean, default: false },
   columns: { type: Number, required: true },
@@ -1439,6 +1462,19 @@ const badgeCssVars = computed(() => {
     "--badge-padding": `${paddingV}px ${paddingH}px`,
   };
 });
+
+/**
+ * Whether this tile is the cover of a stack the user has expanded.
+ *
+ * Only meaningful while the stack is expanded: collapsed, the cover IS the
+ * tile, so flagging it would be noise.
+ *
+ * @param {Object} img
+ * @returns {boolean}
+ */
+function isExpandedStackCover(img) {
+  return isStackExpandedForImage(img) && getStackPositionValue(img) === 0;
+}
 
 const badgeIconSizes = computed(() => {
   const t = badgeSizeT.value;
@@ -4973,7 +5009,6 @@ const {
   showRemoveFromStack,
   mapGridImages,
   getStackCardStyle,
-  getStackBadgeIconStyle,
   getStackBandStyle,
   isStackExpandedForImage,
   rebuildGridImagesFromLastFetch,
@@ -6036,6 +6071,7 @@ watch(
     () => props.tagConfidenceBelowFilter,
     () => props.faceBboxFilter,
     () => props.impossibleSources,
+    () => props.stackStateFilter,
     () => props.sharedOnlyFilter,
     () => props.unassignedOnlyFilter,
   ],
@@ -7729,7 +7765,7 @@ function handleEmptyStateReset() {
 
 /* Lock badge: styled as a sibling of the problem indicator — no scrim, zero
    padding, same left edge and inset. See the shared
-   `.penalised-tag-indicator, .stack-indicator, .thumbnail-lock-badge` rules
+   `.penalised-tag-indicator, .thumbnail-lock-badge` rules
    below, which it joins rather than restating. */
 
 .thumbnail-share-badge {
@@ -8097,7 +8133,10 @@ function handleEmptyStateReset() {
 /* Suppress all hover-revealed elements in touch-select mode */
 .touch-select-mode .image-card:hover .resolution-hover-overlay,
 .touch-select-mode .image-card:hover .thumbnail-id-overlay,
-.touch-select-mode .image-card:hover .thumbnail-top-right-badges {
+.touch-select-mode .image-card:hover .thumbnail-top-right-badges > *,
+/* The permanent stack badge must also clear the corner for the ✓ that a
+   touch-selection stamps at top-right. */
+.touch-select-mode .image-card:has(.selection-overlay) .thumbnail-top-right-badges > * {
   opacity: 0 !important;
   pointer-events: none !important;
 }
@@ -8418,7 +8457,6 @@ function handleEmptyStateReset() {
    Icon size is already shared: both bind `badgeIconSizes.penalised`, so they
    track each other at every column count. */
 .penalised-tag-indicator,
-.stack-indicator,
 .thumbnail-lock-badge {
   display: flex;
   align-items: center;
@@ -8439,8 +8477,22 @@ function handleEmptyStateReset() {
   filter: drop-shadow(0 0 1.5px rgba(0, 0, 0, 0.55));
 }
 
-.stack-indicator {
-  cursor: pointer;
+/* Bottom-left, on the photo scrim: the same corner and the same backing the
+   grid's other permanent chips use, so it reads as one family. */
+.stack-cover-flag {
+  position: absolute;
+  bottom: var(--space-2);
+  left: var(--space-2);
+  z-index: var(--z-raised);
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--scrim-photo);
+  color: rgb(var(--v-theme-on-dark-surface));
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  pointer-events: none;
 }
 
 .stack-band-overlay {
@@ -8474,12 +8526,19 @@ function handleEmptyStateReset() {
   align-items: flex-end;
   gap: 2px;
   z-index: 120;
+  pointer-events: none;
+}
+
+/* Hover-only members of the badge column (the stars). The stack badge
+   (.sbadge) is exempt on purpose: the count is permanent. The opacity lives on
+   the CHILDREN, not the container, precisely so one column can hold both. */
+.thumbnail-top-right-badges > :not(.sbadge) {
   opacity: 0;
   transition: opacity 0.15s ease;
   pointer-events: none;
 }
 
-.image-card:hover .thumbnail-top-right-badges {
+.image-card:hover .thumbnail-top-right-badges > :not(.sbadge) {
   opacity: 1;
   pointer-events: auto;
 }

--- a/frontend/src/components/views/ImageOverlay.vue
+++ b/frontend/src/components/views/ImageOverlay.vue
@@ -645,6 +645,7 @@
             :locked="isCurrentLocked"
             :lock-note="currentLockReason"
             @update-description="handleDescriptionUpdate"
+            @editing-finished="focusOverlayCanvas"
           />
 
           <div class="sidebar-section sidebar-section--faces">
@@ -2084,13 +2085,14 @@ function handleKeydown(e) {
 
   // Undo / redo, handled HERE rather than by App's global binding.
   //
-  // This handler is registered in ImageOverlay's own `onMounted`, and a child
-  // mounts before its parent, so it runs before App's window listener — and it
-  // calls `stopImmediatePropagation()` above. App's `Ctrl+Z` therefore never
-  // sees a keystroke while the lightbox is open, no matter what its own guards
-  // say. The owner ruled that undo must work here anyway, fitted to the
-  // lightbox's own GUI: `OverlayActionReceipt` narrates the result inside the
-  // overlay chrome, so the action is never taken blind.
+  // App's handler stands down while `.image-overlay` is in the DOM (an
+  // explicit guard at its top). Do NOT rely on the stopImmediatePropagation()
+  // above to silence it: that only works when this listener registered first,
+  // and the Duplicates view's grid remount re-registers this one LAST — that
+  // ordering flip is exactly how one Ctrl+Z once ran two undos. The owner
+  // ruled that undo must work here, fitted to the lightbox's own GUI:
+  // `OverlayActionReceipt` narrates the result inside the overlay chrome, so
+  // the action is never taken blind.
   //
   // Above the `chromeHidden` bail on purpose. The narration is a transient HUD
   // like the progress cards and the swipe hint, none of which hide with the
@@ -3258,10 +3260,13 @@ async function fetchOverlayMetadata(imageId) {
     if (data.tags !== undefined) {
       merged.tags = dedupeTagList(dataTags);
     }
-    if (
-      image.value?.description == null ||
-      image.value.description.startsWith("__description::")
-    ) {
+    if (data.description !== undefined) {
+      // The server is authoritative for the description, same reasoning as
+      // smartScore above: this fetch is how an undo/redo (whose WS
+      // descriptions_changed event triggers it) reaches an open overlay, and
+      // the old local-wins rule kept the field stale until reopen. The one
+      // race — a fetch that left before a local save — is closed at the
+      // source: handleDescriptionUpdate invalidates in-flight requests.
       merged.description = data.description ?? null;
     }
     const currentMeta = image.value?.metadata;
@@ -3756,7 +3761,16 @@ function getOverlayBoxStyle(bbox, color) {
   };
 }
 
+/** Return the keyboard to the overlay once a sidebar edit ends. */
+function focusOverlayCanvas() {
+  overlayCanvasRef.value?.focus?.();
+}
+
 function handleDescriptionUpdate(imageId, newDescription) {
+  // Invalidate any in-flight metadata fetch: it left before this save and
+  // would land carrying the pre-save description, which the merge below now
+  // treats as authoritative.
+  metadataRequestId += 1;
   if (image.value && image.value.id === imageId) {
     image.value = { ...image.value, description: newDescription };
   }

--- a/frontend/src/components/views/OverlayDescriptionPanel.test.js
+++ b/frontend/src/components/views/OverlayDescriptionPanel.test.js
@@ -1,0 +1,95 @@
+// OverlayDescriptionPanel — ending an edit returns the keyboard to the overlay.
+//
+// The regression this pins: after Enter saved the description (or Escape
+// cancelled the edit), the textarea kept DOM focus, so the overlay's Ctrl+Z —
+// which rightly defers to typing targets — stayed dead until a click. Ending
+// an edit must blur the field and tell the parent, which refocuses its canvas.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+
+const patchPicture = vi.fn();
+const resetPictureDescription = vi.fn();
+const listTaggers = vi.fn();
+
+vi.mock("../../api/pictures", () => ({
+  patchPicture: (...a) => patchPicture(...a),
+  resetPictureDescription: (...a) => resetPictureDescription(...a),
+}));
+
+vi.mock("../../api/taggers", () => ({
+  listTaggers: (...a) => listTaggers(...a),
+}));
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref } = await import("vue");
+  return { isReadOnly: ref(false) };
+});
+
+vi.mock("vuetify/components", () => ({
+  VIcon: { name: "v-icon", template: "<i><slot /></i>" },
+  VProgressCircular: { name: "v-progress-circular", template: "<i></i>" },
+}));
+
+import OverlayDescriptionPanel from "./OverlayDescriptionPanel.vue";
+
+const IMAGE = { id: 7, description: "a quiet harbour" };
+
+function mountPanel(props = {}) {
+  return mount(OverlayDescriptionPanel, {
+    props: { image: IMAGE, backendUrl: "http://b.test", ...props },
+    attachTo: document.body,
+  });
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.clearAllMocks();
+  patchPicture.mockResolvedValue({});
+  listTaggers.mockResolvedValue([]);
+});
+
+describe("OverlayDescriptionPanel — ending an edit", () => {
+  it("saves on Enter, blurs the field and signals editing-finished", async () => {
+    const w = mountPanel();
+    const area = w.find("textarea");
+    await area.trigger("focus");
+    expect(w.vm.isEditingDescription).toBe(true);
+
+    await area.setValue("a louder harbour");
+    await area.trigger("keydown.enter");
+    await Promise.resolve();
+    await w.vm.$nextTick();
+
+    expect(patchPicture).toHaveBeenCalledWith(
+      7,
+      { description: "a louder harbour" },
+      expect.anything(),
+    );
+    expect(w.emitted("update-description")).toBeTruthy();
+    expect(w.emitted("editing-finished")).toBeTruthy();
+    expect(document.activeElement).not.toBe(area.element);
+  });
+
+  it("cancel blurs the field and signals editing-finished too", async () => {
+    const w = mountPanel();
+    const area = w.find("textarea");
+    await area.trigger("focus");
+    w.vm.cancelEditDescription();
+    await w.vm.$nextTick();
+
+    expect(w.emitted("editing-finished")).toBeTruthy();
+    expect(w.vm.isEditingDescription).toBe(false);
+    expect(document.activeElement).not.toBe(area.element);
+  });
+
+  it("adopts an external description change while not editing", async () => {
+    // This is the panel half of undo/redo reaching an open overlay: the
+    // parent refetches metadata and the prop moves; the field must follow.
+    const w = mountPanel();
+    await w.setProps({ image: { id: 7, description: "restored text" } });
+    await w.vm.$nextTick();
+    expect(w.find("textarea").element.value).toBe("restored text");
+  });
+});

--- a/frontend/src/components/views/OverlayDescriptionPanel.vue
+++ b/frontend/src/components/views/OverlayDescriptionPanel.vue
@@ -171,7 +171,7 @@ const props = defineProps({
 // read-only.
 const readOnly = computed(() => isReadOnly.value || props.locked);
 
-const emit = defineEmits(["update-description"]);
+const emit = defineEmits(["update-description", "editing-finished"]);
 
 const descriptionCollapsed = ref(false);
 const isEditingDescription = ref(false);
@@ -223,6 +223,11 @@ function cancelEditDescription() {
   isSavingDescription.value = false;
   descriptionDraft.value =
     formatDescriptionSentinel(props.image?.description) || "";
+  // Editing is over, so the keyboard must leave the field: a textarea that
+  // keeps DOM focus after Escape still reads as a typing target, and the
+  // overlay's Ctrl+Z (and every other shortcut) stays dead until a click.
+  descriptionEditorRef.value?.blur?.();
+  emit("editing-finished");
 }
 
 async function saveDescription() {
@@ -237,6 +242,10 @@ async function saveDescription() {
     });
     emit("update-description", capturedImageId, newDescription);
     isEditingDescription.value = false;
+    // Same contract as cancel: a save ends the edit, so the keyboard goes
+    // back to the overlay (the parent refocuses its canvas on this signal).
+    descriptionEditorRef.value?.blur?.();
+    emit("editing-finished");
   } catch (err) {
     console.error("Failed to update description", err);
     noticeStore.error(

--- a/frontend/src/components/widgets/ActionReceipt.test.js
+++ b/frontend/src/components/widgets/ActionReceipt.test.js
@@ -199,6 +199,19 @@ describe("ActionReceipt — pause on hover and focus (WCAG 2.2.1)", () => {
     expect(store.receipt).toBeNull();
   });
 
+  it("releases a held pause when the surface unmounts mid-hover", async () => {
+    // The regression this pins: a view change under the pointer unmounted the
+    // pill while paused, no mouseleave ever fired, and the frozen receipt
+    // survived in the store to resurface on whichever surface rendered next.
+    const { store, wrapper } = mountWith(op());
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find(".receipt").trigger("mouseenter");
+    wrapper.unmount();
+    vi.advanceTimersByTime(60000);
+    expect(store.receipt).toBeNull();
+  });
+
   it("freezes the countdown while focus is inside the pill", async () => {
     const { store, wrapper } = mountWith(op());
     await wrapper.vm.$nextTick();

--- a/frontend/src/components/widgets/AppDialog.vue
+++ b/frontend/src/components/widgets/AppDialog.vue
@@ -1,14 +1,19 @@
 <template>
   <v-dialog
     :model-value="open"
-    :max-width="width"
+    :max-width="fullscreen ? undefined : width"
     :scrim="true"
     :persistent="persistent"
     transition="dialog-bottom-transition"
     @update:model-value="(v) => !v && emit('close')"
     @click:outside="emit('close')"
   >
-    <div class="app-dialog" :style="{ width: width + 'px' }" @keydown="onKeydown">
+    <div
+      class="app-dialog"
+      :class="{ 'app-dialog--fullscreen': fullscreen }"
+      :style="fullscreen ? undefined : { width: width + 'px' }"
+      @keydown="onKeydown"
+    >
       <header class="app-dialog__header">
         <div class="app-dialog__titlewrap">
           <h2 class="app-dialog__title">{{ title }}</h2>
@@ -53,6 +58,9 @@ const props = defineProps({
   // dialog where the nav rail and content own their own padding.
   padBody: { type: Boolean, default: true },
   persistent: { type: Boolean, default: false },
+  // Near-viewport-sized dialog for working surfaces (Compare) where the
+  // content is the point and a fixed width would waste the screen.
+  fullscreen: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(["close", "accept"]);
@@ -174,6 +182,20 @@ function onKeydown(e) {
 .app-dialog__body {
   overflow-y: auto;
   padding: var(--space-6);
+}
+
+/* A working surface, not a form: take (nearly) the whole viewport and let the
+   body flex, so the content decides its own internal scrolling. */
+.app-dialog--fullscreen {
+  width: min(1800px, 96vw);
+  height: 94vh;
+}
+
+.app-dialog--fullscreen .app-dialog__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .app-dialog__body--flush {

--- a/frontend/src/components/widgets/DedupAutoStackDialog.test.js
+++ b/frontend/src/components/widgets/DedupAutoStackDialog.test.js
@@ -1,0 +1,188 @@
+// The auto-stack dialog is the single consent for a bulk change, so these tests
+// pin what the user is promised before they give it: the full row list
+// including the zero deletions, a stable layout while the dry run lands, and a
+// confirm button that cannot fire on numbers nobody has seen.
+
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import DedupAutoStackDialog from "./DedupAutoStackDialog.vue";
+import AppButton from "./AppButton.vue";
+
+const AppDialogStub = {
+  name: "AppDialog",
+  template:
+    "<div><slot name='header-right'/><slot/><slot name='footer'/></div>",
+};
+
+const globalOpts = {
+  global: { stubs: { "v-icon": true, AppDialog: AppDialogStub } },
+};
+
+// The backend's dry-run report. Every figure about the run rides in
+// `dry_run_summary`, derived from one read of one group list so the rows cannot
+// disagree with each other. `groups_by_tier` counts only what the run would act
+// on (exact-only), so the "left in the queue" figure is deliberately a separate
+// prop fed from the counts endpoint's per-tier split.
+const SUMMARY = {
+  groups: 1240,
+  groups_by_tier: { exact: 1240, near: 0, embedding: 0 },
+  pictures: 2600,
+  covers_gaining_tags: 300,
+  covers_gaining_score: 120,
+  covers_gaining_metadata: 318,
+};
+
+const PREVIEW = {
+  dry_run: true,
+  groups: 1240,
+  pictures: 2600,
+  dry_run_summary: SUMMARY,
+  failures: [],
+};
+
+function mountDialog(props = {}) {
+  return mount(DedupAutoStackDialog, {
+    ...globalOpts,
+    props: { open: true, preview: PREVIEW, queueRemaining: 88, ...props },
+  });
+}
+
+/** The footer buttons, in render order: Cancel, Create N stacks. */
+function footerButtons(wrapper) {
+  return wrapper.findAllComponents(AppButton);
+}
+
+describe("DedupAutoStackDialog: the dry run", () => {
+  it("states the zero deletions out loud alongside the other counts", () => {
+    // "Nothing is deleted" is the invariant the whole feature rests on; hiding
+    // the row because it is zero is how the user stops believing it.
+    const rows = mountDialog().findAll(".as-row");
+    expect(rows).toHaveLength(5);
+    expect(rows[4].find(".as-term").text()).toContain("Files deleted");
+    expect(rows[4].find(".as-value").text()).toBe("0");
+    expect(rows[0].find(".as-value").text()).toBe((1240).toLocaleString());
+    expect(rows[1].find(".as-value").text()).toBe((2600).toLocaleString());
+  });
+
+  // The design promises this row, and it is the answer to the only real
+  // question a bulk stack raises: whether collapsing copies loses anything.
+  it("reports how many covers gain metadata from the copies", () => {
+    const rows = mountDialog().findAll(".as-row");
+    expect(rows[2].find(".as-term").text()).toContain(
+      "Covers gaining metadata",
+    );
+    expect(rows[2].find(".as-value").text()).toBe((318).toLocaleString());
+  });
+
+  // One read, one set of numbers. Taking the run's counts off the top level
+  // while the metadata row came from the summary is how two rows of the same
+  // dialog end up describing two different moments.
+  it("reads the run's counts from the dry-run summary, not the envelope", () => {
+    const rows = mountDialog({
+      preview: {
+        ...PREVIEW,
+        groups: 7,
+        pictures: 9,
+        dry_run_summary: SUMMARY,
+      },
+    }).findAll(".as-row");
+    expect(rows[0].find(".as-value").text()).toBe((1240).toLocaleString());
+    expect(rows[1].find(".as-value").text()).toBe((2600).toLocaleString());
+  });
+
+  // A server that predates the summary still gets a working dialog rather than
+  // a column of zeroes over a live Create button.
+  it("falls back to the envelope when no summary is served", () => {
+    const rows = mountDialog({
+      preview: { dry_run: true, groups: 12, pictures: 30, failures: [] },
+    }).findAll(".as-row");
+    expect(rows[0].find(".as-value").text()).toBe("12");
+    expect(rows[1].find(".as-value").text()).toBe("30");
+    expect(rows[2].find(".as-value").text()).toBe("0");
+  });
+
+  it("keeps every row in place while the dry run is in flight", () => {
+    // Swapping the rows for a spinner would resize the dialog and move the
+    // confirm button out from under the pointer when the counts land.
+    const rows = mountDialog({ preview: null, loading: true }).findAll(
+      ".as-row",
+    );
+    expect(rows).toHaveLength(5);
+    // The three rows the dry run reports go to placeholders; the queue count
+    // and the zero deletions are known without it and stay readable.
+    expect(rows.map((r) => r.find(".as-value").text())).toEqual([
+      "–",
+      "–",
+      "–",
+      "88",
+      "0",
+    ]);
+  });
+
+  it("spells the undo out in keycaps", () => {
+    const kbds = mountDialog().findAll(".as-reversible kbd");
+    expect(kbds.map((k) => k.text())).toEqual(["Ctrl", "Z"]);
+  });
+});
+
+describe("DedupAutoStackDialog: the confirmation", () => {
+  it("refuses to confirm before the counts land, or when there is nothing to stack", () => {
+    // Confirming during the dry run would act on numbers the user never saw.
+    const loading = footerButtons(
+      mountDialog({ preview: null, loading: true }),
+    )[1];
+    expect(loading.find("button").attributes("disabled")).toBeDefined();
+
+    const empty = footerButtons(
+      mountDialog({
+        preview: {
+          ...PREVIEW,
+          groups: 0,
+          dry_run_summary: {
+            ...SUMMARY,
+            groups: 0,
+            groups_by_tier: { exact: 0, near: 0, embedding: 0 },
+          },
+        },
+      }),
+    )[1];
+    expect(empty.find("button").attributes("disabled")).toBeDefined();
+  });
+
+  // A failed dry run and a genuinely empty one must not be the same screen: a
+  // column of zeroes reads as "there is nothing to stack" when the truth is
+  // "nobody was able to ask".
+  it("says so when the dry run could not be read", () => {
+    const wrapper = mountDialog({ preview: null, previewFailed: true });
+    expect(wrapper.find(".as-failed").exists()).toBe(true);
+    expect(
+      wrapper.findAll(".as-row").map((r) => r.find(".as-value").text()),
+    ).toEqual(["–", "–", "–", "88", "0"]);
+    expect(
+      footerButtons(wrapper)[1].find("button").attributes("disabled"),
+    ).toBeDefined();
+  });
+
+  it("stays quiet about failure on a dry run that worked", () => {
+    expect(mountDialog().find(".as-failed").exists()).toBe(false);
+  });
+
+  // The consent has to describe what the run actually does to the copies it
+  // collapses, or the user is agreeing to a word ("stack") rather than an
+  // outcome.
+  it("promises that the other copies and their metadata survive", () => {
+    const lede = mountDialog().find(".as-lede").text();
+    expect(lede).toContain("stays in your library");
+    expect(lede).toContain("moves onto the stack");
+  });
+
+  it("names the count it is about to create and emits the confirmation", () => {
+    const wrapper = mountDialog();
+    const button = footerButtons(wrapper)[1];
+    expect(button.text()).toContain(`Create ${(1240).toLocaleString()} stacks`);
+
+    button.find("button").trigger("click");
+    expect(wrapper.emitted("confirm")).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/widgets/DedupAutoStackDialog.vue
+++ b/frontend/src/components/widgets/DedupAutoStackDialog.vue
@@ -1,0 +1,307 @@
+<script setup>
+/**
+ * The one consent for bulk-stacking the exact-match tier.
+ *
+ * Usage:
+ *   <DedupAutoStackDialog
+ *     :open="autoStackOpen"
+ *     :preview="dryRun"
+ *     :loading="dryRunLoading"
+ *     :busy="autoStackRunning"
+ *     @close="autoStackOpen = false"
+ *     @confirm="runAutoStack"
+ *   />
+ *
+ * Byte-identical files need no judgment, so this dialog replaces per-group
+ * adjudication for the exact tier: one dry run, one confirmation, one undo
+ * step. The component is presentational: the parent owns the dry run, the real
+ * run and the API.
+ */
+import { computed } from "vue";
+import AppDialog from "./AppDialog.vue";
+import AppButton from "./AppButton.vue";
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  /**
+   * The dry-run report from `POST /dedup/auto-stack`:
+   * `{ dry_run, groups, pictures, scope, dry_run_summary, results, failures }`.
+   * `results` is empty for a dry run, by design.
+   *
+   * Every number this dialog renders about the run comes out of
+   * `dry_run_summary` — `{ groups, groups_by_tier, pictures,
+   * covers_gaining_tags, covers_gaining_score, covers_gaining_metadata }` —
+   * because the server derives the whole summary from one read of one group
+   * list, so its rows cannot disagree with each other the way two separate
+   * counts across a running scan can. The top-level `groups` / `pictures` are
+   * only used as a fallback for a server that predates the summary.
+   */
+  preview: { type: Object, default: null },
+  /**
+   * Unresolved groups in every tier this bulk action does NOT touch, from the
+   * counts endpoint's per-tier split.
+   *
+   * This one deliberately does not come from `dry_run_summary`. That summary's
+   * `groups_by_tier` counts the groups **this run would act on** (exact-only,
+   * zero-filled for the rest), so reading the queue's remainder out of it would
+   * render a confident zero. The remainder is a property of the queue, not of
+   * the run, and only `POST /dedup/counts` knows it.
+   */
+  queueRemaining: { type: Number, default: 0 },
+  /** True while the dry run is in flight. */
+  loading: { type: Boolean, default: false },
+  /**
+   * True when the dry run could not be read. Without this a failed preview and
+   * a genuinely empty one are the same screen: a column of zeroes and a
+   * disabled button, which says "there is nothing to stack" when the truth is
+   * "nobody was able to ask".
+   */
+  previewFailed: { type: Boolean, default: false },
+  /** True while the real run is in flight. */
+  busy: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["close", "confirm"]);
+
+// The rows are declared once so the order is fixed and matches the design's,
+// and so neither the "Covers gaining metadata" row nor the "Files deleted" row
+// can be dropped by a later edit: the first is the whole reason the union is
+// safe, and stating the second's zero out loud is the point of showing it.
+const ROWS = [
+  {
+    key: "groups",
+    icon: "mdi-layers-plus",
+    label: "Stacks to create",
+  },
+  {
+    key: "pictures",
+    icon: "mdi-image-multiple-outline",
+    label: "Pictures collapsed behind a cover",
+  },
+  {
+    key: "coversGainingMetadata",
+    icon: "mdi-tag-multiple-outline",
+    label: "Covers gaining metadata from copies",
+  },
+  {
+    key: "queueRemaining",
+    icon: "mdi-blur",
+    label: "Groups left in the queue to review",
+  },
+  {
+    key: "filesDeleted",
+    icon: "mdi-delete-off-outline",
+    label: "Files deleted",
+  },
+];
+
+/**
+ * The dry run's own aggregates, or null for a server that predates them.
+ *
+ * One read of one group list on the server, so the rows below are internally
+ * consistent even if a scan lands between this request and the next.
+ */
+const summary = computed(() => props.preview?.dry_run_summary ?? null);
+
+/**
+ * Groups this run would stack.
+ *
+ * Read from the summary's per-tier split, which is the same number the
+ * summary's other rows were derived alongside. Auto-stack is exact-only, so the
+ * split is the exact tier plus zeroes; summing it rather than naming `exact`
+ * keeps the dialog correct if the run ever widens.
+ */
+const stacksToCreate = computed(() => {
+  const byTier = summary.value?.groups_by_tier;
+  if (byTier && typeof byTier === "object") {
+    return Object.values(byTier).reduce(
+      (sum, count) => sum + (Number(count) || 0),
+      0,
+    );
+  }
+  return Number(summary.value?.groups ?? props.preview?.groups) || 0;
+});
+
+const picturesCollapsed = computed(
+  () => Number(summary.value?.pictures ?? props.preview?.pictures) || 0,
+);
+
+/**
+ * Covers that would gain a tag or a better score from the union.
+ *
+ * The design's "covers gaining metadata from copies" row, and the answer to the
+ * only real question a bulk stack raises: whether collapsing copies loses
+ * anything. It cannot, because the union runs in the other direction, and this
+ * number says how often it actually will.
+ */
+const coversGainingMetadata = computed(
+  () => Number(summary.value?.covers_gaining_metadata) || 0,
+);
+
+const canConfirm = computed(
+  () =>
+    !props.loading &&
+    !props.busy &&
+    !props.previewFailed &&
+    stacksToCreate.value > 0,
+);
+
+/**
+ * The number a row shows.
+ *
+ * While the dry run is in flight every row shows an en dash rather than a
+ * spinner, so the dialog keeps its height and nothing moves under the pointer
+ * when the counts land.
+ */
+function rowValue(key) {
+  // Deletion is a property of the feature, not a number the server reports:
+  // there is no destructive route on this surface at all in 1.9. Stating the
+  // zero out loud is the point of the row.
+  if (key === "filesDeleted") return "0";
+  // The queue's remainder comes from the counts endpoint, not the dry run, so
+  // it stays readable while the dry run is still in flight.
+  if (key === "queueRemaining") {
+    return (Number(props.queueRemaining) || 0).toLocaleString();
+  }
+  if (props.loading || props.previewFailed) return "–";
+  if (key === "groups") return stacksToCreate.value.toLocaleString();
+  if (key === "pictures") return picturesCollapsed.value.toLocaleString();
+  if (key === "coversGainingMetadata") {
+    return coversGainingMetadata.value.toLocaleString();
+  }
+  return "0";
+}
+</script>
+
+<template>
+  <AppDialog
+    :open="open"
+    title="Auto-stack exact matches"
+    :width="520"
+    @close="emit('close')"
+  >
+    <p class="as-lede">
+      Byte-identical files need no judgment. This groups every exact-match set
+      behind one cover, the largest and best-tagged copy of each. Every other
+      copy stays in your library, and every tag, character and set membership
+      moves onto the stack. Near-duplicates stay in the queue for you to review.
+    </p>
+
+    <p v-if="previewFailed" class="as-failed" role="status">
+      <v-icon size="16" class="as-icon">mdi-alert-outline</v-icon>
+      The preview could not be read, so these counts are unknown. Close this and
+      try again.
+    </p>
+
+    <dl class="as-rows">
+      <div v-for="row in ROWS" :key="row.key" class="as-row">
+        <dt class="as-term">
+          <v-icon size="16" class="as-icon">{{ row.icon }}</v-icon>
+          {{ row.label }}
+        </dt>
+        <dd class="as-value">{{ rowValue(row.key) }}</dd>
+      </div>
+    </dl>
+
+    <p class="as-reversible">
+      <v-icon size="16" class="as-icon">mdi-information-outline</v-icon>
+      Reversible as one step with <kbd>Ctrl</kbd>+<kbd>Z</kbd>.
+    </p>
+
+    <template #footer>
+      <AppButton variant="ghost" @click="emit('close')">Cancel</AppButton>
+      <AppButton
+        variant="primary"
+        icon-left="layers-plus"
+        :disabled="!canConfirm"
+        @click="emit('confirm')"
+      >
+        Create {{ stacksToCreate.toLocaleString() }} stacks
+      </AppButton>
+    </template>
+  </AppDialog>
+</template>
+
+<style scoped>
+.as-lede {
+  margin: 0;
+  font-size: var(--text-base);
+  line-height: var(--leading-body);
+  color: rgba(var(--v-theme-on-surface), 0.8);
+}
+
+/* Same construction as the tier menu's in-place warning, so a failure and a
+   caution read as one family rather than two components. */
+.as-failed {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin: var(--space-5) 0 0;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: rgba(var(--v-theme-warning), 0.12);
+  border: 1px solid rgba(var(--v-theme-warning), 0.35);
+  font-size: var(--text-xs);
+  line-height: var(--leading-body);
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.as-rows {
+  margin: var(--space-5) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.as-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: baseline;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid rgb(var(--v-theme-divider));
+}
+
+.as-row:last-child {
+  border-bottom: none;
+}
+
+.as-term {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: rgba(var(--v-theme-on-surface), 0.8);
+}
+
+.as-icon {
+  color: rgba(var(--v-theme-on-surface), 0.6);
+  flex-shrink: 0;
+}
+
+.as-value {
+  margin: 0;
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.as-reversible {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-5) 0 0;
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+.as-reversible kbd {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.3);
+  border-radius: var(--radius-sm);
+  background: rgba(var(--v-theme-on-surface), 0.08);
+}
+</style>

--- a/frontend/src/components/widgets/DedupCompareDialog.test.js
+++ b/frontend/src/components/widgets/DedupCompareDialog.test.js
@@ -1,0 +1,298 @@
+// The compare dialog is where a duplicate group is actually adjudicated, so
+// these tests pin the things that would quietly make the decision wrong: which
+// value is marked best in each column, which candidate shows its path, and that
+// the two card gestures (pick a cover, leave a copy out) stay separate.
+
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+// The thumbnail URL builder pulls in the Axios client; the dialog only needs a
+// string for `<img src>`.
+vi.mock("../../api/pictures", () => ({
+  pictureThumbnailUrl: (id) => `/pictures/thumbnails/${id}.webp`,
+}));
+
+import DedupCompareDialog from "./DedupCompareDialog.vue";
+import AppButton from "./AppButton.vue";
+
+const AppDialogStub = {
+  name: "AppDialog",
+  template:
+    "<div><slot name='header-right'/><slot/><slot name='footer'/></div>",
+};
+
+const globalOpts = {
+  global: { stubs: { "v-icon": true, AppDialog: AppDialogStub } },
+};
+
+// Three copies with a different winner per column: biggest picture, biggest
+// file and best score, and the most tags.
+// The backend's `DedupGroupModel` shape. Three copies with a different winner
+// per column: biggest picture, biggest file and best score, and the most tags.
+// The last one is the reference-folder copy, the only one that shows a path.
+const GROUP = {
+  signature: "g1",
+  tier: "near",
+  confidence: 0.92,
+  member_count: 3,
+  cover_picture_id: 1,
+  why: [
+    { text: "Same camera", against: false },
+    { text: "Different crop", against: true },
+  ],
+  candidates: [
+    {
+      picture_id: 1,
+      width: 4000,
+      height: 3000,
+      megapixels: 12,
+      size_bytes: 5_000_000,
+      format: "JPEG",
+      is_raw: false,
+      created_at: "2026-05-01T09:00:00",
+      score: 2,
+      tag_count: 3,
+      file_path: null,
+      reference_folder_id: null,
+    },
+    {
+      picture_id: 2,
+      width: 2000,
+      height: 1500,
+      megapixels: 3,
+      size_bytes: 9_500_000,
+      format: "PNG",
+      is_raw: false,
+      created_at: "2026-05-01T09:00:01",
+      score: 4,
+      tag_count: 1,
+      file_path: null,
+      reference_folder_id: null,
+    },
+    {
+      picture_id: 3,
+      width: 1000,
+      height: 750,
+      megapixels: 0.75,
+      size_bytes: 1_000_000,
+      format: "JPEG",
+      is_raw: false,
+      created_at: "2026-05-01T09:00:02",
+      score: 0,
+      tag_count: 12,
+      file_path: "/mnt/ref/2024/img.jpg",
+      reference_folder_id: 3,
+    },
+  ],
+};
+
+function mountDialog(props = {}) {
+  return mount(DedupCompareDialog, {
+    ...globalOpts,
+    props: { open: true, group: GROUP, coverId: 1, ...props },
+  });
+}
+
+/** The metadata values of one card, in render order. */
+function values(card) {
+  return card.findAll(".dc-meta .dc-cell .dc-val");
+}
+
+/** The footer verdict buttons, in render order: Close, Keep separate, Stack. */
+function footerButtons(wrapper) {
+  return wrapper.findAllComponents(AppButton);
+}
+
+describe("DedupCompareDialog: the comparison", () => {
+  it("marks the winner of each column, one card at a time", () => {
+    // A single wrong best-mark is the whole point of the dialog going wrong:
+    // the user picks the cover by reading which value is emphasised.
+    const cards = mountDialog().findAll(".dc-card");
+    const best = (card) =>
+      values(card).map((v) => v.classes().includes("dc-val--best"));
+
+    // ID, then Resolution, File, Captured, Score, Metadata.
+    expect(best(cards[0]).slice(1, 6)).toEqual([
+      true,
+      false,
+      false,
+      false,
+      false,
+    ]);
+    expect(best(cards[1]).slice(1, 6)).toEqual([
+      false,
+      true,
+      false,
+      true,
+      false,
+    ]);
+    expect(best(cards[2]).slice(1, 6)).toEqual([
+      false,
+      false,
+      false,
+      false,
+      true,
+    ]);
+  });
+
+  it("shows a shortened path only for the reference-folder copy", () => {
+    // A managed-library path is an implementation detail; showing it everywhere
+    // buries the values that matter under noise.
+    const cards = mountDialog().findAll(".dc-card");
+    expect(cards[0].find(".dc-path").exists()).toBe(false);
+    expect(cards[1].find(".dc-path").exists()).toBe(false);
+
+    const path = cards[2].find(".dc-path");
+    expect(path.text()).toContain("…/2024/img.jpg");
+    expect(path.attributes("title")).toBe("/mnt/ref/2024/img.jpg");
+  });
+
+  it("renders the counter-evidence pill first", () => {
+    // The red pill is the reason this group needs a careful look, so it must
+    // not be pushed off the end of the row by the supporting evidence.
+    const pills = mountDialog().findAll(".why-pill");
+    expect(pills[0].text()).toContain("Different crop");
+    expect(pills[0].classes()).toContain("why-pill--neg");
+  });
+});
+
+describe("DedupCompareDialog: the blink compare (zoom)", () => {
+  function zoomEl() {
+    return document.querySelector('[data-testid="dedup-zoom"]');
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("opens full-screen from a card's zoom button and flips in place", async () => {
+    const wrapper = mountDialog();
+    expect(zoomEl()).toBeNull();
+
+    await wrapper.findAll(".dc-zoom")[1].trigger("click");
+    expect(zoomEl()).not.toBeNull();
+    expect(wrapper.vm.isZoomOpen()).toBe(true);
+
+    // Flip wraps: a blink loop, not a bounded carousel.
+    wrapper.vm.flipZoom(1);
+    await wrapper.vm.$nextTick();
+    wrapper.vm.flipZoom(1);
+    await wrapper.vm.$nextTick();
+    const onButtons = Array.from(
+      zoomEl().querySelectorAll(".dc-zv-flip button"),
+    ).map((b) => b.classList.contains("dc-zv-on"));
+    expect(onButtons.filter(Boolean)).toHaveLength(1);
+
+    wrapper.vm.closeZoom();
+    await wrapper.vm.$nextTick();
+    expect(zoomEl()).toBeNull();
+    wrapper.unmount();
+  });
+
+  it("opens on the cover when no candidate was named (the Z key path)", async () => {
+    const wrapper = mountDialog({ coverId: 2 });
+    wrapper.vm.openZoom();
+    await wrapper.vm.$nextTick();
+    const on = Array.from(
+      zoomEl().querySelectorAll(".dc-zv-flip button"),
+    ).findIndex((b) => b.classList.contains("dc-zv-on"));
+    expect(GROUP.candidates[on].picture_id).toBe(2);
+    wrapper.unmount();
+  });
+
+  it("toggles actual pixels, and resets to Fit for the next group", async () => {
+    const wrapper = mountDialog();
+    wrapper.vm.openZoom(0);
+    await wrapper.vm.$nextTick();
+    wrapper.vm.toggleZoomPixels();
+    await wrapper.vm.$nextTick();
+    expect(zoomEl().querySelector(".dc-zv-img--px")).not.toBeNull();
+
+    // A new group must start un-zoomed at Fit: a held-over zoom would open
+    // on the wrong picture.
+    await wrapper.setProps({ group: { ...GROUP, signature: "other" } });
+    expect(wrapper.vm.isZoomOpen()).toBe(false);
+    wrapper.unmount();
+  });
+});
+
+describe("DedupCompareDialog: the card gestures", () => {
+  it("makes a clicked card the cover, and marks only that card pressed", () => {
+    // aria-pressed is the only cover signal a screen-reader user gets.
+    const wrapper = mountDialog({ coverId: 3 });
+    const cards = wrapper.findAll(".dc-card");
+    expect(
+      cards.map((c) => c.find(".dc-pick").attributes("aria-pressed")),
+    ).toEqual(["false", "false", "true"]);
+
+    cards[1].find(".dc-pick").trigger("click");
+    expect(wrapper.emitted("set-cover")).toEqual([[2]]);
+  });
+
+  it("leaves a copy out from the in-stack toggle without changing the cover", () => {
+    // The toggle sits inside the card; without the stop it would also promote
+    // that copy to cover, which is the opposite of what the user asked for.
+    const wrapper = mountDialog();
+    wrapper.findAll(".dc-card")[1].find(".dc-toggle").trigger("click");
+    expect(wrapper.emitted("toggle-excluded")).toEqual([[2]]);
+    expect(wrapper.emitted("set-cover")).toBeUndefined();
+  });
+
+  it("leaves a copy out on right-click", () => {
+    const wrapper = mountDialog();
+    wrapper.findAll(".dc-card")[0].trigger("contextmenu");
+    expect(wrapper.emitted("toggle-excluded")).toEqual([[1]]);
+  });
+});
+
+describe("DedupCompareDialog: the verdict footer", () => {
+  it("counts down the Stack label as copies are left out", () => {
+    // The label is the user's only confirmation of how big the stack will be.
+    expect(footerButtons(mountDialog())[2].text()).toContain("Stack 3");
+    expect(
+      footerButtons(mountDialog({ excludedIds: [2] }))[2].text(),
+    ).toContain("Stack 2");
+  });
+
+  it("locks both verdicts while one is in flight, but never Close", () => {
+    // A double-click on Stack would create the stack twice.
+    const buttons = footerButtons(mountDialog({ busy: true }));
+    expect(buttons[0].find("button").attributes("disabled")).toBeUndefined();
+    expect(buttons[1].find("button").attributes("disabled")).toBeDefined();
+    expect(buttons[2].find("button").attributes("disabled")).toBeDefined();
+  });
+
+  it("emits the verdict the user picked", () => {
+    const wrapper = mountDialog();
+    const buttons = footerButtons(wrapper);
+    buttons[1].find("button").trigger("click");
+    buttons[2].find("button").trigger("click");
+    expect(wrapper.emitted("keep-separate")).toHaveLength(1);
+    expect(wrapper.emitted("stack")).toHaveLength(1);
+  });
+
+  // A share session can open Compare, because reading the comparison is not a
+  // verdict. Offering it two buttons the server will refuse is worse than
+  // offering none.
+  it("drops the verdicts, but not Close, in a read-only session", () => {
+    const buttons = footerButtons(mountDialog({ readOnly: true }));
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].text()).toContain("Close");
+  });
+
+  it("drops the gesture hint in a read-only session", () => {
+    expect(mountDialog({ readOnly: true }).find(".dc-hint").exists()).toBe(
+      false,
+    );
+  });
+
+  // The keys work inside Compare, so the hint that teaches the gestures has to
+  // name them too, and it has to repeat the one fact that makes the verdict
+  // safe to give without a confirmation.
+  it("names the keys and the zero deletions in the hint", () => {
+    const hint = mountDialog().find(".dc-hint").text();
+    expect(hint).toContain("press its number");
+    expect(hint).toContain("press X");
+    expect(hint).toContain("No file is ever deleted");
+  });
+});

--- a/frontend/src/components/widgets/DedupCompareDialog.vue
+++ b/frontend/src/components/widgets/DedupCompareDialog.vue
@@ -1,0 +1,1020 @@
+<script setup>
+/**
+ * Field-by-field comparison of one duplicate group.
+ *
+ * Usage:
+ *   <DedupCompareDialog
+ *     ref="compareRef"
+ *     :open="compareOpen"
+ *     :group="group"
+ *     :cover-id="coverId"
+ *     :excluded-ids="excludedIds"
+ *     :busy="verdictInFlight"
+ *     @close="compareOpen = false"
+ *     @set-cover="onSetCover"
+ *     @toggle-excluded="onToggleExcluded"
+ *     @stack="onStack"
+ *     @keep-separate="onKeepSeparate"
+ *   />
+ *
+ * The whole decision is made here: the verdict buttons live in this dialog's
+ * footer, so opening Compare is not a detour the user has to back out of before
+ * they can act. The component is presentational for the queue state — it reads
+ * props and emits intent — but it OWNS the zoom (the design system's
+ * full-screen blink compare): which candidate is up, fit vs actual pixels, the
+ * pan. The queue's keyboard model drives that state through the exposed API so
+ * there is exactly one key owner.
+ *
+ * Layout, per the owner's calls (2026-07-29): the dialog takes the full grid
+ * space (AppDialog `fullscreen`), the images dominate — down-scaled ORIGINALS,
+ * not thumbnails, because the whole point of Compare is fine detail — and the
+ * metadata sits under each picture as the design system's compact two-column
+ * label-over-value grid instead of a tall row list.
+ */
+import { computed, ref, watch } from "vue";
+import AppDialog from "./AppDialog.vue";
+import AppButton from "./AppButton.vue";
+import DedupWhyPills from "./DedupWhyPills.vue";
+import { pictureThumbnailUrl } from "../../api/pictures";
+import { API_BASE_URL } from "../../utils/apiClient";
+import {
+  bestOf,
+  candidateId,
+  candidatePath,
+  candidateSizeMb,
+  candidateMegapixels,
+  confidenceLabel,
+  shortenPath,
+  showsPath,
+} from "../../utils/dedup";
+import { formatUserDate } from "../../utils/utils";
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  /**
+   * The group under comparison:
+   * `{ id, kind, confidence, why: [{label, against}], candidates: [...] }`.
+   */
+  group: { type: Object, default: null },
+  /** The cover currently in force, as chosen by the parent. */
+  coverId: { type: [Number, String], default: null },
+  /** Candidates the user has left out of the stack. */
+  excludedIds: { type: Array, default: () => [] },
+  /** True while a verdict is in flight, which locks the verdict buttons. */
+  busy: { type: Boolean, default: false },
+  /**
+   * True in a share or read-only session. Reading the comparison is still
+   * useful there, so the dialog stays open to it; the verdict footer goes,
+   * because a control that can never work is worse than an absent one.
+   */
+  readOnly: { type: Boolean, default: false },
+});
+
+const emit = defineEmits([
+  "close",
+  "set-cover",
+  "toggle-excluded",
+  "stack",
+  "keep-separate",
+]);
+
+// The en dash placeholder for a value the picture does not carry. A blank cell
+// reads as "still loading"; the dash says "there is nothing here".
+const EMPTY = "–";
+
+/** Formats the browser can decode in an <img>; anything else (RAW, video)
+ * falls back to the thumbnail, which the server already rendered. */
+const BROWSER_IMAGE_FORMATS = new Set([
+  "jpg",
+  "jpeg",
+  "png",
+  "webp",
+  "gif",
+  "bmp",
+  "avif",
+]);
+
+const candidates = computed(() => props.group?.candidates ?? []);
+
+const confidence = computed(() => confidenceLabel(props.group));
+
+/** The per-column maxima that drive the best-value highlight. */
+const bestMegapixels = computed(() =>
+  bestOf(candidates.value, candidateMegapixels),
+);
+const bestFileSize = computed(() => bestOf(candidates.value, candidateSizeMb));
+const bestScore = computed(() => bestOf(candidates.value, (c) => c.score));
+const bestTagCount = computed(() =>
+  bestOf(candidates.value, (c) => c.tag_count),
+);
+
+/** How many pictures the Stack verdict would collapse. */
+const stackCount = computed(
+  () => candidates.value.length - props.excludedIds.length,
+);
+
+function isCover(candidate) {
+  return props.coverId != null && candidateId(candidate) === props.coverId;
+}
+
+function isExcluded(candidate) {
+  return props.excludedIds.includes(candidateId(candidate));
+}
+
+/**
+ * The preview source: the down-scaled ORIGINAL for browser-decodable formats
+ * (Compare exists to judge fine detail, which a grid-scale thumbnail cannot
+ * carry), the server-rendered thumbnail for RAW and video.
+ */
+function previewUrl(candidate) {
+  const format = String(candidate?.format || "").toLowerCase();
+  if (BROWSER_IMAGE_FORMATS.has(format)) {
+    return `${API_BASE_URL}/pictures/${candidateId(candidate)}.${format}`;
+  }
+  return pictureThumbnailUrl(candidateId(candidate), {
+    version: candidate.thumbnail_version,
+    baseUrl: API_BASE_URL,
+  });
+}
+
+/**
+ * Whether a value ties the column maximum, so it renders as the best one.
+ *
+ * A column whose maximum is 0 has nothing to win, so nothing is highlighted.
+ */
+function isBest(value, best) {
+  const numeric = Number(value);
+  return best > 0 && Number.isFinite(numeric) && numeric === best;
+}
+
+function resolutionText(candidate) {
+  const width = Number(candidate?.width);
+  const height = Number(candidate?.height);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return EMPTY;
+  return `${width} x ${height}`;
+}
+
+function fileText(candidate) {
+  const size = candidateSizeMb(candidate);
+  const format = candidate?.format || EMPTY;
+  if (!Number.isFinite(size)) return format;
+  return `${size.toFixed(1)} MB, ${format}`;
+}
+
+function capturedText(candidate) {
+  return candidate?.created_at
+    ? formatUserDate(candidate.created_at, "iso")
+    : EMPTY;
+}
+
+function starCount(candidate) {
+  const score = Math.round(Number(candidate?.score));
+  return Number.isFinite(score) && score > 0 ? score : 0;
+}
+
+function tagText(candidate) {
+  const count = Number(candidate?.tag_count) || 0;
+  return count > 0 ? `${count} tags` : "none";
+}
+
+// ── Zoom: the design system's full-screen blink compare ────────────────────
+// One candidate fills the screen; flipping in place (arrows, 1-9) makes the
+// differences jump out as motion. Fit keeps every candidate registered in the
+// same box; Actual pixels is 1:1 with drag-to-pan, so resolution differences
+// show as size jumps.
+
+const zoomIndex = ref(null);
+const zoomActualPixels = ref(false);
+const zoomImgEl = ref(null);
+const zoomScrollEl = ref(null);
+let panState = null;
+
+const zoomOpen = computed(() => props.open && zoomIndex.value != null);
+const zoomCandidate = computed(() =>
+  zoomOpen.value ? candidates.value[zoomIndex.value] : null,
+);
+
+const zoomMetaText = computed(() => {
+  const c = zoomCandidate.value;
+  if (!c) return "";
+  const parts = [`#${candidateId(c)}`, resolutionText(c), fileText(c)];
+  const stars = starCount(c);
+  if (stars) parts.push("★".repeat(stars));
+  return parts.filter((p) => p !== EMPTY).join(" · ");
+});
+
+/** The cover's index, where Z lands when no candidate was named. */
+function coverIndex() {
+  const index = candidates.value.findIndex((c) => isCover(c));
+  return index >= 0 ? index : 0;
+}
+
+function openZoom(index = null) {
+  if (!candidates.value.length) return;
+  const target = index == null ? coverIndex() : index;
+  zoomIndex.value = Math.max(0, Math.min(candidates.value.length - 1, target));
+}
+
+function closeZoom() {
+  zoomIndex.value = null;
+  panState = null;
+}
+
+/** Flip forward/back, wrapping — a blink loop, not a bounded carousel. */
+function flipZoom(delta) {
+  if (!zoomOpen.value) return;
+  const n = candidates.value.length;
+  zoomIndex.value = (zoomIndex.value + delta + n) % n;
+}
+
+function zoomTo(index) {
+  if (!zoomOpen.value) return;
+  if (index >= 0 && index < candidates.value.length) zoomIndex.value = index;
+}
+
+function toggleZoomPixels() {
+  if (!zoomOpen.value) return;
+  zoomActualPixels.value = !zoomActualPixels.value;
+}
+
+// The queue's keyboard model is the single key owner; it drives the zoom
+// through this surface instead of the dialog competing for the keydown.
+defineExpose({
+  isZoomOpen: () => zoomOpen.value,
+  openZoom,
+  closeZoom,
+  flipZoom,
+  zoomTo,
+  toggleZoomPixels,
+});
+
+// A new group, or a closed dialog, always starts un-zoomed at Fit: a zoom held
+// over from another group would open on the wrong picture.
+watch(
+  () => [props.open, props.group?.signature],
+  () => {
+    closeZoom();
+    zoomActualPixels.value = false;
+  },
+);
+
+// ── Actual-pixels panning ───────────────────────────────────────────────────
+
+function onZoomPointerDown(event) {
+  if (!zoomActualPixels.value || event.button !== 0) return;
+  const el = zoomScrollEl.value;
+  if (!el) return;
+  panState = {
+    x: event.clientX,
+    y: event.clientY,
+    left: el.scrollLeft,
+    top: el.scrollTop,
+    moved: false,
+  };
+}
+
+function onZoomPointerMove(event) {
+  if (!panState) return;
+  const el = zoomScrollEl.value;
+  if (!el) return;
+  const dx = event.clientX - panState.x;
+  const dy = event.clientY - panState.y;
+  if (Math.abs(dx) + Math.abs(dy) > 3) panState.moved = true;
+  el.scrollLeft = panState.left - dx;
+  el.scrollTop = panState.top - dy;
+}
+
+function onZoomPointerUp() {
+  // Cleared on the next tick so the click handler can still tell a drag from
+  // a pick.
+  setTimeout(() => {
+    panState = null;
+  }, 0);
+}
+
+/** Click picks the cover — unless the click was the tail end of a pan. */
+function onZoomClick() {
+  if (panState?.moved) return;
+  const c = zoomCandidate.value;
+  if (c) emit("set-cover", candidateId(c));
+}
+
+function onZoomContextMenu() {
+  const c = zoomCandidate.value;
+  if (c) emit("toggle-excluded", candidateId(c));
+}
+</script>
+
+<template>
+  <AppDialog :open="open" title="Compare group" fullscreen @close="emit('close')">
+    <!-- The confidence claim rides in the header, next to the close button, so
+         it stays visible while the strip below scrolls. -->
+    <template #header-right>
+      <span class="dc-confidence">{{ confidence.label }}</span>
+    </template>
+
+    <!-- ── The candidate strip ─────────────────────────────────────────────
+         One card per copy. The cards GROW into the freed width — the images
+         are the point of this surface — and scroll sideways only once there
+         are too many to fit; the comparison only works when the fields line
+         up across cards. -->
+    <div class="dc-strip">
+      <div
+        v-for="(candidate, index) in candidates"
+        :key="candidateId(candidate)"
+        class="dc-card"
+        :class="{ 'dc-card--out': isExcluded(candidate) }"
+        @contextmenu.prevent="emit('toggle-excluded', candidateId(candidate))"
+      >
+        <button
+          type="button"
+          class="dc-pick"
+          :aria-pressed="isCover(candidate)"
+          :title="'Make this the cover'"
+          @click="emit('set-cover', candidateId(candidate))"
+        >
+          <span class="dc-thumb">
+            <img
+              class="dc-thumb-img"
+              :src="previewUrl(candidate)"
+              :alt="`Copy ${index + 1}`"
+              loading="lazy"
+              decoding="async"
+              draggable="false"
+              @dragstart.prevent
+            />
+            <span class="dc-index">{{ index + 1 }}</span>
+            <span v-if="isCover(candidate)" class="dc-flag dc-flag--cover">
+              Cover
+            </span>
+            <span v-if="isExcluded(candidate)" class="dc-flag dc-flag--out">
+              Not in stack
+            </span>
+          </span>
+        </button>
+        <!-- The zoom trigger is a sibling of the pick button (a button inside
+             a button is invalid markup), absolutely placed over the corner. -->
+        <button
+          type="button"
+          class="dc-zoom"
+          title="Zoom — full-screen blink compare (Z)"
+          :aria-label="`Zoom copy ${index + 1}`"
+          @click.stop="openZoom(index)"
+        >
+          <v-icon size="16">mdi-magnify-plus-outline</v-icon>
+        </button>
+
+        <!-- The design system's compact meta: two columns, label over value,
+             so the numbers read first and the metadata never squeezes the
+             image. -->
+        <span class="dc-meta">
+          <span class="dc-cell">
+            <span class="dc-label">ID</span>
+            <span class="dc-val">#{{ candidateId(candidate) }}</span>
+          </span>
+          <span class="dc-cell">
+            <span class="dc-label">Resolution</span>
+            <span
+              class="dc-val"
+              :class="{
+                'dc-val--best': isBest(
+                  candidateMegapixels(candidate),
+                  bestMegapixels,
+                ),
+              }"
+              >{{ resolutionText(candidate) }}</span
+            >
+          </span>
+          <span class="dc-cell">
+            <span class="dc-label">File</span>
+            <span
+              class="dc-val"
+              :class="{
+                'dc-val--best': isBest(candidateSizeMb(candidate), bestFileSize),
+              }"
+              >{{ fileText(candidate) }}</span
+            >
+          </span>
+          <span class="dc-cell">
+            <span class="dc-label">Captured</span>
+            <span class="dc-val">{{ capturedText(candidate) }}</span>
+          </span>
+          <span class="dc-cell">
+            <span class="dc-label">Score</span>
+            <span
+              class="dc-val"
+              :class="{ 'dc-val--best': isBest(candidate.score, bestScore) }"
+            >
+              <template v-if="starCount(candidate)">
+                <v-icon
+                  v-for="star in starCount(candidate)"
+                  :key="star"
+                  size="13"
+                  class="dc-star"
+                  >mdi-star</v-icon
+                >
+              </template>
+              <template v-else>{{ EMPTY }}</template>
+            </span>
+          </span>
+          <span class="dc-cell">
+            <span class="dc-label">Metadata</span>
+            <span
+              class="dc-val"
+              :class="{
+                'dc-val--best': isBest(candidate.tag_count, bestTagCount),
+              }"
+              >{{ tagText(candidate) }}</span
+            >
+          </span>
+          <span class="dc-cell">
+            <span class="dc-label">In stack</span>
+            <span class="dc-val dc-instack">
+              <button
+                type="button"
+                class="dc-toggle"
+                :aria-pressed="!isExcluded(candidate)"
+                :title="
+                  isExcluded(candidate)
+                    ? 'Put this copy back in the stack'
+                    : 'Leave this copy out of the stack'
+                "
+                @click.stop="emit('toggle-excluded', candidateId(candidate))"
+              >
+                <v-icon size="14">{{
+                  isExcluded(candidate)
+                    ? "mdi-checkbox-blank-outline"
+                    : "mdi-checkbox-marked-outline"
+                }}</v-icon>
+              </button>
+              <span>{{ isExcluded(candidate) ? "No" : "Yes" }}</span>
+            </span>
+          </span>
+          <!-- The path is shown only for a reference-folder picture, where the
+               user manages the files and needs to know which copy is which.
+               Full width: paths do not fit half a column. -->
+          <span v-if="showsPath(candidate)" class="dc-cell dc-cell--wide">
+            <span class="dc-label">Location</span>
+            <span class="dc-val dc-path" :title="candidatePath(candidate)">
+              <v-icon
+                size="13"
+                class="dc-path-icon"
+                title="Reference folder, you manage these files yourself"
+                >mdi-folder-eye-outline</v-icon
+              >
+              {{ shortenPath(candidatePath(candidate)) }}
+            </span>
+          </span>
+        </span>
+      </div>
+    </div>
+
+    <!-- ── Why these were grouped ──────────────────────────────────────────
+         The same pill component the queue row uses, so the evidence a user
+         glanced at in the row is literally the same treatment they study here.
+         Compare shows all of it, where the row shows only the first two. -->
+    <DedupWhyPills class="dc-why" :why="group?.why" />
+
+    <template #footer>
+      <span v-if="!readOnly" class="dc-hint">
+        Click a picture, or press its number, to make it the cover. Right-click,
+        or press X, to leave it out. Z zooms. No file is ever deleted.
+      </span>
+      <AppButton variant="ghost" key-hint="esc" @click="emit('close')"
+        >Close</AppButton
+      >
+      <AppButton
+        v-if="!readOnly"
+        variant="secondary"
+        icon-left="call-split"
+        :disabled="busy"
+        title="Leave these as separate pictures. They stay in your library and stop being suggested."
+        @click="emit('keep-separate')"
+      >
+        Keep separate
+      </AppButton>
+      <AppButton
+        v-if="!readOnly"
+        variant="primary"
+        icon-left="layers-plus"
+        key-hint="enter"
+        :disabled="busy"
+        title="Group these behind one cover. Every file stays on disk, and Ctrl+Z reverses it."
+        @click="emit('stack')"
+      >
+        Stack {{ stackCount }}
+      </AppButton>
+    </template>
+  </AppDialog>
+
+  <!-- ── The blink compare ──────────────────────────────────────────────────
+       Full screen, above the dialog: one candidate at a time, flipped in
+       place so differences show as motion. Deliberately near-black chrome at
+       fixed colors — this is a photo-judgement surface, same rationale as the
+       lightbox. -->
+  <Teleport to="body">
+    <div v-if="zoomOpen" class="dc-zv" data-testid="dedup-zoom">
+      <div class="dc-zv-top">
+        <div class="dc-zv-flip" role="tablist" aria-label="Candidate">
+          <button
+            v-for="(candidate, index) in candidates"
+            :key="candidateId(candidate)"
+            type="button"
+            :class="{ 'dc-zv-on': index === zoomIndex }"
+            @click="zoomTo(index)"
+          >
+            {{ index + 1 }}
+          </button>
+        </div>
+        <span
+          v-if="zoomCandidate && isCover(zoomCandidate)"
+          class="dc-flag dc-flag--zv"
+          >Cover</span
+        >
+        <span
+          v-if="zoomCandidate && isExcluded(zoomCandidate)"
+          class="dc-flag dc-flag--zv"
+          >Not in stack</span
+        >
+        <span class="dc-zv-meta">{{ zoomMetaText }}</span>
+        <div class="dc-zv-mode">
+          <button
+            type="button"
+            :class="{ 'dc-zv-on': !zoomActualPixels }"
+            title="Scale every candidate into the same box — keeps the blink registered"
+            @click="zoomActualPixels = false"
+          >
+            <v-icon size="15">mdi-fit-to-screen-outline</v-icon>
+            Fit
+          </button>
+          <button
+            type="button"
+            :class="{ 'dc-zv-on': zoomActualPixels }"
+            title="1:1 — resolution differences show as size jumps (P)"
+            @click="zoomActualPixels = true"
+          >
+            <v-icon size="15">mdi-magnify-scan</v-icon>
+            Actual pixels
+          </button>
+        </div>
+        <button
+          type="button"
+          class="dc-zv-close"
+          title="Back to compare (Esc)"
+          @click="closeZoom()"
+        >
+          <v-icon size="18">mdi-close</v-icon>
+        </button>
+      </div>
+      <div
+        ref="zoomScrollEl"
+        class="dc-zv-img"
+        :class="{ 'dc-zv-img--px': zoomActualPixels }"
+        @mousedown="onZoomPointerDown"
+        @mousemove="onZoomPointerMove"
+        @mouseup="onZoomPointerUp"
+        @mouseleave="onZoomPointerUp"
+        @click="onZoomClick"
+        @contextmenu.prevent="onZoomContextMenu"
+      >
+        <!-- draggable=false is load-bearing: the browser's native image drag
+             starts on the same gesture as the actual-pixels pan and wins the
+             race, leaving the pan dead and a ghost image under the cursor. -->
+        <img
+          v-if="zoomCandidate"
+          ref="zoomImgEl"
+          :src="previewUrl(zoomCandidate)"
+          alt=""
+          draggable="false"
+          @dragstart.prevent
+        />
+      </div>
+      <div class="dc-zv-foot" aria-hidden="true">
+        <span><kbd>←</kbd><kbd>→</kbd> or <kbd>1</kbd>–<kbd>9</kbd> flip in place — differences jump out as motion</span>
+        <span><kbd>P</kbd> actual pixels</span>
+        <span><kbd>Enter</kbd> stack</span>
+        <span><kbd>S</kbd> keep separate</span>
+        <span><kbd>Esc</kbd> back</span>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.dc-confidence {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: rgba(var(--v-theme-on-surface), 0.7);
+}
+
+/* ── The strip ──────────────────────────────────────────────────────────────
+   The cards grow to spend the fullscreen dialog's width on the images; a
+   sideways scroll appears only when even the minimum card width overflows. */
+.dc-strip {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-4);
+  overflow-x: auto;
+  scrollbar-gutter: stable;
+  padding-bottom: var(--space-3);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--v-theme-on-surface), 0.4) transparent;
+}
+
+.dc-card {
+  position: relative;
+  flex: 1 0 300px;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgb(var(--v-theme-border));
+  border-radius: var(--radius-md);
+  background: rgb(var(--v-theme-surface));
+  box-shadow: var(--elevation-1);
+  overflow: hidden;
+}
+
+/* An excluded copy stays fully readable, because it is still part of the
+   comparison; it is just not going into the stack. */
+.dc-card--out {
+  border-style: dashed;
+  border-color: rgba(var(--v-theme-on-surface), 0.35);
+}
+
+.dc-pick {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  text-align: left;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background var(--dur-1) var(--ease-standard);
+}
+
+.dc-pick:hover {
+  background: var(--hover-wash);
+}
+
+.dc-pick[aria-pressed="true"] {
+  background: var(--active-wash);
+}
+
+.dc-pick:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* The image takes every pixel the metadata does not strictly need. */
+.dc-thumb {
+  position: relative;
+  display: block;
+  flex: 1;
+  min-height: 220px;
+  background: rgba(var(--v-theme-on-surface), 0.06);
+}
+
+.dc-thumb-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+/* Count pill, per the badge rules: primary fill, never the amber accent. */
+.dc-index {
+  position: absolute;
+  top: var(--space-2);
+  left: var(--space-2);
+  min-width: var(--badge-size);
+  height: var(--badge-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
+  background: rgb(var(--v-theme-primary));
+  color: rgb(var(--v-theme-on-primary));
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The flags sit on top of an arbitrary photo, so they take the photo scrim. */
+.dc-flag {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-pill);
+  background: var(--scrim-photo);
+  color: rgb(var(--v-theme-on-dark-surface));
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+}
+
+.dc-flag--out {
+  top: auto;
+  bottom: var(--space-2);
+}
+
+/* The zoom trigger sits under the index pill, over the photo. */
+.dc-zoom {
+  position: absolute;
+  top: calc(var(--space-2) + var(--badge-size) + var(--space-2));
+  left: var(--space-2);
+  z-index: var(--z-raised);
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--scrim-photo);
+  color: rgb(var(--v-theme-on-dark-surface));
+  cursor: pointer;
+}
+
+.dc-zoom:hover {
+  color: rgb(var(--v-theme-accent));
+}
+
+.dc-zoom:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ── The compact meta grid: two columns, label over value ─────────────────── */
+.dc-meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2) var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  align-content: start;
+}
+
+.dc-cell {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.dc-cell--wide {
+  grid-column: 1 / -1;
+}
+
+/* The label is deliberately quiet: the values are what the user compares. */
+.dc-label {
+  font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+.dc-val {
+  font-size: var(--text-sm);
+  color: rgb(var(--v-theme-on-surface));
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The winner of a column reads first: a quiet primary-tinted chip. */
+.dc-val--best {
+  font-weight: var(--weight-semibold);
+  background: rgba(var(--v-theme-primary), 0.18);
+  border: 1px solid rgba(var(--v-theme-primary), 0.5);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-2);
+  align-self: flex-start;
+  max-width: 100%;
+}
+
+.dc-star {
+  color: rgb(var(--v-theme-accent));
+}
+
+.dc-path {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.dc-path-icon {
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+.dc-instack {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.dc-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  cursor: pointer;
+  transition:
+    background var(--dur-1) var(--ease-standard),
+    color var(--dur-1) var(--ease-standard);
+}
+
+.dc-toggle:hover {
+  background: var(--hover-wash);
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.dc-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ── Why pills ───────────────────────────────────────────────────────────── */
+.dc-why {
+  margin-top: var(--space-4);
+  flex-shrink: 0;
+}
+
+.dc-hint {
+  margin-right: auto;
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+/* ── The blink compare ─────────────────────────────────────────────────────
+   Fixed colors on purpose: like the lightbox, a photo-judgement surface gets
+   near-black chrome in both themes. Sits above the modal dialog. */
+.dc-zv {
+  position: fixed;
+  inset: 0;
+  z-index: calc(var(--z-modal) + 100);
+  display: flex;
+  flex-direction: column;
+  background: #0a0a0a;
+}
+
+.dc-zv-top {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  flex-shrink: 0;
+}
+
+.dc-zv-flip {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.dc-zv-flip button {
+  min-width: 30px;
+  height: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: #fff;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+
+.dc-zv-flip button:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.dc-zv .dc-zv-on {
+  background: rgb(var(--v-theme-accent));
+  border-color: rgb(var(--v-theme-accent));
+  color: rgb(var(--v-theme-on-accent));
+  font-weight: var(--weight-semibold);
+}
+
+.dc-flag--zv {
+  position: static;
+}
+
+.dc-zv-meta {
+  flex: 1;
+  font-size: var(--text-xs);
+  color: rgba(255, 255, 255, 0.72);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dc-zv-mode {
+  display: flex;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.dc-zv-mode button {
+  height: 30px;
+  padding: 0 var(--space-3);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: #fff;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.dc-zv-mode button:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.dc-zv-close {
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.72);
+  cursor: pointer;
+}
+
+.dc-zv-close:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+/* Fit: the same box for every candidate, so the blink stays registered. */
+.dc-zv-img {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.dc-zv-img img {
+  width: auto;
+  height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
+
+/* Actual pixels: 1:1, panned by dragging. */
+.dc-zv-img--px {
+  display: block;
+  overflow: auto;
+  cursor: grab;
+  scrollbar-width: thin;
+}
+
+.dc-zv-img--px img {
+  max-width: none;
+  max-height: none;
+  width: auto;
+  height: auto;
+  display: block;
+  margin: auto;
+}
+
+.dc-zv-foot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-5);
+  padding: var(--space-3);
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.dc-zv-foot kbd {
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+}
+</style>

--- a/frontend/src/components/widgets/DedupConfidencePill.test.js
+++ b/frontend/src/components/widgets/DedupConfidencePill.test.js
@@ -1,0 +1,63 @@
+// The per-group confidence chip.
+//
+// The contract worth pinning is a product one, not a styling one: an exact
+// match must never render as a percentage, because "100% similar" makes every
+// near-duplicate suggestion in the queue look as certain as a byte-identical
+// match.
+
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import DedupConfidencePill from "./DedupConfidencePill.vue";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+function mountPill(group) {
+  return mount(DedupConfidencePill, { ...globalOpts, props: { group } });
+}
+
+describe("DedupConfidencePill", () => {
+  it("says Exact, and never a percentage, for an exact group", () => {
+    // The whole reason this component exists: an exact match is a different
+    // kind of claim from a similarity score.
+    const wrapper = mountPill({ kind: "exact", confidence: 1 });
+    expect(wrapper.text()).toBe("Exact");
+    expect(wrapper.text()).not.toMatch(/%/);
+  });
+
+  it("gives the exact tier its own filled treatment", () => {
+    // Rendering both tiers alike would put the two claims on equal footing.
+    expect(mountPill({ kind: "exact" }).find(".conf-pill").classes()).toContain(
+      "conf-pill--exact",
+    );
+  });
+
+  it("renders a near group as a rounded percentage", () => {
+    // The score is a measurement and reads as one.
+    const wrapper = mountPill({ kind: "near", confidence: 0.943 });
+    expect(wrapper.text()).toBe("94% similar");
+  });
+
+  it("gives the near tier the quiet outlined treatment", () => {
+    // A near match must not borrow the settled look of an exact one.
+    expect(
+      mountPill({ kind: "near", confidence: 0.9 }).find(".conf-pill").classes(),
+    ).toContain("conf-pill--near");
+  });
+
+  it("falls back to Similar when no score came through", () => {
+    // A missing score must not render as "NaN% similar".
+    expect(mountPill({ kind: "near" }).text()).toBe("Similar");
+  });
+
+  it("keeps the label in the element that carries the tabular figures", () => {
+    // The percentage lives in `.conf-pill__label`, which is where the
+    // tabular-nums rule sits; moving the text out of it makes a scrolling
+    // column of scores jitter.
+    const label = mountPill({ kind: "near", confidence: 0.8 }).find(
+      ".conf-pill__label",
+    );
+    expect(label.exists()).toBe(true);
+    expect(label.text()).toBe("80% similar");
+  });
+});

--- a/frontend/src/components/widgets/DedupConfidencePill.vue
+++ b/frontend/src/components/widgets/DedupConfidencePill.vue
@@ -1,0 +1,77 @@
+<script setup>
+/**
+ * The per-group confidence chip in the duplicate queue.
+ *
+ * The one thing this component exists to protect: "Exact" is a different KIND of
+ * claim from "94% similar", and rendering it as "100% similar" would make every
+ * near-duplicate suggestion look as certain as a byte-identical match. So the
+ * two tiers get two treatments, not two numbers:
+ *
+ *   • Exact: a filled accent chip with the "identical" glyph. A settled fact.
+ *   • Near: a quiet outlined chip with the blur glyph. A measurement, with
+ *              the percentage in tabular figures so a column of them lines up.
+ *
+ * `confidenceLabel` in `utils/dedup` owns the wording, because the compare view
+ * and the auto-stack dialog have to say the same thing about the same group.
+ */
+import { computed } from "vue";
+
+import { confidenceLabel } from "../../utils/dedup";
+
+const props = defineProps({
+  /** A queue group, carrying `kind` and `confidence`. */
+  group: { type: Object, required: true },
+});
+
+const confidence = computed(() => confidenceLabel(props.group));
+</script>
+
+<template>
+  <span
+    class="conf-pill"
+    :class="confidence.exact ? 'conf-pill--exact' : 'conf-pill--near'"
+  >
+    <v-icon class="conf-pill__ico" size="12">{{
+      confidence.exact ? "mdi-approximately-equal" : "mdi-blur"
+    }}</v-icon>
+    <span class="conf-pill__label">{{ confidence.label }}</span>
+  </span>
+</template>
+
+<style scoped>
+.conf-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+}
+
+/* Filled, because an exact match is the only claim in this queue that is not a
+   judgement call, and it should be the one chip that reads as settled. */
+.conf-pill--exact {
+  background: rgb(var(--v-theme-accent));
+  color: rgb(var(--v-theme-on-accent));
+}
+
+/* Outlined and quiet: a measurement, not a verdict. */
+.conf-pill--near {
+  background: transparent;
+  border-color: rgb(var(--v-theme-border));
+  color: rgba(var(--v-theme-on-surface), 0.8);
+}
+
+/* Tabular figures so a column of percentages does not jitter as it updates. */
+.conf-pill__label {
+  font-variant-numeric: tabular-nums;
+}
+
+.conf-pill__ico {
+  flex-shrink: 0;
+}
+</style>

--- a/frontend/src/components/widgets/DedupGroupRow.test.js
+++ b/frontend/src/components/widgets/DedupGroupRow.test.js
@@ -1,0 +1,124 @@
+// One group in the triage queue.
+//
+// The tests pin the two things the row owes the keyboard and the screen reader,
+// neither of which is visible in a screenshot: only the focused row is a tab
+// stop, and the focused row says so in something other than CSS.
+
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import DedupGroupRow from "./DedupGroupRow.vue";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+/** A group of `n` candidates, in the backend's shape. */
+function group(n = 3) {
+  return {
+    signature: "g1",
+    tier: "near",
+    confidence: 0.94,
+    member_count: n,
+    cover_picture_id: 1,
+    why: [{ text: "same dimensions", against: false }],
+    candidates: Array.from({ length: n }, (_, i) => ({ picture_id: i + 1 })),
+  };
+}
+
+function mountRow(props = {}) {
+  return mount(DedupGroupRow, {
+    ...globalOpts,
+    props: { group: group(), index: 0, coverId: 1, ...props },
+  });
+}
+
+describe("DedupGroupRow — the tab order", () => {
+  // Twenty groups on screen is well over a hundred buttons. A Tab key that
+  // walks all of them is a Tab key nobody presses twice.
+  it("keeps every control out of the tab order on an unfocused row", () => {
+    const wrapper = mountRow({ focused: false });
+    const tabbable = wrapper
+      .findAll("button")
+      .filter((b) => b.attributes("tabindex") !== "-1");
+    expect(tabbable).toHaveLength(0);
+  });
+
+  // The focused row is the only row the keyboard model acts on, so it is the
+  // only row Tab should reach.
+  it("puts the focused row's controls in the tab order", () => {
+    const wrapper = mountRow({ focused: true });
+    const buttons = wrapper.findAll("button");
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      expect(button.attributes("tabindex")).toBe("0");
+    }
+  });
+});
+
+describe("DedupGroupRow — what assistive tech is told", () => {
+  // The focused-row treatment is five CSS signals and nothing else, which says
+  // nothing at all to a screen reader.
+  it("marks the focused row as current", () => {
+    expect(mountRow({ focused: true }).attributes("aria-current")).toBe("true");
+    expect(
+      mountRow({ focused: false }).attributes("aria-current"),
+    ).toBeUndefined();
+  });
+
+  it("names the row and its size", () => {
+    const wrapper = mountRow({ index: 4 });
+    expect(wrapper.attributes("aria-label")).toBe("Group 5, 3 pictures");
+  });
+
+  // Without a label every candidate reaches a screen reader as the same
+  // unlabelled control repeated N times: the image is deliberately decorative.
+  it("names each thumbnail by its position and its state", () => {
+    const wrapper = mountRow({ coverId: 2, excludedIds: [3] });
+    const labels = wrapper
+      .findAll(".gthumb")
+      .map((b) => b.attributes("aria-label"));
+    expect(labels).toEqual([
+      "Picture 1 of 3",
+      "Picture 2 of 3, cover",
+      "Picture 3 of 3, not in the stack",
+    ]);
+  });
+
+  // Only the focused row answers to 1-9 and X, so only the focused row may
+  // claim the keys work.
+  it("names the keys in the tooltip only where they work", () => {
+    expect(
+      mountRow({ focused: true }).find(".gthumb").attributes("title"),
+    ).toContain("press 1");
+    expect(
+      mountRow({ focused: false }).find(".gthumb").attributes("title"),
+    ).not.toContain("press 1");
+  });
+});
+
+describe("DedupGroupRow — what the verdicts cost", () => {
+  // Neither verdict asks for a confirmation, so each has to say what it does
+  // before it is pressed rather than after.
+  it("says that stacking deletes nothing and can be undone", () => {
+    const title = mountRow().find(".gbtn--stack").attributes("title");
+    expect(title).toContain("stays on disk");
+    expect(title).toContain("Ctrl+Z");
+  });
+
+  // The verdict is remembered, and the pictures survive it. The copy must not
+  // promise a "reopen" affordance that does not exist yet.
+  it("says that keeping separate is remembered and loses nothing", () => {
+    const title = mountRow().findAll(".gbtn")[1].attributes("title");
+    expect(title).toContain("stay in your library");
+    expect(title).toContain("stop being suggested");
+    expect(title).not.toContain("reopen");
+  });
+
+  it("locks both verdicts in a read-only session", () => {
+    const wrapper = mountRow({ readOnly: true });
+    for (const button of wrapper.findAll(".gbtn")) {
+      expect(button.attributes("disabled")).toBeDefined();
+    }
+    // Comparing is reading, so it stays live.
+    expect(wrapper.find(".gcompare").attributes("disabled")).toBeUndefined();
+  });
+});

--- a/frontend/src/components/widgets/DedupGroupRow.vue
+++ b/frontend/src/components/widgets/DedupGroupRow.vue
@@ -1,0 +1,617 @@
+<template>
+  <div
+    class="grow"
+    :class="{ 'grow--focus': focused, 'grow--selected': selected }"
+    role="group"
+    :aria-label="`Group ${index + 1}, ${group.candidates.length} pictures`"
+    :aria-current="focused ? 'true' : undefined"
+    :aria-selected="selected ? 'true' : undefined"
+    :data-testid="`dedup-group-${group.signature}`"
+    @click="emit('focus', $event)"
+  >
+    <div class="ginfo">
+      <div class="gn">
+        <v-icon v-if="focused" class="gcaret" size="18">mdi-menu-right</v-icon>
+        <b>Group {{ index + 1 }}</b>
+        <span>{{ group.candidates.length }} pictures</span>
+      </div>
+      <DedupConfidencePill :group="group" />
+      <!-- The evidence stays on every row; the focused row is already marked
+           four ways (bar, caret, wash, filled button) and the kbd chips on the
+           verdict buttons say where the keyboard acts (owner call,
+           2026-07-29: the explicit label was noise). -->
+      <DedupWhyPills :why="group.why" :limit="2" />
+    </div>
+
+    <!-- Thumbnails at grid scale, edge to edge, carrying no metadata: only the
+         cover label and the index, and the index only while the row is focused
+         because that is the only row `1`-`9` can address. -->
+    <div class="gstrip">
+      <button
+        v-for="(candidate, i) in group.candidates"
+        :key="idOf(candidate)"
+        type="button"
+        class="gthumb"
+        :class="{
+          'gthumb--cover':
+            idOf(candidate) === coverId && !isOut(idOf(candidate)),
+          'gthumb--out': isOut(idOf(candidate)),
+        }"
+        :tabindex="focused ? 0 : -1"
+        :aria-pressed="idOf(candidate) === coverId"
+        :aria-label="thumbLabel(candidate, i)"
+        :title="thumbTitle(candidate, i)"
+        @click.stop="onPick(candidate)"
+        @contextmenu.prevent.stop="onToggle(candidate)"
+      >
+        <!-- The IMG sizes its own box: the stored width/height are the raw
+             file dimensions and ignore EXIF rotation, so a portrait phone
+             shot reports landscape numbers. The browser decodes the rotated
+             pixels, so height-fixed + width-auto is the only shape that is
+             always true. The placeholder uses the metadata as an estimate;
+             the image corrects it on load. -->
+        <img
+          v-if="loadThumbnails"
+          class="gt"
+          :src="thumbUrl(candidate)"
+          alt=""
+          loading="lazy"
+          decoding="async"
+        />
+        <span
+          v-else
+          class="gt gt--placeholder"
+          :style="thumbBoxStyle(candidate)"
+          aria-hidden="true"
+        ></span>
+        <span v-if="focused" class="gnum">{{ i + 1 }}</span>
+        <span
+          v-if="idOf(candidate) === coverId && !isOut(idOf(candidate))"
+          class="gcv"
+          >Cover</span
+        >
+        <v-icon v-if="isOut(idOf(candidate))" class="gx" size="20"
+          >mdi-minus-circle-outline</v-icon
+        >
+      </button>
+    </div>
+
+    <div v-if="verdict" class="gact">
+      <!-- A decided row states its verdict and offers the one way back.
+           Clearing never touches pictures: a reopened "stacked" group stays
+           stacked until unstacked from the Stacks view. -->
+      <span class="gverdict" :title="decidedTitle">
+        <v-icon size="15">{{
+          verdict === "stacked" ? "mdi-layers" : "mdi-call-split"
+        }}</v-icon>
+        {{ verdict === "stacked" ? "Stacked" : "Kept separate" }}
+      </span>
+      <button
+        type="button"
+        class="gbtn"
+        :disabled="busy || readOnly"
+        :title="
+          bulk
+            ? `Clear the decision on every one of the ${selectionCount} selected groups: they return to the review queue. Stacked pictures stay stacked until you unstack them.`
+            : 'Clear this decision: the group returns to the review queue. Stacked pictures stay stacked until you unstack them.'
+        "
+        @click.stop="emit('clear-decision')"
+      >
+        <v-icon size="16">mdi-restore</v-icon>
+        <span>{{ bulk ? `Clear ${selectionCount} decisions` : "Clear decision" }}</span>
+      </button>
+    </div>
+    <div v-else class="gact">
+      <!-- The two verdict buttons carry what the verdict COSTS, because neither
+           one asks for a confirmation: stacking never deletes a file, and
+           keeping separate is remembered for good. A user meeting the queue for
+           the first time should not have to run one to find that out. -->
+      <button
+        type="button"
+        class="gbtn gbtn--stack"
+        :tabindex="focused ? 0 : -1"
+        :disabled="busy || readOnly"
+        :title="
+          bulk
+            ? `Stack every one of the ${selectionCount} selected groups behind its own cover. Every file stays on disk, and one Ctrl+Z reverses them all.`
+            : 'Group these behind one cover. Every file stays on disk, and Ctrl+Z reverses it.'
+        "
+        @click.stop="emit('stack')"
+      >
+        <v-icon size="16">mdi-layers-plus</v-icon>
+        <span>{{ bulk ? `Stack ${selectionCount} groups` : `Stack ${stackSize}` }}</span>
+        <kbd v-if="showsVerdictKeys" aria-hidden="true">Enter</kbd>
+      </button>
+      <button
+        type="button"
+        class="gbtn"
+        :tabindex="focused ? 0 : -1"
+        :disabled="busy || readOnly"
+        :title="
+          bulk
+            ? `Leave all ${selectionCount} selected groups as separate pictures. They stay in your library and stop being suggested.`
+            : 'Leave these as separate pictures. They stay in your library and stop being suggested.'
+        "
+        @click.stop="emit('keep-separate')"
+      >
+        <v-icon size="16">mdi-call-split</v-icon>
+        <span>{{ bulk ? `Keep ${selectionCount} separate` : "Keep separate" }}</span>
+        <kbd v-if="showsVerdictKeys" aria-hidden="true">S</kbd>
+      </button>
+      <button
+        type="button"
+        class="gcompare"
+        :tabindex="focused ? 0 : -1"
+        @click.stop="emit('compare')"
+      >
+        <v-icon size="15">mdi-compare-horizontal</v-icon>
+        <span>Compare all {{ group.candidates.length }}</span>
+        <kbd v-if="focused" aria-hidden="true">C</kbd>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+// One group in the triage queue.
+//
+// Exactly one row in the queue is focused, and it says so four ways at once:
+// an accent left bar, a caret, a tinted background and a filled Stack button.
+// That redundancy is the point. `Up`/`Down` then `Enter`/`S` can never be
+// ambiguous about which group they hit, and a user who looks away mid-run can
+// find the cursor again without reading anything. (The former "Keyboard acts
+// here" label was dropped as noise — owner call, 2026-07-29; the kbd chips on
+// the verdict buttons carry that message.)
+//
+// The row owns no data of its own: covers, exclusions and verdicts all belong
+// to the queue, which owns the auto-advance. This component only reports what
+// was clicked.
+//
+// Every control here is a roving tab stop. A screenful of twenty groups holds
+// well over a hundred buttons, and a Tab key that walks all of them is a Tab
+// key nobody presses twice; only the focused row is reachable that way, which
+// is also the only row the keyboard model acts on.
+//
+// `aria-current` on the row is the only part of the focused treatment that is
+// not purely visual. Without it the five CSS signals say nothing at all to a
+// screen reader, and "which group does Enter hit" becomes exactly the ambiguity
+// the treatment exists to remove.
+
+import { computed } from "vue";
+import DedupConfidencePill from "./DedupConfidencePill.vue";
+import DedupWhyPills from "./DedupWhyPills.vue";
+import { pictureThumbnailUrl } from "../../api/pictures";
+import { API_BASE_URL } from "../../utils/apiClient";
+import { candidateId } from "../../utils/dedup";
+import { MIN_STACK_MEMBERS } from "../../stores/useDedupStore";
+
+/** A candidate's picture id. The server calls the field `picture_id`. */
+const idOf = candidateId;
+
+const props = defineProps({
+  group: { type: Object, required: true },
+  index: { type: Number, default: 0 },
+  focused: { type: Boolean, default: false },
+  // Part of a Ctrl/Shift-click multi-selection. While the selection holds two
+  // or more groups, the verdict buttons rename themselves to say they act on
+  // ALL of them — a bulk action must never look like a single one.
+  selected: { type: Boolean, default: false },
+  selectionCount: { type: Number, default: 0 },
+  // True when Enter/S would genuinely take the whole selection (the focused
+  // row is inside it). Every selected row then wears the Enter/S chips;
+  // Compare's C stays on the focused row alone, since it opens one group.
+  bulkKeys: { type: Boolean, default: false },
+  // "stacked" | "keep_separate" on the decided page; empty on the open queue.
+  // A decided row swaps its verdict buttons for the verdict and a Clear.
+  verdict: { type: String, default: "" },
+  decidedAt: { type: String, default: "" },
+  coverId: { type: [Number, String], default: null },
+  excludedIds: { type: Array, default: () => [] },
+  // False for a row outside the read-ahead window: the thumbnails are the
+  // expensive half of a row, so an off-screen group holds a placeholder box of
+  // the same size rather than a decoded image.
+  loadThumbnails: { type: Boolean, default: true },
+  busy: { type: Boolean, default: false },
+  readOnly: { type: Boolean, default: false },
+});
+
+const emit = defineEmits([
+  "focus",
+  "stack",
+  "keep-separate",
+  "compare",
+  "set-cover",
+  "toggle-excluded",
+  "clear-decision",
+]);
+
+/** The verdict label's tooltip, carrying the timestamp when one is known. */
+const decidedTitle = computed(() => {
+  const what =
+    props.verdict === "stacked"
+      ? "This group was stacked."
+      : "This group was kept separate.";
+  return props.decidedAt ? `${what} Decided ${props.decidedAt}.` : what;
+});
+
+const stackSize = computed(
+  () => props.group.candidates.length - props.excludedIds.length,
+);
+
+/** Whether a verdict from this row would act on the whole selection. */
+const bulk = computed(() => props.selected && props.selectionCount > 1);
+
+/** Enter/S chips: the focused row always; every selected row while the bulk
+ * gesture is live, because the keys genuinely act on all of them. */
+const showsVerdictKeys = computed(
+  () => props.focused || (props.selected && props.bulkKeys),
+);
+
+/**
+ * Whether one more exclusion would drop this group below the stack floor.
+ *
+ * The store refuses that exclusion, because the server refuses a one-member
+ * stack. The row has to say so before the gesture rather than after it, or the
+ * tooltip is promising an action that will not happen.
+ */
+const atStackFloor = computed(() => stackSize.value <= MIN_STACK_MEMBERS);
+
+/**
+ * Whether a candidate is currently left out of the stack.
+ * @param {number|string} id
+ * @returns {boolean}
+ */
+function isOut(id) {
+  return props.excludedIds.includes(id);
+}
+
+/**
+ * The thumbnail URL for one candidate.
+ * @param {Object} candidate
+ * @returns {string}
+ */
+function thumbUrl(candidate) {
+  // baseUrl is load-bearing: the SPA and the backend are different origins in
+  // the dev server, the demo and Electron, so a relative /pictures/... 404s.
+  return pictureThumbnailUrl(idOf(candidate), {
+    version: candidate.thumbnail_version,
+    baseUrl: API_BASE_URL,
+  });
+}
+
+/** How tall every strip thumbnail is; widths follow each picture's shape. */
+const THUMB_HEIGHT_PX = 96;
+
+/**
+ * The PLACEHOLDER's estimated shape, from stored dimensions. Only an
+ * estimate: stored width/height ignore EXIF rotation, so the real image may
+ * arrive with the axes swapped — it then sizes the box itself.
+ *
+ * @param {Object} candidate
+ * @returns {Object|null} an inline width, or null when the shape is unknown.
+ */
+function thumbBoxStyle(candidate) {
+  const w = Number(candidate.width);
+  const h = Number(candidate.height);
+  if (!w || !h) return null;
+  const ratio = Math.min(2.4, Math.max(0.45, w / h));
+  return { width: `${Math.round(THUMB_HEIGHT_PX * ratio)}px` };
+}
+
+/**
+ * What a thumbnail button is called.
+ *
+ * The image itself is decorative here (the row deliberately carries no
+ * metadata), so without this every candidate reaches a screen reader as the
+ * same unlabelled control repeated N times.
+ *
+ * @param {Object} candidate
+ * @param {number} i - the candidate's zero-based position.
+ * @returns {string}
+ */
+function thumbLabel(candidate, i) {
+  const parts = [`Picture ${i + 1} of ${props.group.candidates.length}`];
+  if (isOut(idOf(candidate))) parts.push("not in the stack");
+  else if (idOf(candidate) === props.coverId) parts.push("cover");
+  return parts.join(", ");
+}
+
+/**
+ * The tooltip for a thumbnail, naming the key as well as the mouse gesture.
+ *
+ * Only the focused row answers to `1`-`9` and `X`, so only the focused row
+ * claims they work.
+ *
+ * @param {Object} candidate
+ * @param {number} i
+ * @returns {string}
+ */
+function thumbTitle(candidate, i) {
+  if (isOut(idOf(candidate))) {
+    return props.focused
+      ? "Right-click, or press X, to put this picture back in the stack"
+      : "Right-click to put this picture back in the stack";
+  }
+  // At the floor the exclusion gesture is refused, so it must not be offered.
+  if (atStackFloor.value) {
+    return props.focused
+      ? `Click, or press ${i + 1}, to make this the cover. A stack needs at least two pictures, so this one cannot be left out.`
+      : "Click to make this the cover. A stack needs at least two pictures, so this one cannot be left out.";
+  }
+  return props.focused
+    ? `Click, or press ${i + 1}, to make this the cover. Right-click, or press X, to leave it out of the stack.`
+    : "Click to make this the cover, right-click to leave it out";
+}
+
+/**
+ * Clicking a thumbnail focuses the row and makes that picture the cover.
+ * @param {Object} candidate
+ */
+function onPick(candidate) {
+  emit("focus");
+  emit("set-cover", idOf(candidate));
+}
+
+/**
+ * Right-clicking a thumbnail focuses the row and toggles the exclusion.
+ * @param {Object} candidate
+ */
+function onToggle(candidate) {
+  emit("focus");
+  emit("toggle-excluded", idOf(candidate));
+}
+</script>
+
+<style scoped>
+.grow {
+  position: relative;
+  display: grid;
+  /* Three columns — info | pictures | verdicts — per the owner's layout call
+     (2026-07-29): the row reads left to right as "what this is, what's in it,
+     what to do about it". minmax(0, 1fr) on the middle is what makes the
+     picture strip scroll horizontally INSIDE its cell (one scrollbar per row)
+     instead of blowing the row wide, and no column ever wraps under another. */
+  grid-template-columns: minmax(150px, 190px) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3) var(--space-5);
+  padding: var(--space-4);
+  padding-left: var(--space-5);
+  border-radius: var(--radius-md);
+  border: 1px solid rgb(var(--v-theme-divider));
+  background: rgb(var(--v-theme-surface));
+  cursor: pointer;
+  transition:
+    background var(--dur-1) var(--ease-standard),
+    border-color var(--dur-1) var(--ease-standard);
+}
+
+.grow:hover {
+  background: var(--hover-wash);
+}
+
+/* The focused row's five simultaneous signals. The left bar is a pseudo-element
+   so it cannot shift the row's layout when the focus moves. */
+.grow--focus {
+  background: var(--active-wash);
+  border-color: rgba(var(--v-theme-accent), 0.4);
+}
+
+.grow--focus::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
+  background: rgb(var(--v-theme-accent));
+}
+
+/* Part of a multi-selection: the same accent family as the focus treatment,
+   one step quieter — no left bar, that stays the keyboard cursor's. */
+.grow--selected {
+  border-color: rgba(var(--v-theme-accent), 0.55);
+  background: var(--hover-wash);
+}
+
+.grow--selected.grow--focus {
+  background: var(--active-wash);
+}
+
+/* The info column stacks its facts top-to-bottom and never wraps sideways. */
+.ginfo {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.gcaret {
+  color: rgb(var(--v-theme-accent));
+  flex-shrink: 0;
+  align-self: center;
+  margin-left: calc(-1 * var(--space-2));
+}
+
+.gn {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.gn b {
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.gn span {
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+/* The decided row's verdict statement — reads as state, not as a button. */
+.gverdict {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: rgba(var(--v-theme-on-surface), 0.75);
+}
+
+.gstrip {
+  display: flex;
+  gap: var(--space-2);
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-gutter: stable;
+  padding-bottom: var(--space-1);
+}
+
+.gthumb {
+  position: relative;
+  flex: 0 0 auto;
+  /* Width comes from the child: the decoded image (always the true, EXIF-
+     corrected shape) or the placeholder's metadata estimate. */
+  width: auto;
+  min-width: 44px;
+  height: 96px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: rgba(var(--v-theme-on-surface), 0.06);
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.gthumb:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+.gthumb--cover {
+  border-color: rgb(var(--v-theme-accent));
+}
+
+/* An excluded candidate stays visible and stays clickable: it is a choice the
+   user can walk back, not a deletion. */
+.gthumb--out {
+  opacity: 0.4;
+}
+
+.gt {
+  display: block;
+  width: auto;
+  height: 100%;
+  /* A ceiling, not a crop: only a beyond-panoramic shape gets clipped. */
+  max-width: 230px;
+  object-fit: cover;
+}
+
+.gt--placeholder {
+  width: 128px;
+  background: rgba(var(--v-theme-on-surface), 0.08);
+}
+
+.gnum,
+.gcv {
+  position: absolute;
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-2);
+  background: var(--scrim-photo);
+  color: rgb(var(--v-theme-on-dark-surface));
+}
+
+.gnum {
+  top: var(--space-2);
+  left: var(--space-2);
+  min-width: var(--badge-size);
+  text-align: center;
+}
+
+.gcv {
+  bottom: var(--space-2);
+  left: var(--space-2);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+}
+
+.gx {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: rgb(var(--v-theme-on-dark-surface));
+}
+
+/* The verdict column: one action per line, never wrapping under the strip. */
+.gact {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-2);
+}
+
+.gbtn,
+.gcompare {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  height: 27px;
+  padding: 0 var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid rgb(var(--v-theme-border));
+  background: transparent;
+  color: rgb(var(--v-theme-on-surface));
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition:
+    background var(--dur-1) var(--ease-standard),
+    border-color var(--dur-1) var(--ease-standard);
+}
+
+.gbtn:hover:not(:disabled),
+.gcompare:hover {
+  background: var(--hover-wash);
+}
+
+.gbtn:focus-visible,
+.gcompare:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+.gbtn:disabled {
+  opacity: 0.38;
+  cursor: default;
+}
+
+/* The primary verdict fills only on the focused row, so the eye lands on the
+   one button `Enter` would press. */
+.grow--focus .gbtn--stack {
+  background: rgb(var(--v-theme-accent));
+  border-color: rgb(var(--v-theme-accent));
+  color: rgb(var(--v-theme-on-accent));
+}
+
+.gcompare {
+  border-color: transparent;
+  color: rgba(var(--v-theme-on-surface), 0.75);
+}
+
+kbd {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  line-height: var(--leading-snug);
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid currentColor;
+  opacity: 0.7;
+}
+</style>

--- a/frontend/src/components/widgets/DedupScanBanner.test.js
+++ b/frontend/src/components/widgets/DedupScanBanner.test.js
@@ -1,0 +1,120 @@
+// The streaming "still scanning" banner above the duplicate queue.
+//
+// The banner is what makes a partial queue honest, so the tests pin when it
+// appears and disappears, that it never states a figure it does not have, and
+// that its progress track is announced as a progress bar rather than as a
+// decorative strip.
+
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import DedupScanBanner from "./DedupScanBanner.vue";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+/** The store's normalised scan record, which is what the banner is given. */
+function scan(overrides = {}) {
+  return {
+    status: "running",
+    scanned: 1200,
+    total: 48000,
+    percent: 2.5,
+    buckets: 0,
+    totalBuckets: 0,
+    error: null,
+    ...overrides,
+  };
+}
+
+/** Text with runs of whitespace collapsed, so template wrapping is not asserted. */
+function textOf(wrapper) {
+  return wrapper.text().replace(/\s+/g, " ");
+}
+
+function mountBanner(overrides = {}) {
+  return mount(DedupScanBanner, {
+    ...globalOpts,
+    props: { scan: scan(overrides) },
+  });
+}
+
+describe("DedupScanBanner", () => {
+  it("reports how far the comparison has got", () => {
+    // Without the counts a short queue reads as "you have almost no
+    // duplicates" rather than "the scan is 2% in".
+    const text = textOf(mountBanner());
+    expect(text).toContain("Still scanning.");
+    expect(text).toContain(
+      `${(1200).toLocaleString()} of ${(48000).toLocaleString()} pictures compared.`,
+    );
+    expect(text).toContain("Groups appear here as they are found.");
+  });
+
+  // Tier 2 streams its groups in as each candidate bucket finishes, so a scope
+  // whose picture total is not known yet still has honest progress to report.
+  it("counts candidate batches when there is no picture total yet", () => {
+    const text = textOf(
+      mountBanner({ total: 0, scanned: 0, buckets: 3, totalBuckets: 12 }),
+    );
+    expect(text).toContain("3 of 12 candidate batches compared.");
+    expect(text).not.toContain("pictures compared");
+  });
+
+  it("renders nothing once the scan reaches 100 percent", () => {
+    // A banner that stays up after the pass finishes tells the user the list
+    // is still incomplete when it is not.
+    expect(mountBanner({ percent: 100 }).find(".scan-banner").exists()).toBe(
+      false,
+    );
+  });
+
+  it("renders nothing when the scan is not running", () => {
+    // A finished, idle or failed scan must not leave a banner frozen at 99
+    // percent. `pending` and `running` are the only live statuses.
+    for (const status of ["idle", "complete", "failed"]) {
+      expect(
+        mountBanner({ status, percent: 40 }).find(".scan-banner").exists(),
+      ).toBe(false);
+    }
+    expect(
+      mountBanner({ status: "pending", percent: 0 })
+        .find(".scan-banner")
+        .exists(),
+    ).toBe(true);
+  });
+
+  // The server reports no time estimate, and inventing one from a bucket rate
+  // would be a guess presented as a fact. A wrong estimate is worse than none.
+  it("states no time remaining, because the server does not know one", () => {
+    expect(textOf(mountBanner())).not.toContain("min left");
+  });
+
+  it("announces the track as a progress bar", () => {
+    // The track is the only progress readout; unlabelled it is invisible to a
+    // screen reader (WCAG 1.3.1).
+    const track = mountBanner({ percent: 42 }).find(".scan-banner__track");
+    expect(track.attributes("role")).toBe("progressbar");
+    expect(track.attributes("aria-label")).toBe("Duplicate scan progress");
+    expect(track.attributes("aria-valuenow")).toBe("42");
+    expect(track.attributes("aria-valuemin")).toBe("0");
+    expect(track.attributes("aria-valuemax")).toBe("100");
+  });
+
+  it("fills the track to the same figure it prints", () => {
+    // A bar and a number that disagree make the whole readout untrustworthy.
+    const wrapper = mountBanner({ percent: 42.4 });
+    expect(textOf(wrapper)).toContain("42%");
+    expect(wrapper.find(".scan-banner__fill").attributes("style")).toContain(
+      "width: 42%",
+    );
+  });
+
+  it("treats unknown progress as zero instead of NaN", () => {
+    // The first poll of a fresh scan can arrive without a percent.
+    const wrapper = mountBanner({ percent: undefined });
+    expect(textOf(wrapper)).toContain("0%");
+    expect(
+      wrapper.find(".scan-banner__track").attributes("aria-valuenow"),
+    ).toBe("0");
+  });
+});

--- a/frontend/src/components/widgets/DedupScanBanner.vue
+++ b/frontend/src/components/widgets/DedupScanBanner.vue
@@ -1,0 +1,156 @@
+<script setup>
+/**
+ * The streaming "still scanning" banner above the duplicate queue.
+ *
+ * It exists so the queue never blocks on a full pass. Groups stream in as they
+ * are found, and this banner is what makes a partial list honest: it says how
+ * far the comparison has got, so a short list reads as "not finished yet"
+ * rather than as "you have almost no duplicates".
+ *
+ * It removes itself the moment it stops being true, at 100 percent or as soon
+ * as the scan leaves a running state. A banner that lingers at 99 percent after
+ * a cancelled scan would be worse than no banner at all.
+ */
+import { computed } from "vue";
+
+/** Statuses in which a scan is genuinely still comparing pictures. */
+const RUNNING_STATES = new Set(["pending", "running"]);
+
+const props = defineProps({
+  /**
+   * Normalised scan progress from `useDedupStore`:
+   * `{ status, scanned, total, percent, buckets, totalBuckets, error }`.
+   *
+   * The server reports pictures and candidate buckets but no percentage and no
+   * time estimate, so `percent` is derived in the store and there is
+   * deliberately no "N min left": inventing one from a bucket rate would be a
+   * guess presented as a fact, and a wrong estimate is worse than none.
+   */
+  scan: { type: Object, required: true },
+});
+
+/** Progress as a whole number in 0 to 100. Unknown progress reads as 0. */
+const percent = computed(() => {
+  const value = Number(props.scan?.percent);
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(100, Math.max(0, Math.round(value)));
+});
+
+const visible = computed(
+  () => RUNNING_STATES.has(props.scan?.status) && percent.value < 100,
+);
+
+/**
+ * Tier 2 streams its groups in as each candidate bucket finishes, so a scope
+ * whose picture total is not known yet still has honest progress to report.
+ */
+const countsPictures = computed(() => Number(props.scan?.total) > 0);
+const bucketsText = computed(() =>
+  Number(props.scan?.buckets ?? 0).toLocaleString(),
+);
+const totalBucketsText = computed(() =>
+  Number(props.scan?.totalBuckets ?? 0).toLocaleString(),
+);
+
+const scannedText = computed(() =>
+  Number(props.scan?.scanned ?? 0).toLocaleString(),
+);
+const totalText = computed(() =>
+  Number(props.scan?.total ?? 0).toLocaleString(),
+);
+</script>
+
+<template>
+  <div v-if="visible" class="scan-banner">
+    <v-icon class="scan-banner__ico" size="18">mdi-radar</v-icon>
+    <p v-if="countsPictures" class="scan-banner__line">
+      Still scanning. <b>{{ scannedText }}</b> of
+      <b>{{ totalText }}</b> pictures compared. Groups appear here as they are
+      found.
+    </p>
+    <p v-else class="scan-banner__line">
+      Still scanning. <b>{{ bucketsText }}</b> of
+      <b>{{ totalBucketsText }}</b> candidate batches compared. Groups appear
+      here as they are found.
+    </p>
+    <span class="scan-banner__meta">{{ percent }}%</span>
+    <span
+      class="scan-banner__track"
+      role="progressbar"
+      aria-label="Duplicate scan progress"
+      :aria-valuenow="percent"
+      aria-valuemin="0"
+      aria-valuemax="100"
+    >
+      <span class="scan-banner__fill" :style="{ width: `${percent}%` }"></span>
+    </span>
+  </div>
+</template>
+
+<style scoped>
+/* A panel surface, not a notice: this is ambient status about the list below
+   it, it is never dismissed, and it must not compete with the notice stack.
+   `overflow: hidden` is safe here because the banner holds no focusable child
+   whose ring could be clipped; it is what lets the track meet the bottom cap. */
+.scan-banner {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+  margin-inline: var(--space-5);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: rgb(var(--v-theme-panel));
+  color: rgb(var(--v-theme-on-panel));
+  box-shadow: var(--elevation-1);
+  overflow: hidden;
+}
+
+.scan-banner__ico {
+  color: rgb(var(--v-theme-on-panel));
+  flex-shrink: 0;
+}
+
+.scan-banner__line {
+  margin: 0;
+  min-width: 0;
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+}
+
+/* The counts are the part the eye returns to, so they carry the weight, and
+   tabular figures stop the sentence reflowing as the numbers tick up. */
+.scan-banner__line b {
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+.scan-banner__meta {
+  justify-self: end;
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+  color: rgba(var(--v-theme-on-panel), 0.7);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* Pinned to the bottom edge and full width, so the banner itself is the meter.
+   A separate inset bar would read as a second component. */
+.scan-banner__track {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  height: var(--countdown-h);
+  background: rgba(var(--v-theme-on-panel), 0.14);
+}
+
+.scan-banner__fill {
+  display: block;
+  height: 100%;
+  background: rgb(var(--v-theme-accent));
+  /* Progress arrives in polls, so the fill eases between them instead of
+     snapping. The global reduced-motion rule collapses this. */
+  transition: width var(--dur-2) var(--ease-standard);
+}
+</style>

--- a/frontend/src/components/widgets/DedupScopePill.test.js
+++ b/frontend/src/components/widgets/DedupScopePill.test.js
@@ -1,0 +1,69 @@
+// The dismissible pill that says the duplicate queue is scoped to one project,
+// set, character, or folder.
+//
+// The tests pin the two things that matter: the scope is actually stated, and
+// the way out of it is a real, correctly-labelled button.
+
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import DedupScopePill from "./DedupScopePill.vue";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+function mountPill(props = {}) {
+  return mount(DedupScopePill, {
+    ...globalOpts,
+    props: { label: "Iceland 2026", ...props },
+  });
+}
+
+describe("DedupScopePill", () => {
+  it("states the scope it is filtered to", () => {
+    // A filtered queue that does not say so is how a user concludes they have
+    // no duplicates left while looking at one folder.
+    expect(mountPill().text()).toContain("Iceland 2026");
+  });
+
+  it("shows a count when it has one", () => {
+    // Thousands separators, because a raw 12000 is read wrong at a glance.
+    expect(mountPill({ count: 12000 }).find(".scope-pill__count").text()).toBe(
+      (12000).toLocaleString(),
+    );
+  });
+
+  it("omits the count when it is unknown", () => {
+    // A missing count must not render as a misleading "0".
+    expect(mountPill().find(".scope-pill__count").exists()).toBe(false);
+  });
+
+  it("emits dismiss when the control is used", () => {
+    // The pill is the only way back to the whole library.
+    const wrapper = mountPill();
+    wrapper.find(".scope-pill__dismiss").trigger("click");
+    expect(wrapper.emitted("dismiss")).toHaveLength(1);
+  });
+
+  it("labels dismissal by what it does, not by its glyph", () => {
+    // "Close" is meaningless read out of context; the label has to name the
+    // outcome (WCAG 2.4.6).
+    const button = mountPill().find(".scope-pill__dismiss");
+    expect(button.attributes("aria-label")).toBe(
+      "Show duplicates in the whole library",
+    );
+  });
+
+  it("uses a real button, typed so it cannot submit a surrounding form", () => {
+    // A div with a click handler is unreachable by keyboard, and an untyped
+    // button inside a form defaults to submit.
+    const button = mountPill().find(".scope-pill__dismiss");
+    expect(button.element.tagName).toBe("BUTTON");
+    expect(button.attributes("type")).toBe("button");
+  });
+
+  it("shows a genuine zero rather than hiding it", () => {
+    // A scope with nothing left in it is information, not a missing value, and
+    // it is the state that tells the user the scope is done.
+    expect(mountPill({ count: 0 }).find(".scope-pill__count").text()).toBe("0");
+  });
+});

--- a/frontend/src/components/widgets/DedupScopePill.vue
+++ b/frontend/src/components/widgets/DedupScopePill.vue
@@ -1,0 +1,105 @@
+<script setup>
+/**
+ * The dismissible pill that says the duplicate queue is showing one scope: a
+ * project, a set, a character, or a folder.
+ *
+ * A filtered list that does not say it is filtered is how a user concludes they
+ * have no duplicates left when they are looking at one folder's worth. The pill
+ * states the scope, and dismissing it is the way back to the whole library.
+ *
+ * The dismiss control's label says what dismissing DOES, not what the glyph
+ * looks like: "Show duplicates in the whole library" is actionable out of
+ * context, "Close" is not.
+ */
+import { computed } from "vue";
+
+const props = defineProps({
+  /** The scope's name, as the user knows it. */
+  label: { type: String, required: true },
+  /** MDI glyph for the scope's kind. */
+  icon: { type: String, default: "mdi-folder-multiple-image" },
+  /** Pictures in scope. `null` when the count is not known. */
+  count: { type: Number, default: null },
+});
+
+defineEmits(["dismiss"]);
+
+/** Rendered only when the caller actually has a number, never as a "0". */
+const countText = computed(() =>
+  Number.isFinite(props.count) ? props.count.toLocaleString() : "",
+);
+</script>
+
+<template>
+  <span class="scope-pill">
+    <v-icon class="scope-pill__ico" size="14">{{ icon }}</v-icon>
+    <span class="scope-pill__label">{{ label }}</span>
+    <span v-if="countText" class="scope-pill__count">{{ countText }}</span>
+    <button
+      type="button"
+      class="scope-pill__dismiss"
+      aria-label="Show duplicates in the whole library"
+      @click="$emit('dismiss')"
+    >
+      <v-icon size="14">mdi-close</v-icon>
+    </button>
+  </span>
+</template>
+
+<style scoped>
+/* An accent tint rather than a solid accent fill: the pill is a standing state,
+   not a call to action, and the label has to stay `on-surface` body text. */
+.scope-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-2) var(--space-2) var(--space-3);
+  border-radius: var(--radius-pill);
+  background: rgba(var(--v-theme-accent), 0.14);
+  border: 1px solid rgba(var(--v-theme-accent), 0.4);
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  color: rgb(var(--v-theme-on-surface));
+  max-width: 100%;
+}
+
+.scope-pill__ico {
+  color: rgb(var(--v-theme-on-surface));
+  flex-shrink: 0;
+}
+
+.scope-pill__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scope-pill__count {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  flex-shrink: 0;
+}
+
+.scope-pill__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: var(--space-1);
+  border: none;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: rgb(var(--v-theme-on-surface));
+  cursor: pointer;
+}
+.scope-pill__dismiss:hover {
+  background: var(--hover-wash);
+}
+.scope-pill__dismiss:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+</style>

--- a/frontend/src/components/widgets/DedupTierMenu.vue
+++ b/frontend/src/components/widgets/DedupTierMenu.vue
@@ -1,0 +1,338 @@
+<template>
+  <div class="tiermenu" role="group" aria-label="Which duplicates to include">
+    <div class="tm-head">
+      <v-icon size="16">mdi-filter-outline</v-icon>
+      <span class="tm-title">Include</span>
+      <span class="tm-sp"></span>
+      <span class="tm-count">{{ groupCountLabel }}</span>
+    </div>
+
+    <!-- Every row, including the locked one, comes from the server's tier list.
+         A locked row rather than an absent one, because an absent row reads as
+         a missing feature and a locked one reads as an answer. -->
+    <component
+      :is="tier.locked ? 'div' : 'button'"
+      v-for="tier in tiers"
+      :key="tier.id"
+      :type="tier.locked ? undefined : 'button'"
+      class="tierrow"
+      :class="{
+        'tierrow--on': tier.enabled,
+        'tierrow--locked': tier.locked,
+      }"
+      :disabled="tier.locked ? undefined : !isReachable(tier)"
+      :aria-pressed="tier.locked ? undefined : tier.enabled"
+      :title="reasonFor(tier)"
+      @click="tier.locked ? undefined : emit('toggle', tier.id, !tier.enabled)"
+    >
+      <span class="cbox" :class="{ 'cbox--on': tier.enabled }">
+        <v-icon v-if="tier.enabled" size="14">mdi-check</v-icon>
+      </span>
+      <span class="tname"
+        >{{ tier.label }}
+        <span v-if="tier.hint" class="trange">{{ tier.hint }}</span>
+        <span v-if="tier.locked" class="tlock">always included</span></span
+      >
+      <span class="tcount">{{ formatCount(tier.count) }}</span>
+    </component>
+
+    <!-- The threshold and its floor are the server's. Stating a number here
+         would put the same bound in two places that can drift apart. -->
+    <div v-if="hasThreshold" class="tm-threshold">
+      <label class="tm-threshold-label" :for="thresholdId"
+        >Similar enough at</label
+      >
+      <input
+        :id="thresholdId"
+        class="tm-threshold-input"
+        type="range"
+        :min="minThreshold"
+        :max="maxThreshold"
+        step="0.01"
+        :value="threshold"
+        :disabled="!anyLooserTierOn"
+        @change="emit('threshold', Number($event.target.value))"
+      />
+      <output class="tm-threshold-value">{{ thresholdPercent }}%</output>
+    </div>
+
+    <!-- The loosest tier states its own risk in place, so the warning arrives
+         where the decision is made rather than in a preamble nobody reads. -->
+    <p v-if="loosestIsOn" class="tierwarn">
+      <v-icon size="16">mdi-alert-outline</v-icon>
+      <span
+        >Same-scene groups are often genuinely different pictures. Compare
+        before stacking, these are the ones people get wrong.</span
+      >
+    </p>
+  </div>
+</template>
+
+<script setup>
+// The confidence gate in front of the queue.
+//
+// Tier 1 is always included and cannot be switched off. Every looser tier is a
+// separate opt-in, and enabling one requires the tier above it, so a user cannot
+// land on "same scene" suggestions without having deliberately walked down to
+// them. A low threshold produces confident-looking garbage and destroys trust in
+// the count, which is the whole reason this control is a ladder rather than a
+// free slider.
+//
+// Nothing here is hardcoded: the tier ids, their prerequisites, which of them
+// are always on, and the threshold's floor and ceiling all arrive from
+// `GET /dedup/policy` through the store. This component renders them and reports
+// what the user pressed.
+
+import { computed, useId } from "vue";
+
+const props = defineProps({
+  /**
+   * Tier rows from `useDedupStore.tierRows`, strongest evidence first:
+   * `{ id, label, hint, count, locked, requires, enabled }`.
+   */
+  tiers: { type: Array, default: () => [] },
+  /** How many groups the queue currently holds under this gate. */
+  groupCount: { type: Number, default: 0 },
+  /** The similarity threshold in force, or null before the policy has loaded. */
+  threshold: { type: Number, default: null },
+  /** `bounds.min_threshold` from the server. */
+  minThreshold: { type: Number, default: null },
+  /** `bounds.max_threshold` from the server. */
+  maxThreshold: { type: Number, default: null },
+});
+
+const emit = defineEmits(["toggle", "threshold"]);
+
+const thresholdId = useId();
+
+const groupCountLabel = computed(() => {
+  const n = Number(props.groupCount) || 0;
+  return `${n.toLocaleString()} ${n === 1 ? "group" : "groups"}`;
+});
+
+const hasThreshold = computed(
+  () =>
+    Number.isFinite(props.threshold) &&
+    Number.isFinite(props.minThreshold) &&
+    Number.isFinite(props.maxThreshold),
+);
+
+const thresholdPercent = computed(() => Math.round(props.threshold * 100));
+
+/** Whether any tier the threshold applies to is switched on. */
+const anyLooserTierOn = computed(() =>
+  props.tiers.some((tier) => !tier.locked && tier.enabled),
+);
+
+const loosestIsOn = computed(() => {
+  const last = props.tiers[props.tiers.length - 1];
+  return Boolean(last && !last.locked && last.enabled);
+});
+
+/**
+ * Whether a tier may be toggled: its prerequisite has to be on first.
+ * @param {Object} tier
+ * @returns {boolean}
+ */
+function isReachable(tier) {
+  if (!tier?.requires) return true;
+  const prerequisite = props.tiers.find((t) => t.id === tier.requires);
+  return Boolean(prerequisite?.enabled || prerequisite?.locked);
+}
+
+/**
+ * Why a row is the way it is, as a tooltip.
+ *
+ * An unreachable row that just sits there greyed out is a dead end; saying what
+ * to turn on first turns it into an instruction.
+ *
+ * @param {Object} tier
+ * @returns {string|undefined}
+ */
+function reasonFor(tier) {
+  if (tier.locked) return "Identical files are always included";
+  if (isReachable(tier)) return undefined;
+  const prerequisite = props.tiers.find((t) => t.id === tier.requires);
+  return `Turn on ${prerequisite?.label ?? tier.requires} first, so looser suggestions are always a deliberate step down`;
+}
+
+/**
+ * Format a tier count, leaving an unknown count as a placeholder rather than a
+ * confident zero.
+ * @param {number} value
+ * @returns {string}
+ */
+function formatCount(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n.toLocaleString() : "–";
+}
+</script>
+
+<style scoped>
+.tiermenu {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 300px;
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgb(var(--v-theme-border));
+  background: rgb(var(--v-theme-surface));
+  color: rgb(var(--v-theme-on-surface));
+  box-shadow: var(--elevation-3);
+}
+
+.tm-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+}
+
+.tm-title {
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: rgba(var(--v-theme-on-surface), 0.5);
+}
+
+.tm-sp {
+  flex: 1;
+}
+
+.tm-count {
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+.tierrow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: inherit;
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--dur-1) var(--ease-standard);
+}
+
+.tierrow:hover:not(:disabled):not(.tierrow--locked) {
+  background: var(--hover-wash);
+}
+
+.tierrow:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+.tierrow:disabled {
+  opacity: 0.38;
+  cursor: default;
+}
+
+.tierrow--on {
+  background: var(--active-wash);
+}
+
+/* Locked, not disabled: it is on and stays on, so it must not read as an
+   unavailable control. Rendered as a div for the same reason, so the keyboard
+   does not stop on something that cannot be operated. */
+.tierrow--locked {
+  cursor: default;
+  background: var(--active-wash);
+}
+
+.cbox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: var(--space-5);
+  height: var(--space-5);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgb(var(--v-theme-border));
+}
+
+.cbox--on {
+  background: rgb(var(--v-theme-primary));
+  border-color: rgb(var(--v-theme-primary));
+  color: rgb(var(--v-theme-on-primary));
+}
+
+.tname {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.trange,
+.tlock {
+  font-size: var(--text-2xs);
+  color: rgba(var(--v-theme-on-surface), 0.55);
+}
+
+.tcount {
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+.tm-threshold {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+}
+
+.tm-threshold-label {
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  white-space: nowrap;
+}
+
+.tm-threshold-input {
+  flex: 1;
+  min-width: 0;
+  accent-color: rgb(var(--v-theme-accent));
+}
+
+.tm-threshold-input:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+.tm-threshold-input:disabled {
+  opacity: 0.38;
+}
+
+.tm-threshold-value {
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+}
+
+.tierwarn {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin: 0;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: rgba(var(--v-theme-warning), 0.12);
+  border: 1px solid rgba(var(--v-theme-warning), 0.35);
+  font-size: var(--text-xs);
+  line-height: var(--leading-body);
+  color: rgb(var(--v-theme-on-surface));
+}
+</style>

--- a/frontend/src/components/widgets/DedupWhyPills.test.js
+++ b/frontend/src/components/widgets/DedupWhyPills.test.js
@@ -1,0 +1,85 @@
+// The why-pills under a duplicate group.
+//
+// `orderEvidence` is pinned in utils/dedup.test.js; these tests pin what the
+// COMPONENT is responsible for: that the counter-evidence survives truncation,
+// that the for/against split is legible without colour, and that an empty
+// evidence list renders nothing rather than an empty row.
+
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import DedupWhyPills from "./DedupWhyPills.vue";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+/** Two supporting reasons with the warning last, as the server may send it. */
+const MIXED = [
+  { label: "Same size", against: false },
+  { label: "Same camera", against: false },
+  { label: "Different capture time", against: true },
+];
+
+function mountPills(props = {}) {
+  return mount(DedupWhyPills, {
+    ...globalOpts,
+    props: { why: MIXED, ...props },
+  });
+}
+
+describe("DedupWhyPills", () => {
+  it("reads the counter-evidence first", () => {
+    // Regression here means the row that most needs a closer look opens with
+    // two reassuring green pills.
+    const labels = mountPills()
+      .findAll(".why-pill__label")
+      .map((n) => n.text());
+    expect(labels).toEqual([
+      "Different capture time",
+      "Same size",
+      "Same camera",
+    ]);
+  });
+
+  it("marks counter-evidence with its own modifier class", () => {
+    // The class is what carries the red treatment; losing it makes an argument
+    // against stacking look like an argument for it.
+    const pills = mountPills().findAll(".why-pill");
+    expect(pills[0].classes()).toContain("why-pill--neg");
+    expect(pills[1].classes()).toContain("why-pill--pos");
+  });
+
+  it("truncates after ordering, never before", () => {
+    // Truncating the server order first would be free to drop the warning and
+    // leave a row that looks unanimously safe.
+    const labels = mountPills({ limit: 2 })
+      .findAll(".why-pill__label")
+      .map((n) => n.text());
+    expect(labels).toEqual(["Different capture time", "Same size"]);
+  });
+
+  it("shows every pill when no limit is set", () => {
+    // A limit of 0 is the expanded row; silently capping it would hide evidence
+    // the user opened the row to read.
+    expect(mountPills({ limit: 0 }).findAll(".why-pill")).toHaveLength(3);
+  });
+
+  it("states the for/against split in words as well as colour", () => {
+    // WCAG 1.4.1: colour alone must not carry the meaning.
+    const pills = mountPills().findAll(".why-pill");
+    expect(pills[0].attributes("title")).toBe("Argues against stacking");
+    expect(pills[1].attributes("title")).toBe("Supports stacking");
+  });
+
+  it("renders nothing when a group has no evidence", () => {
+    // An empty list would otherwise leave an empty flex row taking up space
+    // under every group that carries no reasoning.
+    const wrapper = mount(DedupWhyPills, { ...globalOpts, props: { why: [] } });
+    expect(wrapper.find(".why-pills").exists()).toBe(false);
+  });
+
+  it("survives a missing why prop", () => {
+    // The queue renders rows before the evidence has streamed in.
+    const wrapper = mount(DedupWhyPills, globalOpts);
+    expect(wrapper.findAll(".why-pill")).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/widgets/DedupWhyPills.vue
+++ b/frontend/src/components/widgets/DedupWhyPills.vue
@@ -1,0 +1,114 @@
+<script setup>
+/**
+ * The why-pills under a duplicate group: the evidence for and against stacking.
+ *
+ * The pills are the group's reasoning, shown where the decision is made, so the
+ * user never has to trust an unexplained suggestion.
+ *
+ * Two rules shape this component:
+ *
+ *   • Counter-evidence reads FIRST (`orderEvidence`). A group carrying red pills
+ *     is exactly the one that needs a closer look, and a collapsed row has room
+ *     for about two pills, so the warning half has to be the half that survives
+ *     the `limit`.
+ *   • Meaning never rides on colour alone (WCAG 1.4.1). The check and the cross
+ *     glyphs carry the for/against split, and each pill states it in its `title`
+ *     as well, so the distinction survives a monochrome or colour-blind read.
+ *
+ * The label sits in `on-surface`, not in `primary` or `error`: an action-fill
+ * token is never small body text on a canvas (visual-language.md §4). The status
+ * colour lives in the tinted fill, the border, and the glyph.
+ */
+import { computed } from "vue";
+
+import { orderEvidence, evidenceLabel } from "../../utils/dedup";
+
+/** The pill's rendered text. The server calls the field `text`. */
+const labelOf = evidenceLabel;
+
+const props = defineProps({
+  /** Evidence entries, the server's `[{ text, against }]`, in its order. */
+  why: { type: Array, default: () => [] },
+  /** Maximum pills to render. 0 means show every one. */
+  limit: { type: Number, default: 0 },
+});
+
+/**
+ * Ordering happens BEFORE truncation, never after: truncating the server order
+ * first would be free to drop the counter-evidence and leave a row that looks
+ * unanimously safe when it is not.
+ */
+const pills = computed(() => {
+  const ordered = orderEvidence(props.why);
+  return props.limit > 0 ? ordered.slice(0, props.limit) : ordered;
+});
+</script>
+
+<template>
+  <ul v-if="pills.length" class="why-pills">
+    <li
+      v-for="(pill, index) in pills"
+      :key="`${index}:${labelOf(pill)}`"
+      class="why-pill"
+      :class="pill.against ? 'why-pill--neg' : 'why-pill--pos'"
+      :title="pill.against ? 'Argues against stacking' : 'Supports stacking'"
+    >
+      <v-icon class="why-pill__ico" size="12">{{
+        pill.against ? "mdi-close" : "mdi-check"
+      }}</v-icon>
+      <span class="why-pill__label">{{ labelOf(pill) }}</span>
+    </li>
+  </ul>
+</template>
+
+<style scoped>
+/* A list, not a row of spans: this is an enumeration of reasons, and a screen
+   reader announcing "list, 3 items" is the correct summary of it. */
+.why-pills {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.why-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+  /* Full-strength body text on a tint. The status hue is carried by the fill,
+     the border, and the glyph, which is where a 12px label cannot go. */
+  color: rgb(var(--v-theme-on-surface));
+  white-space: nowrap;
+}
+
+/* Supports stacking. */
+.why-pill--pos {
+  background: rgba(var(--v-theme-primary), 0.12);
+  border-color: rgba(var(--v-theme-primary), 0.35);
+}
+.why-pill--pos .why-pill__ico {
+  color: rgb(var(--v-theme-primary));
+}
+
+/* Argues against stacking. Same construction, so the two read as one family
+   with one differing signal rather than as two different components. */
+.why-pill--neg {
+  background: rgba(var(--v-theme-error), 0.12);
+  border-color: rgba(var(--v-theme-error), 0.35);
+}
+.why-pill--neg .why-pill__ico {
+  color: rgb(var(--v-theme-error));
+}
+
+.why-pill__ico {
+  flex-shrink: 0;
+}
+</style>

--- a/frontend/src/components/widgets/StackBadge.test.js
+++ b/frontend/src/components/widgets/StackBadge.test.js
@@ -1,0 +1,88 @@
+// The grid tile's stack badge.
+//
+// These pin the two things the badge is responsible for: that a suggestion
+// never renders as an existing stack, and that a click reaches the parent so it
+// can expand the stack or jump to the group in the queue.
+
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import StackBadge from "./StackBadge.vue";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+/** Mount the badge with the given props. */
+function mountBadge(props = {}) {
+  return mount(StackBadge, { ...globalOpts, props });
+}
+
+describe("StackBadge — when it appears", () => {
+  it("renders nothing for a lone picture", () => {
+    // A badge reading "1" on every single-picture tile would be noise on the
+    // overwhelming majority of the grid.
+    const wrapper = mountBadge({ count: 1 });
+    expect(wrapper.find('[data-testid="stack-badge"]').exists()).toBe(false);
+  });
+
+  it("renders nothing when no count was supplied", () => {
+    // Guards the default: a tile whose count has not loaded must not flash a
+    // badge claiming "0".
+    const wrapper = mountBadge();
+    expect(wrapper.find('[data-testid="stack-badge"]').exists()).toBe(false);
+  });
+
+  it("shows the count from two pictures up", () => {
+    // Two is the smallest real stack; anything that hid it would leave the
+    // commonest stack indistinguishable from a single photo.
+    const wrapper = mountBadge({ count: 2 });
+    expect(wrapper.find(".sbcount").text()).toBe("2");
+  });
+});
+
+describe("StackBadge — stacked vs unresolved", () => {
+  it("states the stack as a fact", () => {
+    // The resolved state carries no question mark: this stack exists.
+    const wrapper = mountBadge({ count: 4 });
+    expect(wrapper.find(".sbcount").text()).toBe("4");
+    expect(wrapper.find(".sbcount").text()).not.toContain("?");
+    expect(wrapper.get('[data-testid="stack-badge"]').attributes("title")).toBe(
+      "Stack of 4 pictures",
+    );
+  });
+
+  it("marks an unresolved group with a question mark", () => {
+    // Without it, a queue suggestion looks identical to a stack that already
+    // exists and the user believes pictures were merged when nothing happened.
+    const wrapper = mountBadge({ count: 4, unresolved: true });
+    expect(wrapper.find(".sbcount").text()).toBe("4?");
+    expect(wrapper.get('[data-testid="stack-badge"]').classes()).toContain(
+      "sbadge--unresolved",
+    );
+  });
+
+  it("tells an unresolved group where the decision is made", () => {
+    // The title is the only place the badge can say that nothing is stacked yet
+    // and point at the queue.
+    const wrapper = mountBadge({ count: 3, unresolved: true });
+    expect(wrapper.get('[data-testid="stack-badge"]').attributes("title")).toBe(
+      "3 possible duplicates, not stacked yet. Open Duplicates to decide.",
+    );
+  });
+});
+
+describe("StackBadge — activation", () => {
+  it("emits activate when clicked", () => {
+    // The parent decides what a click means; the badge only reports it.
+    const wrapper = mountBadge({ count: 3 });
+    wrapper.get('[data-testid="stack-badge"]').trigger("click");
+    expect(wrapper.emitted("activate")).toHaveLength(1);
+  });
+
+  it("is a real button, so Enter and Space work without extra handlers", () => {
+    // Keyboard activation is free on a <button> and hand-rolled on a <div>;
+    // this is what stops the badge becoming mouse-only again.
+    const badge = mountBadge({ count: 3 }).get('[data-testid="stack-badge"]');
+    expect(badge.element.tagName).toBe("BUTTON");
+    expect(badge.attributes("type")).toBe("button");
+  });
+});

--- a/frontend/src/components/widgets/StackBadge.vue
+++ b/frontend/src/components/widgets/StackBadge.vue
@@ -1,0 +1,112 @@
+<template>
+  <button
+    v-if="visible"
+    type="button"
+    class="sbadge"
+    :class="{ 'sbadge--unresolved': unresolved }"
+    :title="title"
+    :aria-label="title"
+    data-testid="stack-badge"
+    @click.stop="emit('activate')"
+  >
+    <v-icon class="sbico" size="14">{{ glyph }}</v-icon>
+    <span class="sbcount">{{ label }}</span>
+  </button>
+</template>
+
+<script setup>
+// The corner badge that says "this tile is more than one picture".
+//
+// It replaces the hover-only layers glyph with a count that is readable without
+// touching the mouse, because the number is the thing the user is actually
+// deciding on, and a badge that only exists on hover cannot be scanned.
+//
+// It carries two states, and keeping them visually apart is the whole job:
+//
+//   * stacked: the stack exists, and the count is a fact.
+//   * unresolved: the group is still sitting in the duplicates queue. It is a
+//     suggestion, so it is quieter (muted foreground, no accent) and the count
+//     wears a question mark. A suggestion that looks like a fact would have the
+//     user believing pictures were already merged when nothing has happened.
+//
+// Purely presentational: it reports the click and the parent decides whether
+// that means "expand the stack" or "jump to this group in the queue".
+
+import { computed } from "vue";
+
+const props = defineProps({
+  /** How many pictures this tile stands for. Below 2 there is nothing to say. */
+  count: { type: Number, default: 0 },
+  /** True while the group is still a queue suggestion rather than a stack. */
+  unresolved: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["activate"]);
+
+const visible = computed(() => props.count >= 2);
+
+const glyph = computed(() =>
+  props.unresolved ? "mdi-content-duplicate" : "mdi-image-multiple",
+);
+
+// The question mark is the point: it is what stops an unresolved group reading
+// as a stack that already exists.
+const label = computed(() =>
+  props.unresolved ? `${props.count}?` : `${props.count}`,
+);
+
+const title = computed(() =>
+  props.unresolved
+    ? `${props.count} possible duplicates, not stacked yet. Open Duplicates to decide.`
+    : `Stack of ${props.count} pictures`,
+);
+</script>
+
+<style scoped>
+/* Sits on top of an arbitrary photo, so the backing is the photo scrim and the
+   glyph is `on-dark-surface`: the pair that stays legible over unknown content
+   in both themes (visual-language.md §7, "Scrims"). Deliberately NOT
+   self-positioned: it flows inside the tile's top-right badge column
+   (`.thumbnail-top-right-badges`, the shared home for corner indicators —
+   stars above, this below), so it can never land on top of a sibling badge.
+   `pointer-events` is explicit because that container is pointer-inert. */
+.sbadge {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: var(--badge-size);
+  padding: 0 var(--space-2);
+  border: none;
+  border-radius: var(--radius-pill);
+  background-color: var(--scrim-photo);
+  color: rgb(var(--v-theme-on-dark-surface));
+  font-family: var(--font-ui);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+
+/* Layered as an image so the scrim underneath is preserved: a `background`
+   shorthand on hover would drop the backing and leave the glyph on the photo. */
+.sbadge:hover {
+  background-image: linear-gradient(var(--hover-wash), var(--hover-wash));
+}
+
+.sbadge:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+/* Quieter than a real stack, deliberately. Same scrim so it stays legible over
+   any photo, muted foreground so it never competes with a resolved count. */
+.sbadge--unresolved {
+  color: rgba(var(--v-theme-on-dark-surface), 0.75);
+}
+
+.sbico {
+  flex-shrink: 0;
+}
+</style>

--- a/frontend/src/components/widgets/StackEdgeTicks.test.js
+++ b/frontend/src/components/widgets/StackEdgeTicks.test.js
@@ -1,0 +1,64 @@
+// The deck-of-cards edges behind a collapsed stack's cover.
+//
+// Decoration with one rule: the number of peeking layers, and the fact that it
+// stays out of the accessibility tree and out of the pointer's way.
+
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import StackEdgeTicks from "./StackEdgeTicks.vue";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+/** Mount the ticks with the given props. */
+function mountTicks(props = {}) {
+  return mount(StackEdgeTicks, { ...globalOpts, props });
+}
+
+describe("StackEdgeTicks — how many layers", () => {
+  it("draws nothing for a lone picture", () => {
+    // A single photo with a peeking edge would claim a stack that is not there.
+    const wrapper = mountTicks({ count: 1 });
+    expect(wrapper.find('[data-testid="stack-edge-ticks"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.findAll(".stick")).toHaveLength(0);
+  });
+
+  it("draws nothing when no count was supplied", () => {
+    // Guards the default so a tile mid-load does not render stray edges.
+    expect(mountTicks().findAll(".stick")).toHaveLength(0);
+  });
+
+  it("draws one edge for a pair", () => {
+    // Two pictures is one card behind the cover; a second would overstate it.
+    expect(mountTicks({ count: 2 }).findAll(".stick")).toHaveLength(1);
+  });
+
+  it("caps at two edges however deep the stack is", () => {
+    // A third peek is invisible at grid scale and only softens the corner, so
+    // five and three must render the same deck.
+    expect(mountTicks({ count: 3 }).findAll(".stick")).toHaveLength(2);
+    expect(mountTicks({ count: 5 }).findAll(".stick")).toHaveLength(2);
+    expect(mountTicks({ count: 200 }).findAll(".stick")).toHaveLength(2);
+  });
+});
+
+describe("StackEdgeTicks — it stays decoration", () => {
+  it("hides itself from assistive technology", () => {
+    // The badge carries the meaning; announcing two empty layers is noise.
+    expect(
+      mountTicks({ count: 5 })
+        .get('[data-testid="stack-edge-ticks"]')
+        .attributes("aria-hidden"),
+    ).toBe("true");
+  });
+
+  it("offsets each layer further than the last", () => {
+    // The deck reads only if the two edges are distinguishable; identical
+    // transforms would stack them into one line.
+    const layers = mountTicks({ count: 5 }).findAll(".stick");
+    expect(layers[0].classes()).toContain("stick--1");
+    expect(layers[1].classes()).toContain("stick--2");
+  });
+});

--- a/frontend/src/components/widgets/StackEdgeTicks.vue
+++ b/frontend/src/components/widgets/StackEdgeTicks.vue
@@ -1,0 +1,72 @@
+<template>
+  <span
+    v-if="layers > 0"
+    class="sticks"
+    aria-hidden="true"
+    data-testid="stack-edge-ticks"
+  >
+    <span
+      v-for="n in layers"
+      :key="n"
+      class="stick"
+      :class="`stick--${n}`"
+    ></span>
+  </span>
+</template>
+
+<script setup>
+// The edge ticks behind a collapsed stack's cover.
+//
+// Without them a stack of five reads as a single photo with a number pinned to
+// it, and the user has to read the badge to know the tile is a deck at all.
+// Two peeking edges give the shape away before anything is read.
+//
+// Pure decoration on purpose: `aria-hidden` and pointer-transparent, because
+// the badge already carries the meaning and a screen reader announcing three
+// empty layers would be noise. Two layers is the ceiling, because a third peek is
+// invisible at grid scale and only softens the tile's corner.
+//
+// The caller places this BEFORE the cover image in DOM order so the ticks sit
+// behind it; this component only claims `--z-base`, it does not fight the tile.
+
+import { computed } from "vue";
+
+const props = defineProps({
+  /** How many pictures the tile stands for. Below 2 there is no deck to draw. */
+  count: { type: Number, default: 0 },
+});
+
+const layers = computed(() => {
+  if (props.count < 2) return 0;
+  return props.count === 2 ? 1 : 2;
+});
+</script>
+
+<style scoped>
+.sticks {
+  position: absolute;
+  inset: 0;
+  z-index: var(--z-base);
+  pointer-events: none;
+}
+
+/* Same radius as the tile it hides behind, so the peeking corner follows the
+   cover's curve instead of cutting across it (visual-language.md §6). */
+.stick {
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-md);
+  background: rgba(var(--v-theme-on-surface), 0.25);
+}
+
+/* Up and to the right in `--space-1` steps: the hairline nudge the scale exists
+   for. Anything larger stops reading as a deck and starts reading as a second,
+   misaligned tile. */
+.stick--1 {
+  transform: translate(var(--space-1), calc(var(--space-1) * -1));
+}
+
+.stick--2 {
+  transform: translate(calc(var(--space-1) * 2), calc(var(--space-1) * -2));
+}
+</style>

--- a/frontend/src/components/widgets/StackExpansionStrip.test.js
+++ b/frontend/src/components/widgets/StackExpansionStrip.test.js
@@ -1,0 +1,120 @@
+// The header strip above an expanded stack.
+//
+// These pin the claims the strip makes about the stack — exactly one cover, the
+// evidence it was grouped on — and the two gestures that follow from disagreeing
+// with it, including the one that must stay a no-op.
+
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+// The thumbnail URL builder pulls in the Axios client; the strip only needs a
+// string for `<img src>`.
+vi.mock("../../api/pictures", () => ({
+  pictureThumbnailUrl: (id, options = {}) =>
+    `/pictures/thumbnails/${id}.webp?v=${options.version ?? ""}`,
+}));
+
+import StackExpansionStrip from "./StackExpansionStrip.vue";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+const MEMBERS = [
+  { id: 7, thumbnail_version: 2 },
+  { id: 8, thumbnail_version: 1 },
+  { id: 9, thumbnail_version: 1 },
+];
+
+/** Mount the strip over the three-member stack, with overrides. */
+function mountStrip(props = {}) {
+  return mount(StackExpansionStrip, {
+    ...globalOpts,
+    props: { count: MEMBERS.length, members: MEMBERS, ...props },
+  });
+}
+
+describe("StackExpansionStrip — what it says", () => {
+  it("leads with the count and carries the evidence beside it", () => {
+    // The reason and the date are what make the grouping inspectable rather
+    // than something the app just did.
+    const wrapper = mountStrip({
+      reason: "Burst, 81% similar",
+      capturedLabel: "12 May 2026",
+    });
+    expect(wrapper.find(".sxtitle").text()).toBe("Stack of 3");
+    const meta = wrapper.findAll(".sxmeta").map((node) => node.text());
+    expect(meta).toEqual(["Burst, 81% similar", "12 May 2026"]);
+  });
+
+  it("omits the evidence line when there is none to show", () => {
+    // An empty secondary slot would leave a gap that reads as missing data.
+    expect(mountStrip().findAll(".sxmeta")).toHaveLength(0);
+  });
+
+  it("renders one button per member in stack order", () => {
+    // The strip is the only place the stack's order is visible.
+    const wrapper = mountStrip();
+    const thumbs = wrapper.findAll('[data-testid="stack-member"]');
+    expect(thumbs).toHaveLength(3);
+    expect(thumbs[0].find("img").attributes("src")).toContain("/7.webp");
+    expect(thumbs[2].find("img").attributes("src")).toContain("/9.webp");
+  });
+});
+
+describe("StackExpansionStrip — the cover", () => {
+  it("marks exactly one member as the cover", () => {
+    // Two flagged covers, or none, and the user cannot tell which frame the
+    // collapsed grid tile will show.
+    const wrapper = mountStrip({ coverId: 8 });
+    const pressed = wrapper
+      .findAll('[data-testid="stack-member"]')
+      .filter((node) => node.attributes("aria-pressed") === "true");
+    expect(pressed).toHaveLength(1);
+    expect(wrapper.findAll(".sxcv")).toHaveLength(1);
+    expect(wrapper.findAll(".sxthumb--cover")).toHaveLength(1);
+  });
+
+  it("falls back to stack order when no cover was handed in", () => {
+    // A caller that has not lifted the cover into its own state still gets one
+    // flagged member rather than none.
+    const wrapper = mountStrip();
+    const thumbs = wrapper.findAll('[data-testid="stack-member"]');
+    expect(thumbs[0].attributes("aria-pressed")).toBe("true");
+    expect(thumbs[1].attributes("aria-pressed")).toBe("false");
+  });
+
+  it("emits set-cover with the picture id when another member is clicked", () => {
+    // The id is the whole payload; the strip owns no stack state.
+    const wrapper = mountStrip({ coverId: 7 });
+    wrapper.findAll('[data-testid="stack-member"]')[2].trigger("click");
+    expect(wrapper.emitted("set-cover")).toEqual([[9]]);
+  });
+
+  it("stays silent when the cover itself is clicked", () => {
+    // The commonest misclick in the strip; emitting would hand the caller a
+    // redundant write for the user to undo.
+    const wrapper = mountStrip({ coverId: 7 });
+    wrapper.findAll('[data-testid="stack-member"]')[0].trigger("click");
+    expect(wrapper.emitted("set-cover")).toBeUndefined();
+  });
+});
+
+describe("StackExpansionStrip — actions", () => {
+  it("emits unstack from the trailing action", () => {
+    const wrapper = mountStrip();
+    wrapper.get('[data-testid="stack-unstack"]').trigger("click");
+    expect(wrapper.emitted("unstack")).toHaveLength(1);
+  });
+
+  it("drops both actions in a read-only view", () => {
+    // A shared or guest view can look at the stack but cannot rewrite it, so
+    // neither Unstack nor a cover change may be reachable.
+    const wrapper = mountStrip({ readOnly: true });
+    expect(wrapper.find('[data-testid="stack-unstack"]').exists()).toBe(false);
+
+    const thumbs = wrapper.findAll('[data-testid="stack-member"]');
+    expect(thumbs).toHaveLength(3);
+    expect(thumbs[1].attributes("disabled")).toBeDefined();
+    thumbs[1].trigger("click");
+    expect(wrapper.emitted("set-cover")).toBeUndefined();
+  });
+});

--- a/frontend/src/components/widgets/StackExpansionStrip.vue
+++ b/frontend/src/components/widgets/StackExpansionStrip.vue
@@ -1,0 +1,278 @@
+<template>
+  <div class="sxstrip" data-testid="stack-expansion-strip">
+    <div class="sxhead">
+      <v-icon class="sxico" size="18">mdi-image-multiple</v-icon>
+      <span class="sxtitle">Stack of {{ count }}</span>
+      <span v-if="reason" class="sxmeta">{{ reason }}</span>
+      <span v-if="capturedLabel" class="sxmeta">{{ capturedLabel }}</span>
+    </div>
+
+    <!-- The members at a readable size, in stack order, cover first. Scrolls
+         sideways rather than wrapping: a stack is a sequence, and a wrapped
+         second line breaks the reading order the position numbers rely on. -->
+    <div class="sxrow">
+      <button
+        v-for="member in members"
+        :key="member.id"
+        type="button"
+        class="sxthumb"
+        :class="{ 'sxthumb--cover': isCover(member.id) }"
+        :aria-pressed="isCover(member.id)"
+        :disabled="readOnly"
+        :title="memberTitle(member.id)"
+        data-testid="stack-member"
+        @click.stop="onPick(member)"
+      >
+        <img
+          class="sxt"
+          :src="thumbUrl(member)"
+          alt=""
+          loading="lazy"
+          decoding="async"
+        />
+        <span v-if="isCover(member.id)" class="sxcv">Cover</span>
+      </button>
+
+      <button
+        v-if="!readOnly"
+        type="button"
+        class="sxbtn"
+        data-testid="stack-unstack"
+        @click.stop="emit('unstack')"
+      >
+        <v-icon size="16">mdi-call-split</v-icon>
+        <span>Unstack</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+// The header strip above an expanded stack's members in the grid.
+//
+// It answers the two questions an expanded stack raises: what made these one
+// stack, and which frame is the one the grid shows. The reason and the capture
+// date sit next to the count so the grouping is inspectable rather than
+// something the app just did; picking a different cover and taking the stack
+// apart are the two actions that follow from disagreeing with it.
+//
+// `capturedLabel` arrives preformatted. Date formatting is a locale decision
+// that belongs where the data is read, and a second formatter here would drift
+// from the rest of the grid within a release.
+//
+// Presentational: it owns no stack state and reports both actions upward.
+//
+// NOT MOUNTED YET, deliberately. The strip has to span the full grid width above
+// the stack's members, and `ImageGrid` is virtualised on a uniform tile: its
+// spacer arithmetic and its `img.idx` keys both assume every child is one tile
+// tall. Wedging a spanning row in without teaching `useVirtualScroll` about
+// variable row heights desynchronises the scroll window, which is the failure
+// this grid's "never splice allGridImages" rule exists to prevent. The cover
+// marker, the half of this that a user actually loses when a stack expands,
+// ships separately as the per-tile flag in `ImageGrid`. Mounting the strip is a
+// change to the grid's layout arithmetic and belongs in its own change.
+
+import { computed } from "vue";
+
+import { pictureThumbnailUrl } from "../../api/pictures";
+
+const props = defineProps({
+  /** Members in the stack, including any not rendered in this strip. */
+  count: { type: Number, required: true },
+  /** `[{ id, thumbnail_version }]` in stack order; the first is the cover. */
+  members: { type: Array, default: () => [] },
+  /** The explicit cover, when the caller tracks one apart from stack order. */
+  coverId: { type: [Number, String], default: null },
+  /** Why these are one stack, e.g. "Burst, 81% similar". */
+  reason: { type: String, default: "" },
+  /** Preformatted capture date. Never formatted in this component. */
+  capturedLabel: { type: String, default: "" },
+  /** A shared or guest view: the strip informs, it does not act. */
+  readOnly: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["unstack", "set-cover"]);
+
+// Falls back to stack order, so a caller that has not lifted the cover into its
+// own state still gets exactly one flagged member rather than none.
+const effectiveCoverId = computed(
+  () => props.coverId ?? props.members[0]?.id ?? null,
+);
+
+/**
+ * Whether a member is the stack's cover.
+ * @param {number|string} id
+ * @returns {boolean}
+ */
+function isCover(id) {
+  if (effectiveCoverId.value == null || id == null) return false;
+  return String(id) === String(effectiveCoverId.value);
+}
+
+/**
+ * The tooltip for one member button.
+ * @param {number|string} id
+ * @returns {string}
+ */
+function memberTitle(id) {
+  if (isCover(id)) return "This is the cover";
+  return props.readOnly ? "Stack member" : "Make this the cover";
+}
+
+/**
+ * The thumbnail URL for one member.
+ * @param {Object} member
+ * @returns {string}
+ */
+function thumbUrl(member) {
+  return pictureThumbnailUrl(member.id, { version: member.thumbnail_version });
+}
+
+/**
+ * Clicking a member promotes it to cover. Clicking the cover is a no-op: it is
+ * the commonest misclick in the strip, and emitting there would hand the caller
+ * a redundant write to undo.
+ * @param {Object} member
+ */
+function onPick(member) {
+  if (isCover(member.id)) return;
+  emit("set-cover", member.id);
+}
+</script>
+
+<style scoped>
+.sxstrip {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid rgb(var(--v-theme-divider));
+  background: rgb(var(--v-theme-surface));
+}
+
+.sxhead {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.sxico {
+  color: rgb(var(--v-theme-on-surface));
+  flex-shrink: 0;
+}
+
+.sxtitle {
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: rgb(var(--v-theme-on-surface));
+}
+
+/* The evidence, deliberately de-emphasised. It is there to be checked, not to
+   compete with the count for the first glance. */
+.sxmeta {
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+.sxrow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-gutter: stable;
+  padding-bottom: var(--space-1);
+}
+
+/* Matches the queue's group strip (DedupGroupRow) so a picture is the same size
+   whether the user is deciding on the stack or living with it. */
+.sxthumb {
+  position: relative;
+  flex: 0 0 auto;
+  width: 128px;
+  height: 96px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: rgba(var(--v-theme-on-surface), 0.06);
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.sxthumb:hover:not(:disabled) {
+  background: var(--hover-wash);
+}
+
+.sxthumb:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+/* The cover is flagged twice, by edge and by label, so it survives both a
+   colour-blind read and a glance at a strip of near-identical frames. */
+.sxthumb--cover {
+  border-color: rgb(var(--v-theme-accent));
+}
+
+/* Read-only keeps the pictures at full strength: the strip is still worth
+   looking at when there is nothing to press. Only the cursor changes. */
+.sxthumb:disabled {
+  cursor: default;
+}
+
+.sxt {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Sits directly on the photo, so the photo scrim and `on-dark-surface`. */
+.sxcv {
+  position: absolute;
+  bottom: var(--space-2);
+  left: var(--space-2);
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--scrim-photo);
+  color: rgb(var(--v-theme-on-dark-surface));
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+}
+
+/* Ghost: taking a stack apart is a reversal, not the strip's headline action,
+   so it reads as available rather than inviting. */
+.sxbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: rgba(var(--v-theme-on-surface), 0.75);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  cursor: pointer;
+  transition: background var(--dur-1) var(--ease-standard);
+}
+
+.sxbtn:hover {
+  background: var(--hover-wash);
+}
+
+.sxbtn:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+</style>

--- a/frontend/src/composables/useActionReceipt.js
+++ b/frontend/src/composables/useActionReceipt.js
@@ -152,6 +152,12 @@ export function useActionReceipt({ announce = true } = {}) {
       document.removeEventListener("visibilitychange", onVisibilityChange);
     }
     if (announceTimer != null) clearTimeout(announceTimer);
+    // A surface that unmounts mid-hover (a view change under the pointer)
+    // would otherwise leave the countdown frozen forever: no mouseleave will
+    // ever fire, so the stale receipt survives in the store and resurfaces on
+    // whichever surface renders next. Releasing the pause lets the countdown
+    // finish — or dismiss immediately if it had already drained.
+    store.resumeReceipt();
   });
 
   // A receipt raised while the tab is hidden starts with a running countdown

--- a/frontend/src/composables/useDedupQueueKeyboard.js
+++ b/frontend/src/composables/useDedupQueueKeyboard.js
@@ -1,0 +1,336 @@
+// The triage queue's keyboard model.
+//
+// The queue is designed to be worked without a mouse: the whole point of the
+// focused-row treatment is that `Enter` and `S` can never be ambiguous about
+// which group they hit. That makes the key handler load-bearing rather than a
+// convenience, so it lives here as a pure factory that takes its dependencies
+// by parameter and can be exercised without mounting the view.
+//
+// The model, in one table:
+//
+//   ArrowUp / ArrowDown   move the focus (k / j alias the same pair)
+//   Home / End            jump to the first / last open group
+//   Enter                 stack the focused group
+//   S                     keep the focused group separate
+//   C                     open Compare on the focused group
+//   1 - 9                 point at that candidate and make it the cover
+//   X                     leave the candidate under the cursor out of the stack
+//                         (refused, and said out loud, once only two are left:
+//                         a stack needs two members and the server refuses one)
+//   Ctrl+Z / Cmd+Z        undo, through the shared operation store
+//   Escape                close Compare, otherwise hand control back to the
+//                         queue (`onEscape`)
+//
+// While Compare is open the row-to-row keys go quiet, but the per-group keys
+// stay live: `Enter`, `S`, `1`-`9`, `X` and `Escape` all work there, because
+// Compare exists so the decision is made without a second trip. Only the keys
+// that would move the row behind the open dialog are swallowed, since that is
+// how a user loses their place.
+//
+// Five guards decline the whole handler, each for its own reason:
+//   * a text field has focus (a control keeps its own editing keys),
+//   * `Enter` while a button or link has focus (that key belongs to the
+//     control the user tabbed to, not to the queue underneath it),
+//   * the session is read-only (there is no verdict to give),
+//   * the key is an auto-repeat (a held `Enter` must not empty the queue),
+//   * a modifier other than the undo pair is down (that is a browser shortcut).
+
+import { candidateId } from "../utils/dedup";
+
+/** Keys that move the focus down one group. */
+const NEXT_KEYS = new Set(["arrowdown", "j"]);
+
+/** Keys that move the focus up one group. */
+const PREV_KEYS = new Set(["arrowup", "k"]);
+
+/**
+ * Take ownership of a key: stop the default action AND stop the event reaching
+ * the app shell.
+ *
+ * The shell owns `Ctrl+Z` globally, so a queue that only called
+ * `preventDefault` would undo twice on one press. Claiming the key here keeps
+ * the queue's model in one place instead of teaching the shell about it.
+ *
+ * @param {KeyboardEvent} event
+ */
+function claim(event) {
+  event.preventDefault();
+  if (typeof event.stopPropagation === "function") event.stopPropagation();
+}
+
+/**
+ * Whether the event originated inside something that owns its own keys.
+ * @param {KeyboardEvent} event
+ * @returns {boolean}
+ */
+function isTypingTarget(event) {
+  const target = event?.target;
+  if (!target) return false;
+  if (target.isContentEditable) return true;
+  const tag = String(target.tagName || "").toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select";
+}
+
+/**
+ * Whether the event originated on a control that `Enter` already activates.
+ *
+ * A row carries a Stack, a Keep separate and a Compare button, and Compare's
+ * footer carries three more. Once a user has tabbed onto one of them, `Enter`
+ * belongs to that button: claiming it here would stack the group while the
+ * focus ring sits on Close, which is the worst kind of surprise the queue can
+ * produce. Every one of those buttons does the same job as the shortcut it
+ * displaces, so declining costs nothing.
+ *
+ * @param {KeyboardEvent} event
+ * @returns {boolean}
+ */
+function isActivatableTarget(event) {
+  const target = event?.target;
+  if (!target) return false;
+  const tag = String(target.tagName || "").toLowerCase();
+  if (tag === "button" || tag === "summary") return true;
+  if (tag === "a") return Boolean(target.getAttribute?.("href"));
+  return target.getAttribute?.("role") === "button";
+}
+
+/**
+ * Build the queue's keydown handler.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.store - the dedup store (or any object with the same
+ *   surface: `groups`, `focusIndex`, `focusedGroup`, `busy`, `focusNext`,
+ *   `focusPrev`, `setFocus`, `setCover`, `toggleExcluded`, `coverIdFor`,
+ *   `stack`, `keepSeparate`).
+ * @param {function(): boolean} deps.isCompareOpen
+ * @param {function(): void} deps.openCompare
+ * @param {function(): void} deps.closeCompare
+ * @param {function(): void} deps.undo - the shared operation-store undo.
+ * @param {function(): boolean} [deps.isReadOnly] - defaults to never read-only.
+ * @param {function(): boolean} [deps.isBlocked] - an extra decline hook for a
+ *   modal that is not Compare (the auto-stack dialog uses it).
+ * @param {function(): void} [deps.onEscape] - what `Escape` does when Compare
+ *   is closed. The queue uses it to dismiss its popover and to hand control
+ *   back to the list, so `Escape` is never a key that does nothing.
+ * @param {function(Object): void} [deps.onExclusionRefused] - called with the
+ *   group when `X` was refused because the stack floor was reached. The view
+ *   narrates it; this handler has no opinion on how.
+ * @param {Object} [deps.zoom] - the Compare dialog's blink-compare surface:
+ *   `{ isOpen, open, close, flip, to, togglePixels }`. The zoom's state lives
+ *   in the dialog; the KEYS live here, so the queue keeps exactly one
+ *   keyboard owner. Omitted (the default no-op) in tests that predate it.
+ * @returns {function(KeyboardEvent): void}
+ */
+const NO_ZOOM = {
+  isOpen: () => false,
+  open: () => {},
+  close: () => {},
+  flip: () => {},
+  to: () => {},
+  togglePixels: () => {},
+};
+
+export function createDedupKeyHandler({
+  store,
+  isCompareOpen,
+  openCompare,
+  closeCompare,
+  undo,
+  isReadOnly = () => false,
+  isBlocked = () => false,
+  onEscape = () => {},
+  onExclusionRefused = () => {},
+  zoom = NO_ZOOM,
+}) {
+  /**
+   * Point `1`-`9` and `X` at the focused group, from the list or from Compare.
+   * @param {KeyboardEvent} event
+   * @param {string} key
+   * @param {Object} group
+   * @returns {boolean} whether the key was one of these.
+   */
+  function handleCoverKeys(event, key, group) {
+    if (key === "x") {
+      claim(event);
+      const coverId = store.coverIdFor(group);
+      if (coverId !== null && coverId !== undefined) {
+        const applied = store.toggleExcluded(group, coverId);
+        // The store refuses an exclusion that would drop the group below the
+        // two members a stack needs. Refusing silently is how a one-key action
+        // reads as a dead key, so the refusal is handed to the view to say out
+        // loud rather than swallowed here.
+        if (applied === false) onExclusionRefused(group);
+      }
+      return true;
+    }
+    if (/^[1-9]$/.test(key)) {
+      // Claimed before the candidate is looked up, so `5` on a group of two is
+      // a no-op for the queue rather than an unclaimed key that falls through
+      // to the app shell. Every other key this handler recognises behaves that
+      // way; a digit that only sometimes did was the odd one out.
+      claim(event);
+      const candidate = group.candidates?.[Number(key) - 1];
+      if (!candidate) return true;
+      store.setCover(group.signature, candidateId(candidate));
+      return true;
+    }
+    return false;
+  }
+
+  return function handleKeydown(event) {
+    if (!event) return;
+    if (event.repeat) return;
+    if (isTypingTarget(event)) return;
+
+    const key = String(event.key || "").toLowerCase();
+    const undoChord = (event.ctrlKey || event.metaKey) && !event.altKey;
+
+    // Undo is the one chord that survives every other guard except read-only:
+    // it is the escape hatch a user reaches for precisely when something went
+    // wrong, including while a dialog is up.
+    if (undoChord && key === "z" && !event.shiftKey) {
+      if (isReadOnly()) return;
+      claim(event);
+      undo();
+      return;
+    }
+    // Select-all is the second chord the queue claims: every loaded group, on
+    // the open queue and the Decided page alike. Claimed so the browser does
+    // not also select the page's text.
+    if (
+      (event.ctrlKey || event.metaKey) &&
+      !event.altKey &&
+      !event.shiftKey &&
+      key === "a" &&
+      !isCompareOpen() &&
+      !isBlocked()
+    ) {
+      claim(event);
+      store.selectAll?.();
+      return;
+    }
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+    if (key === "enter" && isActivatableTarget(event)) return;
+
+    if (isCompareOpen()) {
+      // ── The blink compare, when it is up, owns the flip keys ────────────
+      // Escape peels one layer (zoom → compare → queue), arrows and digits
+      // flip the candidate IN PLACE so differences read as motion, P toggles
+      // actual pixels. Enter/S fall through to the verdict keys below —
+      // deciding from inside the zoom is the point of having it.
+      if (zoom.isOpen()) {
+        if (key === "escape") {
+          claim(event);
+          zoom.close();
+          return;
+        }
+        if (key === "arrowright" || key === "arrowdown") {
+          claim(event);
+          zoom.flip(1);
+          return;
+        }
+        if (key === "arrowleft" || key === "arrowup") {
+          claim(event);
+          zoom.flip(-1);
+          return;
+        }
+        if (/^[1-9]$/.test(key)) {
+          claim(event);
+          zoom.to(Number(key) - 1);
+          return;
+        }
+        if (key === "p") {
+          claim(event);
+          zoom.togglePixels();
+          return;
+        }
+      } else if (key === "z") {
+        claim(event);
+        zoom.open();
+        return;
+      }
+      if (key === "escape") {
+        claim(event);
+        closeCompare();
+        return;
+      }
+      if (isReadOnly() || store.busy) return;
+      const group = store.focusedGroup;
+      if (!group) return;
+      if (key === "enter") {
+        claim(event);
+        zoom.close();
+        closeCompare();
+        store.stack(group);
+        return;
+      }
+      if (key === "s") {
+        claim(event);
+        zoom.close();
+        closeCompare();
+        store.keepSeparate(group);
+        return;
+      }
+      // The cover and exclusion keys stay live here: Compare is the view that
+      // shows the fields the cover is chosen on, so making the user close it to
+      // press a number would be the second trip Compare exists to remove.
+      handleCoverKeys(event, key, group);
+      return;
+    }
+
+    // Escape resolves before the block guard, so the popover that raised the
+    // guard is exactly the thing Escape can dismiss.
+    if (key === "escape") {
+      claim(event);
+      onEscape();
+      return;
+    }
+
+    if (isBlocked()) return;
+
+    // Navigation stays live in a read-only session: reading the queue is not a
+    // verdict, and freezing the arrow keys there would make it unreadable.
+    if (NEXT_KEYS.has(key)) {
+      claim(event);
+      store.focusNext();
+      return;
+    }
+    if (PREV_KEYS.has(key)) {
+      claim(event);
+      store.focusPrev();
+      return;
+    }
+    if (key === "home") {
+      claim(event);
+      store.setFocus(0);
+      return;
+    }
+    if (key === "end") {
+      claim(event);
+      store.setFocus(store.groups.length - 1);
+      return;
+    }
+
+    const group = store.focusedGroup;
+    if (!group) return;
+
+    if (key === "c") {
+      claim(event);
+      openCompare();
+      return;
+    }
+
+    if (isReadOnly() || store.busy) return;
+
+    if (key === "enter") {
+      claim(event);
+      store.stack(group);
+      return;
+    }
+    if (key === "s") {
+      claim(event);
+      store.keepSeparate(group);
+      return;
+    }
+    handleCoverKeys(event, key, group);
+  };
+}

--- a/frontend/src/composables/useDedupQueueKeyboard.test.js
+++ b/frontend/src/composables/useDedupQueueKeyboard.test.js
@@ -1,0 +1,480 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createDedupKeyHandler } from "./useDedupQueueKeyboard";
+
+/**
+ * A stand-in with the same surface as the dedup store, so the key model can be
+ * exercised without Pinia, without the network, and without a mounted view.
+ */
+function makeStore() {
+  return {
+    groups: [
+      {
+        signature: "g1",
+        candidates: [{ picture_id: 1 }, { picture_id: 2 }, { picture_id: 3 }],
+      },
+      { signature: "g2", candidates: [{ picture_id: 4 }, { picture_id: 5 }] },
+    ],
+    focusIndex: 0,
+    busy: false,
+    get focusedGroup() {
+      return this.groups[this.focusIndex] ?? null;
+    },
+    focusNext: vi.fn(),
+    focusPrev: vi.fn(),
+    setFocus: vi.fn(),
+    setCover: vi.fn(),
+    toggleExcluded: vi.fn(),
+    coverIdFor: vi.fn(() => 2),
+    stack: vi.fn(),
+    keepSeparate: vi.fn(),
+  };
+}
+
+function keyEvent(key, over = {}) {
+  return {
+    key,
+    repeat: false,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    target: { tagName: "DIV", isContentEditable: false },
+    preventDefault: vi.fn(),
+    ...over,
+  };
+}
+
+let store;
+let compareOpen;
+let deps;
+let handle;
+
+beforeEach(() => {
+  store = makeStore();
+  compareOpen = false;
+  deps = {
+    store,
+    isCompareOpen: () => compareOpen,
+    openCompare: vi.fn(() => {
+      compareOpen = true;
+    }),
+    closeCompare: vi.fn(() => {
+      compareOpen = false;
+    }),
+    undo: vi.fn(),
+    isReadOnly: vi.fn(() => false),
+    isBlocked: vi.fn(() => false),
+    onEscape: vi.fn(),
+    onExclusionRefused: vi.fn(),
+  };
+  handle = createDedupKeyHandler(deps);
+});
+
+describe("dedup keyboard — moving the focus", () => {
+  it("ArrowDown and j both move down", () => {
+    handle(keyEvent("ArrowDown"));
+    handle(keyEvent("j"));
+    expect(store.focusNext).toHaveBeenCalledTimes(2);
+  });
+
+  it("ArrowUp and k both move up", () => {
+    handle(keyEvent("ArrowUp"));
+    handle(keyEvent("k"));
+    expect(store.focusPrev).toHaveBeenCalledTimes(2);
+  });
+
+  it("Home and End jump to the ends of the queue", () => {
+    handle(keyEvent("Home"));
+    expect(store.setFocus).toHaveBeenCalledWith(0);
+    handle(keyEvent("End"));
+    expect(store.setFocus).toHaveBeenCalledWith(1);
+  });
+
+  // Reading the queue is not a verdict, so navigation stays live for a share
+  // session that cannot act on it.
+  it("still navigates in a read-only session", () => {
+    deps.isReadOnly.mockReturnValue(true);
+    handle(keyEvent("ArrowDown"));
+    expect(store.focusNext).toHaveBeenCalled();
+  });
+});
+
+describe("dedup keyboard — verdicts", () => {
+  it("Enter stacks the focused group", () => {
+    handle(keyEvent("Enter"));
+    expect(store.stack).toHaveBeenCalledWith(store.groups[0]);
+  });
+
+  it("S keeps the focused group separate", () => {
+    handle(keyEvent("s"));
+    expect(store.keepSeparate).toHaveBeenCalledWith(store.groups[0]);
+  });
+
+  it("acts on whichever group is focused, not the first", () => {
+    store.focusIndex = 1;
+    handle(keyEvent("Enter"));
+    expect(store.stack).toHaveBeenCalledWith(store.groups[1]);
+  });
+
+  // A held Enter would otherwise empty the queue in one press.
+  it("declines an auto-repeated key", () => {
+    handle(keyEvent("Enter", { repeat: true }));
+    expect(store.stack).not.toHaveBeenCalled();
+  });
+
+  // A verdict already in flight must not be double-sent by an impatient press.
+  it("declines while a verdict is in flight", () => {
+    store.busy = true;
+    handle(keyEvent("Enter"));
+    handle(keyEvent("s"));
+    expect(store.stack).not.toHaveBeenCalled();
+    expect(store.keepSeparate).not.toHaveBeenCalled();
+  });
+
+  it("declines a verdict in a read-only session", () => {
+    deps.isReadOnly.mockReturnValue(true);
+    handle(keyEvent("Enter"));
+    handle(keyEvent("s"));
+    expect(store.stack).not.toHaveBeenCalled();
+    expect(store.keepSeparate).not.toHaveBeenCalled();
+  });
+
+  it("does nothing at all when the queue is empty", () => {
+    store.groups = [];
+    store.focusIndex = -1;
+    handle(keyEvent("Enter"));
+    handle(keyEvent("x"));
+    handle(keyEvent("1"));
+    expect(store.stack).not.toHaveBeenCalled();
+    expect(store.toggleExcluded).not.toHaveBeenCalled();
+    expect(store.setCover).not.toHaveBeenCalled();
+  });
+});
+
+describe("dedup keyboard — cover and exclusion", () => {
+  it("1 to 9 point at that candidate and make it the cover", () => {
+    handle(keyEvent("3"));
+    expect(store.setCover).toHaveBeenCalledWith("g1", 3);
+  });
+
+  // A group of two must not accept a 5; silently picking the last candidate
+  // would set a cover the user never asked for.
+  it("ignores a digit past the end of the group", () => {
+    store.focusIndex = 1;
+    handle(keyEvent("5"));
+    expect(store.setCover).not.toHaveBeenCalled();
+  });
+
+  // Every other key this handler recognises is claimed whether or not it had
+  // anything to do. A digit that fell through unclaimed would reach the app
+  // shell, which owns keys of its own, from the one surface that says the
+  // number keys belong to the focused group.
+  it("claims a digit past the end rather than letting it fall through", () => {
+    store.focusIndex = 1;
+    const event = keyEvent("5");
+    handle(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  // X is a one-key action with no confirmation. The store refuses an exclusion
+  // that would drop the group below the two members a stack needs; refusing it
+  // silently is how a key stops being trusted.
+  it("reports a refused exclusion so the view can narrate it", () => {
+    store.toggleExcluded.mockReturnValue(false);
+    handle(keyEvent("x"));
+    expect(deps.onExclusionRefused).toHaveBeenCalledWith(store.groups[0]);
+  });
+
+  it("stays quiet when the exclusion was applied", () => {
+    store.toggleExcluded.mockReturnValue(true);
+    handle(keyEvent("x"));
+    expect(deps.onExclusionRefused).not.toHaveBeenCalled();
+  });
+
+  it("X leaves the candidate under the cursor out of the stack", () => {
+    handle(keyEvent("x"));
+    expect(store.toggleExcluded).toHaveBeenCalledWith(store.groups[0], 2);
+  });
+
+  it("X does nothing when the group has no cover to point at", () => {
+    store.coverIdFor.mockReturnValue(null);
+    handle(keyEvent("x"));
+    expect(store.toggleExcluded).not.toHaveBeenCalled();
+  });
+});
+
+describe("dedup keyboard — Compare", () => {
+  it("C opens Compare on the focused group", () => {
+    handle(keyEvent("c"));
+    expect(deps.openCompare).toHaveBeenCalled();
+  });
+
+  it("Escape closes Compare", () => {
+    compareOpen = true;
+    handle(keyEvent("Escape"));
+    expect(deps.closeCompare).toHaveBeenCalled();
+  });
+
+  // Compare exists so the decision is made without a second trip.
+  it("Enter and S still give a verdict from inside Compare", () => {
+    compareOpen = true;
+    handle(keyEvent("Enter"));
+    expect(deps.closeCompare).toHaveBeenCalled();
+    expect(store.stack).toHaveBeenCalledWith(store.groups[0]);
+
+    compareOpen = true;
+    handle(keyEvent("s"));
+    expect(store.keepSeparate).toHaveBeenCalledWith(store.groups[0]);
+  });
+
+  // An arrow key moving the row behind an open dialog is how a user loses
+  // their place. Only the row-to-row keys are swallowed.
+  it("swallows the row-to-row keys while Compare is open", () => {
+    compareOpen = true;
+    handle(keyEvent("ArrowDown"));
+    handle(keyEvent("ArrowUp"));
+    handle(keyEvent("Home"));
+    expect(store.focusNext).not.toHaveBeenCalled();
+    expect(store.focusPrev).not.toHaveBeenCalled();
+    expect(store.setFocus).not.toHaveBeenCalled();
+  });
+
+  // Compare is the view that shows the fields a cover is chosen on, so making
+  // the user close it to press a number would be the second trip Compare
+  // exists to remove.
+  it("keeps the cover and exclusion keys live inside Compare", () => {
+    compareOpen = true;
+    handle(keyEvent("2"));
+    expect(store.setCover).toHaveBeenCalledWith("g1", 2);
+    handle(keyEvent("x"));
+    expect(store.toggleExcluded).toHaveBeenCalledWith(store.groups[0], 2);
+  });
+
+  it("declines the cover keys inside Compare in a read-only session", () => {
+    compareOpen = true;
+    deps.isReadOnly.mockReturnValue(true);
+    handle(keyEvent("2"));
+    handle(keyEvent("x"));
+    expect(store.setCover).not.toHaveBeenCalled();
+    expect(store.toggleExcluded).not.toHaveBeenCalled();
+  });
+});
+
+describe("dedup keyboard — select all", () => {
+  it("Ctrl+A selects every loaded group and claims the key", () => {
+    store.selectAll = vi.fn();
+    const event = keyEvent("a", { ctrlKey: true });
+    handle(event);
+    expect(store.selectAll).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("stays quiet while Compare is open — its keys own that surface", () => {
+    store.selectAll = vi.fn();
+    compareOpen = true;
+    handle(keyEvent("a", { ctrlKey: true }));
+    expect(store.selectAll).not.toHaveBeenCalled();
+  });
+});
+
+describe("dedup keyboard — the blink compare (zoom)", () => {
+  let zoomOpen;
+  let zoom;
+
+  beforeEach(() => {
+    zoomOpen = false;
+    zoom = {
+      isOpen: () => zoomOpen,
+      open: vi.fn(() => {
+        zoomOpen = true;
+      }),
+      close: vi.fn(() => {
+        zoomOpen = false;
+      }),
+      flip: vi.fn(),
+      to: vi.fn(),
+      togglePixels: vi.fn(),
+    };
+    compareOpen = true;
+    handle = createDedupKeyHandler({ ...deps, zoom });
+  });
+
+  it("Z opens the zoom from Compare", () => {
+    handle(keyEvent("z"));
+    expect(zoom.open).toHaveBeenCalled();
+  });
+
+  it("arrows flip in place and digits jump — never the cover keys", () => {
+    zoomOpen = true;
+    handle(keyEvent("ArrowRight"));
+    handle(keyEvent("ArrowLeft"));
+    handle(keyEvent("3"));
+    expect(zoom.flip).toHaveBeenCalledWith(1);
+    expect(zoom.flip).toHaveBeenCalledWith(-1);
+    expect(zoom.to).toHaveBeenCalledWith(2);
+    // In the zoom, a digit FLIPS; it must not silently re-pick the cover.
+    expect(store.setCover).not.toHaveBeenCalled();
+    expect(store.focusNext).not.toHaveBeenCalled();
+  });
+
+  it("P toggles actual pixels", () => {
+    zoomOpen = true;
+    handle(keyEvent("p"));
+    expect(zoom.togglePixels).toHaveBeenCalled();
+  });
+
+  it("Escape peels one layer: zoom first, Compare second", () => {
+    zoomOpen = true;
+    handle(keyEvent("Escape"));
+    expect(zoom.close).toHaveBeenCalled();
+    expect(deps.closeCompare).not.toHaveBeenCalled();
+
+    zoomOpen = false;
+    handle(keyEvent("Escape"));
+    expect(deps.closeCompare).toHaveBeenCalled();
+  });
+
+  it("Enter stacks from inside the zoom, closing both layers", () => {
+    zoomOpen = true;
+    handle(keyEvent("Enter"));
+    expect(zoom.close).toHaveBeenCalled();
+    expect(deps.closeCompare).toHaveBeenCalled();
+    expect(store.stack).toHaveBeenCalled();
+  });
+});
+
+describe("dedup keyboard — Escape", () => {
+  // Escape is the way out of a row's buttons. A key that visibly does nothing
+  // is a key the user stops trusting.
+  it("calls onEscape when Compare is closed", () => {
+    handle(keyEvent("Escape"));
+    expect(deps.onEscape).toHaveBeenCalled();
+  });
+
+  // The popover that raised the block guard is exactly the thing Escape has to
+  // be able to dismiss, so Escape resolves before the guard.
+  it("still calls onEscape while another surface blocks the queue", () => {
+    deps.isBlocked.mockReturnValue(true);
+    handle(keyEvent("Escape"));
+    expect(deps.onEscape).toHaveBeenCalled();
+  });
+
+  it("closes Compare rather than calling onEscape while Compare is open", () => {
+    compareOpen = true;
+    handle(keyEvent("Escape"));
+    expect(deps.closeCompare).toHaveBeenCalled();
+    expect(deps.onEscape).not.toHaveBeenCalled();
+  });
+
+  // Reading the queue is not a verdict, so the way out stays live in a share
+  // session.
+  it("works in a read-only session", () => {
+    deps.isReadOnly.mockReturnValue(true);
+    handle(keyEvent("Escape"));
+    expect(deps.onEscape).toHaveBeenCalled();
+  });
+});
+
+describe("dedup keyboard — Enter belongs to a focused control", () => {
+  // A user who tabbed onto Compare and pressed Enter must get Compare, not a
+  // stack of the group behind it.
+  it("declines Enter while a button has focus", () => {
+    handle(keyEvent("Enter", { target: { tagName: "BUTTON" } }));
+    expect(store.stack).not.toHaveBeenCalled();
+  });
+
+  it("declines Enter while a link or a role=button has focus", () => {
+    handle(
+      keyEvent("Enter", {
+        target: { tagName: "A", getAttribute: () => "/somewhere" },
+      }),
+    );
+    handle(
+      keyEvent("Enter", {
+        target: { tagName: "SPAN", getAttribute: () => "button" },
+      }),
+    );
+    expect(store.stack).not.toHaveBeenCalled();
+  });
+
+  // Only Enter is the button's key. The queue keeps the rest, which is what
+  // lets a user act without first tabbing back out of the row.
+  it("keeps the other keys while a button has focus", () => {
+    const onButton = { tagName: "BUTTON" };
+    handle(keyEvent("ArrowDown", { target: onButton }));
+    handle(keyEvent("s", { target: onButton }));
+    expect(store.focusNext).toHaveBeenCalled();
+    expect(store.keepSeparate).toHaveBeenCalled();
+  });
+
+  it("declines Enter on a dialog button while Compare is open", () => {
+    compareOpen = true;
+    handle(keyEvent("Enter", { target: { tagName: "BUTTON" } }));
+    expect(store.stack).not.toHaveBeenCalled();
+    expect(deps.closeCompare).not.toHaveBeenCalled();
+  });
+});
+
+describe("dedup keyboard — undo and the guards", () => {
+  it("Ctrl+Z and Cmd+Z both undo", () => {
+    handle(keyEvent("z", { ctrlKey: true }));
+    handle(keyEvent("z", { metaKey: true }));
+    expect(deps.undo).toHaveBeenCalledTimes(2);
+  });
+
+  // Undo is the escape hatch a user reaches for precisely when a dialog is up
+  // and something went wrong.
+  it("undoes even while Compare is open", () => {
+    compareOpen = true;
+    handle(keyEvent("z", { ctrlKey: true }));
+    expect(deps.undo).toHaveBeenCalled();
+  });
+
+  it("leaves redo to the app shell", () => {
+    handle(keyEvent("z", { ctrlKey: true, shiftKey: true }));
+    handle(keyEvent("y", { ctrlKey: true }));
+    expect(deps.undo).not.toHaveBeenCalled();
+  });
+
+  it("declines undo in a read-only session", () => {
+    deps.isReadOnly.mockReturnValue(true);
+    handle(keyEvent("z", { ctrlKey: true }));
+    expect(deps.undo).not.toHaveBeenCalled();
+  });
+
+  // A text field keeps its own editing keys, including its native undo stack.
+  it("declines every key while a text field has focus", () => {
+    const typing = { tagName: "INPUT", isContentEditable: false };
+    handle(keyEvent("Enter", { target: typing }));
+    handle(keyEvent("s", { target: typing }));
+    handle(keyEvent("z", { target: typing, ctrlKey: true }));
+    expect(store.stack).not.toHaveBeenCalled();
+    expect(store.keepSeparate).not.toHaveBeenCalled();
+    expect(deps.undo).not.toHaveBeenCalled();
+  });
+
+  it("declines inside a contenteditable region", () => {
+    handle(
+      keyEvent("Enter", {
+        target: { tagName: "DIV", isContentEditable: true },
+      }),
+    );
+    expect(store.stack).not.toHaveBeenCalled();
+  });
+
+  // The auto-stack dialog owns the screen while it is up.
+  it("goes quiet while another modal blocks the queue", () => {
+    deps.isBlocked.mockReturnValue(true);
+    handle(keyEvent("Enter"));
+    handle(keyEvent("ArrowDown"));
+    expect(store.stack).not.toHaveBeenCalled();
+    expect(store.focusNext).not.toHaveBeenCalled();
+  });
+
+  it("leaves browser chords alone", () => {
+    handle(keyEvent("s", { ctrlKey: true }));
+    handle(keyEvent("Enter", { altKey: true }));
+    expect(store.stack).not.toHaveBeenCalled();
+    expect(store.keepSeparate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/composables/useGridFetch.js
+++ b/frontend/src/composables/useGridFetch.js
@@ -334,6 +334,11 @@ export function useGridFetch(
     (props.impossibleSources || []).forEach((s) =>
       params.append("impossible_tag_source", s),
     );
+    // "all" is the absence of the filter, so it is expressed by omission rather
+    // than by a sentinel the backend would have to know a second spelling for.
+    if (props.stackStateFilter && props.stackStateFilter !== "all") {
+      params.append("stack_state", props.stackStateFilter);
+    }
     if (props.sharedOnlyFilter) {
       params.append("shared_only", "true");
     }
@@ -387,6 +392,11 @@ export function useGridFetch(
     (props.impossibleSources || []).forEach((s) =>
       params.append("impossible_tag_source", s),
     );
+    // "all" is the absence of the filter, so it is expressed by omission rather
+    // than by a sentinel the backend would have to know a second spelling for.
+    if (props.stackStateFilter && props.stackStateFilter !== "all") {
+      params.append("stack_state", props.stackStateFilter);
+    }
     if (props.applyTagFilter) {
       params.append("apply_tag_filter", "true");
     }

--- a/frontend/src/composables/useOneTimeNotice.js
+++ b/frontend/src/composables/useOneTimeNotice.js
@@ -1,0 +1,91 @@
+// A notice that is shown once and then never again.
+//
+// Distinct from `useNoticeStore` (transient, in-memory, re-raisable) and from
+// `useScopedNotice` (lifetime-scoped within one session): this one is a
+// migration nudge. It has to survive a reload, because its whole job is to
+// explain, exactly once, that something the user used to reach one way now
+// lives somewhere else.
+//
+// It is client-side on purpose. "Have I already told this person where the
+// duplicates went" is a per-browser fact about a UI they are looking at, not a
+// library setting worth a round trip and a server column. A user on a second
+// machine seeing the pointer once more is the correct failure mode; a user
+// whose only machine forgot it and never shows it again is not.
+//
+// Storage failures (private mode, disabled storage, quota) fall back to
+// "unseen": showing a migration notice one extra time is harmless, and
+// swallowing the failure silently would hide a broken storage layer.
+
+import { ref } from "vue";
+
+/** Every key this composable writes is namespaced like the rest of the app. */
+export const ONE_TIME_NOTICE_PREFIX = "pixlstash:seen:";
+
+/**
+ * Read one flag, treating any storage failure as "not yet seen".
+ * @param {string} key - the full storage key.
+ * @returns {boolean}
+ */
+function readSeen(key) {
+  try {
+    return window.localStorage.getItem(key) === "1";
+  } catch (err) {
+    console.warn(
+      `[notice] could not read the one-time notice flag ${key}; showing it again`,
+      err,
+    );
+    return false;
+  }
+}
+
+/**
+ * Write one flag, warning rather than throwing when storage refuses.
+ * @param {string} key - the full storage key.
+ */
+function writeSeen(key) {
+  try {
+    window.localStorage.setItem(key, "1");
+  } catch (err) {
+    console.warn(
+      `[notice] could not persist the one-time notice flag ${key}; it will show again`,
+      err,
+    );
+  }
+}
+
+/**
+ * Track whether a one-time notice has already been shown.
+ *
+ * @param {string} name - a short stable name, namespaced automatically.
+ * @returns {{ visible: import("vue").Ref<boolean>, dismiss: function(): void,
+ *   reset: function(): void, storageKey: string }}
+ *   `visible` is false from the first render once the notice has been
+ *   dismissed; `reset` exists for tests and for a future "show me the tour
+ *   again" affordance.
+ */
+export function useOneTimeNotice(name) {
+  const storageKey = `${ONE_TIME_NOTICE_PREFIX}${name}`;
+  const visible = ref(!readSeen(storageKey));
+
+  /** Hide the notice and remember that it has been seen. */
+  function dismiss() {
+    if (!visible.value) return;
+    visible.value = false;
+    writeSeen(storageKey);
+  }
+
+  /** Forget the dismissal, so the notice shows again. */
+  function reset() {
+    try {
+      window.localStorage.removeItem(storageKey);
+    } catch (err) {
+      console.warn(
+        `[notice] could not clear the one-time notice flag ${storageKey}`,
+        err,
+      );
+    }
+    visible.value = true;
+  }
+
+  return { visible, dismiss, reset, storageKey };
+}

--- a/frontend/src/composables/useOneTimeNotice.test.js
+++ b/frontend/src/composables/useOneTimeNotice.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useOneTimeNotice, ONE_TIME_NOTICE_PREFIX } from "./useOneTimeNotice";
+
+const realStorage = window.localStorage;
+
+/**
+ * Swap in a storage object that throws, the way private mode and a full quota
+ * do. jsdom's own `localStorage` is a host object whose methods cannot be
+ * reliably spied, so the whole property is replaced for the duration.
+ */
+function withBrokenStorage(overrides) {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      ...overrides,
+    },
+  });
+}
+
+beforeEach(() => {
+  realStorage.clear();
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: realStorage,
+  });
+  vi.restoreAllMocks();
+});
+
+describe("useOneTimeNotice", () => {
+  it("shows on a first visit", () => {
+    const { visible } = useOneTimeNotice("dedup-migration");
+    expect(visible.value).toBe(true);
+  });
+
+  // The whole point: a migration nudge that came back after a reload would be
+  // an ad, not a nudge.
+  it("stays hidden after a dismissal survives a reload", () => {
+    const first = useOneTimeNotice("dedup-migration");
+    first.dismiss();
+    expect(first.visible.value).toBe(false);
+
+    const second = useOneTimeNotice("dedup-migration");
+    expect(second.visible.value).toBe(false);
+  });
+
+  it("namespaces its key", () => {
+    const { storageKey, dismiss } = useOneTimeNotice("dedup-migration");
+    expect(storageKey).toBe(`${ONE_TIME_NOTICE_PREFIX}dedup-migration`);
+    dismiss();
+    expect(window.localStorage.getItem(storageKey)).toBe("1");
+  });
+
+  it("dismissing twice is a no-op", () => {
+    const notice = useOneTimeNotice("dedup-migration");
+    notice.dismiss();
+    notice.dismiss();
+    expect(notice.visible.value).toBe(false);
+  });
+
+  it("reset makes it show again", () => {
+    const notice = useOneTimeNotice("dedup-migration");
+    notice.dismiss();
+    notice.reset();
+    expect(notice.visible.value).toBe(true);
+    expect(window.localStorage.getItem(notice.storageKey)).toBe(null);
+  });
+
+  // Two notices must not share a flag, or dismissing one silences the other.
+  it("keeps separate notices independent", () => {
+    const a = useOneTimeNotice("one");
+    const b = useOneTimeNotice("two");
+    a.dismiss();
+    expect(useOneTimeNotice("one").visible.value).toBe(false);
+    expect(useOneTimeNotice("two").visible.value).toBe(true);
+    expect(b.visible.value).toBe(true);
+  });
+
+  // Private mode throws on getItem. Showing the notice once more is the right
+  // failure mode; crashing the view that hosts it is not.
+  it("treats unreadable storage as not yet seen", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    withBrokenStorage({
+      getItem: () => {
+        throw new Error("denied");
+      },
+    });
+    const { visible } = useOneTimeNotice("dedup-migration");
+    expect(visible.value).toBe(true);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("survives storage refusing the write", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    withBrokenStorage({
+      setItem: () => {
+        throw new Error("quota");
+      },
+    });
+    const notice = useOneTimeNotice("dedup-migration");
+    expect(() => notice.dismiss()).not.toThrow();
+    expect(notice.visible.value).toBe(false);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -17,6 +17,8 @@ import App from "../App.vue";
 //   /project/:projectId/character/:id       → Character inside a project
 //   /project/:projectId/set/:id             → Picture set inside a project
 //   /scrapheap                              → Scrapheap
+//   /duplicates                             → Duplicate triage queue
+//   /duplicates?scope=set&scope_id=12       → …scoped to one collection object
 //   /ref-folder/:id                         → Reference folder view (id = numeric)
 //   /import-folder/:id                      → Import folder view (id = numeric)
 //
@@ -37,6 +39,7 @@ const routes = [
   { path: "/project/:projectId/character/:id", name: "project-character", component: App },
   { path: "/project/:projectId/set/:id", name: "project-set", component: App },
   { path: "/scrapheap", name: "scrapheap", component: App },
+  { path: "/duplicates", name: "duplicates", component: App },
   { path: "/ref-folder/:id", name: "ref-folder", component: App },
   { path: "/import-folder/:id", name: "import-folder", component: App },
   // Catch-all: redirect unknown paths to home

--- a/frontend/src/stores/useDedupStore.js
+++ b/frontend/src/stores/useDedupStore.js
@@ -1,0 +1,1267 @@
+// The duplicate triage queue's state.
+//
+// Duplicate detection is a destination with a to-do count, so its state has to
+// outlive the queue view: the sidebar badge and every context menu's "Find
+// duplicates in..." count read from here whether or not the queue is open.
+//
+// Four rules from the design shape the shape of this store:
+//
+//   * **Never block on a full pass.** `loadFirstPage` returns whatever has been
+//     found and keeps `scan` progress alongside it, so the view can render a
+//     partial queue plus a banner rather than a spinner.
+//   * **Never load the queue whole.** Groups are paged by confidence descending.
+//     `loadMore` is called when the focus walks close to the tail, not when the
+//     user scrolls, because the keyboard is the primary way through the queue.
+//   * **Verdicts auto-advance.** Resolving a group removes it from the list and
+//     the focus lands on the next open group, so a run of Enter presses works
+//     the queue without a single extra keystroke.
+//   * **No bound is hardcoded twice.** The threshold, its floor, the tier order
+//     and the prerequisite chain all come from `GET /dedup/policy`.
+//
+// Three consequences of the backend contract are load-bearing here:
+//
+//   * **Paging prefers a keyset cursor.** The queue is ordered by confidence
+//     while a scan is still inserting rows, so an offset can re-serve a group the
+//     client already holds, or skip one. When a page comes back with a
+//     `next_cursor`, the next one is fetched from that cursor and the hazard is
+//     gone. When it does not, `loadMore` falls back to the offset path with the
+//     old mitigations intact: it dedupes by signature and drops a re-seen group
+//     rather than adding it twice, because a duplicated row could be resolved
+//     twice and the second verdict would 400.
+//   * **The sidebar badge is reconciled from the server, not inferred.** A
+//     keep-separate mutates no picture row, so it raises no WebSocket event and
+//     nothing else will ever correct an optimistic decrement. Every verdict
+//     therefore refetches `POST /dedup/counts` behind its own optimistic tick, so
+//     a second tab and a long triage run both stay honest.
+//   * **Keep-separate records no operation.** It changes no reversible picture
+//     facet, so no receipt will ever arrive for it. `keepSeparate` therefore
+//     returns its result for the caller to narrate, and `reopen` is the
+//     documented way back.
+//
+// Cover overrides and exclusions are held per signature rather than on the group
+// object, so a refetch that replaces the group rows cannot silently discard the
+// user's `1`-`9` and `X` choices.
+
+import { defineStore } from "pinia";
+import { ref, computed } from "vue";
+import {
+  getPolicy,
+  listGroups,
+  getCounts,
+  startScan,
+  stackGroup,
+  keepGroupSeparate,
+  reopenGroup,
+  autoStackExact,
+  GLOBAL_SCOPE,
+} from "../api/dedup";
+import { suggestedCoverId, candidateId } from "../utils/dedup";
+import { newOperationBatchId } from "../utils/apiClient";
+
+/** How many groups one queue page holds. */
+export const QUEUE_PAGE_SIZE = 20;
+
+/**
+ * How close to the tail the focus may walk before the next page is fetched.
+ * Three rows is one Enter-Enter-Enter burst of headroom, which is what a user
+ * working the queue by keyboard actually consumes between frames.
+ */
+export const PREFETCH_MARGIN = 3;
+
+/**
+ * The smallest stack the server will create.
+ *
+ * A stack is a grouping row over two or more pictures, so one member is not a
+ * degenerate stack, it is a rejected request. The client holds the same floor so
+ * `X` cannot walk a group into a state the Stack button is still offering.
+ */
+export const MIN_STACK_MEMBERS = 2;
+
+/**
+ * The tier ids the server publishes, mapped to the copy the menu renders.
+ *
+ * Labels are the client's business: the server names its tiers and the client
+ * says what they mean to a person. An id the server adds later renders under
+ * its own id rather than vanishing from the menu.
+ */
+export const TIER_LABELS = Object.freeze({
+  exact: { label: "Exact matches", hint: "identical file" },
+  near: { label: "Near-identical", hint: "bursts, re-exports, resizes" },
+  embedding: { label: "Same scene", hint: "cross-folder, re-framed" },
+});
+
+/** The empty scan record, so consumers never branch on `null`. */
+const IDLE_SCAN = Object.freeze({
+  status: "idle",
+  scanned: 0,
+  total: 0,
+  percent: 100,
+  buckets: 0,
+  totalBuckets: 0,
+  groupsFound: 0,
+  error: null,
+});
+
+/** Scan statuses that mean work is still happening. */
+const RUNNING_STATUSES = new Set(["pending", "running"]);
+
+/**
+ * Cache key for a scope's count.
+ *
+ * Mirrors the `key` the server returns on each scope row, so a cached entry and
+ * a served one land in the same slot.
+ *
+ * @param {string} type
+ * @param {number|string} [id]
+ * @returns {string}
+ */
+export function scopeKey(type, id) {
+  return id === undefined || id === null ? String(type) : `${type}:${id}`;
+}
+
+/**
+ * Normalise a `ScanProgressModel` into what the banner renders.
+ *
+ * The server reports pictures and buckets but no percentage and no estimate, so
+ * the percentage is derived here. Tier 2 streams its groups in per bucket, so a
+ * scope whose picture total is not yet known still shows honest progress from
+ * the bucket counters rather than sitting at zero.
+ *
+ * @param {Object} [raw] - a `ScanProgressModel`.
+ * @returns {Object}
+ */
+function normalizeScan(raw) {
+  if (!raw) return { ...IDLE_SCAN };
+  const scanned = Number(raw.scanned_pictures) || 0;
+  const total = Number(raw.total_pictures) || 0;
+  const buckets = Number(raw.scanned_buckets) || 0;
+  const totalBuckets = Number(raw.total_buckets) || 0;
+  let percent = 100;
+  if (total > 0) percent = Math.round((scanned / total) * 100);
+  else if (totalBuckets > 0)
+    percent = Math.round((buckets / totalBuckets) * 100);
+  return {
+    status: raw.status || "idle",
+    scanned,
+    total,
+    percent: Math.max(0, Math.min(100, percent)),
+    buckets,
+    totalBuckets,
+    groupsFound: Number(raw.groups_found) || 0,
+    error: raw.error ?? null,
+  };
+}
+
+export const useDedupStore = defineStore("dedup", () => {
+  // --- The server's policy, bounds and vocabularies ------------------------
+  const policyDefaults = ref(null);
+  const bounds = ref(null);
+  const policyLoaded = ref(false);
+
+  // --- The sidebar's live count -------------------------------------------
+  const openCount = ref(0);
+  const byTier = ref({});
+  const scan = ref({ ...IDLE_SCAN });
+  const countsLoaded = ref(false);
+
+  // --- Per-scope counts, for the context menus ----------------------------
+  const scopeCounts = ref({});
+  const scopeCountsInFlight = new Map();
+
+  // --- The queue ----------------------------------------------------------
+  const scopeType = ref(GLOBAL_SCOPE);
+  const scopeId = ref(null);
+  const scopeLabel = ref("");
+  const scopeIcon = ref("");
+  const groups = ref([]);
+  const total = ref(0);
+  const nextOffset = ref(0);
+  // The opaque keyset cursor for the next page, when the server publishes one.
+  // Non-null is the only signal that this queue is cursor-paged; it is reset on
+  // every first page, so a policy or scope change never carries a stale one.
+  const nextCursor = ref(null);
+  const hasMore = ref(false);
+  const focusIndex = ref(0);
+  const loading = ref(false);
+  const loadingMore = ref(false);
+  const error = ref(null);
+  const busy = ref(false);
+  const stackedCount = ref(0);
+  const separatedCount = ref(0);
+
+  // --- The tier gate ------------------------------------------------------
+  // Tier 1 is always in and has no switch. Tier 2 is an opt-in; tier 3 requires
+  // tier 2, which the server enforces and this mirrors.
+  const nearEnabled = ref(false);
+  const embeddingEnabled = ref(false);
+  const threshold = ref(null);
+
+  // --- Per-group user choices, keyed by signature --------------------------
+  const coverChoices = ref({});
+  const exclusions = ref({});
+
+  const isScoped = computed(() => scopeType.value !== GLOBAL_SCOPE);
+  const isScanning = computed(() => RUNNING_STATUSES.has(scan.value.status));
+
+  /**
+   * Whether ANY duplicates exist, across every tier — the sidebar's presence
+   * indicator. Deliberately not the policy-filtered count: that number moves
+   * with the tier gate and the threshold, so it kept reading as churn rather
+   * than information (owner call, 2026-07-29 — the badge became a dot).
+   */
+  const hasDuplicates = computed(() => {
+    if (openCount.value > 0) return true;
+    return Object.values(byTier.value || {}).some((n) => Number(n) > 0);
+  });
+  const hasGroups = computed(() => groups.value.length > 0);
+  const focusedGroup = computed(() => groups.value[focusIndex.value] ?? null);
+  const doneCount = computed(() => stackedCount.value + separatedCount.value);
+
+  /** Unresolved exact groups: what the auto-stack button offers to clear. */
+  const exactCount = computed(() => Number(byTier.value.exact) || 0);
+
+  /** Unresolved groups in every tier the queue does not stack in bulk. */
+  const queueOnlyCount = computed(() =>
+    Object.entries(byTier.value).reduce(
+      (sum, [tier, count]) =>
+        tier === "exact" ? sum : sum + (Number(count) || 0),
+      0,
+    ),
+  );
+
+  /** The policy fragment every request travels with, so counts match the queue. */
+  const policyArgs = computed(() => {
+    const args = {
+      nearEnabled: nearEnabled.value,
+      embeddingEnabled: embeddingEnabled.value,
+    };
+    if (Number.isFinite(threshold.value)) args.threshold = threshold.value;
+    return args;
+  });
+
+  /**
+   * The tier rows the menu renders: the server's ids and prerequisites, this
+   * client's copy, and the live per-tier counts.
+   */
+  const tierRows = computed(() => {
+    const ids = bounds.value?.tiers ?? [];
+    const alwaysOn = new Set(bounds.value?.always_on_tiers ?? []);
+    const requires = bounds.value?.tier_requires ?? {};
+    return ids.map((id) => ({
+      id,
+      label: TIER_LABELS[id]?.label ?? id,
+      hint: TIER_LABELS[id]?.hint ?? "",
+      count: Number(byTier.value[id]) || 0,
+      locked: alwaysOn.has(id),
+      requires: requires[id] ?? null,
+      enabled: isTierEnabled(id),
+    }));
+  });
+
+  /**
+   * Whether a tier currently feeds the queue.
+   * @param {string} id
+   * @returns {boolean}
+   */
+  function isTierEnabled(id) {
+    if (id === "near") return nearEnabled.value;
+    if (id === "embedding") return embeddingEnabled.value;
+    // Tier 1 and anything the server adds later are on unless it says otherwise.
+    return true;
+  }
+
+  /**
+   * The cover picture id in force for a group: the user's override when they
+   * made one, otherwise the server's preselection.
+   * @param {Object} group
+   * @returns {number|null}
+   */
+  function coverIdFor(group) {
+    if (!group) return null;
+    const chosen = coverChoices.value[group.signature];
+    if (chosen !== undefined) return chosen;
+    return suggestedCoverId(group);
+  }
+
+  /**
+   * The picture ids the user excluded from a group's stack.
+   * @param {string} signature
+   * @returns {Array<number>}
+   */
+  function excludedFor(signature) {
+    return exclusions.value[signature] ?? [];
+  }
+
+  /**
+   * How many of a group's candidates the Stack button would collect.
+   * @param {Object} group
+   * @returns {number}
+   */
+  function stackSizeFor(group) {
+    if (!group) return 0;
+    return (
+      (group.candidates?.length ?? 0) - excludedFor(group.signature).length
+    );
+  }
+
+  /**
+   * Choose a group's cover.
+   * @param {string} signature
+   * @param {number} pictureId
+   */
+  function setCover(signature, pictureId) {
+    coverChoices.value = { ...coverChoices.value, [signature]: pictureId };
+  }
+
+  /**
+   * Include or exclude one candidate.
+   *
+   * Two invariants ride on this, both because `X` is a one-key action with no
+   * confirmation:
+   *
+   *   * **A stack needs two members.** The server refuses a one-member stack
+   *     outright, so an exclusion that would leave a single included candidate
+   *     is refused here rather than turned into a guaranteed 400 on a Stack the
+   *     row still offers. The floor is {@link MIN_STACK_MEMBERS} *included*
+   *     candidates, not one: a group of two therefore accepts no exclusion at
+   *     all, and the way to reject one of its members is Keep separate.
+   *   * Excluding the cover would leave the stack with no cover, and the server
+   *     rejects a cover that is not an included member. The cover moves to the
+   *     best remaining included candidate instead, using the same formula that
+   *     preselected it.
+   *
+   * @param {Object} group
+   * @param {number} pictureId
+   * @returns {boolean} whether the toggle was applied. False means it was
+   *   refused by the floor, which the caller narrates: a one-key action that
+   *   silently does nothing is a key the user stops trusting.
+   */
+  function toggleExcluded(group, pictureId) {
+    if (!group) return false;
+    const current = excludedFor(group.signature);
+    const isOut = current.includes(pictureId);
+    if (!isOut && stackSizeFor(group) <= MIN_STACK_MEMBERS) return false;
+    const next = isOut
+      ? current.filter((id) => id !== pictureId)
+      : [...current, pictureId];
+    exclusions.value = { ...exclusions.value, [group.signature]: next };
+    if (!isOut && coverIdFor(group) === pictureId) {
+      const remaining = (group.candidates ?? []).filter(
+        (c) => !next.includes(candidateId(c)),
+      );
+      const replacement = suggestedCoverId({ candidates: remaining });
+      if (replacement !== null) setCover(group.signature, replacement);
+    }
+    return true;
+  }
+
+  /**
+   * Whether one more exclusion would drop this group below the stack floor.
+   *
+   * The row and the key handler both read it, so the tooltip that explains the
+   * refusal and the refusal itself can never disagree.
+   *
+   * @param {Object} group
+   * @returns {boolean}
+   */
+  function isAtStackFloor(group) {
+    return Boolean(group) && stackSizeFor(group) <= MIN_STACK_MEMBERS;
+  }
+
+  /**
+   * Read the tier defaults, bounds and closed vocabularies, once.
+   *
+   * Everything the tier menu renders comes from here, so a threshold or a
+   * prerequisite is never stated twice in two places that can drift apart.
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.force=false]
+   * @returns {Promise<void>}
+   */
+  async function loadPolicy({ force = false } = {}) {
+    if (policyLoaded.value && !force) return;
+    try {
+      const data = await getPolicy();
+      policyDefaults.value = data?.defaults ?? null;
+      bounds.value = data?.bounds ?? null;
+      if (!Number.isFinite(threshold.value)) {
+        const served = Number(data?.defaults?.threshold);
+        if (Number.isFinite(served)) threshold.value = served;
+      }
+      policyLoaded.value = true;
+    } catch (err) {
+      console.warn(
+        "[dedup] failed to read the duplicate detection policy",
+        err,
+      );
+    }
+  }
+
+  /**
+   * Refresh the live counts, optionally alongside extra scopes.
+   *
+   * The global badge comes back whether or not a scope was asked for, so this
+   * one call feeds the sidebar, the tier menu's per-tier split and the scan
+   * banner, and the three can never disagree.
+   *
+   * @param {Array<{scopeType: string, scopeId: (number|string|null)}>}
+   *   [extraScopes=[]]
+   * @returns {Promise<Object|null>} the response body, or null on failure.
+   */
+  async function refreshCounts(extraScopes = []) {
+    try {
+      const data = await getCounts({
+        policy: policyArgs.value,
+        scopes: extraScopes,
+      });
+      openCount.value = Number(data?.unresolved_groups) || 0;
+      byTier.value = data?.by_tier ?? {};
+      scan.value = normalizeScan(data?.scan);
+      for (const row of data?.scopes ?? []) {
+        const key = row.key ?? scopeKey(row.scope_type, row.scope_id);
+        scopeCounts.value = {
+          ...scopeCounts.value,
+          [key]: Number(row.unresolved_groups) || 0,
+        };
+      }
+      countsLoaded.value = true;
+      return data;
+    } catch (err) {
+      console.warn("[dedup] failed to read the duplicate counts", err);
+      return null;
+    }
+  }
+
+  /**
+   * Read one scope's duplicate count, for a context menu.
+   *
+   * Cached, and de-duplicated while a request is in flight, because opening a
+   * context menu on the same set twice in a row is the common case and a second
+   * round trip there shows a flicker rather than a number. The same request
+   * refreshes the sidebar badge, since the server returns it either way.
+   *
+   * @param {string} type
+   * @param {number|string} id
+   * @param {Object} [options]
+   * @param {boolean} [options.force=false] - bypass the cache.
+   * @returns {Promise<number|null>} the count, or null when it could not be read.
+   */
+  async function fetchScopeCount(type, id, { force = false } = {}) {
+    const key = scopeKey(type, id);
+    if (!force && scopeCounts.value[key] !== undefined) {
+      return scopeCounts.value[key];
+    }
+    if (scopeCountsInFlight.has(key)) return scopeCountsInFlight.get(key);
+    const request = refreshCounts([{ scopeType: type, scopeId: id }])
+      .then((data) => {
+        if (!data) return null;
+        const value = scopeCounts.value[key];
+        return value === undefined ? 0 : value;
+      })
+      .finally(() => {
+        scopeCountsInFlight.delete(key);
+      });
+    scopeCountsInFlight.set(key, request);
+    return request;
+  }
+
+  /** Drop the cached per-scope counts after anything that could move them. */
+  function invalidateScopeCounts() {
+    scopeCounts.value = {};
+  }
+
+  /**
+   * Point the queue at a scope and load its first page.
+   *
+   * @param {Object} [scope]
+   * @param {string} [scope.type=GLOBAL_SCOPE] - `global`, `project`, `set`,
+   *   `character` or `folder`.
+   * @param {number|string} [scope.id=null]
+   * @param {string} [scope.label=""] - what the scope pill reads.
+   * @param {string} [scope.icon=""] - the pill's mdi glyph.
+   * @returns {Promise<void>}
+   */
+  /**
+   * Apply a URL-restored filter selection, under the same rules the tier menu
+   * enforces: embedding requires near, and the threshold is clamped to the
+   * server's published bounds (loadPolicy has run by the time this is called).
+   *
+   * @param {Object} filters - `{near?, embedding?, threshold?, decided?}`.
+   */
+  function applyUrlFilters(filters) {
+    if (typeof filters.near === "boolean") nearEnabled.value = filters.near;
+    if (typeof filters.embedding === "boolean") {
+      embeddingEnabled.value = filters.embedding;
+      if (filters.embedding) nearEnabled.value = true;
+    }
+    if (!nearEnabled.value) embeddingEnabled.value = false;
+    if (Number.isFinite(filters.threshold)) {
+      const min = Number(bounds.value?.min_threshold);
+      const max = Number(bounds.value?.max_threshold);
+      let next = filters.threshold;
+      if (Number.isFinite(max)) next = Math.min(max, next);
+      if (Number.isFinite(min)) next = Math.max(min, next);
+      threshold.value = next;
+    }
+    if (typeof filters.decided === "boolean") {
+      showingDecided.value = filters.decided;
+    }
+  }
+
+  async function openQueue({
+    type = GLOBAL_SCOPE,
+    id = null,
+    label = "",
+    icon = "",
+    filters = null,
+  } = {}) {
+    // "library" was this lane's own name for the unscoped case before the
+    // backend named it; accept it so an old bookmark still opens the queue.
+    scopeType.value = !type || type === "library" ? GLOBAL_SCOPE : type;
+    scopeId.value = id;
+    scopeLabel.value = label;
+    scopeIcon.value = icon;
+    stackedCount.value = 0;
+    separatedCount.value = 0;
+    showingDecided.value = false;
+    await loadPolicy();
+    // The URL is the source of truth for a restored filter selection: a full
+    // refresh (or a shared link) reopens the queue exactly as it was set.
+    if (filters) applyUrlFilters(filters);
+    // Opening the queue IS the scan trigger (design contract: the queue opens
+    // over whatever has been found while the banner streams progress). The
+    // group cache only fills when a scan runs; without this the queue reads an
+    // empty cache forever and no tier or threshold setting can change that.
+    await triggerScan();
+    await loadFirstPage();
+    refreshCounts();
+  }
+
+  /**
+   * Widen a scoped queue back to the whole vault.
+   *
+   * The focus goes back to the top, exactly as it does when a tier is toggled.
+   * The global queue is ordered by confidence across everything, so position 3
+   * in a set's queue and position 3 in the global one are unrelated groups:
+   * carrying the index over would silently drop the cursor three rows into a
+   * list the user has not seen, with the row treatment insisting that is where
+   * the keyboard acts.
+   *
+   * @returns {Promise<void>}
+   */
+  async function clearScope() {
+    if (!isScoped.value) return;
+    scopeType.value = GLOBAL_SCOPE;
+    scopeId.value = null;
+    scopeLabel.value = "";
+    scopeIcon.value = "";
+    await loadFirstPage();
+    refreshCounts();
+  }
+
+  /**
+   * Read a page's `next_cursor`, normalised to null when the server has none.
+   *
+   * Absent and null mean the same thing here and must: absent is an offset-only
+   * server, null is a cursor server saying this was the last page, and both end
+   * the cursor path.
+   *
+   * @param {Object} [data] - a queue response.
+   * @returns {string|null}
+   */
+  function cursorFrom(data) {
+    const cursor = data?.next_cursor;
+    return typeof cursor === "string" && cursor ? cursor : null;
+  }
+
+  /**
+   * Load the first page of the queue, replacing whatever was there.
+   *
+   * Always an offset-0 request: a cursor is a position inside one ordering, so
+   * the only honest way to start a queue whose policy or scope may just have
+   * changed is from the top. The response decides which path pages it.
+   *
+   * @returns {Promise<void>}
+   */
+  async function loadFirstPage() {
+    loading.value = true;
+    error.value = null;
+    // The list is being rebuilt (scope change, tier change, rescan), so a
+    // selection over the old rows would silently point at different groups.
+    clearSelection();
+    try {
+      const data = await listGroups({
+        ...policyArgs.value,
+        scopeType: scopeType.value,
+        scopeId: scopeId.value,
+        decided: showingDecided.value,
+        offset: 0,
+        limit: QUEUE_PAGE_SIZE,
+      });
+      groups.value = Array.isArray(data?.groups) ? data.groups : [];
+      total.value = Number(data?.total) || groups.value.length;
+      nextOffset.value = groups.value.length;
+      nextCursor.value = cursorFrom(data);
+      // A cursor is the server's own answer to "is there more", and it outranks
+      // the offset arithmetic: `total` is a live count under a running scan.
+      hasMore.value =
+        nextCursor.value !== null || nextOffset.value < total.value;
+      scan.value = normalizeScan(data?.scan);
+      focusIndex.value = groups.value.length ? 0 : -1;
+    } catch (err) {
+      error.value = err;
+      groups.value = [];
+      total.value = 0;
+      nextOffset.value = 0;
+      nextCursor.value = null;
+      hasMore.value = false;
+      focusIndex.value = -1;
+      console.warn("[dedup] failed to load the duplicate queue", err);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /**
+   * Append the next page, if there is one.
+   *
+   * Cursor first: a keyset cursor over `(confidence DESC, signature)` cannot
+   * re-serve or skip a group while a scan inserts rows, so a server that
+   * publishes one is paged from it and the offset is never sent again.
+   *
+   * Without a cursor the offset path stands, mitigations and all: offset paging
+   * over a table a scan is still inserting into can re-serve a group the client
+   * already holds, a duplicated row would be resolvable twice and the second
+   * verdict would fail, so a re-seen signature is dropped. The offset still
+   * advances by the page's full length, because the server counted those rows
+   * even though this client discarded some. The dedupe runs on both paths: it
+   * costs a Set per page and it is the thing that keeps a mid-flight switch
+   * between the two seamless.
+   *
+   * @returns {Promise<void>}
+   */
+  async function loadMore() {
+    if (!hasMore.value || loadingMore.value || loading.value) return;
+    loadingMore.value = true;
+    try {
+      const cursor = nextCursor.value;
+      const data = await listGroups({
+        ...policyArgs.value,
+        scopeType: scopeType.value,
+        scopeId: scopeId.value,
+        decided: showingDecided.value,
+        ...(cursor === null ? { offset: nextOffset.value } : { cursor }),
+        limit: QUEUE_PAGE_SIZE,
+      });
+      const page = Array.isArray(data?.groups) ? data.groups : [];
+      const seen = new Set(groups.value.map((g) => g.signature));
+      groups.value = [
+        ...groups.value,
+        ...page.filter((g) => !seen.has(g.signature)),
+      ];
+      nextOffset.value += page.length;
+      nextCursor.value = cursorFrom(data);
+      total.value = Number(data?.total) || total.value;
+      // An empty page is the end whatever the total or the cursor says: a total
+      // that shrank under a concurrent verdict would otherwise leave this
+      // looping, and so would a server that keeps minting cursors past the end.
+      hasMore.value =
+        page.length > 0 &&
+        (nextCursor.value !== null || nextOffset.value < total.value);
+      scan.value = normalizeScan(data?.scan);
+      // A page that lands into an emptied queue has to be given the cursor, or
+      // the rows arrive with nothing focused and the keyboard model is dead
+      // until the user clicks.
+      if (focusIndex.value < 0 && groups.value.length) focusIndex.value = 0;
+    } catch (err) {
+      console.warn("[dedup] failed to page the duplicate queue", err);
+    } finally {
+      loadingMore.value = false;
+    }
+  }
+
+  /**
+   * Move the focus, clamped to the list, fetching ahead near the tail.
+   * @param {number} index
+   */
+  function setFocus(index) {
+    if (!groups.value.length) {
+      focusIndex.value = -1;
+      return;
+    }
+    const clamped = Math.max(0, Math.min(groups.value.length - 1, index));
+    focusIndex.value = clamped;
+    if (clamped >= groups.value.length - PREFETCH_MARGIN) loadMore();
+  }
+
+  // ── The decided page ─────────────────────────────────────────────────────
+  // The queue's flip side: resolved groups with their live verdict, so a
+  // decision can be reviewed and cleared (owner request, 2026-07-29 — this
+  // replaces the sticky "Kept N pictures separate" notice as the way back).
+
+  const showingDecided = ref(false);
+
+  async function toggleDecided() {
+    showingDecided.value = !showingDecided.value;
+    await loadFirstPage();
+  }
+
+  // ── Multi-select ─────────────────────────────────────────────────────────
+  // Ctrl+click toggles a group in and out; Shift+click selects the range from
+  // the anchor (the last toggled or focused row). A verdict given to any
+  // selected group applies to the whole selection — the row buttons say so.
+
+  const selectedSignatures = ref(new Set());
+  let selectionAnchor = null;
+
+  const selectionCount = computed(() => selectedSignatures.value.size);
+
+  /** @param {string} signature @returns {boolean} */
+  function isSelected(signature) {
+    return selectedSignatures.value.has(signature);
+  }
+
+  function clearSelection() {
+    selectionAnchor = null;
+    if (selectedSignatures.value.size) selectedSignatures.value = new Set();
+  }
+
+  /** Ctrl+click: toggle one group, move the focus and the range anchor there. */
+  function toggleSelected(index) {
+    const sig = groups.value[index]?.signature;
+    if (!sig) return;
+    const next = new Set(selectedSignatures.value);
+    // Grid parity: the FIRST Ctrl+click starts a multi-selection from the row
+    // the user is on, so it must not trade the focused row for the clicked
+    // one — both end up selected. (Ctrl+clicking the focused row itself still
+    // just toggles it.)
+    if (!next.size && focusIndex.value >= 0 && focusIndex.value !== index) {
+      const focusedSig = groups.value[focusIndex.value]?.signature;
+      if (focusedSig) next.add(focusedSig);
+    }
+    if (next.has(sig)) next.delete(sig);
+    else next.add(sig);
+    selectedSignatures.value = next;
+    selectionAnchor = index;
+    setFocus(index);
+  }
+
+  /** Ctrl+A: every loaded group. Selection is a client-side gesture, so it
+   * covers what is loaded — the pages the user has actually seen. */
+  function selectAll() {
+    if (!groups.value.length) return;
+    selectedSignatures.value = new Set(groups.value.map((g) => g.signature));
+    selectionAnchor = null;
+  }
+
+  /** Shift+click: select the whole run from the anchor to `index`. */
+  function selectRange(index) {
+    if (!groups.value.length) return;
+    const from =
+      selectionAnchor ?? (focusIndex.value < 0 ? 0 : focusIndex.value);
+    const [lo, hi] = from <= index ? [from, index] : [index, from];
+    const next = new Set();
+    for (let i = lo; i <= hi; i += 1) {
+      const sig = groups.value[i]?.signature;
+      if (sig) next.add(sig);
+    }
+    selectedSignatures.value = next;
+    setFocus(index);
+  }
+
+  /**
+   * The groups a verdict on `group` applies to: the whole multi-selection when
+   * the acted-on group is part of it, else just that group. Queue order, so
+   * the narration and the auto-advance read top to bottom.
+   *
+   * @param {Object} group
+   * @returns {Object[]}
+   */
+  function verdictTargets(group) {
+    if (
+      group &&
+      selectedSignatures.value.size > 1 &&
+      selectedSignatures.value.has(group.signature)
+    ) {
+      return groups.value.filter((g) =>
+        selectedSignatures.value.has(g.signature),
+      );
+    }
+    return group ? [group] : [];
+  }
+
+  /** Move the focus one group down. */
+  function focusNext() {
+    setFocus(focusIndex.value + 1);
+  }
+
+  /** Move the focus one group up. */
+  function focusPrev() {
+    setFocus(focusIndex.value - 1);
+  }
+
+  /**
+   * Drop a resolved group and land the focus on the next open one.
+   *
+   * Auto-advance keeps the index where it is, because removing the row at that
+   * index means the next group has already slid into it. Only a verdict on the
+   * last row walks the focus backwards.
+   *
+   * @param {string} signature
+   */
+  function removeGroup(signature) {
+    const index = groups.value.findIndex((g) => g.signature === signature);
+    if (index < 0) return;
+    groups.value = groups.value.filter((g) => g.signature !== signature);
+    if (selectedSignatures.value.has(signature)) {
+      const next = new Set(selectedSignatures.value);
+      next.delete(signature);
+      selectedSignatures.value = next;
+    }
+    const { [signature]: _cover, ...restCovers } = coverChoices.value;
+    coverChoices.value = restCovers;
+    const { [signature]: _out, ...restExclusions } = exclusions.value;
+    exclusions.value = restExclusions;
+    // The row left the client's list and the server's unresolved set at once,
+    // so the offset the next page starts from moves with it. A keyset cursor
+    // needs no such correction: it names a position in the ordering rather than
+    // a count of rows before it, so resolving a group cannot shift it.
+    if (nextCursor.value === null) {
+      nextOffset.value = Math.max(0, nextOffset.value - 1);
+    }
+    total.value = Math.max(0, total.value - 1);
+    if (!groups.value.length) {
+      focusIndex.value = -1;
+      // A page can be emptied faster than the read-ahead refills it. Without
+      // this the queue shows its done state while the server still holds
+      // thousands of groups, which is the one lie a to-do count cannot afford.
+      if (hasMore.value) loadMore();
+      return;
+    }
+    setFocus(Math.min(index, groups.value.length - 1));
+  }
+
+  /**
+   * Reconcile the badge with the server after a verdict.
+   *
+   * The optimistic decrement in {@link stack} and {@link keepSeparate} is what
+   * makes the badge feel instant, but nothing else will ever correct it: a
+   * keep-separate mutates no picture row, so it raises no WebSocket event and
+   * `App.refreshSidebar` never runs for it. Left alone the badge is wrong in a
+   * second tab from the first verdict and drifts further with every one after.
+   * One scope, one cheap COUNT, fired behind the optimistic tick rather than
+   * awaited, so auto-advance is not held up by it.
+   */
+  function reconcileCounts() {
+    refreshCounts().catch((err) => {
+      // refreshCounts already swallows and logs its own failures; this only
+      // catches a programming error in it, which must not become an unhandled
+      // rejection on a keypress.
+      console.warn("[dedup] could not reconcile the duplicate counts", err);
+    });
+  }
+
+  /**
+   * Stack one group.
+   *
+   * Records one operation, so the shared receipt narrates it and Ctrl+Z reverses
+   * it without this store doing anything undo-specific.
+   *
+   * @param {Object} group
+   * @param {Object} [options]
+   * @param {string} [options.batchId]
+   * @returns {Promise<Object|null>} the verdict response, or null on failure.
+   */
+  async function stack(group, { batchId } = {}) {
+    // The decided page reviews verdicts; it never gives them. Enter on a
+    // decided row must be inert, not a silent re-stack.
+    if (showingDecided.value) return null;
+    const targets = verdictTargets(group);
+    if (targets.length > 1) {
+      // One gesture, one Ctrl+Z: every selected group shares a client batch
+      // id, so the operation log coalesces the verdicts into one undo step.
+      const gestureId = batchId || newOperationBatchId();
+      let last = null;
+      for (const target of targets) {
+        last = await stackOne(target, { batchId: gestureId });
+        // Stop on the first failure rather than half-applying silently; the
+        // failed group and the rest stay selected and in the queue.
+        if (!last) return null;
+      }
+      clearSelection();
+      return last;
+    }
+    return stackOne(group, { batchId });
+  }
+
+  async function stackOne(group, { batchId } = {}) {
+    if (!group || busy.value) return null;
+    busy.value = true;
+    try {
+      const result = await stackGroup(group.signature, {
+        coverPictureId: coverIdFor(group),
+        excludedPictureIds: excludedFor(group.signature),
+        batchId,
+      });
+      stackedCount.value += 1;
+      removeGroup(group.signature);
+      openCount.value = Math.max(0, openCount.value - 1);
+      invalidateScopeCounts();
+      reconcileCounts();
+      return result;
+    } catch (err) {
+      error.value = err;
+      console.warn(`[dedup] failed to stack group ${group.signature}`, err);
+      return null;
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  /**
+   * Keep one group separate.
+   *
+   * The backend deliberately records **no operation** for this: no picture row
+   * changes, so there is nothing for undo to restore, and an empty operation row
+   * would still consume a Ctrl+Z. The caller must therefore narrate this itself
+   * and offer {@link reopen} as the way back rather than waiting for a receipt.
+   *
+   * @param {Object} group
+   * @returns {Promise<Object|null>} the verdict response, or null on failure.
+   */
+  async function keepSeparate(group) {
+    if (showingDecided.value) return null;
+    const targets = verdictTargets(group);
+    if (targets.length > 1) {
+      let last = null;
+      for (const target of targets) {
+        last = await keepSeparateOne(target);
+        if (!last) return null;
+      }
+      clearSelection();
+      return last;
+    }
+    return keepSeparateOne(group);
+  }
+
+  async function keepSeparateOne(group) {
+    if (!group || busy.value) return null;
+    busy.value = true;
+    try {
+      const result = await keepGroupSeparate(group.signature);
+      separatedCount.value += 1;
+      removeGroup(group.signature);
+      openCount.value = Math.max(0, openCount.value - 1);
+      invalidateScopeCounts();
+      // This verdict raises no WebSocket event at all, so this refetch is the
+      // only thing that will ever correct the tick above.
+      reconcileCounts();
+      return result;
+    } catch (err) {
+      error.value = err;
+      console.warn(
+        `[dedup] failed to keep group ${group.signature} separate`,
+        err,
+      );
+      return null;
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  /**
+   * Return a decided group to the queue.
+   *
+   * The stand-in for undo on a keep-separate. The group comes back only if it
+   * has been re-detected; when it has not, the response says so and the next
+   * scan brings it back, which the caller must report honestly rather than
+   * implying the row will reappear.
+   *
+   * @param {string} signature
+   * @returns {Promise<Object|null>} the reopen response, or null on failure.
+   */
+  async function reopen(signature) {
+    try {
+      const result = await reopenGroup(signature);
+      invalidateScopeCounts();
+      await loadFirstPage();
+      refreshCounts();
+      return result;
+    } catch (err) {
+      error.value = err;
+      console.warn(`[dedup] failed to reopen group ${signature}`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Clear several decisions in one gesture (the Decided page's bulk path).
+   *
+   * One reload at the end rather than per group — reopen() reloads per call,
+   * which is right for one and quadratic for fifty.
+   *
+   * @param {string[]} signatures
+   * @returns {Promise<{cleared: number, returned: number}>}
+   */
+  async function reopenMany(signatures) {
+    let cleared = 0;
+    let returned = 0;
+    for (const signature of signatures) {
+      try {
+        const result = await reopenGroup(signature);
+        cleared += 1;
+        if (result?.group_returned_to_queue) returned += 1;
+      } catch (err) {
+        error.value = err;
+        console.warn(`[dedup] failed to reopen group ${signature}`, err);
+        break;
+      }
+    }
+    if (cleared) {
+      invalidateScopeCounts();
+      await loadFirstPage();
+      refreshCounts();
+    }
+    return { cleared, returned };
+  }
+
+  /**
+   * Turn a tier on or off.
+   *
+   * Enabling a tier requires the tier above it and disabling one drops every
+   * looser tier with it, so a user cannot land on "same scene" suggestions
+   * without having deliberately walked down to them. The server enforces the
+   * same rule; this mirrors it so the UI never sends a request it knows is a
+   * 400.
+   *
+   * @param {string} id - a tier id from `bounds.tiers`.
+   * @param {boolean} on
+   * @returns {Promise<void>}
+   */
+  async function setTierEnabled(id, on) {
+    const before = [nearEnabled.value, embeddingEnabled.value];
+    if (id === "near") {
+      nearEnabled.value = on;
+      if (!on) embeddingEnabled.value = false;
+    } else if (id === "embedding") {
+      embeddingEnabled.value = on;
+      if (on) nearEnabled.value = true;
+    } else {
+      return;
+    }
+    if (
+      before[0] === nearEnabled.value &&
+      before[1] === embeddingEnabled.value
+    ) {
+      return;
+    }
+    // Enabling a tier loosens detection, and looser groups only exist in the
+    // cache once a scan has looked for them. Disabling narrows a query over
+    // the existing superset, so no rescan is needed there.
+    if (on) await triggerScan();
+    await loadFirstPage();
+    refreshCounts();
+  }
+
+  /**
+   * Move the similarity threshold and reload.
+   *
+   * Clamped to the server's published bounds rather than to a number repeated
+   * here: below the floor is a 400, deliberately, because a low threshold
+   * produces confident-looking garbage and destroys trust in the count.
+   *
+   * @param {number} value
+   * @returns {Promise<void>}
+   */
+  async function setThreshold(value) {
+    const next = Number(value);
+    if (!Number.isFinite(next)) return;
+    const min = Number(bounds.value?.min_threshold);
+    const max = Number(bounds.value?.max_threshold);
+    const clamped = Math.max(
+      Number.isFinite(min) ? min : next,
+      Math.min(Number.isFinite(max) ? max : next, next),
+    );
+    if (clamped === threshold.value) return;
+    const loosened = clamped < threshold.value;
+    threshold.value = clamped;
+    // Lowering the threshold asks for groups a stricter scan never wrote to
+    // the cache; raising it just narrows the query over what is already there.
+    if (loosened) await triggerScan();
+    await loadFirstPage();
+    refreshCounts();
+  }
+
+  /**
+   * Queue a scan for the current scope and adopt its progress.
+   * @returns {Promise<void>}
+   */
+  async function triggerScan() {
+    try {
+      const data = await startScan({
+        policy: policyArgs.value,
+        scopeType: scopeType.value,
+        scopeId: scopeId.value,
+      });
+      scan.value = normalizeScan(data);
+      startScanPoll();
+    } catch (err) {
+      console.warn("[dedup] failed to start a duplicate scan", err);
+    }
+  }
+
+  // --- Scan progress polling ----------------------------------------------
+  // The banner and the counts are only honest while someone re-reads them:
+  // tier-2 groups commit after every bucket, but nothing pushes that to the
+  // client. The poll runs only while a scan is pending/running, and reloads
+  // the group list only while the queue is still EMPTY — so the first finds
+  // surface on their own, and a triage already in progress is never yanked
+  // back to the top.
+  let scanPollTimer = null;
+
+  function stopScanPoll() {
+    if (scanPollTimer) {
+      clearInterval(scanPollTimer);
+      scanPollTimer = null;
+    }
+  }
+
+  function startScanPoll() {
+    if (scanPollTimer || !isScanning.value) return;
+    scanPollTimer = setInterval(async () => {
+      await refreshCounts();
+      if (!groups.value.length) await loadFirstPage();
+      if (!isScanning.value) stopScanPoll();
+    }, 2000);
+  }
+
+  /**
+   * Preview the bulk auto-stack of the exact tier.
+   * @returns {Promise<Object|null>} the dry-run report.
+   */
+  async function previewAutoStack() {
+    try {
+      return await autoStackExact({
+        dryRun: true,
+        scopeType: scopeType.value,
+        scopeId: scopeId.value,
+      });
+    } catch (err) {
+      console.warn("[dedup] failed to preview the auto-stack", err);
+      return null;
+    }
+  }
+
+  /**
+   * Run the bulk auto-stack for real.
+   *
+   * The whole run coalesces into one operation batch, so the receipt it raises
+   * reverses every stack it created with a single undo.
+   *
+   * @returns {Promise<Object|null>} the run report, carrying `batch_id` and any
+   *   `failures`.
+   */
+  async function runAutoStack() {
+    busy.value = true;
+    try {
+      const result = await autoStackExact({
+        dryRun: false,
+        scopeType: scopeType.value,
+        scopeId: scopeId.value,
+      });
+      invalidateScopeCounts();
+      await loadFirstPage();
+      await refreshCounts();
+      return result;
+    } catch (err) {
+      error.value = err;
+      console.warn("[dedup] failed to run the auto-stack", err);
+      return null;
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  return {
+    // policy
+    policyDefaults,
+    bounds,
+    policyLoaded,
+    loadPolicy,
+    tierRows,
+    nearEnabled,
+    embeddingEnabled,
+    threshold,
+    setTierEnabled,
+    setThreshold,
+    // counts
+    openCount,
+    byTier,
+    exactCount,
+    queueOnlyCount,
+    scan,
+    countsLoaded,
+    isScanning,
+    scopeCounts,
+    refreshCounts,
+    fetchScopeCount,
+    invalidateScopeCounts,
+    // queue
+    scopeType,
+    scopeId,
+    scopeLabel,
+    scopeIcon,
+    isScoped,
+    groups,
+    total,
+    nextCursor,
+    hasMore,
+    hasGroups,
+    focusIndex,
+    focusedGroup,
+    loading,
+    loadingMore,
+    error,
+    busy,
+    stackedCount,
+    separatedCount,
+    doneCount,
+    openQueue,
+    clearScope,
+    loadFirstPage,
+    loadMore,
+    setFocus,
+    selectionCount,
+    isSelected,
+    clearSelection,
+    toggleSelected,
+    selectAll,
+    selectRange,
+    verdictTargets,
+    reopenMany,
+    hasDuplicates,
+    showingDecided,
+    toggleDecided,
+    applyUrlFilters,
+    focusNext,
+    focusPrev,
+    removeGroup,
+    // per-group choices
+    coverChoices,
+    exclusions,
+    coverIdFor,
+    excludedFor,
+    stackSizeFor,
+    isAtStackFloor,
+    setCover,
+    toggleExcluded,
+    // verdicts and bulk
+    stack,
+    keepSeparate,
+    reopen,
+    triggerScan,
+    stopScanPoll,
+    previewAutoStack,
+    runAutoStack,
+  };
+});

--- a/frontend/src/stores/useDedupStore.test.js
+++ b/frontend/src/stores/useDedupStore.test.js
@@ -1,0 +1,1259 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+
+vi.mock("../api/dedup", () => ({
+  getPolicy: vi.fn(),
+  listGroups: vi.fn(),
+  getCounts: vi.fn(),
+  startScan: vi.fn(),
+  stackGroup: vi.fn(),
+  keepGroupSeparate: vi.fn(),
+  reopenGroup: vi.fn(),
+  autoStackExact: vi.fn(),
+  GLOBAL_SCOPE: "global",
+}));
+
+import {
+  getPolicy,
+  listGroups,
+  getCounts,
+  startScan,
+  stackGroup,
+  keepGroupSeparate,
+  reopenGroup,
+  autoStackExact,
+} from "../api/dedup";
+import { useDedupStore, scopeKey, QUEUE_PAGE_SIZE } from "./useDedupStore";
+
+/** The bounds `GET /dedup/policy` publishes, as the shipped backend does. */
+const BOUNDS = {
+  min_threshold: 0.65,
+  max_threshold: 0.99999,
+  tiers: ["exact", "near", "embedding"],
+  always_on_tiers: ["exact"],
+  tier_requires: { exact: null, near: "exact", embedding: "near" },
+  scope_types: ["global", "project", "set", "character", "folder"],
+  verdicts: ["stacked", "keep_separate"],
+  max_page_size: 200,
+};
+
+/** A queue group in the backend's shape, with `n` candidates of falling size. */
+function group(signature, n = 2, over = {}) {
+  const base = Number(signature.replace(/\D/g, "")) * 100;
+  return {
+    signature,
+    tier: "near",
+    confidence: 0.9,
+    member_count: n,
+    cover_picture_id: null,
+    why: [],
+    candidates: Array.from({ length: n }, (_, i) => ({
+      picture_id: base + i,
+      width: 4000 - i * 1000,
+      height: 3000 - i * 750,
+      megapixels: ((4000 - i * 1000) * (3000 - i * 750)) / 1e6,
+      tag_count: 0,
+      score: 0,
+      format: "JPEG",
+      is_raw: false,
+      created_at: "2026-05-12T14:22:00Z",
+    })),
+    ...over,
+  };
+}
+
+/** The ids of a group's candidates, in order. */
+const idsOf = (g) => g.candidates.map((c) => c.picture_id);
+
+function servePage(groups, over = {}) {
+  listGroups.mockResolvedValue({
+    groups,
+    total: groups.length,
+    offset: 0,
+    limit: QUEUE_PAGE_SIZE,
+    scan: { status: "complete", scanned_pictures: 10, total_pictures: 10 },
+    ...over,
+  });
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  for (const fn of [
+    getPolicy,
+    listGroups,
+    getCounts,
+    startScan,
+    stackGroup,
+    keepGroupSeparate,
+    reopenGroup,
+    autoStackExact,
+  ]) {
+    fn.mockReset();
+  }
+  getPolicy.mockResolvedValue({
+    defaults: { near_enabled: false, embedding_enabled: false, threshold: 0.9 },
+    bounds: BOUNDS,
+  });
+  getCounts.mockResolvedValue({
+    unresolved_groups: 0,
+    by_tier: {},
+    scopes: [],
+  });
+});
+
+describe("useDedupStore — the policy", () => {
+  // Every bound the UI renders comes from here. A threshold stated in the
+  // client as well would be the same number in two places that can drift.
+  it("loads the bounds and adopts the server's default threshold", async () => {
+    const store = useDedupStore();
+    await store.loadPolicy();
+    expect(store.bounds.min_threshold).toBe(0.65);
+    expect(store.threshold).toBe(0.9);
+    expect(store.policyLoaded).toBe(true);
+  });
+
+  it("loads the policy once", async () => {
+    const store = useDedupStore();
+    await store.loadPolicy();
+    await store.loadPolicy();
+    expect(getPolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds the tier rows from the server's list", async () => {
+    const store = useDedupStore();
+    await store.loadPolicy();
+    store.byTier = { exact: 1204, near: 96, embedding: 9 };
+    const rows = store.tierRows;
+    expect(rows.map((r) => r.id)).toEqual(["exact", "near", "embedding"]);
+    expect(rows[0].locked).toBe(true);
+    expect(rows[0].enabled).toBe(true);
+    expect(rows[1].requires).toBe("exact");
+    expect(rows[2].count).toBe(9);
+  });
+});
+
+describe("useDedupStore — loading the queue", () => {
+  it("loads the first page and focuses the first group", async () => {
+    servePage([group("g1"), group("g2")], { total: 2 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.groups).toHaveLength(2);
+    expect(store.focusIndex).toBe(0);
+    expect(listGroups).toHaveBeenCalledWith({
+      nearEnabled: false,
+      embeddingEnabled: false,
+      decided: false,
+      scopeType: "global",
+      scopeId: null,
+      offset: 0,
+      limit: QUEUE_PAGE_SIZE,
+    });
+  });
+
+  // The queue opens on whatever has been found so far; the banner reports the
+  // rest. Blocking on a full pass is the thing this feature exists to avoid.
+  it("adopts partial scan progress alongside a partial queue", async () => {
+    servePage([group("g1")], {
+      scan: {
+        status: "running",
+        scanned_pictures: 6200,
+        total_pictures: 12400,
+      },
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.isScanning).toBe(true);
+    expect(store.scan.percent).toBe(50);
+  });
+
+  // The server reports pictures and buckets but never a percentage.
+  it("derives the percentage the server does not send", async () => {
+    servePage([], {
+      scan: { status: "running", scanned_pictures: 1, total_pictures: 4 },
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.scan.percent).toBe(25);
+  });
+
+  // Tier 2 streams groups in per candidate bucket, so a scope whose picture
+  // total is not known yet still has honest progress to report.
+  it("falls back to bucket progress when no picture total is known", async () => {
+    servePage([], {
+      scan: {
+        status: "running",
+        scanned_pictures: 0,
+        total_pictures: 0,
+        scanned_buckets: 3,
+        total_buckets: 12,
+      },
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.scan.percent).toBe(25);
+  });
+
+  it("reports an empty queue rather than a stale focus", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.hasGroups).toBe(false);
+    expect(store.focusIndex).toBe(-1);
+  });
+
+  it("clears the list when the load fails", async () => {
+    listGroups.mockRejectedValue(new Error("boom"));
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.groups).toEqual([]);
+    expect(store.focusIndex).toBe(-1);
+    expect(store.hasMore).toBe(false);
+    expect(store.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useDedupStore — paging", () => {
+  it("appends the next page at the next offset", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1")],
+      total: 2,
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.hasMore).toBe(true);
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g2")],
+      total: 2,
+      scan: {},
+    });
+    await store.loadMore();
+    expect(store.groups.map((g) => g.signature)).toEqual(["g1", "g2"]);
+    expect(listGroups).toHaveBeenLastCalledWith(
+      expect.objectContaining({ offset: 1 }),
+    );
+    expect(store.hasMore).toBe(false);
+  });
+
+  // Offset paging over a table a scan is still inserting into can re-serve a
+  // group the client already holds. A duplicated row could be resolved twice,
+  // and the second verdict would 400.
+  it("drops a group an offset page repeats", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1"), group("g2")],
+      total: 4,
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g2"), group("g3")],
+      total: 4,
+      scan: {},
+    });
+    await store.loadMore();
+    expect(store.groups.map((g) => g.signature)).toEqual(["g1", "g2", "g3"]);
+  });
+
+  // The server counted the rows it served even though this client discarded
+  // one, so the offset advances by the page's full length or the next page
+  // re-serves the same window forever.
+  it("advances the offset by the served page length, not the kept one", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1"), group("g2")],
+      total: 6,
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g2"), group("g3")],
+      total: 6,
+      scan: {},
+    });
+    await store.loadMore();
+    listGroups.mockResolvedValueOnce({ groups: [], total: 6, scan: {} });
+    await store.loadMore();
+    expect(listGroups).toHaveBeenLastCalledWith(
+      expect.objectContaining({ offset: 4 }),
+    );
+  });
+
+  it("does not page past the end", async () => {
+    servePage([group("g1")], { total: 1 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    listGroups.mockClear();
+    await store.loadMore();
+    expect(listGroups).not.toHaveBeenCalled();
+  });
+
+  // A total that shrank under a concurrent verdict would otherwise leave the
+  // read-ahead looping on an empty page.
+  it("stops when a page comes back empty whatever the total says", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1")],
+      total: 99,
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    listGroups.mockResolvedValueOnce({ groups: [], total: 99, scan: {} });
+    await store.loadMore();
+    expect(store.hasMore).toBe(false);
+  });
+
+  // A keyset cursor over the queue's ordering cannot re-serve or skip a group
+  // while a scan inserts rows, so it is the primary path the moment the server
+  // publishes one.
+  it("pages from the cursor once the server serves one", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1")],
+      total: 3,
+      next_cursor: "c1",
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.nextCursor).toBe("c1");
+    expect(store.hasMore).toBe(true);
+
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g2")],
+      total: 3,
+      next_cursor: "c2",
+      scan: {},
+    });
+    await store.loadMore();
+    const args = listGroups.mock.calls.at(-1)[0];
+    expect(args.cursor).toBe("c1");
+    expect(args.offset).toBeUndefined();
+    expect(store.nextCursor).toBe("c2");
+  });
+
+  // A cursor outranks the offset arithmetic in the other direction too: a
+  // `total` that has not caught up with a running scan must not end the queue
+  // while the server is still handing out cursors.
+  it("keeps paging on a cursor even when the total says it is done", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1")],
+      total: 1,
+      next_cursor: "c1",
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.hasMore).toBe(true);
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g2")],
+      total: 1,
+      next_cursor: "c2",
+      scan: {},
+    });
+    await store.loadMore();
+    expect(store.groups).toHaveLength(2);
+  });
+
+  // A cursor server that runs out mid-queue hands the offset path back a
+  // consistent position, so the fallback is seamless in that direction as well.
+  it("hands the offset path a correct position when the cursor stops", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1"), group("g2")],
+      total: 9,
+      next_cursor: null,
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.nextCursor).toBe(null);
+    expect(store.hasMore).toBe(true);
+    listGroups.mockResolvedValueOnce({ groups: [group("g3")], total: 9, scan: {} });
+    await store.loadMore();
+    expect(listGroups.mock.calls.at(-1)[0].offset).toBe(2);
+  });
+
+  it("stops when the cursor runs out", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1")],
+      total: 2,
+      next_cursor: "c1",
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g2")],
+      total: 2,
+      next_cursor: null,
+      scan: {},
+    });
+    await store.loadMore();
+    expect(store.hasMore).toBe(false);
+    expect(store.nextCursor).toBe(null);
+  });
+
+  // The fallback has to be seamless in both directions: a server with no
+  // cursor pages exactly as before, mitigations and all.
+  it("falls back to the offset path when no cursor is served", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1")],
+      total: 2,
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.nextCursor).toBe(null);
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g2")],
+      total: 2,
+      scan: {},
+    });
+    await store.loadMore();
+    const args = listGroups.mock.calls.at(-1)[0];
+    expect(args.offset).toBe(1);
+    expect(args.cursor).toBeUndefined();
+  });
+
+  // A cursor names a position in the ordering, not a count of rows before it,
+  // so resolving a group must not shift it the way it shifts an offset.
+  it("leaves the cursor alone when a verdict removes a group", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1"), group("g2")],
+      total: 9,
+      next_cursor: "c1",
+      scan: {},
+    });
+    stackGroup.mockResolvedValue({});
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    await store.stack(store.groups[0]);
+    listGroups.mockResolvedValue({ groups: [], total: 8, scan: {} });
+    await store.loadMore();
+    expect(listGroups.mock.calls.at(-1)[0].cursor).toBe("c1");
+  });
+
+  // A first page is always offset 0: a cursor is a position inside one
+  // ordering, and the policy or the scope may just have changed under it.
+  it("restarts from the top rather than reusing a cursor", async () => {
+    listGroups.mockResolvedValue({
+      groups: [group("g1")],
+      total: 1,
+      next_cursor: "c1",
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    await store.loadFirstPage();
+    const args = listGroups.mock.calls.at(-1)[0];
+    expect(args.offset).toBe(0);
+    expect(args.cursor).toBeUndefined();
+  });
+
+  // The keyboard is the primary way through the queue, so the read-ahead is
+  // driven by the focus rather than by scrolling.
+  it("fetches ahead when the focus walks near the tail", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1"), group("g2"), group("g3"), group("g4")],
+      total: 40,
+      scan: {},
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    listGroups.mockClear();
+    listGroups.mockResolvedValue({ groups: [], total: 40, scan: {} });
+    store.setFocus(0);
+    expect(listGroups).not.toHaveBeenCalled();
+    store.setFocus(2);
+    expect(listGroups).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useDedupStore — the focus", () => {
+  it("clamps the focus to the list", async () => {
+    servePage([group("g1"), group("g2")], { total: 2 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    store.focusPrev();
+    expect(store.focusIndex).toBe(0);
+    store.setFocus(99);
+    expect(store.focusIndex).toBe(1);
+    store.focusNext();
+    expect(store.focusIndex).toBe(1);
+  });
+
+  it("reports no focus for an empty queue", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    store.setFocus(0);
+    expect(store.focusIndex).toBe(-1);
+    expect(store.focusedGroup).toBe(null);
+  });
+});
+
+describe("useDedupStore — cover and exclusion", () => {
+  // The server runs the same formula and ships its answer on the group.
+  it("takes the server's cover preselection", async () => {
+    servePage([group("g1", 3, { cover_picture_id: 102 })], { total: 1 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(store.coverIdFor(store.groups[0])).toBe(102);
+  });
+
+  it("falls back to the local formula when no preselection arrives", async () => {
+    servePage([group("g1", 3)], { total: 1 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    const g = store.groups[0];
+    expect(store.coverIdFor(g)).toBe(idsOf(g)[0]);
+  });
+
+  it("lets the user override the preselection", async () => {
+    servePage([group("g1", 3)], { total: 1 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    const g = store.groups[0];
+    store.setCover(g.signature, idsOf(g)[2]);
+    expect(store.coverIdFor(g)).toBe(idsOf(g)[2]);
+  });
+
+  it("counts the stack down as candidates are excluded", async () => {
+    servePage([group("g1", 3)], { total: 1 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    const g = store.groups[0];
+    expect(store.stackSizeFor(g)).toBe(3);
+    store.toggleExcluded(g, idsOf(g)[2]);
+    expect(store.stackSizeFor(g)).toBe(2);
+    store.toggleExcluded(g, idsOf(g)[2]);
+    expect(store.stackSizeFor(g)).toBe(3);
+  });
+
+  // X is a one-key action with no confirmation, so it must never leave the
+  // group in a state the Stack button cannot act on. The server refuses a
+  // one-member stack outright, so the floor is two INCLUDED members: a
+  // two-candidate group accepts no exclusion at all, and letting it fall to one
+  // would make the Stack the row still offers a guaranteed 400.
+  it("refuses an exclusion that would leave a single member", async () => {
+    servePage([group("g1", 2)], { total: 1 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    const g = store.groups[0];
+    expect(store.toggleExcluded(g, idsOf(g)[1])).toBe(false);
+    expect(store.toggleExcluded(g, idsOf(g)[0])).toBe(false);
+    expect(store.stackSizeFor(g)).toBe(2);
+    expect(store.excludedFor("g1")).toEqual([]);
+    expect(store.isAtStackFloor(g)).toBe(true);
+  });
+
+  it("allows exclusions down to the floor and no further", async () => {
+    servePage([group("g1", 4)], { total: 1 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    const g = store.groups[0];
+    expect(store.toggleExcluded(g, idsOf(g)[3])).toBe(true);
+    expect(store.toggleExcluded(g, idsOf(g)[2])).toBe(true);
+    expect(store.stackSizeFor(g)).toBe(2);
+    expect(store.toggleExcluded(g, idsOf(g)[1])).toBe(false);
+    expect(store.stackSizeFor(g)).toBe(2);
+    // Putting one back is never refused: the floor only guards the way down.
+    expect(store.toggleExcluded(g, idsOf(g)[3])).toBe(true);
+    expect(store.stackSizeFor(g)).toBe(3);
+  });
+
+  // The server rejects a cover that is not an included member, so this is a
+  // correctness guard rather than a nicety.
+  it("moves the cover off a candidate the user excludes", async () => {
+    servePage([group("g1", 3)], { total: 1 });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    const g = store.groups[0];
+    const first = idsOf(g)[0];
+    expect(store.coverIdFor(g)).toBe(first);
+    store.toggleExcluded(g, first);
+    expect(store.coverIdFor(g)).toBe(idsOf(g)[1]);
+  });
+});
+
+describe("useDedupStore — verdicts and auto-advance", () => {
+  it("stacks with the cover and the exclusions in force", async () => {
+    servePage([group("g1", 3), group("g2")], { total: 2 });
+    stackGroup.mockResolvedValue({ stack_id: 7, batch_id: "b1" });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    const g = store.groups[0];
+    store.setCover(g.signature, idsOf(g)[1]);
+    store.toggleExcluded(g, idsOf(g)[2]);
+    await store.stack(g);
+    expect(stackGroup).toHaveBeenCalledWith("g1", {
+      coverPictureId: idsOf(g)[1],
+      excludedPictureIds: [idsOf(g)[2]],
+      batchId: undefined,
+    });
+  });
+
+  // Removing the row at the focused index means the next group has already
+  // slid into it, so the focus stays put and the queue advances by itself.
+  it("auto-advances to the next group after a verdict", async () => {
+    servePage([group("g1"), group("g2"), group("g3")], { total: 3 });
+    stackGroup.mockResolvedValue({});
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    await store.stack(store.groups[0]);
+    expect(store.groups.map((g) => g.signature)).toEqual(["g2", "g3"]);
+    expect(store.focusIndex).toBe(0);
+    expect(store.focusedGroup.signature).toBe("g2");
+  });
+
+  it("walks the focus back when the last group is resolved", async () => {
+    servePage([group("g1"), group("g2")], { total: 2 });
+    keepGroupSeparate.mockResolvedValue({ verdict: "keep_separate" });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    store.setFocus(1);
+    await store.keepSeparate(store.groups[1]);
+    expect(store.focusIndex).toBe(0);
+  });
+
+  it("lands on the done state when the last group is resolved", async () => {
+    servePage([group("g1")], { total: 1 });
+    stackGroup.mockResolvedValue({});
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    await store.stack(store.groups[0]);
+    expect(store.hasGroups).toBe(false);
+    expect(store.focusIndex).toBe(-1);
+    expect(store.doneCount).toBe(1);
+  });
+
+  // A page can be emptied faster than the read-ahead refills it. Showing the
+  // done state while the server still holds thousands of groups is the one lie
+  // a to-do count cannot afford.
+  it("refills rather than showing the done state early", async () => {
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g1")],
+      total: 50,
+      scan: {},
+    });
+    stackGroup.mockResolvedValue({});
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    listGroups.mockResolvedValueOnce({
+      groups: [group("g9")],
+      total: 49,
+      scan: {},
+    });
+    await store.stack(store.groups[0]);
+    await Promise.resolve();
+    expect(listGroups).toHaveBeenCalledTimes(2);
+  });
+
+  it("ticks the sidebar count down with each verdict", async () => {
+    servePage([group("g1"), group("g2")], { total: 2 });
+    stackGroup.mockResolvedValue({});
+    keepGroupSeparate.mockResolvedValue({});
+    const store = useDedupStore();
+    await store.refreshCounts();
+    getCounts.mockResolvedValue({ unresolved_groups: 2, by_tier: {} });
+    await store.refreshCounts();
+    await store.loadFirstPage();
+    expect(store.openCount).toBe(2);
+    // The optimistic tick lands with the verdict, before the reconciling
+    // refetch resolves: that immediacy is the whole point of it.
+    getCounts.mockImplementation(
+      () => new Promise(() => {}),
+    );
+    await store.stack(store.groups[0]);
+    await store.keepSeparate(store.groups[0]);
+    expect(store.openCount).toBe(0);
+    expect(store.stackedCount).toBe(1);
+    expect(store.separatedCount).toBe(1);
+  });
+
+  // A keep-separate mutates no picture row, so it raises no WebSocket event and
+  // nothing else will ever correct the optimistic tick above. Left to drift the
+  // badge is wrong in a second tab from the first verdict.
+  it("reconciles the badge with the server after every verdict", async () => {
+    servePage([group("g1"), group("g2")], { total: 2 });
+    stackGroup.mockResolvedValue({});
+    keepGroupSeparate.mockResolvedValue({});
+    getCounts.mockResolvedValue({ unresolved_groups: 41, by_tier: {} });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+
+    getCounts.mockClear();
+    await store.stack(store.groups[0]);
+    await Promise.resolve();
+    expect(getCounts).toHaveBeenCalledTimes(1);
+    expect(store.openCount).toBe(41);
+
+    getCounts.mockClear();
+    await store.keepSeparate(store.groups[0]);
+    await Promise.resolve();
+    expect(getCounts).toHaveBeenCalledTimes(1);
+    expect(store.openCount).toBe(41);
+  });
+
+  // The reconcile must not become an unhandled rejection on a keypress, and a
+  // count read that failed must not undo the verdict.
+  it("survives a reconcile that fails", async () => {
+    servePage([group("g1")], { total: 1 });
+    stackGroup.mockResolvedValue({});
+    getCounts.mockRejectedValue(new Error("nope"));
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    expect(await store.stack(store.groups[0])).toBeTruthy();
+    expect(store.stackedCount).toBe(1);
+  });
+
+  // A failed verdict must not consume the group: the user has to be able to
+  // try again on the row they were looking at.
+  it("keeps the group when the verdict fails", async () => {
+    servePage([group("g1"), group("g2")], { total: 2 });
+    stackGroup.mockRejectedValue(new Error("409"));
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    await store.stack(store.groups[0]);
+    expect(store.groups.map((g) => g.signature)).toEqual(["g1", "g2"]);
+    expect(store.stackedCount).toBe(0);
+  });
+
+  it("refuses a second verdict while one is in flight", async () => {
+    servePage([group("g1"), group("g2")], { total: 2 });
+    let release;
+    stackGroup.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    const first = store.stack(store.groups[0]);
+    await store.stack(store.groups[1]);
+    expect(stackGroup).toHaveBeenCalledTimes(1);
+    release({});
+    await first;
+  });
+
+  it("forgets a resolved group's cover and exclusions", async () => {
+    servePage([group("g1", 3), group("g2")], { total: 2 });
+    stackGroup.mockResolvedValue({});
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    const g = store.groups[0];
+    store.setCover(g.signature, idsOf(g)[1]);
+    store.toggleExcluded(g, idsOf(g)[2]);
+    await store.stack(g);
+    expect(store.coverChoices.g1).toBeUndefined();
+    expect(store.exclusions.g1).toBeUndefined();
+  });
+});
+
+describe("useDedupStore — reopen", () => {
+  // Keep-separate records no operation, so this is the only way back from it.
+  it("reopens a decided group and reloads the queue", async () => {
+    servePage([], { total: 0 });
+    reopenGroup.mockResolvedValue({
+      signature: "g1",
+      previous_verdict: "keep_separate",
+      group_returned_to_queue: true,
+    });
+    const store = useDedupStore();
+    listGroups.mockClear();
+    const result = await store.reopen("g1");
+    expect(reopenGroup).toHaveBeenCalledWith("g1");
+    expect(result.group_returned_to_queue).toBe(true);
+    expect(listGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports nothing when the reopen fails", async () => {
+    reopenGroup.mockRejectedValue(new Error("nope"));
+    const store = useDedupStore();
+    expect(await store.reopen("g1")).toBe(null);
+  });
+});
+
+describe("useDedupStore — the tier gate", () => {
+  it("enabling tier 3 pulls tier 2 in with it", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    await store.setTierEnabled("embedding", true);
+    expect(store.nearEnabled).toBe(true);
+    expect(store.embeddingEnabled).toBe(true);
+  });
+
+  // A user must not be left on "same scene" suggestions when they step back up.
+  it("disabling tier 2 drops tier 3 with it", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    await store.setTierEnabled("embedding", true);
+    await store.setTierEnabled("near", false);
+    expect(store.nearEnabled).toBe(false);
+    expect(store.embeddingEnabled).toBe(false);
+  });
+
+  // Tier 1 has no switch at all, so a stray call must not invent one.
+  it("ignores a toggle for a tier that has no switch", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    listGroups.mockClear();
+    await store.setTierEnabled("exact", false);
+    expect(listGroups).not.toHaveBeenCalled();
+  });
+
+  it("reloads the queue when the gate moves", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    listGroups.mockClear();
+    await store.setTierEnabled("near", true);
+    expect(listGroups).toHaveBeenCalledTimes(1);
+    expect(listGroups).toHaveBeenLastCalledWith(
+      expect.objectContaining({ nearEnabled: true }),
+    );
+  });
+
+  it("does not reload when the gate did not actually move", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    listGroups.mockClear();
+    await store.setTierEnabled("near", false);
+    expect(listGroups).not.toHaveBeenCalled();
+  });
+});
+
+describe("useDedupStore — the threshold", () => {
+  // Below the floor is a 400 by design, so the client must not send one.
+  it("clamps to the server's published bounds", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    await store.loadPolicy();
+    await store.setThreshold(0.1);
+    expect(store.threshold).toBe(0.65);
+    await store.setThreshold(2);
+    expect(store.threshold).toBe(0.99999);
+  });
+
+  it("reloads the queue with the new threshold", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    await store.loadPolicy();
+    listGroups.mockClear();
+    await store.setThreshold(0.8);
+    expect(listGroups).toHaveBeenLastCalledWith(
+      expect.objectContaining({ threshold: 0.8 }),
+    );
+  });
+
+  it("ignores a threshold that did not move, and a non-number", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    await store.loadPolicy();
+    listGroups.mockClear();
+    await store.setThreshold(0.9);
+    await store.setThreshold("nope");
+    expect(listGroups).not.toHaveBeenCalled();
+  });
+});
+
+describe("useDedupStore — scope", () => {
+  it("opens a scoped queue and remembers the pill", async () => {
+    servePage([group("g1")], { total: 1 });
+    const store = useDedupStore();
+    await store.openQueue({
+      type: "set",
+      id: 12,
+      label: "Release Set B",
+      icon: "mdi-folder-multiple-image",
+    });
+    expect(store.isScoped).toBe(true);
+    expect(store.scopeLabel).toBe("Release Set B");
+    expect(listGroups).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeType: "set", scopeId: 12 }),
+    );
+  });
+
+  // This lane called the unscoped case "library" before the backend named it.
+  it("accepts the old name for the unscoped queue", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    await store.openQueue({ type: "library" });
+    expect(store.scopeType).toBe("global");
+    expect(store.isScoped).toBe(false);
+  });
+
+  // Position 3 in a set's queue and position 3 in the global one are unrelated
+  // groups, so carrying the index over would drop the cursor into a row the
+  // user has never seen while the treatment insists that is where Enter lands.
+  it("widening back to the whole vault returns to the first group", async () => {
+    servePage([group("g1"), group("g2"), group("g3")], { total: 3 });
+    const store = useDedupStore();
+    await store.openQueue({ type: "set", id: 12, label: "Set B" });
+    store.setFocus(2);
+    await store.clearScope();
+    expect(store.isScoped).toBe(false);
+    expect(store.scopeLabel).toBe("");
+    expect(store.focusIndex).toBe(0);
+  });
+});
+
+describe("useDedupStore — counts", () => {
+  it("reads the badge, the tier split and the scan in one call", async () => {
+    getCounts.mockResolvedValue({
+      unresolved_groups: 143,
+      by_tier: { exact: 1204, near: 96, embedding: 9 },
+      scopes: [],
+      scan: { status: "running", scanned_pictures: 1, total_pictures: 2 },
+    });
+    const store = useDedupStore();
+    await store.refreshCounts();
+    expect(store.openCount).toBe(143);
+    expect(store.exactCount).toBe(1204);
+    expect(store.queueOnlyCount).toBe(105);
+    expect(store.isScanning).toBe(true);
+    expect(store.countsLoaded).toBe(true);
+  });
+
+  it("sends the tier policy so the counts match the queue", async () => {
+    const store = useDedupStore();
+    await store.setTierEnabled("near", true);
+    getCounts.mockClear();
+    await store.refreshCounts();
+    expect(getCounts).toHaveBeenCalledWith({
+      policy: { nearEnabled: true, embeddingEnabled: false },
+      scopes: [],
+    });
+  });
+
+  it("leaves the badge alone when the count read fails", async () => {
+    getCounts.mockRejectedValue(new Error("nope"));
+    const store = useDedupStore();
+    await store.refreshCounts();
+    expect(store.openCount).toBe(0);
+    expect(store.countsLoaded).toBe(false);
+  });
+
+  // The badge comes back with any scoped request, so a context menu opening
+  // also refreshes the sidebar and the two cannot disagree.
+  it("caches a per-scope count and refreshes the badge with it", async () => {
+    getCounts.mockResolvedValue({
+      unresolved_groups: 143,
+      by_tier: {},
+      scopes: [
+        {
+          scope_type: "set",
+          scope_id: "12",
+          key: "set:12",
+          unresolved_groups: 18,
+        },
+      ],
+    });
+    const store = useDedupStore();
+    expect(await store.fetchScopeCount("set", 12)).toBe(18);
+    expect(store.openCount).toBe(143);
+    expect(await store.fetchScopeCount("set", 12)).toBe(18);
+    expect(getCounts).toHaveBeenCalledTimes(1);
+    expect(store.scopeCounts[scopeKey("set", 12)]).toBe(18);
+  });
+
+  // Opening the same context menu twice in a row is the common case; a second
+  // round trip there shows a flicker instead of a number.
+  it("shares one request between concurrent callers", async () => {
+    getCounts.mockResolvedValue({
+      unresolved_groups: 4,
+      scopes: [
+        {
+          scope_type: "folder",
+          scope_id: "3",
+          key: "folder:3",
+          unresolved_groups: 4,
+        },
+      ],
+    });
+    const store = useDedupStore();
+    const [a, b] = await Promise.all([
+      store.fetchScopeCount("folder", 3),
+      store.fetchScopeCount("folder", 3),
+    ]);
+    expect(a).toBe(4);
+    expect(b).toBe(4);
+    expect(getCounts).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports null rather than a wrong number when the read fails", async () => {
+    getCounts.mockRejectedValue(new Error("nope"));
+    const store = useDedupStore();
+    expect(await store.fetchScopeCount("project", 1)).toBe(null);
+  });
+
+  // A verdict moves every scope that contained the group, so the cache cannot
+  // survive one.
+  it("drops the cached scope counts after a verdict", async () => {
+    servePage([group("g1")], { total: 1 });
+    stackGroup.mockResolvedValue({});
+    getCounts.mockResolvedValue({
+      unresolved_groups: 4,
+      scopes: [
+        {
+          scope_type: "set",
+          scope_id: "12",
+          key: "set:12",
+          unresolved_groups: 4,
+        },
+      ],
+    });
+    const store = useDedupStore();
+    await store.loadFirstPage();
+    await store.fetchScopeCount("set", 12);
+    // The reconciling refetch that follows a verdict asks for no extra scopes,
+    // so it cannot refill the cache it just dropped.
+    getCounts.mockResolvedValue({ unresolved_groups: 3, scopes: [] });
+    await store.stack(store.groups[0]);
+    await Promise.resolve();
+    expect(store.scopeCounts).toEqual({});
+  });
+});
+
+describe("useDedupStore — multi-select", () => {
+  async function openWith(groups) {
+    servePage(groups);
+    const store = useDedupStore();
+    await store.loadPolicy();
+    await store.loadFirstPage();
+    return store;
+  }
+
+  it("toggles per group and ranges from the anchor", async () => {
+    const store = await openWith([group("g1"), group("g2"), group("g3"), group("g4")]);
+    store.toggleSelected(1);
+    expect(store.isSelected("g2")).toBe(true);
+    store.selectRange(3);
+    expect(store.selectionCount).toBe(3);
+    expect(store.isSelected("g1")).toBe(false);
+    store.toggleSelected(2);
+    expect(store.selectionCount).toBe(2);
+    store.clearSelection();
+    expect(store.selectionCount).toBe(0);
+  });
+
+  it("the first ctrl-toggle keeps the focused row selected too (grid parity)", async () => {
+    const store = await openWith([group("g1"), group("g2")]);
+    store.setFocus(0);
+    store.toggleSelected(1);
+    expect(store.isSelected("g1")).toBe(true);
+    expect(store.isSelected("g2")).toBe(true);
+    expect(store.selectionCount).toBe(2);
+  });
+
+  it("ctrl-toggling the focused row itself just toggles it", async () => {
+    const store = await openWith([group("g1"), group("g2")]);
+    store.setFocus(0);
+    store.toggleSelected(0);
+    expect(store.selectionCount).toBe(1);
+    store.toggleSelected(0);
+    expect(store.selectionCount).toBe(0);
+  });
+
+  it("selects every loaded group on Ctrl+A", async () => {
+    const store = await openWith([group("g1"), group("g2"), group("g3")]);
+    store.selectAll();
+    expect(store.selectionCount).toBe(3);
+  });
+
+  it("clears several decisions with one reload at the end", async () => {
+    const store = await openWith([group("g1")]);
+    reopenGroup.mockResolvedValue({ group_returned_to_queue: true });
+    listGroups.mockClear();
+    const result = await store.reopenMany(["a", "b", "c"]);
+    expect(result).toEqual({ cleared: 3, returned: 3 });
+    expect(reopenGroup).toHaveBeenCalledTimes(3);
+    // reopen() reloads per call; the bulk path must reload exactly once.
+    expect(listGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it("stacks every selected group under one client batch id", async () => {
+    const store = await openWith([group("g1"), group("g2"), group("g3")]);
+    store.toggleSelected(0);
+    store.toggleSelected(2);
+    stackGroup.mockResolvedValue({});
+
+    const result = await store.stack(store.groups.find((g) => g.signature === "g3"));
+    expect(result).toBeTruthy();
+    expect(stackGroup).toHaveBeenCalledTimes(2);
+    expect(stackGroup.mock.calls.map((c) => c[0])).toEqual(["g1", "g3"]);
+    const ids = stackGroup.mock.calls.map((c) => c[1].batchId);
+    expect(ids[0]).toMatch(/^cli-/);
+    expect(ids[1]).toBe(ids[0]);
+    // The gesture is over: nothing stays selected, and the rows are gone.
+    expect(store.selectionCount).toBe(0);
+    expect(store.groups.map((g) => g.signature)).toEqual(["g2"]);
+  });
+
+  it("keeps every selected group separate in one gesture", async () => {
+    const store = await openWith([group("g1"), group("g2")]);
+    store.toggleSelected(0);
+    store.toggleSelected(1);
+    keepGroupSeparate.mockResolvedValue({});
+    const result = await store.keepSeparate(store.groups[0]);
+    expect(result).toBeTruthy();
+    expect(keepGroupSeparate).toHaveBeenCalledTimes(2);
+    expect(store.selectionCount).toBe(0);
+  });
+
+  it("a verdict on a group outside the selection stays single", async () => {
+    const store = await openWith([group("g1"), group("g2"), group("g3")]);
+    store.toggleSelected(0);
+    store.toggleSelected(1);
+    stackGroup.mockResolvedValue({});
+    await store.stack(store.groups[2]);
+    expect(stackGroup).toHaveBeenCalledTimes(1);
+    expect(stackGroup.mock.calls[0][0]).toBe("g3");
+    expect(store.selectionCount).toBe(2);
+  });
+
+  it("stops at the first failure and keeps the unresolved groups selected", async () => {
+    const store = await openWith([group("g1"), group("g2")]);
+    store.toggleSelected(0);
+    store.toggleSelected(1);
+    stackGroup.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error("locked"));
+    const result = await store.stack(store.groups[0]);
+    expect(result).toBeNull();
+    // g1 landed and left; g2 failed and stays both queued and selected.
+    expect(store.groups.map((g) => g.signature)).toEqual(["g2"]);
+    expect(store.isSelected("g2")).toBe(true);
+  });
+
+  it("clears the selection when the list reloads", async () => {
+    const store = await openWith([group("g1"), group("g2")]);
+    store.toggleSelected(0);
+    await store.loadFirstPage();
+    expect(store.selectionCount).toBe(0);
+  });
+});
+
+describe("useDedupStore — scans and bulk auto-stack", () => {
+  it("opening the queue queues a scan: the cache only fills when one runs", async () => {
+    // The regression this pins: openQueue read the (empty) cache and nothing
+    // ever requested a scan, so the queue stayed empty no matter which tiers
+    // or threshold the user set.
+    servePage([]);
+    const store = useDedupStore();
+    await store.openQueue({});
+    expect(startScan).toHaveBeenCalledTimes(1);
+  });
+
+  it("rescans when a tier is enabled, not when one is disabled", async () => {
+    servePage([]);
+    const store = useDedupStore();
+    await store.loadPolicy();
+    await store.setTierEnabled("near", true);
+    expect(startScan).toHaveBeenCalledTimes(1);
+    await store.setTierEnabled("near", false);
+    expect(startScan).toHaveBeenCalledTimes(1);
+  });
+
+  it("rescans when the threshold is lowered, not when it is raised", async () => {
+    // A stricter scan never wrote the looser groups; a raise only narrows the
+    // query over what is already cached.
+    servePage([]);
+    const store = useDedupStore();
+    await store.loadPolicy();
+    await store.setThreshold(0.8);
+    expect(startScan).toHaveBeenCalledTimes(1);
+    await store.setThreshold(0.95);
+    expect(startScan).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the empty queue refreshing while a scan runs, then stops", async () => {
+    vi.useFakeTimers();
+    try {
+      startScan.mockResolvedValue({
+        status: "running",
+        scanned_pictures: 0,
+        total_pictures: 10,
+      });
+      getCounts.mockResolvedValue({
+        unresolved_groups: 0,
+        by_tier: {},
+        scopes: [],
+        scan: { status: "running", scanned_pictures: 2, total_pictures: 10 },
+      });
+      servePage([], {
+        scan: { status: "running", scanned_pictures: 2, total_pictures: 10 },
+      });
+      const store = useDedupStore();
+      await store.triggerScan();
+      expect(store.isScanning).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(2100);
+      expect(getCounts).toHaveBeenCalled();
+      // The queue is empty, so the poll also surfaces the first finds.
+      expect(listGroups).toHaveBeenCalled();
+
+      getCounts.mockResolvedValue({
+        unresolved_groups: 1,
+        by_tier: {},
+        scopes: [],
+        scan: { status: "complete", scanned_pictures: 10, total_pictures: 10 },
+      });
+      servePage([], {
+        scan: { status: "complete", scanned_pictures: 10, total_pictures: 10 },
+      });
+      await vi.advanceTimersByTimeAsync(2100);
+      const settled = listGroups.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(6300);
+      expect(listGroups.mock.calls.length).toBe(settled);
+    } finally {
+      const store = useDedupStore();
+      store.stopScanPoll();
+      vi.useRealTimers();
+    }
+  });
+
+  it("queues a scan for the current scope under the current policy", async () => {
+    startScan.mockResolvedValue({
+      status: "running",
+      scanned_pictures: 0,
+      total_pictures: 100,
+    });
+    const store = useDedupStore();
+    await store.triggerScan();
+    expect(startScan).toHaveBeenCalledWith({
+      policy: { nearEnabled: false, embeddingEnabled: false },
+      scopeType: "global",
+      scopeId: null,
+    });
+    expect(store.isScanning).toBe(true);
+    store.stopScanPoll();
+  });
+
+  it("previews the auto-stack without writing", async () => {
+    autoStackExact.mockResolvedValue({ dry_run: true, groups: 1204 });
+    const store = useDedupStore();
+    const preview = await store.previewAutoStack();
+    expect(autoStackExact).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: true }),
+    );
+    expect(preview.groups).toBe(1204);
+  });
+
+  // The whole run reverses with one Ctrl+Z, so the batch id has to reach the
+  // caller that narrates it.
+  it("returns the batch id from a real run and reloads the queue", async () => {
+    servePage([]);
+    autoStackExact.mockResolvedValue({ batch_id: "b-9", groups: 1204 });
+    const store = useDedupStore();
+    listGroups.mockClear();
+    const result = await store.runAutoStack();
+    expect(result.batch_id).toBe("b-9");
+    expect(listGroups).toHaveBeenCalledTimes(1);
+    expect(getCounts).toHaveBeenCalled();
+  });
+
+  it("reports nothing when the bulk run fails", async () => {
+    autoStackExact.mockRejectedValue(new Error("boom"));
+    const store = useDedupStore();
+    expect(await store.runAutoStack()).toBe(null);
+    expect(store.busy).toBe(false);
+  });
+});

--- a/frontend/src/stores/useFilterStore.js
+++ b/frontend/src/stores/useFilterStore.js
@@ -20,6 +20,11 @@ export const useFilterStore = defineStore("filter", () => {
   // Impossible-tag grid filter: array of source keys ("no_face" / "no_humans"),
   // OR'd together. Empty array means the filter is off.
   const impossibleSources = ref([]);
+  // Stack state: 'all' | 'stacked' | 'unstacked' | 'unresolved'. Stacked and
+  // unstacked are a filter rather than a destination, because neither carries a
+  // to-do count. 'unresolved' is the third state the grid needs a name for: a
+  // group the duplicate queue has found but nobody has ruled on yet.
+  const stackStateFilter = ref("all");
 
   function resetFilters() {
     mediaTypeFilter.value = "all";
@@ -37,6 +42,7 @@ export const useFilterStore = defineStore("filter", () => {
     comfyuiModelFilter.value = [];
     comfyuiLoraFilter.value = [];
     impossibleSources.value = [];
+    stackStateFilter.value = "all";
   }
 
   const isActive = computed(
@@ -61,7 +67,8 @@ export const useFilterStore = defineStore("filter", () => {
         impossibleSources.value.length > 0) ||
       faceBboxFilter.value != null ||
       sharedOnlyFilter.value ||
-      unassignedOnlyFilter.value,
+      unassignedOnlyFilter.value ||
+      stackStateFilter.value !== "all",
   );
 
   const activeCount = computed(() => {
@@ -87,6 +94,7 @@ export const useFilterStore = defineStore("filter", () => {
     if (faceBboxFilter.value != null) count++;
     if (sharedOnlyFilter.value) count++;
     if (unassignedOnlyFilter.value) count++;
+    if (stackStateFilter.value !== "all") count++;
     return count;
   });
 
@@ -107,6 +115,7 @@ export const useFilterStore = defineStore("filter", () => {
     comfyuiLoraFilter,
     comfyuiConfigured,
     impossibleSources,
+    stackStateFilter,
     resetFilters,
     isActive,
     activeCount,

--- a/frontend/src/utils/dedup.js
+++ b/frontend/src/utils/dedup.js
@@ -1,0 +1,284 @@
+// Pure helpers for the duplicate triage queue. No Vue, no Pinia, no network.
+//
+// The cover formula lives here rather than in a component because three
+// surfaces need the same answer: the queue row's preselected cover, the compare
+// view's "best value" highlight per column, and the auto-stack dialog's
+// explanation of which copy it keeps. Three implementations would drift.
+//
+// The field names here are the backend's (`routes/dedup.py`): a candidate is
+// keyed on `picture_id`, carries `is_raw`, `size_bytes`, `created_at`,
+// `reference_folder_id` and `file_path`, and already ships its own
+// `cover_score`. The local formula is kept as the fallback and as the thing
+// the tests pin, so a server that stops sending `cover_score` degrades to a
+// correct preselection rather than to none.
+
+/**
+ * Megapixels of a candidate, from whichever shape the record carries.
+ * @param {Object} candidate
+ * @returns {number} megapixels, or 0 when the dimensions are unknown.
+ */
+export function candidateMegapixels(candidate) {
+  if (!candidate) return 0;
+  const direct = Number(candidate.megapixels);
+  if (Number.isFinite(direct) && direct > 0) return direct;
+  const width = Number(candidate.width);
+  const height = Number(candidate.height);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return 0;
+  if (width <= 0 || height <= 0) return 0;
+  return (width * height) / 1e6;
+}
+
+/**
+ * Whether a candidate is a RAW capture, which earns the cover-score bonus.
+ *
+ * RAW wins the tie against a same-resolution JPEG because it is the copy that
+ * still holds the latitude to be re-edited; losing it to a re-export is the
+ * expensive mistake this bonus exists to prevent.
+ *
+ * @param {Object} candidate
+ * @returns {boolean}
+ */
+export function isRawCandidate(candidate) {
+  // The server decides this: it knows the decoder that opened the file, where
+  // the client only has an extension. The format list below is the fallback.
+  if (typeof candidate?.is_raw === "boolean") return candidate.is_raw;
+  const format = String(candidate?.format ?? "").toUpperCase();
+  return format === "RAW" || RAW_FORMATS.has(format);
+}
+
+const RAW_FORMATS = new Set([
+  "ARW",
+  "CR2",
+  "CR3",
+  "DNG",
+  "NEF",
+  "ORF",
+  "RAF",
+  "RW2",
+]);
+
+/** The RAW bonus, in cover-score points. */
+export const RAW_COVER_BONUS = 8;
+
+/**
+ * The design's cover score: `pixels x 4 + tags x 3 + userScore x 2 + RAW bonus`.
+ *
+ * Higher wins. The weights are the design's, not a heuristic to tune here.
+ *
+ * @param {Object} candidate
+ * @returns {number}
+ */
+export function coverScore(candidate) {
+  if (!candidate) return 0;
+  const served = Number(candidate.cover_score);
+  if (Number.isFinite(served)) return served;
+  const megapixels = candidateMegapixels(candidate);
+  const tags = Number(candidate.tag_count) || 0;
+  const score = Number(candidate.score) || 0;
+  return (
+    megapixels * 4 +
+    tags * 3 +
+    score * 2 +
+    (isRawCandidate(candidate) ? RAW_COVER_BONUS : 0)
+  );
+}
+
+/**
+ * Capture time as a sortable number, for the tie-break.
+ * @param {Object} candidate
+ * @returns {number} epoch ms, or `Infinity` when unknown so an undated
+ *   candidate never wins a tie against a dated one.
+ */
+function captureTime(candidate) {
+  const raw = candidate?.created_at ?? candidate?.captured_at;
+  if (!raw) return Number.POSITIVE_INFINITY;
+  const parsed = Date.parse(raw);
+  return Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed;
+}
+
+/**
+ * Index of the candidate the cover formula preselects.
+ *
+ * Ties break to the oldest capture time, so the original beats the copy that
+ * was made from it.
+ *
+ * @param {Array<Object>} candidates
+ * @returns {number} the winning index, or -1 for an empty list.
+ */
+export function pickCoverIndex(candidates) {
+  if (!Array.isArray(candidates) || !candidates.length) return -1;
+  let best = 0;
+  let bestScore = coverScore(candidates[0]);
+  let bestTime = captureTime(candidates[0]);
+  for (let i = 1; i < candidates.length; i += 1) {
+    const score = coverScore(candidates[i]);
+    const time = captureTime(candidates[i]);
+    if (score > bestScore || (score === bestScore && time < bestTime)) {
+      best = i;
+      bestScore = score;
+      bestTime = time;
+    }
+  }
+  return best;
+}
+
+/**
+ * The picture id the cover formula preselects, honouring a server preselection.
+ *
+ * The backend runs the same formula, so its answer wins when present; the local
+ * computation is the fallback that keeps the queue usable if the field is ever
+ * absent, and is what the tests pin the formula against.
+ *
+ * @param {Object} group - a queue group.
+ * @returns {number|string|null}
+ */
+export function suggestedCoverId(group) {
+  if (
+    group?.cover_picture_id !== undefined &&
+    group.cover_picture_id !== null
+  ) {
+    return group.cover_picture_id;
+  }
+  const candidates = group?.candidates ?? [];
+  const index = pickCoverIndex(candidates);
+  return index < 0 ? null : (candidateId(candidates[index]) ?? null);
+}
+
+/**
+ * A candidate's picture id.
+ *
+ * One accessor rather than `candidate.picture_id` scattered through the views,
+ * so the day a candidate carries something else the change is here.
+ *
+ * @param {Object} candidate
+ * @returns {number|null}
+ */
+export function candidateId(candidate) {
+  const id = candidate?.picture_id ?? candidate?.id;
+  return id === undefined ? null : id;
+}
+
+/**
+ * The largest value of one numeric field across a group's candidates.
+ *
+ * Drives the compare view's per-column "best value" highlight.
+ *
+ * @param {Array<Object>} candidates
+ * @param {function(Object): number} read - reads the field off a candidate.
+ * @returns {number} the maximum, or 0 when nothing is comparable.
+ */
+export function bestOf(candidates, read) {
+  if (!Array.isArray(candidates) || !candidates.length) return 0;
+  let best = 0;
+  for (const candidate of candidates) {
+    const value = Number(read(candidate));
+    if (Number.isFinite(value) && value > best) best = value;
+  }
+  return best;
+}
+
+/**
+ * Order a group's evidence so the counter-evidence is read first.
+ *
+ * A group carrying red pills is exactly the one that needs Compare, so the
+ * pills do the warning instead of a generic "review carefully" line. Putting
+ * them first means the two pills a collapsed row has room for are the two that
+ * matter.
+ *
+ * @param {Array<Object>} why - `[{ text, against }]` evidence entries, the
+ *   backend's `WhyPillModel` shape.
+ * @returns {Array<Object>} counter-evidence first, original order within each
+ *   half.
+ */
+export function orderEvidence(why) {
+  if (!Array.isArray(why)) return [];
+  return [...why.filter((w) => w?.against), ...why.filter((w) => !w?.against)];
+}
+
+/**
+ * A pill's rendered label.
+ *
+ * The backend calls it `text`; accepting `label` as well keeps a fixture or a
+ * hand-built pill working rather than rendering an empty chip.
+ *
+ * @param {Object} pill
+ * @returns {string}
+ */
+export function evidenceLabel(pill) {
+  return String(pill?.text ?? pill?.label ?? "");
+}
+
+/**
+ * Shorten a file path to its last two segments, head first.
+ *
+ * Truncation happens in JS rather than with `direction: rtl` because the RTL
+ * trick reorders punctuation inside the filename on some paths, which is worse
+ * than the overflow it fixes.
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+export function shortenPath(path) {
+  if (!path) return "";
+  const segments = String(path).split("/").filter(Boolean);
+  if (segments.length <= 2) return path;
+  return `…/${segments.slice(-2).join("/")}`;
+}
+
+/**
+ * Whether a candidate's path should be shown.
+ *
+ * File location is shown only for pictures in reference folders, where the user
+ * manages the files themselves and needs to know which copy is which. For a
+ * managed library picture the path is an implementation detail.
+ *
+ * @param {Object} candidate
+ * @returns {boolean}
+ */
+export function showsPath(candidate) {
+  // The server already applies this rule: `file_path` is populated only for a
+  // reference-folder picture and is null for a managed one. The id check is
+  // belt and braces, so a future server that always sent the path would not
+  // silently start leaking library layout into the UI.
+  const path = candidatePath(candidate);
+  return Boolean(path) && candidate?.reference_folder_id != null;
+}
+
+/**
+ * A candidate's file path, or an empty string when it has none to show.
+ * @param {Object} candidate
+ * @returns {string}
+ */
+export function candidatePath(candidate) {
+  return String(candidate?.file_path ?? candidate?.path ?? "");
+}
+
+/**
+ * A candidate's file size in megabytes, from the stored byte count.
+ * @param {Object} candidate
+ * @returns {number} 0 when the size is unknown.
+ */
+export function candidateSizeMb(candidate) {
+  const bytes = Number(candidate?.size_bytes);
+  if (Number.isFinite(bytes) && bytes > 0) return bytes / 1e6;
+  const mb = Number(candidate?.file_size_mb);
+  return Number.isFinite(mb) && mb > 0 ? mb : 0;
+}
+
+/**
+ * Human label for a group's confidence.
+ *
+ * The exact tier is not a percentage and must not be rendered as "100% similar":
+ * "Exact" is a different kind of claim, and blurring the two is what makes a
+ * near-duplicate suggestion look more certain than it is.
+ *
+ * @param {Object} group
+ * @returns {{ exact: boolean, label: string }}
+ */
+export function confidenceLabel(group) {
+  const tier = group?.tier ?? group?.kind;
+  if (tier === "exact") return { exact: true, label: "Exact" };
+  const confidence = Number(group?.confidence);
+  if (!Number.isFinite(confidence)) return { exact: false, label: "Similar" };
+  return { exact: false, label: `${Math.round(confidence * 100)}% similar` };
+}

--- a/frontend/src/utils/dedup.test.js
+++ b/frontend/src/utils/dedup.test.js
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import {
+  candidateMegapixels,
+  isRawCandidate,
+  coverScore,
+  pickCoverIndex,
+  suggestedCoverId,
+  bestOf,
+  orderEvidence,
+  shortenPath,
+  showsPath,
+  confidenceLabel,
+  candidateSizeMb,
+  evidenceLabel,
+  RAW_COVER_BONUS,
+} from "./dedup";
+
+const candidate = (over = {}) => ({
+  id: 1,
+  width: 4000,
+  height: 3000,
+  tag_count: 0,
+  score: 0,
+  format: "JPEG",
+  captured_at: "2026-05-12T14:22:00Z",
+  ...over,
+});
+
+describe("utils/dedup — megapixels", () => {
+  it("derives megapixels from the dimensions", () => {
+    expect(candidateMegapixels(candidate({ width: 6000, height: 4000 }))).toBe(
+      24,
+    );
+  });
+
+  it("prefers an explicit megapixel field", () => {
+    expect(candidateMegapixels(candidate({ megapixels: 12.2 }))).toBe(12.2);
+  });
+
+  it("returns 0 for unknown dimensions rather than NaN", () => {
+    expect(candidateMegapixels({ width: null, height: null })).toBe(0);
+    expect(candidateMegapixels(null)).toBe(0);
+  });
+});
+
+describe("utils/dedup — the cover formula", () => {
+  it("scores pixels x4 + tags x3 + score x2", () => {
+    const c = candidate({ width: 1000, height: 1000, tag_count: 2, score: 3 });
+    // 1 MP -> 4, 2 tags -> 6, score 3 -> 6
+    expect(coverScore(c)).toBeCloseTo(16);
+  });
+
+  it("adds the RAW bonus", () => {
+    const jpeg = candidate({ width: 1000, height: 1000 });
+    const raw = candidate({ width: 1000, height: 1000, format: "ARW" });
+    expect(isRawCandidate(raw)).toBe(true);
+    expect(coverScore(raw) - coverScore(jpeg)).toBe(RAW_COVER_BONUS);
+  });
+
+  it("picks the higher-scoring candidate", () => {
+    const list = [
+      candidate({ picture_id: 1, width: 1920, height: 1440 }),
+      candidate({ picture_id: 2, width: 4032, height: 3024, tag_count: 4 }),
+    ];
+    expect(pickCoverIndex(list)).toBe(1);
+  });
+
+  // The original beats the copy that was made from it.
+  it("breaks a tie to the oldest capture time", () => {
+    const list = [
+      candidate({ picture_id: 1, captured_at: "2026-06-11T18:40:00Z" }),
+      candidate({ picture_id: 2, captured_at: "2026-06-03T09:11:00Z" }),
+    ];
+    expect(pickCoverIndex(list)).toBe(1);
+  });
+
+  it("keeps the first candidate when a tie has no usable dates", () => {
+    const list = [
+      candidate({ picture_id: 1, captured_at: null, created_at: null }),
+      candidate({ picture_id: 2, captured_at: null, created_at: null }),
+    ];
+    expect(pickCoverIndex(list)).toBe(0);
+  });
+
+  it("returns -1 for an empty candidate list", () => {
+    expect(pickCoverIndex([])).toBe(-1);
+    expect(pickCoverIndex(null)).toBe(-1);
+  });
+
+  // The backend runs the same formula; its answer is authoritative so the queue
+  // and a later rescan cannot disagree about the cover.
+  it("suggestedCoverId honours the server preselection", () => {
+    const group = {
+      cover_picture_id: 99,
+      candidates: [candidate({ picture_id: 1 }), candidate({ picture_id: 2 })],
+    };
+    expect(suggestedCoverId(group)).toBe(99);
+  });
+
+  it("suggestedCoverId falls back to the local formula", () => {
+    const group = {
+      candidates: [
+        candidate({ picture_id: 1, width: 1000, height: 1000 }),
+        candidate({ picture_id: 2, width: 6000, height: 4000 }),
+      ],
+    };
+    expect(suggestedCoverId(group)).toBe(2);
+  });
+
+  it("suggestedCoverId is null for a group with no candidates", () => {
+    expect(suggestedCoverId({ candidates: [] })).toBe(null);
+    expect(suggestedCoverId(null)).toBe(null);
+  });
+});
+
+describe("utils/dedup — compare highlighting", () => {
+  it("bestOf returns the maximum of a read field", () => {
+    const list = [{ size: 8.4 }, { size: 1.1 }, { size: 12.6 }];
+    expect(bestOf(list, (c) => c.size)).toBe(12.6);
+  });
+
+  it("bestOf ignores unusable values", () => {
+    const list = [{ size: null }, { size: "nope" }, { size: 3 }];
+    expect(bestOf(list, (c) => c.size)).toBe(3);
+    expect(bestOf([], (c) => c.size)).toBe(0);
+  });
+});
+
+describe("utils/dedup — evidence and paths", () => {
+  // Counter-evidence first, because a collapsed row only has room for two pills
+  // and the warning is the half that matters.
+  it("orderEvidence puts counter-evidence first", () => {
+    const why = [
+      { label: "96% visual match" },
+      { label: "Different resolution", against: true },
+      { label: "Same capture second" },
+      { label: "One is a re-export", against: true },
+    ];
+    expect(orderEvidence(why).map((w) => w.label)).toEqual([
+      "Different resolution",
+      "One is a re-export",
+      "96% visual match",
+      "Same capture second",
+    ]);
+  });
+
+  it("orderEvidence tolerates a missing list", () => {
+    expect(orderEvidence(undefined)).toEqual([]);
+  });
+
+  it("shortenPath keeps the last two segments", () => {
+    expect(shortenPath("/shoots/may/june/DSC_4417.jpg")).toBe(
+      "…/june/DSC_4417.jpg",
+    );
+  });
+
+  it("shortenPath leaves a short path alone", () => {
+    expect(shortenPath("/may/DSC_4417.jpg")).toBe("/may/DSC_4417.jpg");
+    expect(shortenPath("")).toBe("");
+  });
+
+  // A managed library picture's path is an implementation detail; only a
+  // reference-folder picture needs it to tell the copies apart.
+  it("showsPath is true only for a reference-folder picture with a path", () => {
+    expect(showsPath({ reference_folder_id: 3, file_path: "/a/b.jpg" })).toBe(
+      true,
+    );
+    // The server sends no path for a managed picture, and a stray one must not
+    // start leaking the library's layout into the UI either.
+    expect(
+      showsPath({ reference_folder_id: null, file_path: "/a/b.jpg" }),
+    ).toBe(false);
+    expect(showsPath({ reference_folder_id: 3, file_path: null })).toBe(false);
+  });
+
+  it("candidateSizeMb converts the stored byte count", () => {
+    expect(candidateSizeMb({ size_bytes: 8400000 })).toBeCloseTo(8.4);
+    expect(candidateSizeMb({ size_bytes: null })).toBe(0);
+  });
+
+  it("evidenceLabel reads the backend's pill text", () => {
+    expect(evidenceLabel({ text: "Identical file hash" })).toBe(
+      "Identical file hash",
+    );
+    expect(evidenceLabel(null)).toBe("");
+  });
+});
+
+describe("utils/dedup — confidence", () => {
+  // "Exact" is a different claim from "100% similar"; blurring them makes a
+  // near-duplicate suggestion look more certain than it is.
+  it("labels the exact tier distinctly", () => {
+    expect(confidenceLabel({ kind: "exact", confidence: 1 })).toEqual({
+      exact: true,
+      label: "Exact",
+    });
+  });
+
+  it("labels a near tier as a rounded percentage", () => {
+    expect(confidenceLabel({ kind: "near", confidence: 0.964 })).toEqual({
+      exact: false,
+      label: "96% similar",
+    });
+  });
+
+  it("falls back when the confidence is missing", () => {
+    expect(confidenceLabel({ kind: "near" }).label).toBe("Similar");
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -46,5 +46,16 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     include: ['src/**/*.test.{js,ts}'],
+    server: {
+      deps: {
+        // Vuetify ships its component CSS as sibling `.css` imports, which Node
+        // cannot load. Any test that mounts a component importing from
+        // "vuetify/components" therefore died at import with
+        // `Unknown file extension ".css"`. Inlining routes Vuetify through
+        // Vite's transform, where the CSS import is handled, so a component that
+        // uses AppDialog or AppButton is testable at all.
+        inline: ['vuetify'],
+      },
+    },
   },
 })

--- a/pixlstash/authz/registry.py
+++ b/pixlstash/authz/registry.py
@@ -469,6 +469,77 @@ ROUTE_POLICIES: dict[tuple[str, str], RoutePolicy] = {
             "as tag_health). POST is also blocked for READ tokens"
         ),
     ),
+    # ── dedup.py (v1.9 tiered duplicate queue) ──────────────────────────────
+    # Every route on this surface is OWNER_ONLY for one of two reasons, both of
+    # which are the tag-health reasoning: a vault-wide aggregate cannot be
+    # narrowed to a share token's scope without leaking the existence and count
+    # of out-of-scope pictures, and a verdict mutates stacks across arbitrary
+    # pictures that a scoped token has no business touching.
+    ("GET", "/api/v1/dedup/policy"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Tier defaults/bounds for the duplicate queue; an owner-only "
+            "operator surface returning no per-object data"
+        ),
+    ),
+    ("GET", "/api/v1/dedup/groups"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Returns duplicate groups with picture ids, dimensions and (for "
+            "reference-folder pictures) file paths from anywhere in the vault. "
+            "A group is defined by content identity, not by collection "
+            "membership, so it routinely spans a share token's scope boundary "
+            "and cannot be narrowed without leaking that out-of-scope copies "
+            "exist"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/counts"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Vault-wide and per-scope duplicate counts. Read-only but POST "
+            "because the scope list does not fit a URL; POST is also blocked "
+            "for READ tokens. Counts describe pictures outside any token's "
+            "scope (same reasoning as tag_health)"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/scan"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Queues a background scan over the whole vault or a chosen scope; "
+            "an owner-only maintenance trigger. POST is also blocked for READ "
+            "tokens"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/verdicts/stack"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Mutates stack membership, tags, project/set membership and scores "
+            "across pictures identified only by a content signature, which can "
+            "name any picture in the vault. POST is also blocked for READ tokens"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/verdicts/keep-separate"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Writes a permanent verdict about an arbitrary set of vault "
+            "pictures. POST is also blocked for READ tokens"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/verdicts/reopen"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Reverses a stored verdict about an arbitrary set of vault "
+            "pictures. POST is also blocked for READ tokens"
+        ),
+    ),
+    ("POST", "/api/v1/dedup/auto-stack"): RoutePolicy(
+        _OWNER,
+        justification=(
+            "Bulk stacking across the whole vault under one undo batch; the "
+            "most far-reaching mutation on this surface. POST is also blocked "
+            "for READ tokens"
+        ),
+    ),
     # ── characters.py ───────────────────────────────────────────────────────
     ("GET", "/api/v1/characters"): _LIST_AWARE,
     ("GET", "/api/v1/characters/{id}"): RoutePolicy(_CHAR, id_param="id"),

--- a/pixlstash/db_models/__init__.py
+++ b/pixlstash/db_models/__init__.py
@@ -1,4 +1,10 @@
 from .character import Character  # noqa: F401
+from .dedup import (  # noqa: F401
+    DedupGroup,
+    DedupGroupMember,
+    DedupScan,
+    DedupVerdict,
+)
 from .deleted_file_log import DeletedFileLog  # noqa: F401
 from .entity_project import (  # noqa: F401
     CharacterProjectMember,

--- a/pixlstash/db_models/dedup.py
+++ b/pixlstash/db_models/dedup.py
@@ -1,0 +1,253 @@
+"""Persistent state for the tiered duplicate detection queue (v1.9).
+
+Three concerns, three tables:
+
+* :class:`DedupGroup` / :class:`DedupGroupMember` — the **found groups cache**.
+  Detection writes groups here as it finds them, so the queue is paged from the
+  database by confidence descending and never materialised whole in memory (the
+  design's "10 groups and 10,000 perform identically" rule). Without this cache a
+  "page 40 of the queue" request would have to redo the whole scan.
+* :class:`DedupVerdict` — the **verdict memory**. Keyed on a group *signature*
+  (see :func:`pixlstash.services.dedup_tier_service.group_signature`), not on
+  group or picture ids, so a rescan or a re-import that produces the same set of
+  files finds the same signature and never re-asks. "Keep separate" is permanent
+  until the user reopens it.
+* :class:`DedupScan` — the **scan progress** behind the "scanned N of M" banner
+  and the scoped-scan entry points, one row per scope key.
+
+Nothing here stores pixels, and no row in this module ever causes a delete: a
+verdict is either a stack (additive) or a "keep separate" note.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String
+from sqlmodel import Field, SQLModel
+
+# ``DedupGroup.tier`` / scan tier values. Ordered loosest-last: tier 1 is exact
+# and always on, each looser tier is an opt-in that requires the tier above it.
+TIER_EXACT = "exact"
+TIER_NEAR = "near"
+TIER_EMBEDDING = "embedding"
+
+# ``DedupVerdict.verdict`` values. The only two verdicts in 1.9 — there is no
+# deletion verdict anywhere in this release.
+VERDICT_STACKED = "stacked"
+VERDICT_KEEP_SEPARATE = "keep_separate"
+
+# ``DedupScan.status`` values.
+SCAN_PENDING = "pending"
+SCAN_RUNNING = "running"
+SCAN_COMPLETE = "complete"
+SCAN_FAILED = "failed"
+
+
+class DedupGroup(SQLModel, table=True):
+    """One detected duplicate group awaiting (or carrying) a verdict.
+
+    A group is identified by its :attr:`signature` rather than its id, so the
+    same set of files always maps to the same row across rescans. Detection
+    upserts on the signature; the queue pages on ``(resolved, confidence DESC)``.
+
+    Attributes:
+        signature: Stable hash of the sorted member content keys. Unique.
+        tier: Which tier found it (:data:`TIER_EXACT` / :data:`TIER_NEAR` /
+            :data:`TIER_EMBEDDING`). Exact is always shown; the looser tiers are
+            filtered by the caller's :class:`~pixlstash.services.dedup_tier_service.TierPolicy`.
+        confidence: 1.0 for an exact match, otherwise the group's weakest
+            pairwise similarity — the value the queue sorts by, descending.
+        member_count: Number of members, denormalised so the queue page does not
+            need a join to render "Stack 3".
+        cover_picture_id: The server's cover preselection (never silent — the
+            client shows it and the user may override with 1-9).
+        evidence: JSON ``[[text, against_bool], ...]`` — the why-pills. Stored
+            with the group because it describes *this* grouping, and recomputing
+            it would need the member metadata the queue page is trying to avoid
+            loading for every group.
+        resolved: True once a verdict covers this signature. The sidebar badge
+            counts ``resolved IS FALSE``.
+        scan_id: The :class:`DedupScan` that produced it, or NULL for a group
+            found outside a tracked scan.
+    """
+
+    __tablename__ = "dedupgroup"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    signature: str = Field(
+        sa_column=Column("signature", String, nullable=False, unique=True, index=True)
+    )
+    tier: str = Field(sa_column=Column("tier", String, nullable=False, index=True))
+    confidence: float = Field(default=0.0, index=True)
+    member_count: int = Field(default=0)
+    cover_picture_id: Optional[int] = Field(default=None)
+    evidence: Optional[str] = Field(
+        default=None, sa_column=Column("evidence", String, nullable=True)
+    )
+    resolved: bool = Field(default=False, index=True)
+    scan_id: Optional[int] = Field(default=None, index=True)
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column("created_at", DateTime, nullable=False),
+    )
+
+    __table_args__ = (
+        # The queue's only hot query: unresolved groups, confidence descending.
+        Index("ix_dedupgroup_queue", "resolved", "confidence"),
+    )
+
+
+class DedupGroupMember(SQLModel, table=True):
+    """Membership of a picture in a :class:`DedupGroup`.
+
+    ``picture_id`` is indexed because the scoped counts (project / set /
+    character / folder context menus) and the invalidation path both start from
+    a picture id set and ask which groups it touches.
+    """
+
+    __tablename__ = "dedupgroupmember"
+
+    group_id: int = Field(
+        sa_column=Column(
+            "group_id",
+            Integer,
+            ForeignKey("dedupgroup.id", ondelete="CASCADE"),
+            primary_key=True,
+            index=True,
+        )
+    )
+    picture_id: int = Field(
+        sa_column=Column(
+            "picture_id",
+            Integer,
+            ForeignKey("picture.id", ondelete="CASCADE"),
+            primary_key=True,
+            index=True,
+        )
+    )
+    position: int = Field(default=0)
+
+
+class DedupVerdict(SQLModel, table=True):
+    """A remembered decision about one group signature.
+
+    This is what makes the sidebar count trustworthy: a rescan re-derives the
+    same signature and resolves the group immediately instead of asking again.
+    A "keep separate" verdict is permanent until :attr:`reopened_at` is stamped
+    from the Stacks view.
+
+    Attributes:
+        signature: The group signature this verdict covers. Unique.
+        verdict: :data:`VERDICT_STACKED` or :data:`VERDICT_KEEP_SEPARATE`.
+        picture_ids: JSON list of the member ids the verdict was made on, for
+            the audit trail and for the reopen path.
+        excluded_picture_ids: JSON list of members the user left out of the
+            stack (the design's X key). Empty for keep-separate.
+        cover_picture_id: The cover the user confirmed or chose.
+        stack_id: The stack the members landed in, for a ``stacked`` verdict.
+        batch_id: The operation-log batch this verdict was recorded under; bulk
+            auto-stack shares one batch id across every group so N stacks
+            reverse with a single undo.
+        reopened_at: When the user reopened the decision. A reopened verdict no
+            longer resolves its group, so the group returns to the queue.
+    """
+
+    __tablename__ = "dedupverdict"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    signature: str = Field(
+        sa_column=Column("signature", String, nullable=False, unique=True, index=True)
+    )
+    verdict: str = Field(
+        sa_column=Column("verdict", String, nullable=False, index=True)
+    )
+    picture_ids: str = Field(
+        default="[]", sa_column=Column("picture_ids", String, nullable=False)
+    )
+    excluded_picture_ids: str = Field(
+        default="[]", sa_column=Column("excluded_picture_ids", String, nullable=False)
+    )
+    cover_picture_id: Optional[int] = Field(default=None)
+    stack_id: Optional[int] = Field(default=None, index=True)
+    batch_id: Optional[str] = Field(
+        default=None, sa_column=Column("batch_id", String, nullable=True, index=True)
+    )
+    decided_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column("decided_at", DateTime, nullable=False),
+    )
+    reopened_at: Optional[datetime] = Field(
+        default=None, sa_column=Column("reopened_at", DateTime, nullable=True)
+    )
+
+
+class DedupScan(SQLModel, table=True):
+    """Progress of one scan, keyed on its scope.
+
+    One row per scope key ("global", "project:3", "set:9", ...), reused across
+    rescans of that scope so the banner has a stable place to read from and a
+    scoped scan can report "reused cached hashes" without inventing a new row
+    every time.
+
+    Attributes:
+        scope_key: Canonical scope identifier. Unique.
+        scanned_pictures / total_pictures: The "scanned N of M" banner.
+        scanned_buckets / total_buckets: Tier-2 bucket progress; a bucket's
+            groups become visible in the queue the moment its bucket finishes.
+        tiers: JSON list of the tiers this scan was asked to run.
+    """
+
+    __tablename__ = "dedupscan"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    scope_key: str = Field(
+        sa_column=Column("scope_key", String, nullable=False, unique=True, index=True)
+    )
+    scope_type: str = Field(
+        default="global", sa_column=Column("scope_type", String, nullable=False)
+    )
+    scope_id: Optional[str] = Field(
+        default=None, sa_column=Column("scope_id", String, nullable=True)
+    )
+    tiers: str = Field(default="[]", sa_column=Column("tiers", String, nullable=False))
+    threshold: float = Field(default=0.9)
+    status: str = Field(
+        default=SCAN_PENDING,
+        sa_column=Column("status", String, nullable=False, index=True),
+    )
+    total_pictures: int = Field(default=0)
+    scanned_pictures: int = Field(default=0)
+    total_buckets: int = Field(default=0)
+    scanned_buckets: int = Field(default=0)
+    groups_found: int = Field(default=0)
+    error: Optional[str] = Field(
+        default=None, sa_column=Column("error", String, nullable=True)
+    )
+    started_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column("started_at", DateTime, nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column("updated_at", DateTime, nullable=False),
+    )
+    finished_at: Optional[datetime] = Field(
+        default=None, sa_column=Column("finished_at", DateTime, nullable=True)
+    )
+
+
+__all__ = [
+    "DedupGroup",
+    "DedupGroupMember",
+    "DedupScan",
+    "DedupVerdict",
+    "SCAN_COMPLETE",
+    "SCAN_FAILED",
+    "SCAN_PENDING",
+    "SCAN_RUNNING",
+    "TIER_EMBEDDING",
+    "TIER_EXACT",
+    "TIER_NEAR",
+    "VERDICT_KEEP_SEPARATE",
+    "VERDICT_STACKED",
+]

--- a/pixlstash/db_models/picture.py
+++ b/pixlstash/db_models/picture.py
@@ -834,7 +834,41 @@ class Picture(SQLModel, table=True):
         # was unacceptably slow on large libraries.
         if stack_leaders_only:
             project_scope = search.get("project_id", _NO_PROJECT_SCOPE)
-            if project_scope is _NO_PROJECT_SCOPE or isinstance(
+            id_scope: list[int] = []
+            raw_id_scope = search.get("id")
+            if isinstance(raw_id_scope, (list, tuple, set)):
+                for raw in raw_id_scope:
+                    try:
+                        id_scope.append(int(raw))
+                    except (TypeError, ValueError):
+                        continue
+            if id_scope:
+                # An explicit id filter (a picture set, a share token's scope, a
+                # split) narrows the grid to those pictures. Represent each
+                # stack by its lowest-positioned member INSIDE that filter:
+                # the global position-0 leader may not be in it, and requiring
+                # it rendered NEITHER picture — a set containing only a
+                # non-cover stack member showed 5 tiles for its 6 members and
+                # no stack at all (the owner's #670/#1746 report). Same rule
+                # as the project-scoped branch below, scoped to the id list.
+                sibling = aliased(cls)
+                cur_pos = func.coalesce(cls.stack_position, 999999)
+                sib_pos = func.coalesce(sibling.stack_position, 999999)
+                has_higher_ranked_sibling = exists(
+                    select(sibling.id).where(
+                        sibling.stack_id == cls.stack_id,
+                        sibling.deleted.is_(False),
+                        sibling.id.in_(id_scope),
+                        or_(
+                            sib_pos < cur_pos,
+                            (sib_pos == cur_pos) & (sibling.id < cls.id),
+                        ),
+                    )
+                )
+                query = query.where(
+                    or_(cls.stack_id.is_(None), ~has_higher_ranked_sibling)
+                )
+            elif project_scope is _NO_PROJECT_SCOPE or isinstance(
                 project_scope, (list, tuple)
             ):
                 # Unscoped (or multi-project) grid: fast path — leader is the

--- a/pixlstash/migrations/versions/0088_add_dedup_tier_tables.py
+++ b/pixlstash/migrations/versions/0088_add_dedup_tier_tables.py
@@ -1,0 +1,164 @@
+"""Add the tiered duplicate-detection tables (v1.9 Dedup -> Stacks).
+
+Four tables backing the Duplicates queue:
+
+* ``dedupgroup`` / ``dedupgroupmember`` — the found-groups cache. Detection
+  writes groups as it finds them so the queue can be paged from the database by
+  confidence descending instead of being materialised whole.
+* ``dedupverdict`` — verdict memory keyed on a group signature (the sorted
+  member content hashes), so rescans and re-imports never re-ask.
+* ``dedupscan`` — per-scope scan progress for the "scanned N of M" banner.
+
+**No reprocessing reset is needed on `picture`.** Tier 1 reuses the existing
+indexed ``picture.pixel_sha`` column and tier 2 the existing
+``picture.perceptual_hash`` / ``picture.size_bin_index`` columns; nothing
+computed by an earlier release becomes invalid, so no column is NULLed here.
+Pictures whose ``pixel_sha`` was never computed are backfilled by
+``MissingPixelShaFinder`` at runtime, which already selects on
+``pixel_sha IS NULL`` — a reset would be a no-op.
+
+**Stale signatures are purged.** The group signature was changed during review to
+include the ``size_bytes`` co-key (``<pixel_sha>:<size_bytes>``), because the
+digest alone is sampled above 128 KiB and did not identify a file — two distinct
+exact groups could collide on one signature. Rows written before that change are
+keyed on the old format: a stale ``dedupverdict`` would silently never match
+again (a remembered decision quietly forgotten) and a stale ``dedupgroup`` would
+linger forever, matching no future detection while still inflating the sidebar
+badge. Neither self-heals, so this migration empties the four tables when they
+already exist. That can only affect a developer machine that ran this feature
+branch before the fix — the tables ship for the first time here — and rebuilding
+them costs one rescan. Amending the migration rather than stacking a second one
+follows the feature-branch rule in CLAUDE.md.
+
+Revision ID: 0088_add_dedup_tier_tables
+Revises: 0087_add_entity_project_membership
+Create Date: 2026-07-29 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0088_add_dedup_tier_tables"
+down_revision: Union[str, None] = "0087_add_entity_project_membership"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "dedupgroup" not in existing_tables:
+        op.create_table(
+            "dedupgroup",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("signature", sa.String(), nullable=False),
+            sa.Column("tier", sa.String(), nullable=False),
+            sa.Column("confidence", sa.Float(), nullable=True),
+            sa.Column("member_count", sa.Integer(), nullable=True),
+            sa.Column("cover_picture_id", sa.Integer(), nullable=True),
+            sa.Column("evidence", sa.String(), nullable=True),
+            sa.Column("resolved", sa.Boolean(), nullable=True),
+            sa.Column("scan_id", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_dedupgroup_signature", "dedupgroup", ["signature"], unique=True
+        )
+        op.create_index("ix_dedupgroup_tier", "dedupgroup", ["tier"])
+        op.create_index("ix_dedupgroup_confidence", "dedupgroup", ["confidence"])
+        op.create_index("ix_dedupgroup_resolved", "dedupgroup", ["resolved"])
+        op.create_index("ix_dedupgroup_scan_id", "dedupgroup", ["scan_id"])
+        op.create_index("ix_dedupgroup_queue", "dedupgroup", ["resolved", "confidence"])
+
+    if "dedupgroupmember" not in existing_tables:
+        op.create_table(
+            "dedupgroupmember",
+            sa.Column("group_id", sa.Integer(), nullable=False),
+            sa.Column("picture_id", sa.Integer(), nullable=False),
+            sa.Column("position", sa.Integer(), nullable=True),
+            sa.ForeignKeyConstraint(
+                ["group_id"], ["dedupgroup.id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(["picture_id"], ["picture.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("group_id", "picture_id"),
+        )
+        op.create_index(
+            "ix_dedupgroupmember_group_id", "dedupgroupmember", ["group_id"]
+        )
+        op.create_index(
+            "ix_dedupgroupmember_picture_id", "dedupgroupmember", ["picture_id"]
+        )
+
+    if "dedupverdict" not in existing_tables:
+        op.create_table(
+            "dedupverdict",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("signature", sa.String(), nullable=False),
+            sa.Column("verdict", sa.String(), nullable=False),
+            sa.Column("picture_ids", sa.String(), nullable=False),
+            sa.Column("excluded_picture_ids", sa.String(), nullable=False),
+            sa.Column("cover_picture_id", sa.Integer(), nullable=True),
+            sa.Column("stack_id", sa.Integer(), nullable=True),
+            sa.Column("batch_id", sa.String(), nullable=True),
+            sa.Column("decided_at", sa.DateTime(), nullable=False),
+            sa.Column("reopened_at", sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_dedupverdict_signature", "dedupverdict", ["signature"], unique=True
+        )
+        op.create_index("ix_dedupverdict_verdict", "dedupverdict", ["verdict"])
+        op.create_index("ix_dedupverdict_stack_id", "dedupverdict", ["stack_id"])
+        op.create_index("ix_dedupverdict_batch_id", "dedupverdict", ["batch_id"])
+
+    if "dedupscan" not in existing_tables:
+        op.create_table(
+            "dedupscan",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("scope_key", sa.String(), nullable=False),
+            sa.Column("scope_type", sa.String(), nullable=False),
+            sa.Column("scope_id", sa.String(), nullable=True),
+            sa.Column("tiers", sa.String(), nullable=False),
+            sa.Column("threshold", sa.Float(), nullable=True),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("total_pictures", sa.Integer(), nullable=True),
+            sa.Column("scanned_pictures", sa.Integer(), nullable=True),
+            sa.Column("total_buckets", sa.Integer(), nullable=True),
+            sa.Column("scanned_buckets", sa.Integer(), nullable=True),
+            sa.Column("groups_found", sa.Integer(), nullable=True),
+            sa.Column("error", sa.String(), nullable=True),
+            sa.Column("started_at", sa.DateTime(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), nullable=False),
+            sa.Column("finished_at", sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_dedupscan_scope_key", "dedupscan", ["scope_key"], unique=True
+        )
+        op.create_index("ix_dedupscan_status", "dedupscan", ["status"])
+
+    # Purge rows written under the pre-review signature format (see the module
+    # docstring). Only a table that already existed can hold them; a table just
+    # created above is empty, so the DELETE is a no-op there. Children first so
+    # the foreign key holds on databases that enforce it.
+    for table in ("dedupgroupmember", "dedupgroup", "dedupverdict", "dedupscan"):
+        if table in existing_tables:
+            op.execute(sa.text(f"DELETE FROM {table}"))  # noqa: S608 - fixed literals
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    for table in ("dedupscan", "dedupverdict", "dedupgroupmember", "dedupgroup"):
+        if table in existing_tables:
+            op.drop_table(table)

--- a/pixlstash/routes/dedup.py
+++ b/pixlstash/routes/dedup.py
@@ -1,34 +1,68 @@
-"""HTTP routes for the vault-wide near-duplicate sweep (dry run only).
+"""HTTP routes for duplicate detection: the tiered queue plus the sweep dry run.
 
-Two endpoints, both owner-only:
+Two surfaces live here, and every route is owner-only.
 
-* ``GET  /dedup/sweep/policy``  — the default confidence policy plus the bounds
-  every knob is validated against, so a client renders its controls from the
-  server's values instead of re-hardcoding thresholds.
-* ``POST /dedup/sweep/dry-run`` — resolve every near-duplicate group in the vault
-  under a supplied policy and return the plan: how many groups auto-collapse, how
-  many need review, why each review group needs review, what each group would do
-  to existing stacks, and how many bytes the non-keeper members hold.
+**The v1.9 Duplicates queue** (:mod:`pixlstash.services.dedup_tier_service` and
+:mod:`pixlstash.services.dedup_verdict_service`):
 
-**Nothing here mutates anything.** The sweep's execution step is a later lane;
-this surface is the policy-level consent screen's data source. Resolution means
-stacking, never deleting — see :mod:`pixlstash.services.dedup_sweep_service`.
+* ``GET  /dedup/policy``            — tier defaults + bounds; the client renders
+  its tier switches and threshold slider from these values rather than
+  re-hardcoding 0.90 and 0.65.
+* ``GET  /dedup/groups``            — one page of the queue, confidence
+  descending, plus this scope's scan progress for the banner.
+* ``POST /dedup/counts``            — the sidebar badge, the per-tier counts, and
+  as many scoped counts as the context menus need, in one request. Read-only
+  despite the verb: the scope list does not fit in a URL.
+* ``POST /dedup/scan``              — queue a scoped scan; returns immediately.
+* ``POST /dedup/verdicts/stack``    — stack a group behind a chosen cover.
+* ``POST /dedup/verdicts/keep-separate`` — remember that a group is not
+  duplicates; permanent until reopened.
+* ``POST /dedup/verdicts/reopen``   — return a decided group to the queue.
+* ``POST /dedup/auto-stack``        — the exact tier's bulk action, one
+  operation-log batch id so N stacks reverse with one undo.
 
-Authorization is declared in ``pixlstash/authz/registry.py`` (both routes
+**The vault-wide sweep dry run** (:mod:`pixlstash.services.dedup_sweep_service`),
+unchanged and still non-destructive:
+
+* ``GET  /dedup/sweep/policy``  — the default confidence policy plus its bounds.
+* ``POST /dedup/sweep/dry-run`` — the vault-wide plan behind "N groups
+  auto-collapse, M need review".
+
+**Nothing in v1.9 deletes a picture.** A verdict is either a stack (additive, and
+a stack is a grouping row plus a cover pointer) or a note that the group is not
+duplicates. There is no destructive route on this surface.
+
+Authorization is declared in ``pixlstash/authz/registry.py`` (every route
 ``OWNER_ONLY``) and enforced by the central gate before these handlers run; per
 §16.1 there is deliberately no inline scope check here. A vault-wide aggregate
 cannot be narrowed to a share token's scope without leaking counts about pictures
-outside it, which is the same reasoning that makes the tag-health board owner-only.
+outside it, which is the same reasoning that makes the tag-health board
+owner-only, and the verdict routes mutate stacks across arbitrary pictures.
 """
 
+import re
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
-from fastapi import APIRouter, Body, HTTPException
+from fastapi import APIRouter, Body, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from pixlstash.pixl_logging import get_logger
-from pixlstash.services import dedup_sweep_service
+from pixlstash.services import dedup_sweep_service, dedup_tier_service
+from pixlstash.services import dedup_verdict_service, operation_log_service
+from pixlstash.services.dedup_tier_service import (
+    DEFAULT_PAGE_SIZE,
+    DEFAULT_THRESHOLD,
+    MAX_PAGE_SIZE,
+    MAX_THRESHOLD,
+    MIN_THRESHOLD,
+    DedupCursorError,
+    DedupScope,
+    DedupTier,
+    ScopeType,
+    TierPolicy,
+)
+from pixlstash.services.dedup_verdict_service import DedupVerdictError
 from pixlstash.services.dedup_sweep_service import (
     DEFAULT_AUTO_RESOLVE_LIKENESS,
     DEFAULT_LIKENESS_THRESHOLD,
@@ -46,6 +80,41 @@ from pixlstash.services.dedup_sweep_service import (
 )
 
 logger = get_logger(__name__)
+
+CLIENT_BATCH_ID_PREFIX = "cli-"
+MAX_BATCH_ID_LENGTH = 80
+CLIENT_BATCH_ID_RE = re.compile(r"^cli-[A-Za-z0-9_-]{4,76}$")
+"""The shape a **client-supplied** operation batch id must have.
+
+Batch ids are namespaced so the log can tell who minted one: the server mints
+``srv-<uuid4hex>`` (:func:`operation_log_service.new_batch_id`) and a client may
+group its own gestures under ``cli-…``. Taken verbatim, a client could submit
+``srv-…`` and have its rows read as a server batch — and, worse, graft them into
+an existing batch so one Ctrl+Z reverses more than the user did.
+
+The pattern is duplicated here on purpose: the shared definition lands in
+``pixlstash/utils/request_origin.py`` with the ``X-Operation-Batch-Id`` header
+contract (branch ``feature/gesture-batch-id``), which is not on this branch.
+When that merges, both sites must import it from there instead. Note the
+difference in disposition: an unusable *header* is dropped and ignored, because a
+header is ambient; an unusable *body* field is a 400, because the client named it
+deliberately and silently ignoring it would mis-group its undo.
+"""
+
+MAX_CURSOR_LENGTH = 128
+"""Cap on the opaque queue cursor a client may send back.
+
+The cursors this server mints are ~40 characters; anything longer is not one of
+ours, and bounding it here keeps a malformed value from reaching the base64
+decoder as an unbounded string."""
+
+MAX_COUNT_SCOPES = 200
+"""Cap on the scope list of one ``POST /dedup/counts``.
+
+Each scope is a separate correlated ``COUNT`` subquery, so an uncapped list turns
+one request into thousands of queries against the owner's own server. 200 is far
+more than any real context menu needs (the sidebar asks for a handful) and keeps
+the worst case bounded."""
 
 
 class SweepPolicyModel(BaseModel):
@@ -373,8 +442,951 @@ class SweepReportResponse(BaseModel):
     )
 
 
+# --- Tiered queue models ----------------------------------------------------
+
+
+class TierPolicyModel(BaseModel):
+    """Which tiers feed the queue, and how similar counts as similar.
+
+    Tier 1 (exact) has no switch: it is always included and cannot be turned
+    off. Each looser tier is a separate opt-in, and enabling one requires the
+    tier above it, so a user cannot land on "same scene" suggestions without
+    having deliberately walked down to them.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    near_enabled: bool = Field(
+        default=False,
+        description=(
+            "Tier 2: perceptual hashes compared inside candidate buckets (same "
+            "dimensions / capture minute / import batch / folder). Opt-in."
+        ),
+    )
+    embedding_enabled: bool = Field(
+        default=False,
+        description=(
+            "Tier 3: full embedding similarity, for cross-folder and "
+            "differently-framed near-duplicates. Opt-in, and requires "
+            "`near_enabled` - enabling a tier requires the tier above it."
+        ),
+    )
+    threshold: float = Field(
+        default=DEFAULT_THRESHOLD,
+        ge=MIN_THRESHOLD,
+        le=MAX_THRESHOLD,
+        description=(
+            f"Minimum similarity for a near or embedding group to be suggested. "
+            f"Defaults to {DEFAULT_THRESHOLD}. Exact matches are always shown "
+            f"regardless. Below {MIN_THRESHOLD} nothing is suggested at all: a "
+            "low threshold produces confident-looking garbage and destroys trust "
+            "in the count, so a lower value is refused (422 from this bound), "
+            "never a silent clamp."
+        ),
+    )
+
+    min_group_size: int = Field(
+        default=dedup_tier_service.DEFAULT_MIN_GROUP_SIZE,
+        ge=2,
+        description="Smallest group that counts as a duplicate group at all.",
+    )
+    max_group_size: int = Field(
+        default=dedup_tier_service.DEFAULT_MAX_GROUP_SIZE,
+        ge=2,
+        description=(
+            "Groups larger than this keep every member but carry an "
+            "`Unusually large group` evidence-against pill, because a large "
+            "transitively-chained blob is rarely one duplicate cluster."
+        ),
+    )
+
+    def to_policy(self) -> TierPolicy:
+        """Convert to the service parameter object, raising ``ValueError``."""
+        return TierPolicy(
+            near_enabled=self.near_enabled,
+            embedding_enabled=self.embedding_enabled,
+            threshold=self.threshold,
+            min_group_size=self.min_group_size,
+            max_group_size=self.max_group_size,
+        )
+
+
+class TierPolicyBoundsModel(BaseModel):
+    """The values a client should render its tier controls from."""
+
+    model_config = ConfigDict(extra="allow")
+
+    min_threshold: float = Field(
+        description="Hard floor. Nothing below this is ever suggested."
+    )
+    max_threshold: float = Field(description="Upper bound for the threshold.")
+    tiers: list[str] = Field(
+        description=("Every tier id, strongest evidence first. `exact` is always on.")
+    )
+    always_on_tiers: list[str] = Field(description="Tiers the user cannot switch off.")
+    tier_requires: dict[str, Optional[str]] = Field(
+        description=(
+            "Per tier, the tier that must be enabled before it can be. `null` "
+            "for a tier with no prerequisite."
+        )
+    )
+    scope_types: list[str] = Field(
+        description="Every accepted `scope_type` for a scoped scan or count."
+    )
+    verdicts: list[str] = Field(
+        description=("Every verdict a group can carry. There is no deletion verdict.")
+    )
+    max_page_size: int = Field(description="Largest accepted queue page size.")
+
+
+class TierPolicyResponse(BaseModel):
+    """Server defaults plus the bounds and closed vocabularies."""
+
+    model_config = ConfigDict(extra="allow")
+
+    defaults: TierPolicyModel = Field(
+        description="The policy used when a request omits a field."
+    )
+    bounds: TierPolicyBoundsModel = Field(
+        description="Validation bounds and closed vocabularies."
+    )
+
+
+class WhyPillModel(BaseModel):
+    """One piece of evidence, in either direction.
+
+    Signals cut both ways: matching evidence renders as an olive check, and
+    anything arguing against a stack (different resolution, different aspect
+    ratio, fewer tags) as a red x. A group carrying red pills is exactly the one
+    that needs a closer look, so the pills do the warning rather than generic
+    "review carefully" copy. The server reports reasons; the user concludes.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    text: str = Field(description="The pill's label, ready to render.")
+    against: bool = Field(
+        description="True when this argues against stacking the group."
+    )
+
+
+class DedupCandidateModel(BaseModel):
+    """One picture in a group, with the fields Compare shows column by column."""
+
+    model_config = ConfigDict(extra="allow")
+
+    picture_id: int = Field(description="The picture.")
+    width: Optional[int] = Field(default=None, description="Stored pixel width.")
+    height: Optional[int] = Field(default=None, description="Stored pixel height.")
+    megapixels: float = Field(
+        description="Total pixels in millions - the cover formula's first term."
+    )
+    size_bytes: Optional[int] = Field(
+        default=None, description="Size of the stored file."
+    )
+    format: Optional[str] = Field(default=None, description="Stored image format.")
+    is_raw: bool = Field(
+        description="Whether this is a camera original, which earns a cover bonus."
+    )
+    score: Optional[int] = Field(default=None, description="The user's own rating.")
+    tag_count: int = Field(description="How many tags this picture carries.")
+    created_at: Optional[datetime] = Field(
+        default=None, description="Capture time; the cover tie-break, oldest wins."
+    )
+    imported_at: Optional[datetime] = Field(
+        default=None, description="When it entered the library."
+    )
+    stack_id: Optional[int] = Field(
+        default=None, description="Stack it already belongs to, if any."
+    )
+    reference_folder_id: Optional[int] = Field(
+        default=None, description="Reference folder it belongs to, if any."
+    )
+    file_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Full path, populated **only for reference-folder pictures**, where "
+            "the user manages the files and needs to know which copy is which. "
+            "Null for managed-library pictures, where the path is an "
+            "implementation detail."
+        ),
+    )
+    thumbnail_version: str = Field(
+        description=(
+            "Cache-buster token for this picture's thumbnail URL: append it as "
+            "`?v=`, exactly as the batch-thumbnail endpoint does (both call the "
+            "same helper). It changes whenever the stored bitmap is regenerated, "
+            "so a thumbnail rebuilt mid-triage refetches instead of the queue "
+            'painting the stale cached image. `"0"` until the picture has been '
+            "processed."
+        )
+    )
+    cover_score: float = Field(
+        description=(
+            "`megapixels*4 + tags*3 + score*2 + 8 if RAW`. The highest wins the "
+            "cover preselection; ties break to the oldest capture time."
+        )
+    )
+    why: list[WhyPillModel] = Field(
+        default_factory=list,
+        description=(
+            "Per-candidate evidence, both directions: what this picture is best "
+            "at and where it loses. Rendered so the user can disagree with the "
+            "preselection knowing why it was made."
+        ),
+    )
+
+
+class DedupGroupModel(BaseModel):
+    """One queue row: a group, its evidence, and its cover preselection."""
+
+    model_config = ConfigDict(extra="allow")
+
+    signature: str = Field(
+        description=(
+            "Stable identity of this *set of files* (a hash of the sorted member "
+            "content hashes). Verdicts are keyed on it, so a rescan or a "
+            "re-import never re-asks. This is the id every verdict route takes."
+        )
+    )
+    tier: DedupTier = Field(
+        description="Which tier found the group: `exact`, `near` or `embedding`."
+    )
+    confidence: float = Field(
+        description=(
+            "1.0 for an exact match; otherwise the group's **weakest** pairwise "
+            "similarity, so a transitive chain is judged by its weak link. The "
+            "queue is ordered by this, descending."
+        )
+    )
+    member_count: int = Field(description="How many pictures are in the group.")
+    cover_picture_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "The server's cover preselection. Always a preselection, never a "
+            "silent decision: the client shows it and the user may override it."
+        ),
+    )
+    why: list[WhyPillModel] = Field(
+        default_factory=list, description="Group-level evidence, both directions."
+    )
+    created_at: Optional[datetime] = Field(
+        default=None, description="When the group was first detected."
+    )
+    verdict: Optional[str] = Field(
+        default=None,
+        description=(
+            "On a `decided=true` page only: the live verdict that resolved the "
+            "group, `stacked` or `keep_separate`. Null on the open queue."
+        ),
+    )
+    decided_at: Optional[datetime] = Field(
+        default=None,
+        description="On a `decided=true` page only: when the verdict was made.",
+    )
+    candidates: list[DedupCandidateModel] = Field(
+        default_factory=list,
+        description="Every member, cover first, with its own evidence.",
+    )
+
+
+class ScanProgressModel(BaseModel):
+    """The "scanned N of M" banner's data."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = Field(
+        description="`idle`, `pending`, `running`, `complete` or `failed`."
+    )
+    scanned_pictures: int = Field(description="Pictures covered so far.")
+    total_pictures: int = Field(description="Pictures in scope.")
+    scanned_buckets: int = Field(
+        description="Tier-2 candidate buckets finished. Groups appear as these land."
+    )
+    total_buckets: int = Field(description="Tier-2 candidate buckets in total.")
+    groups_found: int = Field(description="Unresolved groups this scan produced.")
+    error: Optional[str] = Field(
+        default=None, description="Why the scan failed, when it did."
+    )
+
+
+class DedupQueueResponse(BaseModel):
+    """One page of the queue plus everything the header needs."""
+
+    model_config = ConfigDict(extra="allow")
+
+    groups: list[DedupGroupModel] = Field(
+        default_factory=list, description="This page, confidence descending."
+    )
+    total: int = Field(
+        description=(
+            "Complete unresolved-group count in scope, so the client can size "
+            "its scrollbar without a second request. The queue is paged from the "
+            "database and is never loaded whole."
+        )
+    )
+    offset: int = Field(
+        description=(
+            "Echo of the requested offset. **Deprecated** - offset paging skips "
+            "groups whenever the queue changes underneath it (a verdict on a "
+            "delivered row, or a tier-2 scan committing a bucket, shifts every "
+            "later row up). Page with `cursor` instead; `0` is echoed when "
+            "cursor paging."
+        )
+    )
+    limit: int = Field(description="Effective page size after clamping.")
+    cursor: Optional[str] = Field(
+        default=None, description="Echo of the cursor this page was read from."
+    )
+    next_cursor: Optional[str] = Field(
+        default=None,
+        description=(
+            "Pass as `cursor` to fetch the next page. `null` at end-of-found. "
+            "Opaque: pass it back verbatim, never construct or parse one."
+        ),
+    )
+    policy: TierPolicyModel = Field(description="The policy this page was read under.")
+    scope: dict[str, Any] = Field(description="The scope this page was read under.")
+    scan: ScanProgressModel = Field(description="Scan progress for this scope.")
+
+
+class ScopeRequestModel(BaseModel):
+    """A scope to scan or count."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope_type: ScopeType = Field(
+        default=ScopeType.GLOBAL,
+        description=(
+            "`global` for the whole vault, or the collection kind behind a "
+            '"Find duplicates in ..." context-menu entry.'
+        ),
+    )
+    scope_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "The collection's id, or the absolute folder path for "
+            "`scope_type=folder`. Required unless `scope_type` is `global`."
+        ),
+    )
+
+    def to_scope(self) -> DedupScope:
+        """Convert to the service scope, raising ``ValueError``."""
+        return DedupScope(scope_type=self.scope_type, scope_id=self.scope_id)
+
+
+class DedupCountsRequestModel(BaseModel):
+    """Ask for the sidebar badge and any number of scoped counts at once."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    policy: Optional[TierPolicyModel] = Field(
+        default=None, description="Tier policy; server defaults when omitted."
+    )
+    scopes: list[ScopeRequestModel] = Field(
+        default_factory=list,
+        max_length=MAX_COUNT_SCOPES,
+        description=(
+            "Extra scopes to count. The global count is always returned, so a "
+            "context menu can ask for its own scopes and get the badge for free. "
+            f"At most {MAX_COUNT_SCOPES} per request: each scope is a separate "
+            "correlated COUNT, so an uncapped list turns one request into "
+            "thousands of queries."
+        ),
+    )
+
+
+class DedupCountsResponse(BaseModel):
+    """Live counts: the sidebar badge, the per-tier split, and scoped counts."""
+
+    model_config = ConfigDict(extra="allow")
+
+    unresolved_groups: int = Field(
+        description=(
+            "The sidebar badge: duplicate decisions still to make across the "
+            "whole vault, under the supplied policy."
+        )
+    )
+    by_tier: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Unresolved groups per tier, **including tiers that are switched "
+            "off**, so the user can see what enabling a tier would add before "
+            "enabling it."
+        ),
+    )
+    scopes: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="One `{scope_type, scope_id, key, unresolved_groups}` per requested scope.",
+    )
+    policy: TierPolicyModel = Field(
+        description="The policy these counts were read under."
+    )
+    scan: ScanProgressModel = Field(description="Global scan progress.")
+
+
+class DedupScanRequestModel(BaseModel):
+    """Queue a scan. Returns immediately; poll ``GET /dedup/groups`` for progress."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    policy: Optional[TierPolicyModel] = Field(
+        default=None, description="Tier policy; server defaults when omitted."
+    )
+    scope: Optional[ScopeRequestModel] = Field(
+        default=None, description="Scope to scan; the whole vault when omitted."
+    )
+
+
+class StackVerdictRequestModel(BaseModel):
+    """Stack a group behind a chosen cover."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    signature: str = Field(description="The group signature from the queue.")
+    cover_picture_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "The cover the user chose or confirmed. Defaults to the server's "
+            "preselection stored on the group. Must be an included member."
+        ),
+    )
+    excluded_picture_ids: list[int] = Field(
+        default_factory=list,
+        description=(
+            "Members the user left out of the stack. They are untouched and "
+            "recorded on the verdict, so a rescan does not treat the exclusion "
+            "as an unfinished decision."
+        ),
+    )
+    batch_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Operation-log batch to record this verdict under. Supply the same "
+            "`cli-<4-76 chars of A-Z a-z 0-9 _ ->` id across several calls to "
+            "make them reverse as one undo. Omit it and the server mints its own "
+            "`srv-` id; any other shape is a 400, so a client cannot mint what "
+            "reads as a server batch or graft its rows into one."
+        ),
+    )
+
+
+class SignatureRequestModel(BaseModel):
+    """A verdict route that needs nothing but the group signature."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    signature: str = Field(description="The group signature.")
+    batch_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Operation-log batch to record under. Must be a client-namespaced "
+            "`cli-…` id; omit it to have the server mint one."
+        ),
+    )
+
+
+class VerdictResponse(BaseModel):
+    """What a verdict did, for the action receipt."""
+
+    model_config = ConfigDict(extra="allow")
+
+    signature: str = Field(description="The signature the verdict was recorded on.")
+    verdict: str = Field(description="`stacked` or `keep_separate`.")
+    stack_id: Optional[int] = Field(
+        default=None, description="The resulting stack, for a stack verdict."
+    )
+    cover_picture_id: Optional[int] = Field(
+        default=None, description="The picture the stack leads with."
+    )
+    picture_ids: list[int] = Field(
+        default_factory=list, description="Members the verdict covers."
+    )
+    excluded_picture_ids: list[int] = Field(
+        default_factory=list, description="Members deliberately left out."
+    )
+    batch_id: Optional[str] = Field(
+        default=None, description="Operation-log batch this verdict belongs to."
+    )
+    metadata_union: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "What the metadata union changed: `tags_added`, `scores_lifted`, "
+            "`characters_pending`, `membership_changed`. Stacking unions tags, "
+            "project and set membership onto every member and lifts every member "
+            "to the highest score. Nothing is overwritten or lost."
+        ),
+    )
+
+
+class ReopenResponse(BaseModel):
+    """The result of returning a decided group to the queue."""
+
+    model_config = ConfigDict(extra="allow")
+
+    signature: str = Field(description="The reopened signature.")
+    previous_verdict: str = Field(description="The verdict that was in force.")
+    reopened_at: Optional[datetime] = Field(
+        default=None, description="When it was reopened."
+    )
+    group_returned_to_queue: bool = Field(
+        description=(
+            "Whether a group row for this signature exists and is back in the "
+            "queue. False when the group has not been re-detected yet; the next "
+            "scan will bring it back."
+        )
+    )
+
+
+class AutoStackRequestModel(BaseModel):
+    """The exact tier's bulk action, behind one consent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope: Optional[ScopeRequestModel] = Field(
+        default=None, description="Restrict to a scope; the whole vault when omitted."
+    )
+    dry_run: bool = Field(
+        default=True,
+        description=(
+            "True (the default) counts what would happen and writes nothing - "
+            "this is what the consent dialog reads. Send `false` to apply."
+        ),
+    )
+    batch_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Operation-log batch id. Omit to have the server mint one (`srv-…`); "
+            "every stack in the run shares it, so N stacks reverse with one "
+            "undo. A supplied id must be client-namespaced `cli-…`."
+        ),
+    )
+    limit: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Cap the number of groups acted on, for a paged run.",
+    )
+
+
+class AutoStackDryRunSummaryModel(BaseModel):
+    """Aggregates for the consent dialog, from the dry run's own snapshot."""
+
+    model_config = ConfigDict(extra="allow")
+
+    groups: int = Field(description="Groups the run would act on.")
+    groups_by_tier: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Group count per tier, zero-filled for every tier. Only `exact` is "
+            "ever non-zero today - auto-stack is exact-only - but the shape is "
+            "stable so the dialog does not need a special case if that changes."
+        ),
+    )
+    pictures: int = Field(description="Pictures across those groups.")
+    covers_gaining_tags: int = Field(
+        description="Covers that would gain at least one tag from the union."
+    )
+    covers_gaining_score: int = Field(
+        description="Covers whose score the union would lift."
+    )
+    covers_gaining_metadata: int = Field(
+        description=(
+            "Covers gaining tags **or** score - the design's "
+            '"covers gaining metadata" row. Derived from the planned verdicts in '
+            "the same read as the counts above, so the dialog's numbers can never "
+            "disagree with each other; the union itself is not run and nothing is "
+            "written."
+        )
+    )
+
+
+class AutoStackResponse(BaseModel):
+    """What the bulk auto-stack did, or would do."""
+
+    model_config = ConfigDict(extra="allow")
+
+    batch_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "The shared batch id, and the `POST /operations/batches/{batch_id}/"
+            "undo` handle for the whole run. Always present on an applied run - "
+            "including a partially applied one - so work that did happen is "
+            "never left without a way to reverse it. Null only for a dry run "
+            "with none supplied."
+        ),
+    )
+    dry_run: bool = Field(description="Whether anything was written.")
+    groups: int = Field(
+        description="Exact groups actually stacked (or, on a dry run, that would be)."
+    )
+    pictures: int = Field(description="Pictures across the stacked groups.")
+    scope: dict[str, Any] = Field(description="The scope the run covered.")
+    dry_run_summary: Optional[AutoStackDryRunSummaryModel] = Field(
+        default=None,
+        description="Consent-dialog aggregates. Present on a dry run only.",
+    )
+    results: list[VerdictResponse] = Field(
+        default_factory=list,
+        description=(
+            'One entry per applied group, each with `outcome: "applied"`. Empty '
+            "for a dry run."
+        ),
+    )
+    failures: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "One entry per group that was not applied: `{signature, outcome, "
+            "status_code, error}`, where `outcome` is `blocked` (a guard refused "
+            "it - in practice a locked picture set, 423) or `failed` (it could "
+            "not be resolved at all). A single unstackable group never aborts "
+            "the run, so a partial result is reported honestly rather than "
+            "hidden, and the run still returns its `batch_id`."
+        ),
+    )
+    blocked: int = Field(
+        default=0, description="Groups refused by a guard, typically a locked set."
+    )
+    failed: int = Field(default=0, description="Groups that could not be resolved.")
+
+
 def create_router(server) -> APIRouter:
     router = APIRouter()
+
+    def _policy(model: Optional[TierPolicyModel]) -> TierPolicy:
+        """Build the service policy from a request model, 400 on a bad one."""
+        try:
+            return (model or TierPolicyModel()).to_policy()
+        except ValueError as exc:
+            logger.info("[dedup] rejected tier policy %s: %s", model, exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    def _batch_id(value: Optional[str]) -> Optional[str]:
+        """Accept only a client-namespaced batch id, 400 on anything else.
+
+        The server mints ``srv-…`` for a verdict that arrives without one; a
+        client that wants several verdicts to reverse together supplies its own
+        ``cli-…``. Accepting an arbitrary string let a client mint what reads as
+        a server batch, or graft its rows into someone else's batch so one undo
+        reverses more than the user did.
+        """
+        if value is None:
+            return None
+        text = str(value)
+        if len(text) > MAX_BATCH_ID_LENGTH or not CLIENT_BATCH_ID_RE.fullmatch(text):
+            logger.info("[dedup] rejected client batch_id %r", text[:120])
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"batch_id must match {CLIENT_BATCH_ID_PREFIX}<4-76 chars of "
+                    "A-Z a-z 0-9 _ ->; omit it to have the server mint one"
+                ),
+            )
+        return text
+
+    def _scope(model: Optional[ScopeRequestModel]) -> DedupScope:
+        """Build the service scope from a request model, 400 on a bad one."""
+        try:
+            return (model or ScopeRequestModel()).to_scope()
+        except ValueError as exc:
+            logger.info("[dedup] rejected scope %s: %s", model, exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.get(
+        "/dedup/policy",
+        summary="Duplicate detection tier defaults",
+        description=(
+            "Returns the tier gating defaults plus the bounds and closed "
+            "vocabularies a client builds its tier switches and threshold "
+            "slider from, so 0.90 and the 0.65 floor are never hardcoded twice. "
+            "Read-only."
+        ),
+        response_model=TierPolicyResponse,
+    )
+    def get_tier_policy():
+        return {
+            "defaults": TierPolicyModel(),
+            "bounds": {
+                "min_threshold": MIN_THRESHOLD,
+                "max_threshold": MAX_THRESHOLD,
+                "tiers": [tier.value for tier in dedup_tier_service.TIER_ORDER],
+                "always_on_tiers": [DedupTier.EXACT.value],
+                "tier_requires": {
+                    DedupTier.EXACT.value: None,
+                    DedupTier.NEAR.value: DedupTier.EXACT.value,
+                    DedupTier.EMBEDDING.value: DedupTier.NEAR.value,
+                },
+                "scope_types": [item.value for item in ScopeType],
+                "verdicts": [
+                    dedup_tier_service.VERDICT_STACKED,
+                    dedup_tier_service.VERDICT_KEEP_SEPARATE,
+                ],
+                "max_page_size": MAX_PAGE_SIZE,
+            },
+        }
+
+    @router.get(
+        "/dedup/groups",
+        summary="One page of the duplicate queue",
+        description=(
+            "Returns unresolved duplicate groups, confidence descending, with "
+            "each group's evidence pills, its cover preselection and every "
+            "candidate's own evidence - so the client renders reasons rather "
+            "than conclusions. The queue is paged from the database and is never "
+            "loaded whole: 10 groups and 10,000 cost the same per page. The "
+            "response also carries this scope's scan progress for the banner.\n\n"
+            "Page with `cursor`: pass the previous page's `next_cursor` back "
+            "verbatim, and stop when `next_cursor` is `null`. The queue is a "
+            "live list - deciding a verdict on a delivered group removes it, and "
+            "a tier-2 scan commits new groups after every bucket - so `offset` "
+            "paging skips exactly as many groups as the previous page changed. "
+            "`offset` still works for compatibility but is deprecated, and "
+            "sending both `cursor` and `offset` is a 400."
+        ),
+        response_model=DedupQueueResponse,
+    )
+    def get_dedup_groups(
+        near_enabled: bool = Query(
+            default=False, description="Include tier 2 (bucketed near-duplicates)."
+        ),
+        embedding_enabled: bool = Query(
+            default=False,
+            description="Include tier 3. Requires `near_enabled`.",
+        ),
+        threshold: float = Query(
+            default=DEFAULT_THRESHOLD,
+            ge=MIN_THRESHOLD,
+            le=MAX_THRESHOLD,
+            description="Minimum similarity; exact matches are always included.",
+        ),
+        scope_type: ScopeType = Query(
+            default=ScopeType.GLOBAL, description="Scope kind."
+        ),
+        scope_id: Optional[str] = Query(
+            default=None, description="Scope id, required unless scope is global."
+        ),
+        offset: Optional[int] = Query(
+            default=None,
+            ge=0,
+            deprecated=True,
+            description=(
+                "Groups to skip. Deprecated - use `cursor`; offset paging skips "
+                "groups when the queue changes between pages. Mutually exclusive "
+                "with `cursor`."
+            ),
+        ),
+        cursor: Optional[str] = Query(
+            default=None,
+            max_length=MAX_CURSOR_LENGTH,
+            description=(
+                "Opaque keyset position from the previous page's `next_cursor`. "
+                "Omit for the first page. Mutually exclusive with `offset`."
+            ),
+        ),
+        limit: int = Query(
+            default=DEFAULT_PAGE_SIZE,
+            ge=1,
+            le=MAX_PAGE_SIZE,
+            description="Groups per page.",
+        ),
+        decided: bool = Query(
+            default=False,
+            description=(
+                "Page the DECIDED groups instead of the open queue: resolved "
+                "groups with their live verdict (`stacked` / `keep_separate`) "
+                "and `decided_at`, so a decision can be reviewed and cleared "
+                "via `POST /dedup/verdicts/reopen`. Ignores the tier gate and "
+                "the threshold - a policy change must not hide a decision."
+            ),
+        ),
+    ):
+        if cursor is not None and offset is not None:
+            # Refused rather than silently preferring one: a client that sends
+            # both has two different ideas of where it is, and answering either
+            # one hands back a page it did not ask for.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "cursor and offset are mutually exclusive; page with cursor "
+                    "(offset is deprecated)"
+                ),
+            )
+        policy = _policy(
+            TierPolicyModel(
+                near_enabled=near_enabled,
+                embedding_enabled=embedding_enabled,
+                threshold=threshold,
+            )
+        )
+        scope = _scope(ScopeRequestModel(scope_type=scope_type, scope_id=scope_id))
+        try:
+            return dedup_tier_service.queue_response(
+                server.vault, policy, scope, offset or 0, limit, cursor, decided
+            )
+        except DedupCursorError as exc:
+            logger.info("[dedup] rejected queue cursor: %s", exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.post(
+        "/dedup/counts",
+        summary="Live duplicate counts, global and scoped",
+        description=(
+            "Returns the sidebar badge (unresolved duplicate groups across the "
+            "vault), the per-tier split including tiers that are switched off, "
+            "and one count per requested scope so a context menu can label every "
+            'its "Find duplicates in ..." entries in a single request. '
+            "Read-only despite being a POST: the scope list does not fit a URL."
+        ),
+        response_model=DedupCountsResponse,
+    )
+    def post_dedup_counts(
+        payload: Optional[DedupCountsRequestModel] = Body(default=None),
+    ):
+        request_model = payload or DedupCountsRequestModel()
+        policy = _policy(request_model.policy)
+        scopes = [_scope(item) for item in request_model.scopes]
+        return dedup_tier_service.counts_response(server.vault, policy, scopes)
+
+    @router.post(
+        "/dedup/scan",
+        summary="Queue a duplicate scan",
+        description=(
+            "Queues a scan for the given scope and returns its progress row "
+            "immediately - the queue can be opened while it runs. Cached hashes "
+            "are reused (`pixel_sha` and `perceptual_hash` are computed on "
+            "import), so a scoped scan only reads and compares them. Tier 1 "
+            "completes in milliseconds; tier 2 streams its groups in as each "
+            "candidate bucket finishes."
+        ),
+        response_model=ScanProgressModel,
+    )
+    def post_dedup_scan(payload: Optional[DedupScanRequestModel] = Body(default=None)):
+        request_model = payload or DedupScanRequestModel()
+        policy = _policy(request_model.policy)
+        scope = _scope(request_model.scope)
+        return dedup_tier_service.request_scan(server.vault, policy, scope)
+
+    @router.post(
+        "/dedup/verdicts/stack",
+        summary="Stack a duplicate group",
+        description=(
+            "Stacks the group's included members behind the chosen cover and "
+            "applies the metadata union: tags, project and set membership are "
+            "unioned onto every member and every member is lifted to the highest "
+            "score. Nothing is overwritten, nothing is deleted, and no file "
+            "moves - a stack is a grouping row plus a cover pointer, so dropping "
+            "it restores the flat grid exactly. The verdict is remembered "
+            "against the group signature, so a rescan never re-asks."
+        ),
+        response_model=VerdictResponse,
+    )
+    def post_stack_verdict(request: Request, payload: StackVerdictRequestModel):
+        # §21 origin discipline: actor / source / origin_client_id are read from
+        # the request HERE, on the request's own task, and passed down
+        # explicitly. The contextvar is dead on the DB worker thread, so the
+        # service must never read it for itself.
+        context = operation_log_service.request_context(request)
+        # The gesture header (X-Operation-Batch-Id) also arrives via
+        # request_context. Precedence: an explicit body batch_id wins over the
+        # ambient header; the service mints srv- when both are absent.
+        header_batch_id = context.pop("batch_id", None)
+        try:
+            result = dedup_verdict_service.apply_stack_verdict(
+                server.vault,
+                payload.signature,
+                payload.cover_picture_id,
+                list(payload.excluded_picture_ids),
+                _batch_id(payload.batch_id) or header_batch_id,
+                **context,
+            )
+        except DedupVerdictError as exc:
+            logger.info("[dedup] stack verdict rejected: %s", exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return result.as_dict()
+
+    @router.post(
+        "/dedup/verdicts/keep-separate",
+        summary="Record that a group is not duplicates",
+        description=(
+            "Remembers that these pictures should stay separate. No picture row "
+            "changes. The decision is permanent until it is reopened from the "
+            "Stacks view, which is what lets the sidebar count reach zero and "
+            "stay there across rescans and re-imports."
+        ),
+        response_model=VerdictResponse,
+    )
+    def post_keep_separate_verdict(payload: SignatureRequestModel):
+        # No request_context here on purpose: keep-separate writes no operation
+        # row (it changes no reversible picture facet — see
+        # dedup_verdict_service.OP_TYPE_STACK), so actor / source would be dead
+        # arguments. If this verdict ever starts recording, wire it up like
+        # post_stack_verdict does.
+        try:
+            result = dedup_verdict_service.apply_keep_separate(
+                server.vault, payload.signature, _batch_id(payload.batch_id)
+            )
+        except DedupVerdictError as exc:
+            logger.info("[dedup] keep-separate verdict rejected: %s", exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return result.as_dict()
+
+    @router.post(
+        "/dedup/verdicts/reopen",
+        summary="Return a decided group to the queue",
+        description=(
+            "Clears the memory of a verdict so the group is offered again. The "
+            "pictures are untouched: reopening a `stacked` verdict does not "
+            "unstack anything, because unstacking is the Stacks view's own "
+            "action. The verdict row is kept and marked reopened rather than "
+            "deleted, so the decision history survives."
+        ),
+        response_model=ReopenResponse,
+    )
+    def post_reopen_verdict(payload: SignatureRequestModel):
+        # No request_context here on purpose — see post_keep_separate_verdict.
+        # batch_id is unused by reopen (it records no operation) but is still
+        # validated, so no route on this surface accepts a malformed one.
+        _batch_id(payload.batch_id)
+        try:
+            return dedup_verdict_service.reopen_verdict(server.vault, payload.signature)
+        except DedupVerdictError as exc:
+            logger.info("[dedup] reopen rejected: %s", exc)
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.post(
+        "/dedup/auto-stack",
+        summary="Bulk auto-stack the exact tier",
+        description=(
+            "Stacks every unresolved **exact** group under one operation-log "
+            "batch id, so a thousand stacks reverse with a single undo. Exact "
+            "matches are the tier with no human judgment left in them, which is "
+            "why they get one consent dialog instead of per-group adjudication; "
+            "near and embedding groups always go through the queue no matter how "
+            "confident they look. Defaults to `dry_run=true`, which returns the "
+            "counts the dialog shows and writes nothing."
+        ),
+        response_model=AutoStackResponse,
+    )
+    def post_auto_stack(
+        request: Request,
+        payload: Optional[AutoStackRequestModel] = Body(default=None),
+    ):
+        request_model = payload or AutoStackRequestModel()
+        scope = _scope(request_model.scope)
+        # §21 origin discipline, read in the handler — see post_stack_verdict.
+        # This is the most far-reaching mutation on the surface, so it is the one
+        # that most needs an attributed audit row.
+        context = operation_log_service.request_context(request)
+        # Body batch_id wins over the ambient gesture header (see
+        # post_stack_verdict); the service mints srv- when both are absent.
+        header_batch_id = context.pop("batch_id", None)
+        return dedup_verdict_service.bulk_auto_stack(
+            server.vault,
+            scope,
+            _batch_id(request_model.batch_id) or header_batch_id,
+            request_model.dry_run,
+            request_model.limit,
+            **context,
+        )
 
     @router.get(
         "/dedup/sweep/policy",

--- a/pixlstash/routes/pictures/_thumbnails.py
+++ b/pixlstash/routes/pictures/_thumbnails.py
@@ -551,9 +551,10 @@ def register_routes(router, server):
                 # old key was imported_at, which never changed on regen -> the
                 # browser kept painting the pre-upgrade square bitmap into the
                 # justified layout's AR cell -> squashed thumbnails.
-                tw = getattr(pic, "thumbnail_width", None)
-                th = getattr(pic, "thumbnail_height", None)
-                v = f"{tw}x{th}" if tw and th else "0"
+                v = ImageUtils.thumbnail_cache_token(
+                    getattr(pic, "thumbnail_width", None),
+                    getattr(pic, "thumbnail_height", None),
+                )
                 thumbnail_url = f"/pictures/thumbnails/{pic.id}.webp?v={v}"
                 # Whole-frame AR-bitmap dimensions and the face-weighted square-crop
                 # rectangle (bitmap pixel space). All are NULL until the picture is

--- a/pixlstash/services/dedup_tier_service.py
+++ b/pixlstash/services/dedup_tier_service.py
@@ -1,0 +1,2105 @@
+"""Tiered duplicate detection: exact, bucketed near, and embedding.
+
+The v1.9 Dedup -> Stacks design replaces the "Similarity to ..." sort order with
+a **Duplicates** destination whose queue is filled by three tiers of increasing
+cost and decreasing certainty. This module owns detection, the tier policy, the
+cover preselection and the evidence pills; :mod:`pixlstash.services.dedup_verdict_service`
+owns what happens when the user decides.
+
+Tier 1 — exact
+--------------
+``GROUP BY`` on an indexed hash column. **The column is the existing
+``picture.pixel_sha``** (``Field(default=None, index=True)`` in
+:mod:`pixlstash.db_models.picture`), not a new one. Being honest about what it
+is: ``ImageUtils._calculate_sha256_digest`` hashes the whole file only up to
+128 KiB and otherwise samples 8 chunks of 8 KiB spread across the file, so it is
+a *sampled* content digest, not a full-file SHA-256. Two files can in principle
+share a ``pixel_sha`` while differing in an unsampled region.
+
+That is why tier 1 groups on ``(pixel_sha, size_bytes)`` rather than
+``pixel_sha`` alone: the sample offsets are derived from the file size, so equal
+size plus equal sampled digest is a far stronger claim than the digest alone,
+and the extra column costs nothing (the ``pixel_sha`` index already narrows the
+group). It is still not a cryptographic identity proof, which is exactly why the
+design routes exact matches through a bulk auto-stack **dialog** with a dry-run
+count rather than stacking them at import without consent, and why no tier ever
+deletes anything.
+
+A new full-file hash column was considered and rejected: it would mean re-reading
+every byte of every file in the library on upgrade to buy a guarantee the feature
+does not need (the failure mode of a false exact match is two genuinely different
+pictures ending up in one *stack*, which is reversible with one keystroke).
+``pixel_sha`` is already computed incrementally on every import path, and
+:class:`~pixlstash.tasks.missing_pixel_sha_finder.MissingPixelShaFinder` backfills
+the rows that predate it.
+
+Tier 2 — bucketed near
+----------------------
+Perceptual hashes compared **only within candidate buckets**, never library-wide.
+The buckets reuse what the library already precomputes:
+
+* ``picture.size_bin_index`` — an indexed ``(width << 32) + height`` column
+  maintained by ``LikenessParameterUtils.size_bin_index``. Exact-dimension
+  bucket; catches re-saves, re-encodes and burst frames.
+* capture minute — ``created_at`` truncated to the minute; catches bursts and
+  re-exports that changed dimensions.
+* import batch / folder — ``import_source_folder``, and the containing directory
+  of ``file_path`` for reference-folder pictures.
+
+``LikenessParameter.PHASH_PREFIX`` was investigated and is deliberately **not**
+used as a bucket key. Despite the name it stores the *entire* 64-bit dHash
+linearly normalised into ``[0, 1]`` (``int(phash[:16], 16) / (2**64 - 1)``), so
+numeric proximity in that slot is dominated by the top bit and says nothing about
+Hamming proximity. ``LikenessUtils.PHASH_PREFIX_LEN = 3`` is dead code with no
+reader. Within a bucket this module does the real thing: XOR + popcount over the
+64-bit dHash, vectorised with numpy.
+
+Each bucket is an independent unit of work, so buckets stream into the queue as
+they finish rather than the queue waiting for a full pass.
+
+Tier 3 — embedding
+------------------
+The existing :class:`~pixlstash.db_models.picture_likeness.PictureLikeness` edge
+table, folded into components by the shipped
+:mod:`pixlstash.services.dedup_sweep_service` planner. Opt-in, appended to the
+same queue. Nothing is recomputed: this tier is a different reading of data the
+image-embedding worker already produced.
+
+Policy
+------
+:class:`TierPolicy` replaces the shipped :class:`~pixlstash.services.dedup_sweep_service.SweepPolicy`
+auto/review split *for the queue*. Tier 1 is always on and cannot be switched
+off; each looser tier is a separate opt-in that requires the tier above it; the
+similarity threshold defaults to 0.90 and **nothing below 0.65 is ever
+suggested**. The dry-run planner and its report stay exactly as shipped — they
+are the non-destructive foundation this builds on, and ``SweepPolicy`` remains
+the parameter object for that surface.
+"""
+
+from __future__ import annotations
+
+import base64
+import math
+import hashlib
+import json
+from binascii import Error as BinasciiError
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Optional
+
+import numpy as np
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from pixlstash.db_models import Picture
+from pixlstash.db_models.dedup import (
+    SCAN_PENDING,
+    TIER_EMBEDDING,
+    TIER_EXACT,
+    TIER_NEAR,
+    VERDICT_KEEP_SEPARATE,
+    VERDICT_STACKED,
+    DedupGroup,
+    DedupGroupMember,
+    DedupScan,
+    DedupVerdict,
+)
+from pixlstash.db_models.picture_project import PictureProjectMember
+from pixlstash.db_models.picture_set import PictureSetMember
+from pixlstash.db_models.face import Face
+from pixlstash.db_models.tag import Tag
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services import dedup_sweep_service
+from pixlstash.utils.image_processing.image_utils import ImageUtils
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pixlstash.vault import Vault
+
+logger = get_logger(__name__)
+
+# --- Policy constants -------------------------------------------------------
+
+DEFAULT_THRESHOLD = 0.90
+"""The near-duplicate similarity default (design §7 "Threshold")."""
+
+MIN_THRESHOLD = 0.65
+"""Hard floor. Below this nothing is suggested at all — a low threshold produces
+confident-looking garbage and destroys trust in the sidebar count. Never a silent
+clamp: :class:`TierPolicy` raises ``ValueError`` here, and every route carries the
+same bound as a pydantic ``ge=``, so over HTTP a low threshold is refused with a
+**422** before any handler runs."""
+
+MAX_THRESHOLD = 0.99999
+
+DEFAULT_MIN_GROUP_SIZE = 2
+DEFAULT_MAX_GROUP_SIZE = 24
+"""Ceiling on a single detected group. A larger transitively-chained blob is
+almost never one duplicate cluster; it is split no further but reported with a
+lower confidence so it sorts to the bottom of the queue."""
+
+DEFAULT_PAGE_SIZE = 20
+MAX_PAGE_SIZE = 200
+
+MAX_BUCKET_MEMBERS = 4000
+"""Cap on one tier-2 bucket. The within-bucket comparison is O(k^2) popcounts,
+which numpy does in milliseconds at k=4000 (~8M comparisons); beyond that the
+bucket is split into shards rather than being dropped, so nothing is silently
+skipped. This bounds **CPU**, not memory — see :data:`MAX_PAIRS_PER_BUCKET`."""
+
+MAX_PAIRS_PER_BUCKET = 50_000
+"""Cap on the *materialised* near-pairs of one bucket.
+
+``MAX_BUCKET_MEMBERS`` bounds the comparison work; it does not bound the result.
+A bucket whose members are mutually near-identical (a burst of near-black frames,
+a folder of solid-colour placeholders, one image copied 4000 times) yields
+``k*(k-1)/2`` pairs: ~8M tuples, roughly 580 MB, for a component the union-find
+only needs a spanning subset of. 50 000 pairs is ~4 MB.
+
+**The cap can lose membership.** Pairs are emitted in increasing member-offset
+order, so the cap keeps the nearest-offset edges and drops the wider ones. For a
+uniformly near-identical bucket that costs only confidence resolution (the
+offset-1 edges alone span the block). For a dense but *non-uniform* block —
+~700 mutually matching members exhaust the cap well inside the low offsets — a
+member whose only match sits at a wider offset gets no edge at all and is split
+off into its own group or drops out of the queue. Hitting the cap logs a warning
+naming the bucket, the offset it stopped at and that consequence; the cap is
+never silent and the comment is not reassuring about a case it cannot cover.
+Mitigation: resolve the dense block and rescan, narrow the bucket, or raise this
+constant for the memory it costs."""
+
+MAX_TRACKED_PAIRS = 400_000
+"""Cap on the pairs a whole streaming scan keeps in memory across buckets.
+
+A scan holds pairs from every finished bucket so a chain spanning two buckets
+becomes one group. That set is what grows without bound over a large library;
+capping it at ~32 MB keeps the scan's footprint flat. Reaching it is logged."""
+
+PHASH_BITS = 64
+PHASH_HEX_LEN = PHASH_BITS // 4
+
+RAW_FORMATS = frozenset(
+    {
+        "raw",
+        "arw",
+        "cr2",
+        "cr3",
+        "crw",
+        "dng",
+        "erf",
+        "nef",
+        "nrw",
+        "orf",
+        "pef",
+        "raf",
+        "rw2",
+        "sr2",
+        "srw",
+        "x3f",
+    }
+)
+"""Formats treated as a camera original by the cover formula's RAW bonus."""
+
+COVER_RAW_BONUS = 8.0
+COVER_PIXEL_WEIGHT = 4.0
+COVER_TAG_WEIGHT = 3.0
+COVER_SCORE_WEIGHT = 2.0
+
+ID_CHUNK = 900
+"""SQLite bound-variable safety margin for ``IN`` loads."""
+
+
+class DedupTier(str, Enum):
+    """The three detection tiers, ordered strongest evidence first."""
+
+    EXACT = TIER_EXACT
+    NEAR = TIER_NEAR
+    EMBEDDING = TIER_EMBEDDING
+
+
+TIER_ORDER: tuple[DedupTier, ...] = (
+    DedupTier.EXACT,
+    DedupTier.NEAR,
+    DedupTier.EMBEDDING,
+)
+
+TIER_STRENGTH: dict[str, int] = {
+    TIER_EXACT: 3,
+    TIER_NEAR: 2,
+    TIER_EMBEDDING: 1,
+}
+"""How strong each tier's evidence is, for the upsert's tier precedence.
+
+Two tiers can find the *same* group: a byte-identical pair is also perceptually
+identical, so a near-enabled rescan rediscovers every exact pair. The upsert is
+keyed on the signature, so without precedence the later (weaker) tier overwrote
+the stronger one — and an ``exact`` pair silently downgraded to ``near``
+disappeared from the exact-only default queue *and* from ``POST
+/dedup/auto-stack``, which only ever acts on ``exact``.
+"""
+
+
+def tier_strength(tier: Optional[str]) -> int:
+    """Rank a stored tier value; an unknown or missing tier ranks lowest."""
+    return TIER_STRENGTH.get(str(tier or ""), 0)
+
+
+class ScopeType(str, Enum):
+    """Where a scan or a count is scoped to.
+
+    ``GLOBAL`` is the sidebar's vault-wide badge; the rest are the context-menu
+    "Find duplicates in ..." entry points.
+    """
+
+    GLOBAL = "global"
+    PROJECT = "project"
+    SET = "set"
+    CHARACTER = "character"
+    FOLDER = "folder"
+
+
+_NUMERIC_SCOPE_TYPES = frozenset(
+    {ScopeType.PROJECT, ScopeType.SET, ScopeType.CHARACTER}
+)
+"""Scopes whose ``scope_id`` is a row id and must parse as an integer."""
+
+LIKE_ESCAPE_CHAR = "\\"
+"""Escape character for the folder scope's ``LIKE`` prefix match."""
+
+
+@dataclass(frozen=True)
+class DedupScope:
+    """A scan / count scope and the SQL that narrows a picture query to it.
+
+    Attributes:
+        scope_type: Which collection kind, or :attr:`ScopeType.GLOBAL`.
+        scope_id: The collection's id, or the absolute folder path for
+            :attr:`ScopeType.FOLDER`. ``None`` only for ``GLOBAL``.
+    """
+
+    scope_type: ScopeType = ScopeType.GLOBAL
+    scope_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope_type, ScopeType):
+            object.__setattr__(self, "scope_type", ScopeType(str(self.scope_type)))
+        if self.scope_type is ScopeType.GLOBAL:
+            object.__setattr__(self, "scope_id", None)
+            return
+        if self.scope_id is None or str(self.scope_id) == "":
+            raise ValueError(f"scope_id is required for scope_type={self.scope_type}")
+        if self.scope_type in _NUMERIC_SCOPE_TYPES:
+            # Validate at construction, not at query time. The id reaches SQL as
+            # ``int(...)`` in picture_predicate(); leaving a non-numeric string to
+            # blow up there turned a bad request into a 500 on three read routes,
+            # and POST /dedup/scan *persisted* the unparseable scope before
+            # anything ever tried to parse it. Failing here makes it a 400 at the
+            # boundary, before any write.
+            try:
+                object.__setattr__(self, "scope_id", str(int(str(self.scope_id))))
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"scope_id for scope_type={self.scope_type.value} must be an "
+                    f"integer id, got {self.scope_id!r}"
+                ) from exc
+            return
+        if self.scope_type is ScopeType.FOLDER:
+            # Normalise here, not at query time, and reject what normalises away.
+            # The predicate strips trailing separators before building its LIKE
+            # prefix, so "/", "\", "///" all became an empty prefix and a LIKE
+            # pattern of "%" — a "Find duplicates in this folder" request that
+            # silently meant the whole vault, and a persisted dedupscan row whose
+            # scope_key claimed otherwise. Normalising at construction also makes
+            # "/photos" and "/photos/" the same scope key instead of two scans.
+            prefix = str(self.scope_id).rstrip("/\\")
+            if not prefix:
+                raise ValueError(
+                    "scope_id for scope_type=folder must name a folder; "
+                    f"{self.scope_id!r} normalises to an empty prefix, which "
+                    "would match the whole vault"
+                )
+            object.__setattr__(self, "scope_id", prefix)
+
+    @property
+    def key(self) -> str:
+        """Canonical ``DedupScan.scope_key`` for this scope."""
+        if self.scope_type is ScopeType.GLOBAL:
+            return "global"
+        return f"{self.scope_type.value}:{self.scope_id}"
+
+    def picture_predicate(self):
+        """Return the SQLAlchemy predicate restricting ``Picture`` to this scope.
+
+        ``None`` for the global scope, so a caller can skip the ``WHERE`` entirely
+        rather than emitting a tautology.
+        """
+        if self.scope_type is ScopeType.GLOBAL:
+            return None
+        if self.scope_type is ScopeType.PROJECT:
+            return Picture.id.in_(
+                select(PictureProjectMember.picture_id).where(
+                    PictureProjectMember.project_id == int(self.scope_id)
+                )
+            )
+        if self.scope_type is ScopeType.SET:
+            return Picture.id.in_(
+                select(PictureSetMember.picture_id).where(
+                    PictureSetMember.set_id == int(self.scope_id)
+                )
+            )
+        if self.scope_type is ScopeType.CHARACTER:
+            return Picture.id.in_(
+                select(Face.picture_id).where(Face.character_id == int(self.scope_id))
+            )
+        # FOLDER: a picture is in the folder when it was imported from it or its
+        # file lives under it. Both are prefix matches on an indexed column.
+        #
+        # The LIKE pattern escapes ``%`` / ``_`` / the escape character itself:
+        # unescaped, a scope_id of "%" would silently mean "everywhere", so a
+        # "Find duplicates in this folder" entry could match far more than the
+        # folder it named. The literal path is still compared exactly on
+        # import_source_folder. ``scope_id`` was already stripped of trailing
+        # separators and rejected if that left it empty (__post_init__).
+        prefix = str(self.scope_id)
+        pattern = (
+            prefix.replace(LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CHAR * 2)
+            .replace("%", f"{LIKE_ESCAPE_CHAR}%")
+            .replace("_", f"{LIKE_ESCAPE_CHAR}_")
+        )
+        return (Picture.import_source_folder == prefix) | (
+            Picture.file_path.like(f"{pattern}%", escape=LIKE_ESCAPE_CHAR)
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "scope_type": self.scope_type.value,
+            "scope_id": self.scope_id,
+            "key": self.key,
+        }
+
+
+@dataclass(frozen=True)
+class TierPolicy:
+    """Which tiers feed the queue, and how similar is similar enough.
+
+    This is the design's tier gating, and it replaces ``SweepPolicy``'s
+    auto/review split as the queue's policy surface. Validated in
+    ``__post_init__``: an invalid combination raises :class:`ValueError` (the
+    route turns that into a 400) rather than being silently corrected, because a
+    silently-retuned duplicate scan is exactly the surprise the feature cannot
+    afford.
+
+    Attributes:
+        near_enabled: Tier 2. Opt-in.
+        embedding_enabled: Tier 3. Opt-in, and requires ``near_enabled`` — the
+            design's "enabling one requires the tier above it", so a user cannot
+            land on "same scene" suggestions without having deliberately walked
+            down to them.
+        threshold: Minimum similarity for a near / embedding group to be
+            suggested at all. Defaults to :data:`DEFAULT_THRESHOLD`; may never go
+            below :data:`MIN_THRESHOLD`.
+        min_group_size: Smallest group that counts.
+        max_group_size: Groups larger than this keep their members but are
+            flagged in their evidence and pushed down the queue.
+
+    Tier 1 (exact) has no flag. It is always included and cannot be switched off.
+    """
+
+    near_enabled: bool = False
+    embedding_enabled: bool = False
+    threshold: float = DEFAULT_THRESHOLD
+    min_group_size: int = DEFAULT_MIN_GROUP_SIZE
+    max_group_size: int = DEFAULT_MAX_GROUP_SIZE
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.threshold, (int, float)) or not (
+            MIN_THRESHOLD <= float(self.threshold) <= MAX_THRESHOLD
+        ):
+            raise ValueError(
+                f"threshold must be between {MIN_THRESHOLD} and {MAX_THRESHOLD}, "
+                f"got {self.threshold!r}. Below {MIN_THRESHOLD} nothing is "
+                "suggested at all."
+            )
+        if self.embedding_enabled and not self.near_enabled:
+            raise ValueError(
+                "embedding_enabled requires near_enabled: each looser tier "
+                "requires the tier above it"
+            )
+        if int(self.min_group_size) < 2:
+            raise ValueError(
+                f"min_group_size must be at least 2, got {self.min_group_size!r}"
+            )
+        if int(self.max_group_size) < int(self.min_group_size):
+            raise ValueError(
+                "max_group_size must be >= min_group_size "
+                f"({self.max_group_size} < {self.min_group_size})"
+            )
+
+    @property
+    def tiers(self) -> tuple[DedupTier, ...]:
+        """The enabled tiers, strongest first. Always starts with EXACT."""
+        enabled = [DedupTier.EXACT]
+        if self.near_enabled:
+            enabled.append(DedupTier.NEAR)
+        if self.embedding_enabled:
+            enabled.append(DedupTier.EMBEDDING)
+        return tuple(enabled)
+
+    def includes(self, tier: DedupTier) -> bool:
+        """Whether *tier* is switched on."""
+        return tier in self.tiers
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "near_enabled": bool(self.near_enabled),
+            "embedding_enabled": bool(self.embedding_enabled),
+            "threshold": float(self.threshold),
+            "min_group_size": int(self.min_group_size),
+            "max_group_size": int(self.max_group_size),
+        }
+
+
+@dataclass
+class CandidateMember:
+    """One picture in a detected group, with everything cover + evidence need.
+
+    Loaded once per group by :func:`load_candidates`; the queue page never reads
+    a picture row a second time.
+    """
+
+    id: int
+    file_path: Optional[str] = None
+    format: Optional[str] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    size_bytes: Optional[int] = None
+    score: Optional[int] = None
+    created_at: Optional[datetime] = None
+    imported_at: Optional[datetime] = None
+    stack_id: Optional[int] = None
+    reference_folder_id: Optional[int] = None
+    pixel_sha: Optional[str] = None
+    perceptual_hash: Optional[str] = None
+    thumbnail_width: Optional[int] = None
+    thumbnail_height: Optional[int] = None
+    tag_count: int = 0
+
+    @property
+    def thumbnail_version(self) -> str:
+        """The ``?v=`` token the queue's thumbnail URLs must carry.
+
+        Same value and same semantics as the batch-thumbnail endpoint's — both
+        call :meth:`ImageUtils.thumbnail_cache_token`. Without it a thumbnail
+        regenerated mid-triage would keep painting the stale cached bitmap in the
+        queue, because the queue's URL would never change.
+        """
+        return ImageUtils.thumbnail_cache_token(
+            self.thumbnail_width, self.thumbnail_height
+        )
+
+    @property
+    def pixels(self) -> int:
+        """Total pixel count; 0 when the dimensions were never recorded."""
+        return int(self.width or 0) * int(self.height or 0)
+
+    @property
+    def megapixels(self) -> float:
+        return round(self.pixels / 1_000_000.0, 2)
+
+    @property
+    def is_raw(self) -> bool:
+        """Whether this is a camera original, by format or by file extension."""
+        fmt = (self.format or "").strip().lower().lstrip(".")
+        if fmt in RAW_FORMATS:
+            return True
+        path = self.file_path or ""
+        suffix = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+        return suffix in RAW_FORMATS
+
+    @property
+    def aspect_ratio(self) -> Optional[float]:
+        if not self.width or not self.height:
+            return None
+        return round(float(self.width) / float(self.height), 4)
+
+    @property
+    def content_key(self) -> str:
+        """The member's contribution to the group signature.
+
+        ``pixel_sha:size_bytes`` when the hash exists. **The size is a co-key
+        here for the same reason it is one in tier-1 detection** (§22.1):
+        ``pixel_sha`` is a *sampled* digest above 128 KiB, so the digest alone
+        does not identify a file. Detection has always grouped on
+        ``(pixel_sha, size_bytes)``; identity omitting the size made
+        :func:`group_signature` non-injective over groups, which meant two
+        distinct exact groups differing only in size collapsed onto one
+        signature — the upsert dropped one from the queue, a ``keep_separate``
+        silenced both file sets, and a stack verdict's write target depended on
+        scan order rather than on what the user saw.
+
+        A picture whose hash has not been computed yet falls back to ``id:<n>``,
+        which is stable but *not* stable across a re-import of the same file — so
+        a verdict made on a group containing such a member will be re-asked after
+        a re-import. That is the honest behaviour: pretending two un-hashed rows
+        are the same file would make the verdict memory lie.
+        ``MissingPixelShaFinder`` closes the gap in the background.
+        """
+        if self.pixel_sha:
+            return f"{self.pixel_sha}:{self.size_bytes}"
+        return f"id:{self.id}"
+
+    @property
+    def cover_score(self) -> float:
+        """The design's cover formula: ``px*4 + tags*3 + userScore*2 + RAW``."""
+        return (
+            self.megapixels * COVER_PIXEL_WEIGHT
+            + float(self.tag_count) * COVER_TAG_WEIGHT
+            + float(self.score or 0) * COVER_SCORE_WEIGHT
+            + (COVER_RAW_BONUS if self.is_raw else 0.0)
+        )
+
+    def as_dict(self, *, why: Optional[list[dict[str, Any]]] = None) -> dict[str, Any]:
+        """Serialise for the queue / compare API.
+
+        ``file_path`` is included **only for reference-folder pictures** (design
+        §7 "Paths only where they matter"): there the user manages the files and
+        needs to know which copy is which, while for a managed-library picture
+        the path is an implementation detail.
+        """
+        return {
+            "picture_id": self.id,
+            "width": self.width,
+            "height": self.height,
+            "megapixels": self.megapixels,
+            "size_bytes": self.size_bytes,
+            "format": self.format,
+            "is_raw": self.is_raw,
+            "score": self.score,
+            "tag_count": self.tag_count,
+            "created_at": self.created_at,
+            "imported_at": self.imported_at,
+            "stack_id": self.stack_id,
+            "reference_folder_id": self.reference_folder_id,
+            "file_path": (
+                self.file_path if self.reference_folder_id is not None else None
+            ),
+            "thumbnail_version": self.thumbnail_version,
+            "cover_score": round(self.cover_score, 4),
+            "why": why if why is not None else [],
+        }
+
+
+@dataclass
+class DetectedGroup:
+    """A group produced by one of the tiers, before it is persisted.
+
+    Attributes:
+        tier: Which tier found it.
+        confidence: 1.0 for exact; the weakest pairwise similarity otherwise.
+        members: Every member, in cover-preselection order (cover first).
+        cover_picture_id: The cover preselection.
+        evidence: The group-level why-pills.
+        signature: The verdict-memory key.
+    """
+
+    tier: DedupTier
+    confidence: float
+    members: list[CandidateMember]
+    cover_picture_id: int
+    evidence: list[dict[str, Any]] = field(default_factory=list)
+    signature: str = ""
+
+    @property
+    def picture_ids(self) -> list[int]:
+        return [member.id for member in self.members]
+
+
+# --- Signature --------------------------------------------------------------
+
+
+def group_signature(content_keys: Iterable[str]) -> str:
+    """Stable identity for a *set of files*, independent of ids and order.
+
+    The design keys verdict memory on "sorted member content hashes"; this is
+    that, hashed down to a fixed-width string so it indexes cheaply. Sorting
+    first is what makes the signature survive a rescan finding the members in a
+    different order, and hashing content rather than ids is what makes it survive
+    a re-import that assigns new picture ids.
+
+    Args:
+        content_keys: Per-member content keys (see
+            :attr:`CandidateMember.content_key`).
+
+    Returns:
+        A 64-character lowercase hex digest.
+    """
+    joined = "\x1f".join(sorted(str(key) for key in content_keys))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+# --- Cover selection --------------------------------------------------------
+
+
+def cover_order_key(member: CandidateMember) -> tuple[float, float, int]:
+    """Sort key implementing the design's cover rule.
+
+    ``pixels*4 + tags*3 + userScore*2 + RAW bonus``, highest wins; ties break to
+    the **oldest capture time** (the original, not a later re-export), then to
+    the lowest id so the choice is deterministic for two rows with no timestamp.
+    """
+    created = member.created_at
+    created_ts = created.timestamp() if isinstance(created, datetime) else float("inf")
+    return (-member.cover_score, created_ts, int(member.id))
+
+
+def select_cover(members: list[CandidateMember]) -> int:
+    """Return the preselected cover's picture id.
+
+    Never silent: the caller surfaces this as a *preselection* the user overrides
+    with 1-9, together with the per-candidate evidence that explains it.
+    """
+    if not members:
+        raise ValueError("select_cover requires at least one member")
+    return min(members, key=cover_order_key).id
+
+
+# --- Evidence ---------------------------------------------------------------
+
+
+def _pill(text: str, against: bool = False) -> dict[str, Any]:
+    """One why-pill: matching evidence (olive check) or evidence against (red x)."""
+    return {"text": text, "against": bool(against)}
+
+
+def _humanise_gap(seconds: float) -> str:
+    if seconds < 2:
+        return f"{seconds:.1f}s apart"
+    if seconds < 120:
+        return f"{int(round(seconds))}s apart"
+    if seconds < 7200:
+        return f"{int(round(seconds / 60))} min apart"
+    if seconds < 172800:
+        return f"{int(round(seconds / 3600))} hours apart"
+    return f"{int(round(seconds / 86400))} days apart"
+
+
+def build_group_evidence(
+    tier: DedupTier, confidence: float, members: list[CandidateMember]
+) -> list[dict[str, Any]]:
+    """The group-level why-pills, both directions.
+
+    The design's rule is that signals cut both ways: matching evidence is an
+    olive check, anything arguing *against* a stack is a red x, and a group
+    carrying red pills is exactly the one that needs Compare. So this deliberately
+    reports resolution / aspect-ratio / format mismatches alongside the match.
+
+    Nothing here is a conclusion — the client renders reasons and the user
+    decides.
+    """
+    pills: list[dict[str, Any]] = []
+    if tier is DedupTier.EXACT:
+        pills.append(_pill("Identical file hash"))
+    else:
+        pills.append(_pill(f"{int(round(confidence * 100))}% visual match"))
+
+    dimensions = {(m.width, m.height) for m in members if m.width and m.height}
+    if len(dimensions) == 1:
+        pills.append(_pill("Same dimensions"))
+    elif len(dimensions) > 1:
+        pills.append(_pill("Different resolution", against=True))
+
+    ratios = {m.aspect_ratio for m in members if m.aspect_ratio is not None}
+    if len(ratios) > 1 and max(ratios) - min(ratios) > 0.01:
+        pills.append(_pill("Different aspect ratio", against=True))
+
+    formats = {(m.format or "").lower() for m in members if m.format}
+    if len(formats) > 1:
+        pills.append(_pill("Different file format", against=True))
+
+    captures = sorted(m.created_at for m in members if m.created_at is not None)
+    if len(captures) >= 2:
+        span = (captures[-1] - captures[0]).total_seconds()
+        if span <= 1.0:
+            pills.append(_pill("Same capture second"))
+        elif span <= 5.0:
+            pills.append(_pill(f"Burst - {_humanise_gap(span)}"))
+        else:
+            pills.append(_pill(f"Captured {_humanise_gap(span)}"))
+
+    folders = {_parent_folder(m.file_path) for m in members if m.file_path}
+    folders.discard(None)
+    if len(folders) == 1 and len(members) > 1:
+        pills.append(_pill("Same folder"))
+
+    imports = sorted(m.imported_at for m in members if m.imported_at is not None)
+    if len(imports) >= 2:
+        span = (imports[-1] - imports[0]).total_seconds()
+        if span <= 600:
+            pills.append(_pill(f"Imported {_humanise_gap(span)}"))
+
+    return pills
+
+
+def build_candidate_evidence(
+    member: CandidateMember, members: list[CandidateMember], cover_id: int
+) -> list[dict[str, Any]]:
+    """Per-candidate why-pills, so the client renders reasons, not conclusions.
+
+    These are the signals the cover formula actually used, stated per candidate:
+    what this picture is best at, and where it loses. The client pairs them with
+    the numeric ``cover_score`` so a user can see *why* the preselection landed
+    where it did and disagree with it.
+    """
+    pills: list[dict[str, Any]] = []
+    best_pixels = max((m.pixels for m in members), default=0)
+    best_tags = max((m.tag_count for m in members), default=0)
+    best_score = max((int(m.score or 0) for m in members), default=0)
+
+    if member.pixels and member.pixels == best_pixels:
+        pills.append(_pill("Highest resolution"))
+    elif member.pixels and best_pixels:
+        shortfall = 100 - int(round(100 * member.pixels / best_pixels))
+        pills.append(_pill(f"{shortfall}% fewer pixels than the best", against=True))
+
+    if member.is_raw:
+        pills.append(_pill("Camera original (RAW)"))
+
+    if best_tags and member.tag_count == best_tags:
+        pills.append(_pill(f"Most metadata ({member.tag_count} tags)"))
+    elif best_tags and member.tag_count < best_tags:
+        pills.append(
+            _pill(
+                f"Fewer tags than the best ({member.tag_count} of {best_tags})",
+                against=True,
+            )
+        )
+
+    if best_score and int(member.score or 0) == best_score:
+        pills.append(_pill(f"Highest score ({best_score})"))
+
+    if member.id == cover_id:
+        pills.append(_pill("Preselected as cover"))
+    return pills
+
+
+def _parent_folder(file_path: Optional[str]) -> Optional[str]:
+    if not file_path:
+        return None
+    normalised = file_path.replace("\\", "/")
+    if "/" not in normalised:
+        return None
+    return normalised.rsplit("/", 1)[0]
+
+
+# --- Candidate loading ------------------------------------------------------
+
+
+def load_candidates(
+    session: Session, picture_ids: Iterable[int]
+) -> dict[int, CandidateMember]:
+    """Load the cover / evidence columns for *picture_ids*, plus their tag counts.
+
+    One query per id chunk for the picture columns and one for the tag counts —
+    never a per-picture round trip, because the queue loads a whole page of
+    groups at once.
+    """
+    ordered = sorted({int(pid) for pid in picture_ids})
+    if not ordered:
+        return {}
+    members: dict[int, CandidateMember] = {}
+    for start in range(0, len(ordered), ID_CHUNK):
+        chunk = ordered[start : start + ID_CHUNK]
+        rows = session.exec(
+            select(
+                Picture.id,
+                Picture.file_path,
+                Picture.format,
+                Picture.width,
+                Picture.height,
+                Picture.size_bytes,
+                Picture.score,
+                Picture.created_at,
+                Picture.imported_at,
+                Picture.stack_id,
+                Picture.reference_folder_id,
+                Picture.pixel_sha,
+                Picture.perceptual_hash,
+                Picture.thumbnail_width,
+                Picture.thumbnail_height,
+            ).where(Picture.id.in_(chunk), Picture.deleted.is_(False))
+        ).all()
+        for row in rows:
+            members[int(row[0])] = CandidateMember(
+                id=int(row[0]),
+                file_path=row[1],
+                format=row[2],
+                width=row[3],
+                height=row[4],
+                size_bytes=row[5],
+                score=row[6],
+                created_at=row[7],
+                imported_at=row[8],
+                stack_id=row[9],
+                reference_folder_id=row[10],
+                pixel_sha=row[11],
+                perceptual_hash=row[12],
+                thumbnail_width=row[13],
+                thumbnail_height=row[14],
+            )
+        tag_rows = session.exec(
+            select(Tag.picture_id, func.count(Tag.id))
+            .where(Tag.picture_id.in_(chunk))
+            .group_by(Tag.picture_id)
+        ).all()
+        for picture_id, count in tag_rows:
+            member = members.get(int(picture_id))
+            if member is not None:
+                member.tag_count = int(count or 0)
+    return members
+
+
+def assemble_group(
+    tier: DedupTier, confidence: float, members: list[CandidateMember]
+) -> DetectedGroup:
+    """Turn raw members into a :class:`DetectedGroup` with cover and evidence."""
+    ordered = sorted(members, key=cover_order_key)
+    cover_id = ordered[0].id
+    return DetectedGroup(
+        tier=tier,
+        confidence=round(float(confidence), 6),
+        members=ordered,
+        cover_picture_id=cover_id,
+        evidence=build_group_evidence(tier, confidence, ordered),
+        signature=group_signature(m.content_key for m in ordered),
+    )
+
+
+# --- Tier 1: exact ----------------------------------------------------------
+
+
+def find_exact_groups_in_session(
+    session: Session, scope: Optional[DedupScope] = None
+) -> list[DetectedGroup]:
+    """Tier 1. ``GROUP BY pixel_sha, size_bytes HAVING count(*) > 1``.
+
+    Two indexed-column queries: one aggregate to find the duplicated hashes, one
+    to pull the member ids for exactly those hashes. No image is decoded, no
+    model runs, and the whole tier is milliseconds on a library-sized table
+    because ``picture.pixel_sha`` is indexed.
+
+    See the module docstring for why ``size_bytes`` is a co-key.
+    """
+    scope = scope or DedupScope()
+    predicate = scope.picture_predicate()
+
+    duplicated = (
+        select(Picture.pixel_sha, Picture.size_bytes)
+        .where(
+            Picture.pixel_sha.is_not(None),
+            Picture.deleted.is_(False),
+        )
+        .group_by(Picture.pixel_sha, Picture.size_bytes)
+        .having(func.count(Picture.id) > 1)
+    )
+    if predicate is not None:
+        duplicated = duplicated.where(predicate)
+    keys = [(row[0], row[1]) for row in session.exec(duplicated).all()]
+    if not keys:
+        return []
+
+    shas = sorted({key[0] for key in keys})
+    wanted = set(keys)
+    by_key: dict[tuple[Optional[str], Optional[int]], list[int]] = defaultdict(list)
+    for start in range(0, len(shas), ID_CHUNK):
+        chunk = shas[start : start + ID_CHUNK]
+        member_query = select(Picture.id, Picture.pixel_sha, Picture.size_bytes).where(
+            Picture.pixel_sha.in_(chunk), Picture.deleted.is_(False)
+        )
+        if predicate is not None:
+            member_query = member_query.where(predicate)
+        for picture_id, sha, size_bytes in session.exec(member_query).all():
+            key = (sha, size_bytes)
+            if key in wanted:
+                by_key[key].append(int(picture_id))
+
+    member_ids = [ids for ids in by_key.values() if len(ids) > 1]
+    candidates = load_candidates(session, [pid for ids in member_ids for pid in ids])
+    groups: list[DetectedGroup] = []
+    for ids in member_ids:
+        members = [candidates[pid] for pid in ids if pid in candidates]
+        if len(members) < 2:
+            continue
+        groups.append(assemble_group(DedupTier.EXACT, 1.0, members))
+    logger.info(
+        "[dedup-tier1] scope=%s produced %d exact group(s) from %d hash key(s)",
+        scope.key,
+        len(groups),
+        len(keys),
+    )
+    return groups
+
+
+# --- Tier 2: bucketed near --------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NearBucket:
+    """One candidate bucket: a bucket key and the picture ids inside it.
+
+    A bucket is a unit of work. It is scanned on its own, its groups become
+    visible in the queue as soon as it finishes, and its cost is bounded by
+    :data:`MAX_BUCKET_MEMBERS`.
+    """
+
+    kind: str
+    key: str
+    picture_ids: tuple[int, ...]
+
+
+def _bucket_rows(session: Session, scope: DedupScope) -> list[tuple]:
+    """Load the bucketing columns for every picture that has a perceptual hash."""
+    query = select(
+        Picture.id,
+        Picture.size_bin_index,
+        Picture.created_at,
+        Picture.import_source_folder,
+        Picture.file_path,
+    ).where(
+        Picture.deleted.is_(False),
+        Picture.perceptual_hash.is_not(None),
+    )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(predicate)
+    return list(session.exec(query).all())
+
+
+def build_near_buckets(
+    session: Session, scope: Optional[DedupScope] = None
+) -> list[NearBucket]:
+    """Group the scope's pictures into tier-2 candidate buckets.
+
+    Four bucket kinds, all cheap and all reusing precomputed columns:
+
+    * ``size_bin`` — the indexed ``picture.size_bin_index`` (exact width/height).
+    * ``capture_minute`` — ``created_at`` truncated to the minute.
+    * ``import_folder`` — the ``import_source_folder`` batch.
+    * ``folder`` — the containing directory of ``file_path``.
+
+    A picture appears in several buckets; that is the point. Buckets larger than
+    :data:`MAX_BUCKET_MEMBERS` are split on the leading hex digits of the picture
+    id ordering rather than dropped, so no candidate is silently skipped.
+
+    Singleton buckets are discarded here rather than in the scan, so the scan's
+    "N of M buckets" progress describes real work.
+    """
+    scope = scope or DedupScope()
+    grouped: dict[tuple[str, str], list[int]] = defaultdict(list)
+    for picture_id, size_bin, created_at, import_folder, file_path in _bucket_rows(
+        session, scope
+    ):
+        picture_id = int(picture_id)
+        if size_bin is not None:
+            grouped[("size_bin", str(size_bin))].append(picture_id)
+        if isinstance(created_at, datetime):
+            grouped[("capture_minute", created_at.strftime("%Y-%m-%dT%H:%M"))].append(
+                picture_id
+            )
+        if import_folder:
+            grouped[("import_folder", str(import_folder))].append(picture_id)
+        folder = _parent_folder(file_path)
+        if folder:
+            grouped[("folder", folder)].append(picture_id)
+
+    buckets: list[NearBucket] = []
+    for (kind, key), ids in grouped.items():
+        if len(ids) < 2:
+            continue
+        ordered = sorted(set(ids))
+        if len(ordered) <= MAX_BUCKET_MEMBERS:
+            buckets.append(NearBucket(kind=kind, key=key, picture_ids=tuple(ordered)))
+            continue
+        # Oversized bucket: split into contiguous shards. Neighbouring ids come
+        # from the same import run, so a shard boundary rarely separates a real
+        # pair, and the alternative (dropping the bucket) would hide duplicates.
+        logger.info(
+            "[dedup-tier2] bucket %s=%s has %d members; splitting into shards of %d",
+            kind,
+            key,
+            len(ordered),
+            MAX_BUCKET_MEMBERS,
+        )
+        for start in range(0, len(ordered), MAX_BUCKET_MEMBERS):
+            shard = ordered[start : start + MAX_BUCKET_MEMBERS]
+            if len(shard) < 2:
+                continue
+            buckets.append(
+                NearBucket(
+                    kind=kind,
+                    key=f"{key}#{start // MAX_BUCKET_MEMBERS}",
+                    picture_ids=tuple(shard),
+                )
+            )
+    buckets.sort(key=lambda bucket: (bucket.kind, bucket.key))
+    logger.info(
+        "[dedup-tier2] scope=%s produced %d candidate bucket(s)",
+        scope.key,
+        len(buckets),
+    )
+    return buckets
+
+
+def _popcount64(values: np.ndarray) -> np.ndarray:
+    """Vectorised 64-bit population count (SWAR), matching ``likeness_utils``."""
+    counts = values - ((values >> np.uint64(1)) & np.uint64(0x5555555555555555))
+    counts = (counts & np.uint64(0x3333333333333333)) + (
+        (counts >> np.uint64(2)) & np.uint64(0x3333333333333333)
+    )
+    counts = (counts + (counts >> np.uint64(4))) & np.uint64(0x0F0F0F0F0F0F0F0F)
+    return (counts * np.uint64(0x0101010101010101)) >> np.uint64(56)
+
+
+def near_pairs_in_bucket(
+    session: Session, bucket: NearBucket, threshold: float
+) -> list[tuple[int, int, float]]:
+    """Compare perceptual hashes **within one bucket** and return the near pairs.
+
+    ``similarity = 1 - hamming(dhash_a, dhash_b) / 64`` over the 64-bit dHash
+    stored in ``picture.perceptual_hash``. The comparison is a numpy XOR plus a
+    SWAR popcount over the bucket's upper triangle, so a 4000-member bucket is
+    ~8M popcounts — milliseconds — and the library-wide O(n^2) never happens.
+
+    Returns:
+        ``(picture_id_a, picture_id_b, similarity)`` with ``a < b``, similarity
+        at or above *threshold*.
+    """
+    ids = list(bucket.picture_ids)
+    if len(ids) < 2:
+        return []
+    values: list[int] = []
+    kept: list[int] = []
+    for start in range(0, len(ids), ID_CHUNK):
+        chunk = ids[start : start + ID_CHUNK]
+        rows = session.exec(
+            select(Picture.id, Picture.perceptual_hash).where(
+                Picture.id.in_(chunk),
+                Picture.deleted.is_(False),
+                Picture.perceptual_hash.is_not(None),
+            )
+        ).all()
+        for picture_id, phash in rows:
+            text = str(phash or "")
+            if len(text) < PHASH_HEX_LEN:
+                logger.warning(
+                    "[dedup-tier2] picture %s has a %d-char perceptual_hash %r "
+                    "(expected %d); excluded from bucket %s=%s",
+                    picture_id,
+                    len(text),
+                    text,
+                    PHASH_HEX_LEN,
+                    bucket.kind,
+                    bucket.key,
+                )
+                continue
+            try:
+                values.append(int(text[:PHASH_HEX_LEN], 16))
+            except ValueError:
+                logger.warning(
+                    "[dedup-tier2] picture %s has an unparseable perceptual_hash "
+                    "%r; excluded from bucket %s=%s",
+                    picture_id,
+                    text,
+                    bucket.kind,
+                    bucket.key,
+                )
+                continue
+            kept.append(int(picture_id))
+    if len(kept) < 2:
+        return []
+
+    hashes = np.array(values, dtype=np.uint64)
+    id_array = np.array(kept, dtype=np.int64)
+    max_hamming = int((1.0 - float(threshold)) * PHASH_BITS)
+    pairs: list[tuple[int, int, float]] = []
+    truncated_at_offset: Optional[int] = None
+    for offset in range(1, len(kept)):
+        distances = _popcount64(hashes[:-offset] ^ hashes[offset:])
+        hits = np.nonzero(distances <= max_hamming)[0]
+        if hits.size == 0:
+            continue
+        for index in hits:
+            if len(pairs) >= MAX_PAIRS_PER_BUCKET:
+                truncated_at_offset = offset
+                break
+            left = int(id_array[index])
+            right = int(id_array[index + offset])
+            similarity = 1.0 - float(distances[index]) / PHASH_BITS
+            pairs.append((min(left, right), max(left, right), round(similarity, 6)))
+        if truncated_at_offset is not None:
+            break
+    if truncated_at_offset is not None:
+        # Never silent (CLAUDE.md's no-silent-caps rule), and never dishonest.
+        # Pairs are emitted in increasing member-offset order, so the cap keeps
+        # the *nearest-offset* edges and drops every edge at a wider offset. In a
+        # bucket where members are mutually near-identical that is harmless: the
+        # offset-1 edges alone form a spanning path (k-1 <= MAX_PAIRS_PER_BUCKET
+        # for any bucket, since MAX_BUCKET_MEMBERS is far smaller), so every
+        # member still lands in one component and only confidence *resolution*
+        # suffers.
+        #
+        # It is NOT harmless in a dense but non-uniform block. ~700 mutually
+        # matching members exhaust the cap inside the low offsets; a member whose
+        # only match sits at a wider offset then never gets an edge at all, so it
+        # is split into a separate group or drops out of the queue entirely. The
+        # cap can therefore lose membership, and this warning says so. The
+        # mitigations are to resolve the dense block and rescan (the survivors
+        # then fit under the cap), to narrow the bucket, or to raise
+        # MAX_PAIRS_PER_BUCKET for the memory it costs.
+        logger.warning(
+            "[dedup-tier2] bucket %s=%s hit the %d-pair cap at member offset %d "
+            "of %d with %d members: no edge at a wider offset was emitted, so a "
+            "member whose only match is further away may be split into its own "
+            "group or missing from the queue, and reported confidences are "
+            "measured over a subset of the edges. Resolve this block and rescan, "
+            "narrow the bucket, or raise MAX_PAIRS_PER_BUCKET.",
+            bucket.kind,
+            bucket.key,
+            MAX_PAIRS_PER_BUCKET,
+            truncated_at_offset,
+            len(kept) - 1,
+            len(kept),
+        )
+    return pairs
+
+
+def groups_from_pairs(
+    session: Session,
+    pairs: list[tuple[int, int, float]],
+    policy: TierPolicy,
+    tier: DedupTier = DedupTier.NEAR,
+) -> list[DetectedGroup]:
+    """Fold near pairs into connected components and assemble them.
+
+    Reuses :class:`~pixlstash.services.dedup_sweep_service._LikenessForest` — the
+    shipped union-find that already accumulates per-component min/max similarity,
+    so the group's confidence is its **weakest link**, not its strongest.
+    """
+    if not pairs:
+        return []
+    forest = dedup_sweep_service._LikenessForest()
+    for picture_id_a, picture_id_b, similarity in pairs:
+        forest.add_edge(picture_id_a, picture_id_b, similarity)
+    components = forest.components(policy.min_group_size)
+    candidates = load_candidates(
+        session, [pid for member_ids, _, _ in components for pid in member_ids]
+    )
+    groups: list[DetectedGroup] = []
+    for member_ids, similarity_min, _similarity_max in components:
+        members = [candidates[pid] for pid in member_ids if pid in candidates]
+        if len(members) < policy.min_group_size:
+            continue
+        confidence = float(similarity_min)
+        if confidence < policy.threshold:
+            continue
+        group = assemble_group(tier, confidence, members)
+        if len(members) > policy.max_group_size:
+            group.evidence.append(
+                _pill(f"Unusually large group ({len(members)} pictures)", against=True)
+            )
+        groups.append(group)
+    return groups
+
+
+def find_near_groups_in_session(
+    session: Session,
+    policy: TierPolicy,
+    scope: Optional[DedupScope] = None,
+    buckets: Optional[list[NearBucket]] = None,
+) -> list[DetectedGroup]:
+    """Tier 2 end to end: build buckets, compare inside them, assemble groups.
+
+    Callers that want the streaming behaviour (groups visible as each bucket
+    finishes) drive :func:`build_near_buckets` and :func:`near_pairs_in_bucket`
+    themselves from the task system; this convenience wrapper runs the whole
+    tier in one call and is what the tests and the synchronous scoped scan use.
+    """
+    scope = scope or DedupScope()
+    buckets = buckets if buckets is not None else build_near_buckets(session, scope)
+    pairs: dict[tuple[int, int], float] = {}
+    for bucket in buckets:
+        for picture_id_a, picture_id_b, similarity in near_pairs_in_bucket(
+            session, bucket, policy.threshold
+        ):
+            key = (picture_id_a, picture_id_b)
+            # The same pair can surface in several buckets; keep the strongest
+            # observation, which is the same number either way (the hashes do
+            # not change between buckets) but makes the merge order-independent.
+            if similarity > pairs.get(key, 0.0):
+                pairs[key] = similarity
+    edges = [(a, b, similarity) for (a, b), similarity in pairs.items()]
+    return groups_from_pairs(session, edges, policy, DedupTier.NEAR)
+
+
+# --- Tier 3: embedding ------------------------------------------------------
+
+
+def find_embedding_groups_in_session(
+    session: Session, policy: TierPolicy, scope: Optional[DedupScope] = None
+) -> list[DetectedGroup]:
+    """Tier 3. Fold the existing likeness edge table into groups.
+
+    Nothing is recomputed: this reads the ``PictureLikeness`` rows the image
+    embedding worker already produced, through the shipped keyset-paginated
+    edge stream, so the tier costs one table scan and no GPU time. Opt-in
+    because that table is only complete once the embedding worker has caught up.
+    """
+    scope = scope or DedupScope()
+    in_scope: Optional[set[int]] = None
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        in_scope = {
+            int(row)
+            for row in session.exec(
+                select(Picture.id).where(Picture.deleted.is_(False), predicate)
+            ).all()
+        }
+        if not in_scope:
+            return []
+
+    pairs: list[tuple[int, int, float]] = []
+    for (
+        picture_id_a,
+        picture_id_b,
+        likeness,
+    ) in dedup_sweep_service.stream_likeness_edges(session, policy.threshold):
+        if in_scope is not None and (
+            picture_id_a not in in_scope or picture_id_b not in in_scope
+        ):
+            continue
+        pairs.append((picture_id_a, picture_id_b, likeness))
+    return groups_from_pairs(session, pairs, policy, DedupTier.EMBEDDING)
+
+
+# --- Persistence ------------------------------------------------------------
+
+
+def verdict_signatures_in_session(
+    session: Session, signatures: Iterable[str]
+) -> set[str]:
+    """Return the subset of *signatures* that already carry a live verdict.
+
+    A verdict with ``reopened_at`` set is not live: reopening returns the group
+    to the queue, which is exactly what "permanent until the user reopens it"
+    means.
+    """
+    wanted = sorted({str(signature) for signature in signatures})
+    if not wanted:
+        return set()
+    found: set[str] = set()
+    for start in range(0, len(wanted), ID_CHUNK):
+        chunk = wanted[start : start + ID_CHUNK]
+        rows = session.exec(
+            select(DedupVerdict.signature).where(
+                DedupVerdict.signature.in_(chunk),
+                DedupVerdict.reopened_at.is_(None),
+            )
+        ).all()
+        found.update(str(row) for row in rows)
+    return found
+
+
+def persist_groups_in_session(
+    session: Session,
+    groups: list[DetectedGroup],
+    scan_id: Optional[int] = None,
+) -> int:
+    """Upsert detected groups on their signature; return how many are unresolved.
+
+    Upserting rather than inserting is what makes a rescan idempotent: the same
+    files produce the same signature, so the row is refreshed in place and the
+    queue does not grow duplicates of its own. A group whose signature already
+    carries a live verdict is stored ``resolved=True`` and never re-asked.
+    """
+    if not groups:
+        return 0
+    resolved_signatures = verdict_signatures_in_session(
+        session, (group.signature for group in groups)
+    )
+    unresolved = 0
+    for group in groups:
+        existing = session.exec(
+            select(DedupGroup).where(DedupGroup.signature == group.signature)
+        ).first()
+        resolved = group.signature in resolved_signatures
+        if existing is None:
+            row = DedupGroup(
+                signature=group.signature,
+                tier=group.tier.value,
+                confidence=group.confidence,
+                member_count=len(group.members),
+                cover_picture_id=group.cover_picture_id,
+                evidence=json.dumps(group.evidence),
+                resolved=resolved,
+                scan_id=scan_id,
+            )
+            session.add(row)
+            session.flush()
+        else:
+            row = existing
+            # Tier precedence: a stronger tier is never downgraded by a weaker
+            # one rediscovering the same signature. Exact pairs are perceptually
+            # identical too, so a near-enabled rescan finds every one of them
+            # again; overwriting unconditionally moved them out of the
+            # exact-only default view and out of auto-stack's eligibility.
+            # Tier, confidence and evidence describe the *same* finding, so they
+            # move together — mixing a stored exact tier with a near
+            # confidence would misreport both.
+            if tier_strength(group.tier.value) >= tier_strength(row.tier):
+                row.tier = group.tier.value
+                row.confidence = group.confidence
+                row.evidence = json.dumps(group.evidence)
+                row.cover_picture_id = group.cover_picture_id
+            else:
+                logger.debug(
+                    "[dedup] keeping tier %s for signature %s; %s rediscovered "
+                    "the same group with weaker evidence",
+                    row.tier,
+                    group.signature,
+                    group.tier.value,
+                )
+            # Membership is pinned by the signature (it hashes the sorted member
+            # content keys), so it is refreshed either way: a re-import can give
+            # the same content new picture ids.
+            row.member_count = len(group.members)
+            row.resolved = resolved
+            row.scan_id = scan_id
+            session.add(row)
+            session.exec(
+                DedupGroupMember.__table__.delete().where(
+                    DedupGroupMember.__table__.c.group_id == row.id
+                )
+            )
+        for position, member in enumerate(group.members):
+            session.add(
+                DedupGroupMember(
+                    group_id=int(row.id), picture_id=member.id, position=position
+                )
+            )
+        if not resolved:
+            unresolved += 1
+    session.commit()
+    return unresolved
+
+
+def prune_stale_groups_in_session(session: Session) -> int:
+    """Drop groups whose members no longer exist or no longer number two.
+
+    Called after any verdict and at the start of a rescan. Without it a group
+    whose members were soft-deleted would keep inflating the sidebar badge, and
+    the badge is the whole reason the verdict memory exists.
+    """
+    live_counts = dict(
+        session.exec(
+            select(DedupGroupMember.group_id, func.count(DedupGroupMember.picture_id))
+            .join(Picture, Picture.id == DedupGroupMember.picture_id)
+            .where(Picture.deleted.is_(False))
+            .group_by(DedupGroupMember.group_id)
+        ).all()
+    )
+    removed = 0
+    for row in session.exec(select(DedupGroup)).all():
+        if live_counts.get(int(row.id), 0) >= 2:
+            continue
+        session.delete(row)
+        removed += 1
+    if removed:
+        session.commit()
+        logger.info("[dedup] pruned %d stale group(s)", removed)
+    return removed
+
+
+# --- Queue reads ------------------------------------------------------------
+
+
+def _tier_filter(policy: TierPolicy):
+    return DedupGroup.tier.in_([tier.value for tier in policy.tiers])
+
+
+CURSOR_VERSION = "1"
+"""Version tag inside the opaque queue cursor, so its encoding can change."""
+
+
+class DedupCursorError(ValueError):
+    """A queue cursor could not be decoded (truncated, edited or foreign)."""
+
+
+def encode_queue_cursor(confidence: float, group_id: int) -> str:
+    """Encode the keyset position of the last delivered row.
+
+    The queue's order is ``(confidence DESC, id ASC)``, so the position after a
+    row is exactly that pair. The wire form is base64url (unpadded) over
+    ``"1|<confidence>|<group id>"``, with the confidence written at 17
+    significant digits so a float round-trips exactly and the ``=`` tie-break
+    branch of the keyset predicate is reliable. It is opaque by intent — clients
+    must pass it back verbatim, never construct or interpret one.
+
+    Args:
+        confidence: The last delivered group's confidence.
+        group_id: The last delivered group's row id.
+
+    Returns:
+        The cursor to hand back as ``next_cursor``.
+    """
+    raw = f"{CURSOR_VERSION}|{float(confidence):.17g}|{int(group_id)}"
+    return base64.urlsafe_b64encode(raw.encode("ascii")).decode("ascii").rstrip("=")
+
+
+def decode_queue_cursor(cursor: str) -> tuple[float, int]:
+    """Decode a cursor produced by :func:`encode_queue_cursor`.
+
+    Raises:
+        DedupCursorError: The cursor is not a cursor this server minted. A bad
+            cursor is a 400, never a silent restart from the top — silently
+            paging from offset 0 would hand the client the same page forever.
+    """
+    text = str(cursor or "")
+    try:
+        padded = text + "=" * (-len(text) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode("ascii")).decode("ascii")
+        version, confidence, group_id = raw.split("|")
+        if version != CURSOR_VERSION:
+            raise ValueError(f"unsupported cursor version {version!r}")
+        parsed = float(confidence)
+        if not math.isfinite(parsed):
+            # float() happily parses "inf"/"nan"; a non-finite confidence makes
+            # the keyset predicate match everything, which is exactly the
+            # silent-restart this function's contract refuses (CSO R6).
+            raise ValueError(f"non-finite cursor confidence {confidence!r}")
+        return parsed, int(group_id)
+    except (ValueError, UnicodeDecodeError, BinasciiError) as exc:
+        raise DedupCursorError(f"malformed queue cursor {cursor!r}: {exc}") from exc
+
+
+def _keyset_predicate(cursor: str):
+    """The ``WHERE`` that resumes ``(confidence DESC, id ASC)`` after *cursor*.
+
+    The tie-break half is load-bearing: several groups routinely share a
+    confidence (every exact group is 1.0), so ``confidence < c`` alone would skip
+    the rest of the tied run and ``confidence <= c`` would repeat it forever.
+    """
+    confidence, group_id = decode_queue_cursor(cursor)
+    return (DedupGroup.confidence < confidence) | (
+        (DedupGroup.confidence == confidence) & (DedupGroup.id > group_id)
+    )
+
+
+def _live_groups_filter():
+    """Only groups that still POSE a decision.
+
+    Two conditions, one HAVING clause over the live (non-scrapheaped) members:
+
+    * **Two or more of them.** A soft-delete thins its groups the moment it
+      lands, but :func:`prune_stale_groups_in_session` only runs on the next
+      verdict or scan; without this the badge counts a group with one picture.
+    * **Spanning two or more stack units** (``COALESCE(stack_id, -id)`` — every
+      unstacked picture is its own unit, stacked pictures share one). Members
+      already stacked TOGETHER are a decision the user has made, whether or
+      not it was made through this queue: the grid's own stack actions never
+      touch ``dedupgroup``, so an exact pair the user stacked by hand stayed
+      "unresolved" here and was re-offered forever. Re-offering the answered
+      is how the count stops being trusted. A group where a stack would still
+      FOLD something in (two stacks, or a stack plus a loner) keeps counting.
+    """
+    stack_unit = func.coalesce(Picture.stack_id, 0 - Picture.id)
+    return DedupGroup.id.in_(
+        select(DedupGroupMember.group_id)
+        .join(Picture, Picture.id == DedupGroupMember.picture_id)
+        .where(Picture.deleted.is_(False))
+        .group_by(DedupGroupMember.group_id)
+        .having(func.count(DedupGroupMember.picture_id) >= 2)
+        .having(func.count(func.distinct(stack_unit)) >= 2)
+    )
+
+
+def count_unresolved_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> int:
+    """The sidebar badge / context-menu count: unresolved groups in scope.
+
+    Groups, not pictures: the to-do count is the number of decisions left to
+    make, which is what the queue actually asks the user for.
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    query = select(func.count(func.distinct(DedupGroup.id))).where(
+        DedupGroup.resolved.is_(False),
+        _tier_filter(policy),
+        DedupGroup.confidence >= policy.threshold,
+        _live_groups_filter(),
+    )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(
+            DedupGroup.id.in_(
+                select(DedupGroupMember.group_id)
+                .join(Picture, Picture.id == DedupGroupMember.picture_id)
+                .where(Picture.deleted.is_(False), predicate)
+            )
+        )
+    return int(session.exec(query).one())
+
+
+def count_by_tier_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> dict[str, int]:
+    """Unresolved group count per tier, including the tiers that are switched off.
+
+    The design gives each tier its own live count so the user can see what
+    turning a tier on would add before turning it on. That means this ignores
+    the policy's tier gating on purpose and reports every tier; only the
+    threshold applies, and exact is always counted in full.
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    query = select(DedupGroup.tier, func.count(DedupGroup.id)).where(
+        DedupGroup.resolved.is_(False), _live_groups_filter()
+    )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(
+            DedupGroup.id.in_(
+                select(DedupGroupMember.group_id)
+                .join(Picture, Picture.id == DedupGroupMember.picture_id)
+                .where(Picture.deleted.is_(False), predicate)
+            )
+        )
+    # An exact match is always shown regardless of where the threshold sits, so
+    # the threshold is applied to the looser tiers only.
+    query = query.where(
+        (DedupGroup.tier == TIER_EXACT) | (DedupGroup.confidence >= policy.threshold)
+    )
+    counts = {tier.value: 0 for tier in DedupTier}
+    for tier, count in session.exec(query.group_by(DedupGroup.tier)).all():
+        counts[str(tier)] = int(count)
+    return counts
+
+
+def page_queue_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+    offset: int = 0,
+    limit: int = DEFAULT_PAGE_SIZE,
+    cursor: Optional[str] = None,
+    decided: bool = False,
+) -> tuple[list[dict[str, Any]], int, Optional[str]]:
+    """One page of the queue, confidence descending. Never loads the whole list.
+
+    Exactly ``limit`` group rows are read, then one candidate load for that
+    page's members. 10 groups and 10,000 cost the same per page, which is the
+    design's virtual-queue requirement expressed on the server side.
+
+    **Page with the cursor, not the offset.** The queue is a live list: deciding
+    a verdict on a delivered row removes it from ``resolved=False``, and a tier-2
+    scan commits new groups after every bucket. Both shift every later row's
+    offset, so ``offset=limit`` on the second request skips exactly as many
+    groups as the first page's decisions removed — a deterministic, silent skip
+    reproduced with a single verdict between two pages. The keyset cursor encodes
+    *where the last row was in the ordering* rather than *how many rows to
+    discard*, so a row that never moved is never skipped.
+
+    Args:
+        session: Pre-opened session.
+        policy: Tier gating and threshold; server defaults when omitted.
+        scope: Scope to page within; the whole vault when omitted.
+        offset: Deprecated rows-to-skip paging. Ignored when *cursor* is given —
+            the route rejects the combination before it reaches here.
+        limit: Page size, clamped to :data:`MAX_PAGE_SIZE`.
+        cursor: Opaque keyset position from a previous page's ``next_cursor``.
+
+    Returns:
+        ``(groups, total, next_cursor)``. *total* is the complete unresolved
+        count in scope, so the client can size its scrollbar without a second
+        request. *next_cursor* is ``None`` once the page is not full, which is
+        end-of-found.
+
+    Raises:
+        DedupCursorError: *cursor* is not a cursor this server minted.
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    limit = max(1, min(int(limit), MAX_PAGE_SIZE))
+    offset = max(0, int(offset))
+
+    # The DECIDED page deliberately ignores the tier gate and the threshold:
+    # a decision was made under whatever policy was live at the time, and a
+    # later policy change must not hide it from the "clear my decision" list.
+    query = select(DedupGroup).where(DedupGroup.resolved.is_(decided))
+    if not decided:
+        # The open queue lists only groups that still pose a decision — same
+        # live-membership rule as the counts, so the badge and the list agree.
+        # The decided page keeps thinned groups: the verdict already happened,
+        # and hiding it would hide the "clear decision" way back.
+        query = query.where(
+            _tier_filter(policy),
+            DedupGroup.confidence >= policy.threshold,
+            _live_groups_filter(),
+        )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(
+            DedupGroup.id.in_(
+                select(DedupGroupMember.group_id)
+                .join(Picture, Picture.id == DedupGroupMember.picture_id)
+                .where(Picture.deleted.is_(False), predicate)
+            )
+        )
+    if cursor:
+        query = query.where(_keyset_predicate(cursor))
+    query = query.order_by(
+        DedupGroup.confidence.desc(),
+        DedupGroup.id.asc(),
+    ).limit(limit)
+    if not cursor:
+        query = query.offset(offset)
+    rows = session.exec(query).all()
+    if decided:
+        count_query = select(func.count(func.distinct(DedupGroup.id))).where(
+            DedupGroup.resolved.is_(True)
+        )
+        if predicate is not None:
+            count_query = count_query.where(
+                DedupGroup.id.in_(
+                    select(DedupGroupMember.group_id)
+                    .join(Picture, Picture.id == DedupGroupMember.picture_id)
+                    .where(Picture.deleted.is_(False), predicate)
+                )
+            )
+        total = int(session.exec(count_query).one() or 0)
+    else:
+        total = count_unresolved_in_session(session, policy, scope)
+    if not rows:
+        return [], total, None
+    # A short page is end-of-found; a full page may or may not be, and handing
+    # back a cursor that yields one empty page is cheaper than the extra COUNT
+    # that would be needed to know for certain.
+    next_cursor = (
+        encode_queue_cursor(float(rows[-1].confidence or 0.0), int(rows[-1].id))
+        if len(rows) == limit
+        else None
+    )
+
+    # A decided row says WHICH verdict resolved it, so the client can render
+    # "Stacked" and "Kept separate" differently and offer the right way back.
+    verdict_by_signature: dict[str, DedupVerdict] = {}
+    if decided:
+        verdict_rows = session.exec(
+            select(DedupVerdict).where(
+                DedupVerdict.signature.in_([row.signature for row in rows]),
+                DedupVerdict.reopened_at.is_(None),
+            )
+        ).all()
+        verdict_by_signature = {v.signature: v for v in verdict_rows}
+
+    group_ids = [int(row.id) for row in rows]
+    member_rows = session.exec(
+        select(
+            DedupGroupMember.group_id,
+            DedupGroupMember.picture_id,
+            DedupGroupMember.position,
+        )
+        .where(DedupGroupMember.group_id.in_(group_ids))
+        .order_by(DedupGroupMember.group_id, DedupGroupMember.position)
+    ).all()
+    ids_by_group: dict[int, list[int]] = defaultdict(list)
+    for group_id, picture_id, _position in member_rows:
+        ids_by_group[int(group_id)].append(int(picture_id))
+    candidates = load_candidates(
+        session, [pid for ids in ids_by_group.values() for pid in ids]
+    )
+
+    payload: list[dict[str, Any]] = []
+    for row in rows:
+        members = [
+            candidates[pid]
+            for pid in ids_by_group.get(int(row.id), [])
+            if pid in candidates
+        ]
+        if len(members) < 2:
+            # Members disappeared between the scan and this read. Report the row
+            # as-is rather than dropping it silently; prune_stale_groups removes
+            # it on the next verdict or scan.
+            logger.info(
+                "[dedup-queue] group %s has %d live member(s); it will be pruned",
+                row.signature,
+                len(members),
+            )
+        cover_id = (
+            int(row.cover_picture_id)
+            if row.cover_picture_id is not None
+            else (members[0].id if members else None)
+        )
+        verdict = verdict_by_signature.get(row.signature)
+        payload.append(
+            {
+                "signature": row.signature,
+                "tier": row.tier,
+                "confidence": float(row.confidence or 0.0),
+                "member_count": int(row.member_count or len(members)),
+                "cover_picture_id": cover_id,
+                "why": json.loads(row.evidence) if row.evidence else [],
+                "created_at": row.created_at,
+                "verdict": verdict.verdict if verdict else None,
+                "decided_at": verdict.decided_at if verdict else None,
+                "candidates": [
+                    member.as_dict(
+                        why=build_candidate_evidence(member, members, cover_id)
+                    )
+                    for member in members
+                ],
+            }
+        )
+    return payload, total, next_cursor
+
+
+def scope_counts_in_session(
+    session: Session,
+    scopes: list[DedupScope],
+    policy: Optional[TierPolicy] = None,
+) -> list[dict[str, Any]]:
+    """Unresolved counts for several scopes in one request.
+
+    The context menus need a count per project / set / character / folder; asking
+    for them one at a time would be a request per menu item.
+    """
+    policy = policy or TierPolicy()
+    return [
+        {
+            **scope.as_dict(),
+            "unresolved_groups": count_unresolved_in_session(session, policy, scope),
+        }
+        for scope in scopes
+    ]
+
+
+# --- Scan requests and progress ---------------------------------------------
+
+
+def request_scan_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> dict[str, Any]:
+    """Queue a scan for *scope* and return its progress row immediately.
+
+    The route returns as soon as this row exists, which is what makes the
+    context-menu "Find duplicates in ..." entry feel instant: the hashes are
+    already cached (``pixel_sha`` and ``perceptual_hash`` are computed on import),
+    so the scan only has to read and compare them, and the queue can be opened
+    while it does.
+
+    One row per scope key, reused across rescans, so a scope has exactly one
+    place to read progress from.
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    row = session.exec(
+        select(DedupScan).where(DedupScan.scope_key == scope.key)
+    ).first()
+    now = datetime.utcnow()
+    if row is None:
+        row = DedupScan(scope_key=scope.key)
+    row.scope_type = scope.scope_type.value
+    row.scope_id = scope.scope_id
+    row.tiers = json.dumps([tier.value for tier in policy.tiers])
+    row.threshold = float(policy.threshold)
+    row.status = SCAN_PENDING
+    row.error = None
+    row.started_at = now
+    row.updated_at = now
+    row.finished_at = None
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    logger.info(
+        "[dedup-scan] requested scan for scope=%s tiers=%s threshold=%.4f",
+        scope.key,
+        row.tiers,
+        policy.threshold,
+    )
+    return scan_progress(row)
+
+
+def scan_progress(row: Optional[DedupScan]) -> dict[str, Any]:
+    """Serialise a scan row for the "scanned N of M" banner.
+
+    ``None`` (no scan has ever run for this scope) is reported as an idle scan
+    rather than as an error: the queue is still perfectly usable, it just shows
+    whatever an earlier global scan found.
+    """
+    if row is None:
+        return {
+            "status": "idle",
+            "scanned_pictures": 0,
+            "total_pictures": 0,
+            "scanned_buckets": 0,
+            "total_buckets": 0,
+            "groups_found": 0,
+            "started_at": None,
+            "finished_at": None,
+            "error": None,
+        }
+    return {
+        "scan_id": row.id,
+        "scope_key": row.scope_key,
+        "status": row.status,
+        "tiers": json.loads(row.tiers or "[]"),
+        "threshold": float(row.threshold or DEFAULT_THRESHOLD),
+        "scanned_pictures": int(row.scanned_pictures or 0),
+        "total_pictures": int(row.total_pictures or 0),
+        "scanned_buckets": int(row.scanned_buckets or 0),
+        "total_buckets": int(row.total_buckets or 0),
+        "groups_found": int(row.groups_found or 0),
+        "started_at": row.started_at,
+        "updated_at": row.updated_at,
+        "finished_at": row.finished_at,
+        "error": row.error,
+    }
+
+
+def scan_progress_in_session(
+    session: Session, scope: Optional[DedupScope] = None
+) -> dict[str, Any]:
+    """Current scan progress for *scope*."""
+    scope = scope or DedupScope()
+    row = session.exec(
+        select(DedupScan).where(DedupScan.scope_key == scope.key)
+    ).first()
+    return scan_progress(row)
+
+
+def run_scan_now_in_session(
+    session: Session,
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> dict[str, Any]:
+    """Run every enabled tier synchronously and persist the groups.
+
+    The background path is :class:`~pixlstash.tasks.dedup_scan_task.DedupScanTask`;
+    this is the same work without the task system, for tests and for a caller
+    that genuinely wants to block (a small scope where the round trip is cheaper
+    than polling).
+    """
+    policy = policy or TierPolicy()
+    scope = scope or DedupScope()
+    prune_stale_groups_in_session(session)
+    found = 0
+    for tier in iter_tiers(policy):
+        if tier is DedupTier.EXACT:
+            groups = find_exact_groups_in_session(session, scope)
+        elif tier is DedupTier.NEAR:
+            groups = find_near_groups_in_session(session, policy, scope)
+        else:
+            groups = find_embedding_groups_in_session(session, policy, scope)
+        found += persist_groups_in_session(session, groups)
+    return {
+        "scope": scope.as_dict(),
+        "policy": policy.as_dict(),
+        "unresolved_groups": found,
+    }
+
+
+# --- Vault wrappers ---------------------------------------------------------
+
+
+def count_unresolved(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> int:
+    """Read-only vault wrapper around :func:`count_unresolved_in_session`."""
+    return vault.db.run_immediate_read_task(count_unresolved_in_session, policy, scope)
+
+
+def page_queue(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+    offset: int = 0,
+    limit: int = DEFAULT_PAGE_SIZE,
+    cursor: Optional[str] = None,
+) -> tuple[list[dict[str, Any]], int, Optional[str]]:
+    """Read-only vault wrapper around :func:`page_queue_in_session`."""
+    return vault.db.run_immediate_read_task(
+        page_queue_in_session, policy, scope, offset, limit, cursor
+    )
+
+
+def _queue_response_in_session(
+    session: Session,
+    policy: TierPolicy,
+    scope: DedupScope,
+    offset: int,
+    limit: int,
+    cursor: Optional[str] = None,
+    decided: bool = False,
+) -> dict[str, Any]:
+    """The whole ``GET /dedup/groups`` payload, on one session.
+
+    Assembled here rather than in the route so the page and the scan progress it
+    is captioned with come from the same read, and so the route never touches
+    ``vault.db`` (§10.1).
+    """
+    groups, total, next_cursor = page_queue_in_session(
+        session, policy, scope, offset, limit, cursor, decided
+    )
+    return {
+        "groups": groups,
+        "total": total,
+        "offset": offset,
+        "limit": min(int(limit), MAX_PAGE_SIZE),
+        "cursor": cursor,
+        "next_cursor": next_cursor,
+        "policy": policy.as_dict(),
+        "scope": scope.as_dict(),
+        "scan": scan_progress_in_session(session, scope),
+    }
+
+
+def queue_response(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+    offset: int = 0,
+    limit: int = DEFAULT_PAGE_SIZE,
+    cursor: Optional[str] = None,
+    decided: bool = False,
+) -> dict[str, Any]:
+    """Read-only vault wrapper producing the full queue-page response."""
+    return vault.db.run_immediate_read_task(
+        _queue_response_in_session,
+        policy or TierPolicy(),
+        scope or DedupScope(),
+        offset,
+        limit,
+        cursor,
+        decided,
+    )
+
+
+def _counts_response_in_session(
+    session: Session, policy: TierPolicy, scopes: list[DedupScope]
+) -> dict[str, Any]:
+    """The whole ``POST /dedup/counts`` payload, on one session."""
+    return {
+        "unresolved_groups": count_unresolved_in_session(session, policy),
+        "by_tier": count_by_tier_in_session(session, policy),
+        "scopes": scope_counts_in_session(session, scopes, policy),
+        "policy": policy.as_dict(),
+        "scan": scan_progress_in_session(session),
+    }
+
+
+def counts_response(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scopes: Optional[list[DedupScope]] = None,
+) -> dict[str, Any]:
+    """Read-only vault wrapper producing the live-counts response."""
+    return vault.db.run_immediate_read_task(
+        _counts_response_in_session, policy or TierPolicy(), list(scopes or [])
+    )
+
+
+def request_scan(
+    vault: "Vault",
+    policy: Optional[TierPolicy] = None,
+    scope: Optional[DedupScope] = None,
+) -> dict[str, Any]:
+    """Queue a scan and wake the work planner so it starts now.
+
+    Write-path vault wrapper: the row is the request, and the planner turns it
+    into a :class:`~pixlstash.tasks.dedup_scan_task.DedupScanTask`.
+    """
+    progress = vault.db.run_task(
+        request_scan_in_session,
+        policy or TierPolicy(),
+        scope or DedupScope(),
+    )
+    vault.wake()
+    return progress
+
+
+def iter_tiers(policy: TierPolicy) -> Iterator[DedupTier]:
+    """Yield the enabled tiers strongest first (exact, near, embedding)."""
+    for tier in TIER_ORDER:
+        if policy.includes(tier):
+            yield tier
+
+
+__all__ = [
+    "COVER_PIXEL_WEIGHT",
+    "COVER_RAW_BONUS",
+    "COVER_SCORE_WEIGHT",
+    "COVER_TAG_WEIGHT",
+    "CURSOR_VERSION",
+    "DEFAULT_MAX_GROUP_SIZE",
+    "DEFAULT_MIN_GROUP_SIZE",
+    "DEFAULT_PAGE_SIZE",
+    "DEFAULT_THRESHOLD",
+    "MAX_BUCKET_MEMBERS",
+    "MAX_PAGE_SIZE",
+    "MAX_THRESHOLD",
+    "MIN_THRESHOLD",
+    "RAW_FORMATS",
+    "TIER_ORDER",
+    "TIER_STRENGTH",
+    "VERDICT_KEEP_SEPARATE",
+    "VERDICT_STACKED",
+    "CandidateMember",
+    "DedupCursorError",
+    "DedupScope",
+    "DedupTier",
+    "DetectedGroup",
+    "NearBucket",
+    "ScopeType",
+    "TierPolicy",
+    "assemble_group",
+    "build_candidate_evidence",
+    "build_group_evidence",
+    "build_near_buckets",
+    "count_by_tier_in_session",
+    "count_unresolved",
+    "count_unresolved_in_session",
+    "counts_response",
+    "cover_order_key",
+    "decode_queue_cursor",
+    "encode_queue_cursor",
+    "find_embedding_groups_in_session",
+    "find_exact_groups_in_session",
+    "find_near_groups_in_session",
+    "group_signature",
+    "groups_from_pairs",
+    "iter_tiers",
+    "load_candidates",
+    "near_pairs_in_bucket",
+    "page_queue",
+    "page_queue_in_session",
+    "persist_groups_in_session",
+    "prune_stale_groups_in_session",
+    "queue_response",
+    "request_scan",
+    "request_scan_in_session",
+    "run_scan_now_in_session",
+    "scan_progress",
+    "scan_progress_in_session",
+    "scope_counts_in_session",
+    "select_cover",
+    "tier_strength",
+    "verdict_signatures_in_session",
+]

--- a/pixlstash/services/dedup_verdict_service.py
+++ b/pixlstash/services/dedup_verdict_service.py
@@ -1,0 +1,1092 @@
+"""Applying and remembering duplicate verdicts.
+
+There are exactly two verdicts in v1.9 and neither of them deletes anything:
+
+* **stack** — the chosen members become one stack led by the chosen cover, with
+  the metadata union applied; excluded members stay exactly where they were;
+* **keep separate** — nothing changes on disk or in the picture rows, but the
+  group's signature is remembered so no rescan and no re-import ever re-asks.
+
+Both are recorded against the group *signature*, not against picture or group
+ids, which is what makes the memory survive a re-import (see
+:func:`pixlstash.services.dedup_tier_service.group_signature`). "Keep separate"
+is permanent until :func:`reopen_verdict_in_session` is called from the Stacks
+view.
+
+Metadata union (design delta 5)
+-------------------------------
+Stacking unions **tags, project membership, set membership and characters** onto
+every member and lifts every member to the **highest score** in the group.
+Nothing is overwritten and nothing is lost — a union cannot break an album,
+which is the failure mode that burns Immich users.
+
+Project and set membership already had a union in
+:func:`pixlstash.services.stack_membership.reconcile_stack_membership`; this
+module calls it and adds the three the design requires on top:
+
+* **tags** — every member gains every non-sentinel tag any member carries.
+  Sentinel tags (``__tag``, ``__tag:<engine>``) are pipeline markers, not user
+  metadata, so they are deliberately excluded: copying a "needs retagging"
+  marker onto a picture that was already tagged would re-queue it for no reason.
+* **score** — every member is lifted to ``max(score)``. Only lifted: a union
+  never lowers a rating the user set.
+* **characters** — a real face-to-character union is not expressible without
+  fabricating :class:`~pixlstash.db_models.face.Face` rows (a face has a bbox and
+  an embedding that belong to one specific picture), and inventing detection data
+  is worse than not unioning. Instead, when the group's members between them
+  reference exactly **one** character, every member that does not already carry
+  it gets ``Picture.pending_character_id`` set — the shipped deferred-assignment
+  mechanism that the face-extraction task consumes. A group spanning several
+  characters is left alone and logged; the members keep their own faces, which is
+  the non-lossy outcome.
+
+Operation log (§21)
+-------------------
+Every verdict raises an action receipt and lands in the operation log. Each
+verdict records **exactly one** :class:`~pixlstash.db_models.operation.Operation`
+row, and a bulk auto-stack shares a single ``batch_id`` across every group in the
+run, so ``POST /operations/batches/{batch_id}/undo`` reverses a thousand stacks in
+one step.
+
+Two details this module owns rather than inherits:
+
+* **It does not go through** ``routes/stacks.py``. Those handlers already wrap
+  themselves in ``run_recorded_metadata_task``; calling them would produce a
+  second operation row per verdict, and "one verdict, one undo" would stop being
+  true. :func:`_stack_members` does the stacking in-session instead, and this
+  module records once around the whole verdict.
+* **It snapshots the stack-expanded set**, not just the group's members
+  (§21's ``expand_stacks`` rule). Folding an existing stack into the new one
+  reparents co-members the group never named, and ``normalize_stack_positions``
+  renumbers *every* member including soft-deleted ones — so the snapshot is taken
+  over :func:`expand_picture_ids_to_stacks` with ``include_deleted=True``, or an
+  undo would restore the group and leave its siblings behind.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Iterable, Optional
+
+from fastapi import HTTPException
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from pixlstash.db_models import Picture, PictureStack
+from pixlstash.db_models.dedup import (
+    TIER_EXACT,
+    VERDICT_KEEP_SEPARATE,
+    VERDICT_STACKED,
+    DedupGroup,
+    DedupGroupMember,
+    DedupVerdict,
+)
+from pixlstash.db_models.face import Face
+from pixlstash.db_models.operation import Operation
+from pixlstash.db_models.tag import Tag, is_tag_sentinel
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services import operation_log_service
+from pixlstash.services.dedup_tier_service import (
+    ID_CHUNK,
+    DedupScope,
+    DedupTier,
+    prune_stale_groups_in_session,
+)
+from pixlstash.services.stack_membership import (
+    expand_picture_ids_to_stacks,
+    reconcile_stack_membership,
+)
+from pixlstash.stacking import normalize_stack_positions
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pixlstash.vault import Vault
+
+logger = get_logger(__name__)
+
+# The one op_type this module records. Stable — part of the API contract the
+# frontend keys its undo affordances off. A bulk auto-stack shares one batch_id
+# across every row it writes, so the whole run reverses in a single step.
+#
+# Keep-separate and reopen have no op_type on purpose: they change no reversible
+# picture facet, so they record nothing rather than writing a no-op row that
+# would still consume a Ctrl+Z.
+OP_TYPE_STACK = "dedup.stack"
+
+# Per-group outcome vocabulary for a bulk auto-stack. Closed set; the response
+# reports every group under exactly one of these, so a partial run is legible
+# rather than inferred from a count mismatch.
+BULK_REASON_APPLIED = "applied"
+BULK_REASON_BLOCKED = "blocked"
+"""The group was refused by a guard that returns an HTTP status — in practice a
+locked picture set (423). Nothing was written for it."""
+BULK_REASON_FAILED = "failed"
+"""The group could not be resolved at all (stale signature, too few members)."""
+
+
+class DedupVerdictError(Exception):
+    """A verdict could not be applied (unknown signature, bad cover, ...)."""
+
+
+@dataclass(frozen=True)
+class VerdictResult:
+    """What a verdict did, for the response and the action receipt.
+
+    Attributes:
+        signature: The group signature the verdict was recorded against.
+        verdict: ``"stacked"`` or ``"keep_separate"``.
+        stack_id: The resulting stack, for a stack verdict.
+        cover_picture_id: The cover the stack leads with.
+        picture_ids: Members the verdict covers.
+        excluded_picture_ids: Members deliberately left out of the stack.
+        batch_id: The operation-log batch this verdict belongs to.
+        metadata_union: What the union actually changed, so the receipt can say
+            so instead of claiming a silent merge.
+    """
+
+    signature: str
+    verdict: str
+    stack_id: Optional[int]
+    cover_picture_id: Optional[int]
+    picture_ids: list[int]
+    excluded_picture_ids: list[int]
+    batch_id: Optional[str]
+    metadata_union: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "signature": self.signature,
+            "verdict": self.verdict,
+            "stack_id": self.stack_id,
+            "cover_picture_id": self.cover_picture_id,
+            "picture_ids": list(self.picture_ids),
+            "excluded_picture_ids": list(self.excluded_picture_ids),
+            "batch_id": self.batch_id,
+            "metadata_union": dict(self.metadata_union),
+        }
+
+
+def new_batch_id() -> str:
+    """Mint a batch id grouping one bulk action's operations into one undo.
+
+    Delegates to :func:`operation_log_service.new_batch_id` rather than minting
+    its own shape: batch ids are namespaced (``srv-`` for server-minted, ``cli-``
+    for a client-supplied one, validated at the request boundary), and a third
+    un-namespaced shape from this module would make a dedup batch
+    indistinguishable from a client-grafted one in the log.
+    """
+    return operation_log_service.new_batch_id()
+
+
+def _record_operation(
+    session: Session,
+    *,
+    op_type: str,
+    before: dict[str, dict],
+    after: dict[str, dict],
+    batch_id: Optional[str],
+    summary: str,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
+) -> None:
+    """Append **one** operation row for this verdict.
+
+    Called once per verdict, around the whole mutation, on the verdict's own
+    session — so the row and the change it describes commit against the same
+    serialised writer (§21). The verdict path deliberately does not reuse
+    ``routes/stacks.py``, which records itself; going through it would produce a
+    second row and break "one verdict, one undo".
+    """
+    operation_log_service.record_operation_in_session(
+        session,
+        op_type=op_type,
+        before=before,
+        after=after,
+        batch_id=batch_id,
+        summary=summary,
+        actor=actor,
+        source=source,
+        origin_client_id=origin_client_id,
+    )
+
+
+def _capture_state(session: Session, picture_ids: list[int]) -> dict[str, dict]:
+    """Snapshot every reversible facet of *picture_ids* (§21's undo payload)."""
+    return operation_log_service.capture_state_in_session(session, picture_ids)
+
+
+def _undo_targets(session: Session, picture_ids: list[int]) -> list[int]:
+    """The ids an undo of this verdict has to restore.
+
+    Stacking is stack-atomic: folding an existing stack into the verdict's stack
+    reparents co-members the group never named, and ``normalize_stack_positions``
+    renumbers **every** member of an affected stack, soft-deleted ones included.
+    Snapshotting only the group's members would leave those siblings stranded on
+    undo, which is exactly the ``expand_stacks`` /
+    ``expand_stacks_include_deleted`` pairing §21 requires of a grouping mutation.
+    """
+    return expand_picture_ids_to_stacks(session, picture_ids, include_deleted=True)
+
+
+# --- Group lookup -----------------------------------------------------------
+
+
+def _load_group(session: Session, signature: str) -> tuple[DedupGroup, list[int]]:
+    """Return the group row and its live member ids, or raise."""
+    group = session.exec(
+        select(DedupGroup).where(DedupGroup.signature == signature)
+    ).first()
+    if group is None:
+        raise DedupVerdictError(f"No duplicate group with signature {signature!r}")
+    member_ids = [
+        int(row)
+        for row in session.exec(
+            select(DedupGroupMember.picture_id)
+            .join(Picture, Picture.id == DedupGroupMember.picture_id)
+            .where(
+                DedupGroupMember.group_id == group.id,
+                Picture.deleted.is_(False),
+            )
+            .order_by(DedupGroupMember.position)
+        ).all()
+    ]
+    return group, member_ids
+
+
+def _upsert_verdict(
+    session: Session,
+    *,
+    signature: str,
+    verdict: str,
+    picture_ids: list[int],
+    excluded_picture_ids: list[int],
+    cover_picture_id: Optional[int],
+    stack_id: Optional[int],
+    batch_id: Optional[str],
+) -> DedupVerdict:
+    """Write (or refresh) the verdict row and mark its group resolved."""
+    row = session.exec(
+        select(DedupVerdict).where(DedupVerdict.signature == signature)
+    ).first()
+    if row is None:
+        row = DedupVerdict(signature=signature, verdict=verdict)
+    row.verdict = verdict
+    row.picture_ids = json.dumps(sorted(picture_ids))
+    row.excluded_picture_ids = json.dumps(sorted(excluded_picture_ids))
+    row.cover_picture_id = cover_picture_id
+    row.stack_id = stack_id
+    row.batch_id = batch_id
+    row.decided_at = datetime.utcnow()
+    row.reopened_at = None
+    session.add(row)
+
+    group = session.exec(
+        select(DedupGroup).where(DedupGroup.signature == signature)
+    ).first()
+    if group is not None:
+        group.resolved = True
+        session.add(group)
+    return row
+
+
+# --- Metadata union ---------------------------------------------------------
+
+
+def apply_metadata_union_in_session(
+    session: Session, picture_ids: list[int], stack_id: int
+) -> dict[str, Any]:
+    """Union tags, membership, score and (where safe) characters across a stack.
+
+    Additive only. See the module docstring for why characters go through
+    ``pending_character_id`` rather than through fabricated ``Face`` rows.
+
+    Args:
+        session: Pre-opened session. Not committed here — the caller owns the
+            transaction so a verdict lands as one unit.
+        picture_ids: The stack's members.
+        stack_id: The stack they were just placed in; the project / set union
+            reconciles over the whole stack, not only over the group.
+
+    Returns:
+        A summary of what changed, for the action receipt.
+    """
+    # Imported locally: set_lock_service imports stack_membership, so a
+    # module-level import here would be circular.
+    from pixlstash.services.set_lock_service import enforce_pictures_not_locked
+
+    if len(picture_ids) < 2:
+        return {"tags_added": 0, "scores_lifted": 0, "characters_pending": 0}
+
+    # The union writes tags and scores, which are curation state. A picture
+    # frozen by a locked set must not have either changed behind the user's
+    # back, so this is a hard 423 rather than a skip: a partially applied union
+    # would be worse than a refused one.
+    enforce_pictures_not_locked(session, picture_ids, "union duplicate metadata")
+
+    membership_changed = reconcile_stack_membership(session, stack_id)
+
+    # --- Tags: every member gains every real tag any member carries ---
+    tag_rows = session.exec(
+        select(Tag.picture_id, Tag.tag).where(Tag.picture_id.in_(picture_ids))
+    ).all()
+    tags_by_picture: dict[int, set[str]] = {pid: set() for pid in picture_ids}
+    union: set[str] = set()
+    for picture_id, tag in tag_rows:
+        if is_tag_sentinel(tag):
+            continue
+        tags_by_picture.setdefault(int(picture_id), set()).add(str(tag))
+        union.add(str(tag))
+    tags_added = 0
+    for picture_id in picture_ids:
+        for tag in sorted(union - tags_by_picture.get(picture_id, set())):
+            session.add(Tag(picture_id=picture_id, tag=tag))
+            tags_added += 1
+
+    # --- Score: lift every member to the highest rating in the group ---
+    pictures = session.exec(select(Picture).where(Picture.id.in_(picture_ids))).all()
+    best_score = max((int(pic.score or 0) for pic in pictures), default=0)
+    scores_lifted = 0
+    if best_score > 0:
+        for pic in pictures:
+            if int(pic.score or 0) < best_score:
+                pic.score = best_score
+                session.add(pic)
+                scores_lifted += 1
+
+    # --- Characters: only the unambiguous single-character case ---
+    character_ids = {
+        int(row)
+        for row in session.exec(
+            select(Face.character_id).where(
+                Face.picture_id.in_(picture_ids), Face.character_id.is_not(None)
+            )
+        ).all()
+        if row is not None
+    }
+    characters_pending = 0
+    if len(character_ids) == 1:
+        character_id = next(iter(character_ids))
+        assigned = {
+            int(row)
+            for row in session.exec(
+                select(Face.picture_id).where(
+                    Face.picture_id.in_(picture_ids),
+                    Face.character_id == character_id,
+                )
+            ).all()
+        }
+        for pic in pictures:
+            if int(pic.id) in assigned or pic.pending_character_id == character_id:
+                continue
+            pic.pending_character_id = character_id
+            session.add(pic)
+            characters_pending += 1
+    elif len(character_ids) > 1:
+        logger.info(
+            "[dedup-verdict] stack over pictures %s references %d characters %s; "
+            "characters are left as-is rather than guessing which one the stack "
+            "belongs to (no face data is fabricated)",
+            picture_ids,
+            len(character_ids),
+            sorted(character_ids),
+        )
+
+    return {
+        "tags_added": tags_added,
+        "scores_lifted": scores_lifted,
+        "characters_pending": characters_pending,
+        "membership_changed": bool(membership_changed),
+        "best_score": best_score,
+    }
+
+
+# --- Stacking ---------------------------------------------------------------
+
+
+def _stack_members(
+    session: Session, picture_ids: list[int], cover_picture_id: int
+) -> int:
+    """Put *picture_ids* into one stack led by *cover_picture_id*.
+
+    Reuses an existing stack when the members already share one (growing it
+    rather than orphaning it), and folds several stacks into the cover's when the
+    group spans more than one. Always additive: no picture leaves a stack it was
+    in, and no stack row is dropped that still has members.
+    """
+    # Imported locally: set_lock_service imports stack_membership, which imports
+    # this package's siblings; a module-level import here would be circular.
+    from pixlstash.services.set_lock_service import enforce_stack_membership_not_locked
+
+    pictures = {
+        int(pic.id): pic
+        for pic in session.exec(
+            select(Picture).where(Picture.id.in_(picture_ids))
+        ).all()
+    }
+    missing = sorted(set(picture_ids) - set(pictures))
+    if missing:
+        raise DedupVerdictError(f"pictures {missing} no longer exist")
+
+    existing_stack_ids = sorted(
+        {int(pic.stack_id) for pic in pictures.values() if pic.stack_id is not None}
+    )
+    cover = pictures[cover_picture_id]
+    if cover.stack_id is not None:
+        stack_id = int(cover.stack_id)
+    elif existing_stack_ids:
+        stack_id = existing_stack_ids[0]
+    else:
+        stack = PictureStack(name=None)
+        session.add(stack)
+        session.flush()
+        stack_id = int(stack.id)
+
+    enforce_stack_membership_not_locked(
+        session, list(picture_ids), stack_id, "stack duplicates together"
+    )
+
+    # Pull in every member of any stack this group touches: stacks move as a unit.
+    folded_ids = [sid for sid in existing_stack_ids if sid != stack_id]
+    if folded_ids:
+        for pic in session.exec(
+            select(Picture).where(Picture.stack_id.in_(folded_ids))
+        ).all():
+            pictures.setdefault(int(pic.id), pic)
+
+    # The cover sorts ahead of everything so normalize_stack_positions lands it
+    # at position 0 — the leader convention the whole app reads.
+    for pic in pictures.values():
+        pic.stack_id = stack_id
+        pic.stack_position = -1 if int(pic.id) == cover_picture_id else 1
+        session.add(pic)
+    session.flush()
+
+    for folded_id in folded_ids:
+        remaining = session.exec(
+            select(func.count(Picture.id)).where(Picture.stack_id == folded_id)
+        ).one()
+        if int(remaining) == 0:
+            orphan = session.get(PictureStack, folded_id)
+            if orphan is not None:
+                session.delete(orphan)
+
+    normalize_stack_positions(session, stack_id)
+    stack = session.get(PictureStack, stack_id)
+    if stack is not None:
+        stack.updated_at = datetime.utcnow()
+        session.add(stack)
+    return stack_id
+
+
+# --- Bulk dry-run aggregates -------------------------------------------------
+
+
+def _dry_run_summary_in_session(
+    session: Session, groups: list[DedupGroup]
+) -> dict[str, Any]:
+    """Aggregate what a bulk auto-stack would do, for the consent dialog.
+
+    Computed from the **same** ``groups`` list the dry-run counts come from, in
+    the same read, so the dialog's "N groups" and its "M covers gain metadata"
+    row cannot disagree because a scan landed between two queries.
+
+    The union is **not** run to work this out — nothing is written and no
+    membership is reconciled. Each figure is derived from the planned verdict:
+    the cover is the group's stored preselection, and a cover "gains" a facet
+    when some other member of its group already carries something the cover does
+    not (which is exactly what :func:`apply_metadata_union_in_session` would then
+    copy onto it).
+
+    Returns:
+        ``groups_by_tier`` (always keyed by every tier, zero-filled),
+        ``pictures``, ``covers_gaining_tags``, ``covers_gaining_score`` and
+        ``covers_gaining_metadata`` (the union of the previous two — the row the
+        design's dialog promises).
+    """
+    summary: dict[str, Any] = {
+        "groups_by_tier": {tier.value: 0 for tier in DedupTier},
+        "groups": len(groups),
+        "pictures": 0,
+        "covers_gaining_tags": 0,
+        "covers_gaining_score": 0,
+        "covers_gaining_metadata": 0,
+    }
+    if not groups:
+        return summary
+
+    group_ids = [int(group.id) for group in groups]
+    members_by_group: dict[int, list[int]] = defaultdict(list)
+    for group_id, picture_id in session.exec(
+        select(DedupGroupMember.group_id, DedupGroupMember.picture_id)
+        .join(Picture, Picture.id == DedupGroupMember.picture_id)
+        .where(
+            DedupGroupMember.group_id.in_(group_ids),
+            Picture.deleted.is_(False),
+        )
+    ).all():
+        members_by_group[int(group_id)].append(int(picture_id))
+
+    all_ids = [pid for ids in members_by_group.values() for pid in ids]
+    scores = dict(
+        session.exec(
+            select(Picture.id, Picture.score).where(Picture.id.in_(all_ids))
+        ).all()
+    )
+    tags_by_picture: dict[int, set[str]] = defaultdict(set)
+    for picture_id, tag in session.exec(
+        select(Tag.picture_id, Tag.tag).where(Tag.picture_id.in_(all_ids))
+    ).all():
+        if not is_tag_sentinel(tag):
+            tags_by_picture[int(picture_id)].add(str(tag))
+
+    for group in groups:
+        member_ids = members_by_group.get(int(group.id), [])
+        summary["groups_by_tier"][str(group.tier)] = (
+            summary["groups_by_tier"].get(str(group.tier), 0) + 1
+        )
+        summary["pictures"] += len(member_ids)
+        cover_id = int(group.cover_picture_id or (member_ids[0] if member_ids else 0))
+        if cover_id not in member_ids:
+            continue
+        others = [pid for pid in member_ids if pid != cover_id]
+        gains_tags = any(
+            tags_by_picture[pid] - tags_by_picture[cover_id] for pid in others
+        )
+        gains_score = any(
+            int(scores.get(pid) or 0) > int(scores.get(cover_id) or 0) for pid in others
+        )
+        summary["covers_gaining_tags"] += int(gains_tags)
+        summary["covers_gaining_score"] += int(gains_score)
+        summary["covers_gaining_metadata"] += int(gains_tags or gains_score)
+    return summary
+
+
+# --- Verdicts ---------------------------------------------------------------
+
+
+def apply_stack_verdict_in_session(
+    session: Session,
+    signature: str,
+    cover_picture_id: Optional[int] = None,
+    excluded_picture_ids: Optional[Iterable[int]] = None,
+    batch_id: Optional[str] = None,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
+) -> VerdictResult:
+    """Stack a group's members and remember the decision.
+
+    Args:
+        session: Pre-opened session; this function commits once, so the stack,
+            the metadata union and the verdict row land together or not at all.
+        signature: The group signature from the queue.
+        cover_picture_id: The cover the user confirmed. Defaults to the server's
+            preselection stored on the group.
+        excluded_picture_ids: Members the user left out (the design's X key).
+            They keep their current stack and are recorded on the verdict so a
+            rescan does not treat the exclusion as an unfinished decision.
+        batch_id: Operation-log batch. Bulk auto-stack passes one id for every
+            group so the whole run reverses with a single undo.
+        actor: Who performed the change, from ``request_context`` in the handler.
+        source: WS-envelope source, likewise read from the request (§21 origin
+            discipline: never from a contextvar, which is dead on this thread).
+        origin_client_id: WS-envelope per-tab origin, likewise.
+
+    Returns:
+        The :class:`VerdictResult` behind the action receipt.
+
+    Raises:
+        DedupVerdictError: Unknown signature, a cover that is not a member, or
+            fewer than two members left after exclusions.
+    """
+    group, member_ids = _load_group(session, signature)
+    # Always under a batch id, even for a single verdict. The batch id is the key
+    # that ties the recorded Operation back to the DedupVerdict row, which is how
+    # an undo knows to reopen the verdict as well as restoring the pictures (see
+    # :func:`restore_verdicts_in_session`). A verdict recorded without one would
+    # be undoable on the picture side and permanently decided on the queue side.
+    batch_id = batch_id or new_batch_id()
+    excluded = sorted({int(pid) for pid in (excluded_picture_ids or [])})
+    unknown = sorted(set(excluded) - set(member_ids))
+    if unknown:
+        raise DedupVerdictError(
+            f"excluded pictures {unknown} are not members of group {signature!r}"
+        )
+    included = [pid for pid in member_ids if pid not in set(excluded)]
+    if len(included) < 2:
+        raise DedupVerdictError(
+            f"group {signature!r} has {len(included)} member(s) left after "
+            "exclusions; a stack needs at least two"
+        )
+
+    cover_id = (
+        int(cover_picture_id)
+        if cover_picture_id is not None
+        else int(group.cover_picture_id or included[0])
+    )
+    if cover_id not in included:
+        raise DedupVerdictError(
+            f"cover {cover_id} is not an included member of group {signature!r}"
+        )
+
+    # Snapshot the stack-expanded set: folding an existing stack in reparents
+    # co-members this group never named, and they must be restorable too.
+    undo_targets = _undo_targets(session, included)
+    before = _capture_state(session, undo_targets)
+    stack_id = _stack_members(session, included, cover_id)
+    union = apply_metadata_union_in_session(session, included, stack_id)
+    _upsert_verdict(
+        session,
+        signature=signature,
+        verdict=VERDICT_STACKED,
+        picture_ids=included,
+        excluded_picture_ids=excluded,
+        cover_picture_id=cover_id,
+        stack_id=stack_id,
+        batch_id=batch_id,
+    )
+    after = _capture_state(session, undo_targets)
+    _record_operation(
+        session,
+        op_type=OP_TYPE_STACK,
+        before=before,
+        after=after,
+        batch_id=batch_id,
+        summary=f"Stacked {len(included)} duplicates",
+        actor=actor,
+        source=source,
+        origin_client_id=origin_client_id,
+    )
+    session.commit()
+    logger.info(
+        "[dedup-verdict] stacked %d picture(s) into stack %s (cover=%s, "
+        "excluded=%s, signature=%s, batch=%s)",
+        len(included),
+        stack_id,
+        cover_id,
+        excluded,
+        signature,
+        batch_id,
+    )
+    return VerdictResult(
+        signature=signature,
+        verdict=VERDICT_STACKED,
+        stack_id=stack_id,
+        cover_picture_id=cover_id,
+        picture_ids=included,
+        excluded_picture_ids=excluded,
+        batch_id=batch_id,
+        metadata_union=union,
+    )
+
+
+def apply_keep_separate_in_session(
+    session: Session, signature: str, batch_id: Optional[str] = None
+) -> VerdictResult:
+    """Remember that this group is *not* duplicates. Changes no picture row.
+
+    Permanent until :func:`reopen_verdict_in_session`. This is the verdict that
+    makes the sidebar count trustworthy: without it every rescan would re-offer
+    the same rejected group and the badge would never reach zero.
+    """
+    _group, member_ids = _load_group(session, signature)
+    # batch_id is deliberately NOT stored on the row: keep-separate records no
+    # operation, so a stored id could only correlate it to OTHER verdicts'
+    # restores. With a shared client gesture id that made undoing a stack
+    # silently reverse an unrelated keep-separate (CSO R5). The id is still
+    # echoed in the response so the client can group its receipts.
+    _upsert_verdict(
+        session,
+        signature=signature,
+        verdict=VERDICT_KEEP_SEPARATE,
+        picture_ids=member_ids,
+        excluded_picture_ids=[],
+        cover_picture_id=None,
+        stack_id=None,
+        batch_id=None,
+    )
+    # No operation row: keep-separate changes no reversible picture facet, so
+    # there is nothing for undo to restore. Recording an empty diff would be a
+    # no-op row (``record_operation_in_session`` returns None for one) that still
+    # consumed a Ctrl+Z, which is worse than not offering undo here. The user's
+    # way back is the explicit reopen action, which is what the Stacks view shows.
+    session.commit()
+    logger.info(
+        "[dedup-verdict] keep-separate recorded for signature=%s (%d members)",
+        signature,
+        len(member_ids),
+    )
+    return VerdictResult(
+        signature=signature,
+        verdict=VERDICT_KEEP_SEPARATE,
+        stack_id=None,
+        cover_picture_id=None,
+        picture_ids=member_ids,
+        excluded_picture_ids=[],
+        batch_id=batch_id,
+        metadata_union={},
+    )
+
+
+def reopen_verdict_in_session(session: Session, signature: str) -> dict[str, Any]:
+    """Undo the *memory* of a verdict so the group returns to the queue.
+
+    Stamps ``reopened_at`` rather than deleting the row: the decision history is
+    worth keeping, and a reopened verdict is simply no longer live. The pictures
+    are untouched — reopening a ``stacked`` verdict does not unstack anything,
+    because unstacking is the Stacks view's own action.
+    """
+    row = session.exec(
+        select(DedupVerdict).where(DedupVerdict.signature == signature)
+    ).first()
+    if row is None:
+        raise DedupVerdictError(f"No verdict recorded for signature {signature!r}")
+    if row.reopened_at is not None:
+        raise DedupVerdictError(f"Verdict for {signature!r} is already reopened")
+    row.reopened_at = datetime.utcnow()
+    session.add(row)
+    group = session.exec(
+        select(DedupGroup).where(DedupGroup.signature == signature)
+    ).first()
+    if group is not None:
+        group.resolved = False
+        session.add(group)
+    # No operation row, for the same reason as keep-separate: reopening touches
+    # only the verdict row, which is not a reversible picture facet.
+    session.commit()
+    logger.info("[dedup-verdict] reopened verdict for signature=%s", signature)
+    return {
+        "signature": signature,
+        "previous_verdict": row.verdict,
+        "reopened_at": row.reopened_at,
+        "group_returned_to_queue": group is not None,
+    }
+
+
+def restore_verdicts_in_session(
+    session: Session, operations: list[Operation], direction: str
+) -> None:
+    """Reopen (on undo) or re-decide (on redo) the verdicts *operations* recorded.
+
+    Registered with the operation log as the post-restore hook for
+    :data:`OP_TYPE_STACK` (see
+    :func:`pixlstash.services.operation_log_service.register_post_restore_hook`).
+
+    Why this is needed at all: the operation log restores the reversible *picture*
+    facets, and a stack verdict changes two more things that are not picture
+    facets — the ``DedupVerdict`` row (decided) and the ``DedupGroup`` row
+    (resolved). Without this hook an undo unstacked the pictures but left the
+    group decided, so it never returned to the queue, survived a rescan (the
+    signature still carried a live verdict) and was recoverable only through
+    ``POST /dedup/verdicts/reopen``.
+
+    Correlation is by ``batch_id``: a stack verdict is always recorded under one
+    (minted server-side when the caller supplies none), and the verdict row
+    stores the same id. One query covers a 2 700-group batch undo, which is why
+    the hook takes the whole list rather than one operation at a time.
+
+    Args:
+        session: The restore's own session. Not committed here — the operation
+            log commits the restore and this together, so the pictures and the
+            queue can never disagree.
+        operations: Every :data:`OP_TYPE_STACK` operation in this restore.
+        direction: ``operation_log_service.RESTORE_UNDO`` or ``RESTORE_REDO``.
+    """
+    batch_ids = sorted({op.batch_id for op in operations if op.batch_id})
+    unbatched = sorted(int(op.id) for op in operations if not op.batch_id and op.id)
+    if unbatched:
+        # Rows written before verdicts were always batched. Nothing correlates
+        # them to a verdict, so say so rather than silently half-restoring: the
+        # pictures are back but the group stays decided until the user reopens it.
+        logger.warning(
+            "[dedup-verdict] %s: operation(s) %s carry no batch_id, so their "
+            "duplicate verdict cannot be located; the pictures were restored but "
+            "the group stays decided. Use POST /dedup/verdicts/reopen to return "
+            "it to the queue.",
+            direction,
+            unbatched,
+        )
+    if not batch_ids:
+        return
+
+    is_redo = direction == operation_log_service.RESTORE_REDO
+    reopened_at = None if is_redo else datetime.utcnow()
+    signatures: list[str] = []
+    for start in range(0, len(batch_ids), ID_CHUNK):
+        chunk = batch_ids[start : start + ID_CHUNK]
+        for row in session.exec(
+            # Only STACK verdicts: the restored operations are OP_TYPE_STACK, and
+            # a keep-separate sharing the same client gesture batch id (#644)
+            # must not be silently reversed by undoing the stack — the product
+            # calls keep-separate permanent-until-reopened (CSO R5).
+            select(DedupVerdict).where(
+                DedupVerdict.batch_id.in_(chunk),
+                DedupVerdict.verdict == VERDICT_STACKED,
+            )
+        ).all():
+            # decided_at is deliberately not re-stamped on redo: it records when
+            # the user decided, and the row is "live" precisely when reopened_at
+            # is NULL, so one field carries the whole lifecycle honestly.
+            row.reopened_at = reopened_at
+            session.add(row)
+            signatures.append(str(row.signature))
+    if not signatures:
+        return
+    for start in range(0, len(signatures), ID_CHUNK):
+        chunk = signatures[start : start + ID_CHUNK]
+        for group in session.exec(
+            select(DedupGroup).where(DedupGroup.signature.in_(chunk))
+        ).all():
+            group.resolved = is_redo
+            session.add(group)
+    logger.info(
+        "[dedup-verdict] %s returned %d verdict(s) to %s across batch(es) %s",
+        direction,
+        len(signatures),
+        "decided" if is_redo else "the queue",
+        batch_ids,
+    )
+
+
+def bulk_auto_stack_in_session(
+    session: Session,
+    scope: Optional[DedupScope] = None,
+    batch_id: Optional[str] = None,
+    dry_run: bool = False,
+    limit: Optional[int] = None,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Stack every unresolved **exact** group under one batch id.
+
+    Tier 1 is the tier with no human judgment left in it, so the design gives it
+    a single consent dialog instead of per-group adjudication: the dialog shows
+    the dry-run counts, and accepting stacks them all under one operation-log
+    batch id so N stacks reverse with one Ctrl+Z.
+
+    Only exact groups are eligible. A near or embedding group always goes through
+    the queue, no matter how confident it looks.
+
+    Args:
+        session: Pre-opened session.
+        scope: Restrict to a scope; defaults to the whole vault.
+        batch_id: The shared batch id. Minted when omitted and returned.
+        dry_run: Count what would happen and write nothing. This is what the
+            consent dialog reads.
+        limit: Cap the number of groups acted on, for a paged run.
+        actor: Who performed the change, from ``request_context`` in the handler.
+        source: WS-envelope source, likewise read from the request.
+        origin_client_id: WS-envelope per-tab origin, likewise.
+
+    Returns:
+        The batch id, the counts, and a per-group outcome for **every** group the
+        run considered: ``results`` for the applied ones and ``failures`` for the
+        rest, each carrying an ``outcome`` of :data:`BULK_REASON_APPLIED`,
+        :data:`BULK_REASON_BLOCKED` or :data:`BULK_REASON_FAILED`. The batch id is
+        always present, so a partially applied run always hands back its undo
+        handle.
+    """
+    scope = scope or DedupScope()
+    query = select(DedupGroup).where(
+        DedupGroup.resolved.is_(False), DedupGroup.tier == TIER_EXACT
+    )
+    predicate = scope.picture_predicate()
+    if predicate is not None:
+        query = query.where(
+            DedupGroup.id.in_(
+                select(DedupGroupMember.group_id)
+                .join(Picture, Picture.id == DedupGroupMember.picture_id)
+                .where(Picture.deleted.is_(False), predicate)
+            )
+        )
+    query = query.order_by(DedupGroup.confidence.desc(), DedupGroup.id.asc())
+    if limit is not None:
+        query = query.limit(max(1, int(limit)))
+    groups = session.exec(query).all()
+
+    if dry_run:
+        picture_total = 0
+        for group in groups:
+            picture_total += int(group.member_count or 0)
+        return {
+            "dry_run_summary": _dry_run_summary_in_session(session, groups),
+            "batch_id": batch_id,
+            "dry_run": True,
+            "groups": len(groups),
+            "pictures": picture_total,
+            "scope": scope.as_dict(),
+            "results": [],
+        }
+
+    batch_id = batch_id or new_batch_id()
+    results: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for group in groups:
+        try:
+            result = apply_stack_verdict_in_session(
+                session,
+                group.signature,
+                batch_id=batch_id,
+                actor=actor,
+                source=source,
+                origin_client_id=origin_client_id,
+            )
+        except (DedupVerdictError, HTTPException) as exc:
+            # One unstackable group must never abort the run: every earlier group
+            # has already committed, so aborting here would leave a partially
+            # applied bulk mutation whose batch id the caller never receives —
+            # i.e. no undo handle for work that did happen.
+            #
+            # HTTPException is caught alongside DedupVerdictError because the
+            # locked-set guards raise 423, and a locked member is the *most
+            # likely* reason a group cannot be stacked. Catching only the former
+            # made this function's own API description ("a single unstackable
+            # group never aborts the run") false for the common case.
+            session.rollback()
+            if isinstance(exc, HTTPException):
+                reason, detail, status_code = (
+                    BULK_REASON_BLOCKED,
+                    exc.detail,
+                    exc.status_code,
+                )
+            else:
+                reason, detail, status_code = BULK_REASON_FAILED, str(exc), None
+            logger.warning(
+                "[dedup-verdict] auto-stack %s group %s (batch=%s): %s",
+                reason,
+                group.signature,
+                batch_id,
+                detail,
+            )
+            failures.append(
+                {
+                    "signature": group.signature,
+                    "outcome": reason,
+                    "status_code": status_code,
+                    "error": detail,
+                }
+            )
+            continue
+        results.append({**result.as_dict(), "outcome": BULK_REASON_APPLIED})
+    prune_stale_groups_in_session(session)
+    logger.info(
+        "[dedup-verdict] auto-stacked %d exact group(s) under batch %s "
+        "(%d blocked, %d failed)",
+        len(results),
+        batch_id,
+        sum(1 for f in failures if f["outcome"] == BULK_REASON_BLOCKED),
+        sum(1 for f in failures if f["outcome"] == BULK_REASON_FAILED),
+    )
+    return {
+        # Always present once anything could have committed, so the caller always
+        # holds the POST /operations/batches/{batch_id}/undo handle.
+        "batch_id": batch_id,
+        "dry_run": False,
+        "groups": len(results),
+        "pictures": sum(len(item["picture_ids"]) for item in results),
+        "scope": scope.as_dict(),
+        "results": results,
+        "failures": failures,
+        "blocked": sum(1 for f in failures if f["outcome"] == BULK_REASON_BLOCKED),
+        "failed": sum(1 for f in failures if f["outcome"] == BULK_REASON_FAILED),
+    }
+
+
+# --- Vault wrappers ---------------------------------------------------------
+
+
+def apply_stack_verdict(
+    vault: "Vault",
+    signature: str,
+    cover_picture_id: Optional[int] = None,
+    excluded_picture_ids: Optional[Iterable[int]] = None,
+    batch_id: Optional[str] = None,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
+) -> VerdictResult:
+    """Write-path vault wrapper around :func:`apply_stack_verdict_in_session`.
+
+    ``actor`` / ``source`` / ``origin_client_id`` come from
+    ``operation_log_service.request_context(request)``, evaluated in the handler
+    on the request's own task — never read here, where the contextvar is dead.
+    """
+    return vault.db.run_task(
+        apply_stack_verdict_in_session,
+        signature,
+        cover_picture_id,
+        list(excluded_picture_ids or []),
+        batch_id,
+        actor,
+        source,
+        origin_client_id,
+    )
+
+
+def apply_keep_separate(
+    vault: "Vault", signature: str, batch_id: Optional[str] = None
+) -> VerdictResult:
+    """Write-path vault wrapper around :func:`apply_keep_separate_in_session`."""
+    return vault.db.run_task(apply_keep_separate_in_session, signature, batch_id)
+
+
+def reopen_verdict(vault: "Vault", signature: str) -> dict[str, Any]:
+    """Write-path vault wrapper around :func:`reopen_verdict_in_session`."""
+    return vault.db.run_task(reopen_verdict_in_session, signature)
+
+
+def bulk_auto_stack(
+    vault: "Vault",
+    scope: Optional[DedupScope] = None,
+    batch_id: Optional[str] = None,
+    dry_run: bool = False,
+    limit: Optional[int] = None,
+    actor: Optional[str] = None,
+    source: str = "external",
+    origin_client_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Write-path vault wrapper around :func:`bulk_auto_stack_in_session`."""
+    return vault.db.run_task(
+        bulk_auto_stack_in_session,
+        scope,
+        batch_id,
+        dry_run,
+        limit,
+        actor,
+        source,
+        origin_client_id,
+    )
+
+
+# Registered at import time, and this module is imported by
+# ``pixlstash/routes/dedup.py``, which ``Server`` mounts at startup — so the hook
+# is in place before any request can reach undo. The registration lives here, not
+# in the operation log, so the op-log core keeps no dedup knowledge.
+operation_log_service.register_post_restore_hook(
+    OP_TYPE_STACK, restore_verdicts_in_session
+)
+
+
+__all__ = [
+    "BULK_REASON_APPLIED",
+    "BULK_REASON_BLOCKED",
+    "BULK_REASON_FAILED",
+    "OP_TYPE_STACK",
+    "DedupVerdictError",
+    "VerdictResult",
+    "apply_keep_separate",
+    "apply_keep_separate_in_session",
+    "apply_metadata_union_in_session",
+    "apply_stack_verdict",
+    "apply_stack_verdict_in_session",
+    "bulk_auto_stack",
+    "bulk_auto_stack_in_session",
+    "new_batch_id",
+    "reopen_verdict",
+    "reopen_verdict_in_session",
+    "restore_verdicts_in_session",
+]

--- a/pixlstash/services/operation_log_service.py
+++ b/pixlstash/services/operation_log_service.py
@@ -418,11 +418,18 @@ def diff_states(
 SummarySpec = Union[str, Callable[[dict, dict], Optional[str]], None]
 
 
-# Server-minted batch ids are namespaced so a client-supplied correlation id
-# (``X-Operation-Batch-Id``, validated to the ``cli-`` namespace in
-# ``utils/request_origin.py``) can never collide with one and graft its own
-# requests onto a batch the server created.
 SERVER_BATCH_ID_PREFIX = "srv-"
+"""Namespace for a batch id the *server* minted.
+
+A batch id can also arrive from a client — the ``cli-`` shape, validated at
+both request boundaries (the ``X-Operation-Batch-Id`` header in
+``utils/request_origin.py``, the dedup verdict body field in
+``routes/dedup.py``) — and the two must be distinguishable in the log: an
+un-namespaced id makes a client-supplied grouping key indistinguishable from a
+server-minted one, so a client could graft its rows into what reads as a
+server batch. Every minting site in the backend goes through
+:func:`new_batch_id`.
+"""
 
 
 def new_batch_id() -> str:
@@ -1148,6 +1155,56 @@ def serialize(operation: Operation, include_state: bool = False) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Post-restore hooks — reopening the domain state an operation also decided
+# ---------------------------------------------------------------------------
+
+RESTORE_UNDO = "undo"
+RESTORE_REDO = "redo"
+
+# op_type -> callback(session, operations, direction). Registered by the feature
+# that owns the op_type; this module never imports a feature module, so the core
+# stays free of domain knowledge and an unregistered op_type simply has no hook.
+#
+# Why hooks exist at all: the recorded before/after state covers the reversible
+# *picture* facets (:data:`FACETS`). An operation may additionally have decided
+# something that is not a picture facet — the v1.9 duplicate verdict is the first
+# — and restoring the pictures without reopening that decision leaves the two
+# halves disagreeing. The hook runs inside the restore's own transaction, after
+# every state has been applied, so the decision and the pictures commit together
+# or not at all.
+_POST_RESTORE_HOOKS: dict[str, Callable[[Session, list[Operation], str], None]] = {}
+
+
+def register_post_restore_hook(
+    op_type: str, hook: Callable[[Session, list[Operation], str], None]
+) -> None:
+    """Register *hook* to run after an ``op_type`` operation is undone or redone.
+
+    Args:
+        op_type: The ``Operation.op_type`` this hook owns.
+        hook: ``(session, operations, direction) -> None``, called **once** per
+            restore with every operation of this type in that restore (so a
+            batch of 2 700 rows is one call, not 2 700). *direction* is
+            :data:`RESTORE_UNDO` or :data:`RESTORE_REDO`. It runs on the
+            restore's session, before the commit, and must not commit: raising
+            aborts the whole undo, which is the intended fail-closed behaviour.
+    """
+    _POST_RESTORE_HOOKS[str(op_type)] = hook
+
+
+def _run_post_restore_hooks(
+    session: Session, operations: list[Operation], direction: str
+) -> None:
+    """Dispatch the registered hooks for *operations*, grouped by ``op_type``."""
+    by_type: dict[str, list[Operation]] = {}
+    for operation in operations:
+        if operation.op_type in _POST_RESTORE_HOOKS:
+            by_type.setdefault(operation.op_type, []).append(operation)
+    for op_type, members in by_type.items():
+        _POST_RESTORE_HOOKS[op_type](session, members, direction)
+
+
+# ---------------------------------------------------------------------------
 # Undo / redo
 # ---------------------------------------------------------------------------
 
@@ -1183,6 +1240,11 @@ def _restore(
 ) -> tuple[list[int], set[str], dict[str, list[int]]]:
     """Apply the before- (undo) or after- (redo) state of *operations* in order.
 
+    Once every state is written, the registered post-restore hooks run on this
+    same session (see :func:`register_post_restore_hook`) so an operation that
+    also decided something outside the picture facets can reopen that decision in
+    the same transaction. A hook that raises aborts the restore.
+
     Returns:
         ``(touched_ids, facets, lifecycle)`` where *lifecycle* is
         ``{"scrapheaped": [...], "restored": [...]}`` — the pictures this
@@ -1212,6 +1274,9 @@ def _restore(
         moved_out, moved_in = lifecycle_split(state)
         scrapheaped.update(moved_out)
         restored.update(moved_in)
+    _run_post_restore_hooks(
+        session, operations, RESTORE_UNDO if to_before else RESTORE_REDO
+    )
     lifecycle = {
         "scrapheaped": sorted(scrapheaped),
         "restored": sorted(restored),

--- a/pixlstash/tasks/__init__.py
+++ b/pixlstash/tasks/__init__.py
@@ -40,6 +40,10 @@ from .scrapheap_retention_purge_task import ScrapheapRetentionPurgeTask
 from .scrapheap_retention_purge_finder import ScrapheapRetentionPurgeFinder
 from .thumbnail_generation_task import ThumbnailGenerationTask
 from .missing_thumbnail_finder import MissingThumbnailFinder
+from .pixel_sha_task import PixelShaTask
+from .missing_pixel_sha_finder import MissingPixelShaFinder
+from .dedup_scan_task import DedupScanTask
+from .dedup_scan_finder import DedupScanFinder
 
 __all__ = [
     "TaskType",
@@ -83,4 +87,8 @@ __all__ = [
     "ScrapheapRetentionPurgeFinder",
     "ThumbnailGenerationTask",
     "MissingThumbnailFinder",
+    "PixelShaTask",
+    "MissingPixelShaFinder",
+    "DedupScanTask",
+    "DedupScanFinder",
 ]

--- a/pixlstash/tasks/dedup_scan_finder.py
+++ b/pixlstash/tasks/dedup_scan_finder.py
@@ -1,0 +1,49 @@
+"""Finder that picks up requested duplicate scans.
+
+A scoped scan is *requested* by writing a
+:class:`~pixlstash.db_models.dedup.DedupScan` row with status ``pending`` (the
+``POST /dedup/scan`` route does exactly that and returns immediately, so the
+context-menu entry point never blocks). This finder turns that row into a
+:class:`~pixlstash.tasks.dedup_scan_task.DedupScanTask`.
+
+It is not a :class:`SimpleMissingFinder`: the unit of work is a scan row, not a
+batch of pictures, so there is nothing to claim.
+"""
+
+from pixlstash.pixl_logging import get_logger
+from pixlstash.tasks.base_task_finder import BaseTaskFinder
+from pixlstash.tasks.dedup_scan_task import DedupScanTask
+from pixlstash.tasks.task_type import TaskType
+
+logger = get_logger(__name__)
+
+
+class DedupScanFinder(BaseTaskFinder):
+    """Create one :class:`DedupScanTask` per pending scan request."""
+
+    def __init__(self, database):
+        super().__init__()
+        self._db = database
+
+    def finder_name(self) -> str:
+        return "DedupScanFinder"
+
+    def max_inflight_tasks(self) -> int:
+        # One scan at a time. Two concurrent scans would fight over the same
+        # upserted group rows for no gain: the work is IO-bound on one table.
+        return 1
+
+    def depends_on(self) -> list:
+        # Tier 1 is only complete once every picture has a pixel_sha, and tier 2
+        # needs the perceptual hash the embedding worker writes. Waiting for both
+        # means a scan reports honest counts instead of a partial library.
+        return [TaskType.PIXEL_SHA, TaskType.IMAGE_EMBEDDING]
+
+    def find_task(self):
+        scan = self._db.run_immediate_read_task(DedupScanTask.find_pending_scan)
+        if scan is None:
+            return None
+        logger.info(
+            "[dedup-scan] queueing scan %s for scope %s", scan.id, scan.scope_key
+        )
+        return DedupScanTask(database=self._db, scan_id=int(scan.id))

--- a/pixlstash/tasks/dedup_scan_task.py
+++ b/pixlstash/tasks/dedup_scan_task.py
@@ -1,0 +1,285 @@
+"""Run one duplicate scan, streaming its groups into the queue as it goes.
+
+The design's first performance rule is that the queue never blocks on a full
+pass: it opens with whatever has been found so far, behind a "scanned N of M"
+banner. This task is what makes that true.
+
+* **Tier 1** runs first and in one shot. It is an indexed ``GROUP BY``, so it
+  completes in milliseconds and the queue is never empty while the slow tiers
+  work.
+* **Tier 2** iterates the candidate buckets built by
+  :func:`~pixlstash.services.dedup_tier_service.build_near_buckets`, persisting
+  and committing after **each bucket**. A bucket's groups are visible in the
+  queue the moment that bucket finishes, and the scan's ``scanned_buckets``
+  counter advances with it.
+* **Tier 3** appends the embedding groups last, because it is the tier whose
+  input (the likeness edge table) is the one that may still be filling.
+
+The task is driven by a :class:`~pixlstash.db_models.dedup.DedupScan` row, which
+is both the request (status ``pending``) and the progress readout. Restarting a
+scan is safe: group persistence upserts on the signature, so a re-run refreshes
+rows rather than duplicating them.
+"""
+
+import json
+import time
+
+from datetime import datetime
+
+from sqlmodel import Session, select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models.dedup import (
+    SCAN_COMPLETE,
+    SCAN_FAILED,
+    SCAN_PENDING,
+    SCAN_RUNNING,
+    DedupScan,
+)
+from pixlstash.db_models.picture import Picture
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services import dedup_tier_service
+from pixlstash.services.dedup_tier_service import (
+    DedupScope,
+    DedupTier,
+    ScopeType,
+    TierPolicy,
+)
+from pixlstash.tasks.base_task import BaseTask, TaskPriority
+
+logger = get_logger(__name__)
+
+
+class DedupScanTask(BaseTask):
+    """Execute the tiers requested by one :class:`DedupScan` row."""
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    def __init__(self, database, scan_id: int):
+        super().__init__(
+            task_type="DedupScanTask",
+            # ``picture_ids`` is the key BaseTaskFinder releases its claims from;
+            # this task claims no pictures, so it is deliberately empty.
+            params={"picture_ids": [], "scan_id": int(scan_id)},
+        )
+        self._db = database
+        self._scan_id = int(scan_id)
+
+    def _run_task(self):
+        start = time.time()
+        try:
+            summary = self._db.run_task(
+                DedupScanTask.run_scan_in_session,
+                self._scan_id,
+                priority=DBPriority.LOW,
+            )
+        except Exception as exc:
+            logger.error("DedupScanTask failed for scan_id=%s: %s", self._scan_id, exc)
+            self._db.run_task(
+                DedupScanTask._mark_failed,
+                self._scan_id,
+                str(exc),
+                priority=DBPriority.LOW,
+            )
+            raise
+        logger.info(
+            "DedupScanTask scan_id=%s finished in %.2fs: %s",
+            self._scan_id,
+            time.time() - start,
+            summary,
+        )
+        return summary
+
+    @staticmethod
+    def _policy_for(scan: DedupScan) -> TierPolicy:
+        """Rebuild the requested tier policy from the persisted scan row."""
+        tiers = set(json.loads(scan.tiers or "[]"))
+        return TierPolicy(
+            near_enabled=DedupTier.NEAR.value in tiers,
+            embedding_enabled=DedupTier.EMBEDDING.value in tiers,
+            threshold=float(scan.threshold or dedup_tier_service.DEFAULT_THRESHOLD),
+        )
+
+    @staticmethod
+    def _scope_for(scan: DedupScan) -> DedupScope:
+        return DedupScope(scope_type=ScopeType(scan.scope_type), scope_id=scan.scope_id)
+
+    @staticmethod
+    def _mark_failed(session: Session, scan_id: int, error: str) -> None:
+        scan = session.get(DedupScan, scan_id)
+        if scan is None:
+            logger.warning(
+                "[dedup-scan] cannot mark scan %s failed: the row is gone", scan_id
+            )
+            return
+        scan.status = SCAN_FAILED
+        scan.error = error[:2000]
+        scan.updated_at = datetime.utcnow()
+        session.add(scan)
+        session.commit()
+
+    @staticmethod
+    def run_scan_in_session(session: Session, scan_id: int) -> dict:
+        """Run every requested tier for *scan_id*, committing as tiers finish."""
+        scan = session.get(DedupScan, scan_id)
+        if scan is None:
+            raise ValueError(f"DedupScan {scan_id} no longer exists")
+        policy = DedupScanTask._policy_for(scan)
+        scope = DedupScanTask._scope_for(scan)
+
+        dedup_tier_service.prune_stale_groups_in_session(session)
+
+        total_query = select(Picture.id).where(Picture.deleted.is_(False))
+        predicate = scope.picture_predicate()
+        if predicate is not None:
+            total_query = total_query.where(predicate)
+        total_pictures = len(session.exec(total_query).all())
+
+        scan.status = SCAN_RUNNING
+        scan.total_pictures = total_pictures
+        scan.scanned_pictures = 0
+        scan.scanned_buckets = 0
+        scan.total_buckets = 0
+        scan.groups_found = 0
+        scan.error = None
+        scan.finished_at = None
+        scan.updated_at = datetime.utcnow()
+        session.add(scan)
+        session.commit()
+
+        found = 0
+
+        # --- Tier 1: exact. Indexed GROUP BY, so the queue fills immediately.
+        exact_groups = dedup_tier_service.find_exact_groups_in_session(session, scope)
+        found += dedup_tier_service.persist_groups_in_session(
+            session, exact_groups, scan_id
+        )
+        scan = session.get(DedupScan, scan_id)
+        scan.groups_found = found
+        scan.scanned_pictures = total_pictures if not policy.near_enabled else 0
+        scan.updated_at = datetime.utcnow()
+        session.add(scan)
+        session.commit()
+
+        # --- Tier 2: bucketed near, one commit per bucket.
+        if policy.near_enabled:
+            buckets = dedup_tier_service.build_near_buckets(session, scope)
+            scan = session.get(DedupScan, scan_id)
+            scan.total_buckets = len(buckets)
+            scan.updated_at = datetime.utcnow()
+            session.add(scan)
+            session.commit()
+
+            seen_pictures: set[int] = set()
+            # Pairs are kept across buckets so a chain spanning two buckets folds
+            # into ONE group rather than two. That is a real requirement, but it
+            # is also the scan's only unbounded structure, so it is capped —
+            # see MAX_TRACKED_PAIRS.
+            pair_cache: dict[tuple[int, int], float] = {}
+            pair_cap_reported = False
+            near_groups = 0
+            for index, bucket in enumerate(buckets, start=1):
+                # Ids whose grouping this bucket could have changed. Only groups
+                # touching one of these are re-persisted below; previously the
+                # scan re-derived and re-wrote EVERY group after EVERY bucket,
+                # which is O(buckets x groups) DELETE+INSERT on the single DB
+                # writer thread — every import, tag edit and verdict queues
+                # behind a running scan.
+                touched: set[int] = set()
+                for a, b, similarity in dedup_tier_service.near_pairs_in_bucket(
+                    session, bucket, policy.threshold
+                ):
+                    key = (a, b)
+                    if key not in pair_cache and len(pair_cache) >= (
+                        dedup_tier_service.MAX_TRACKED_PAIRS
+                    ):
+                        if not pair_cap_reported:
+                            # Never silent: the scan continues and every bucket is
+                            # still compared, but cross-bucket chaining stops
+                            # growing, so two buckets' halves of one chain can be
+                            # reported as two groups instead of one.
+                            logger.warning(
+                                "[dedup-scan] scan %s reached the %d tracked-pair "
+                                "cap at bucket %d of %d; further cross-bucket "
+                                "chaining is dropped and some chains may be "
+                                "reported as separate groups. Narrow the scope or "
+                                "raise MAX_TRACKED_PAIRS.",
+                                scan_id,
+                                dedup_tier_service.MAX_TRACKED_PAIRS,
+                                index,
+                                len(buckets),
+                            )
+                            pair_cap_reported = True
+                        continue
+                    if similarity > pair_cache.get(key, 0.0):
+                        pair_cache[key] = similarity
+                        touched.update(key)
+                seen_pictures.update(bucket.picture_ids)
+
+                if touched:
+                    groups = dedup_tier_service.groups_from_pairs(
+                        session,
+                        [(a, b, sim) for (a, b), sim in pair_cache.items()],
+                        policy,
+                        DedupTier.NEAR,
+                    )
+                    near_groups = len(groups)
+                    # Persist only the groups this bucket could have changed. A
+                    # group untouched by this bucket is byte-identical to the row
+                    # already stored, so rewriting it buys nothing.
+                    changed = [
+                        group
+                        for group in groups
+                        if touched.intersection(group.picture_ids)
+                    ]
+                    dedup_tier_service.persist_groups_in_session(
+                        session, changed, scan_id
+                    )
+                scan = session.get(DedupScan, scan_id)
+                scan.scanned_buckets = index
+                scan.scanned_pictures = min(len(seen_pictures), total_pictures)
+                scan.groups_found = found + near_groups
+                scan.updated_at = datetime.utcnow()
+                session.add(scan)
+                session.commit()
+            found = session.get(DedupScan, scan_id).groups_found
+
+        # --- Tier 3: embedding, appended to the same queue.
+        if policy.embedding_enabled:
+            embedding_groups = dedup_tier_service.find_embedding_groups_in_session(
+                session, policy, scope
+            )
+            found += dedup_tier_service.persist_groups_in_session(
+                session, embedding_groups, scan_id
+            )
+
+        scan = session.get(DedupScan, scan_id)
+        scan.status = SCAN_COMPLETE
+        scan.scanned_pictures = total_pictures
+        scan.groups_found = found
+        scan.finished_at = datetime.utcnow()
+        scan.updated_at = scan.finished_at
+        session.add(scan)
+        session.commit()
+        return {
+            "scan_id": scan_id,
+            "scope": scope.key,
+            "total_pictures": total_pictures,
+            "groups_found": found,
+        }
+
+    @staticmethod
+    def find_pending_scan(session: Session) -> "DedupScan | None":
+        """Oldest scan waiting to run, or the one interrupted mid-flight.
+
+        A ``running`` row with no live task means the server restarted during a
+        scan; picking it up again is correct because group persistence is an
+        upsert on the signature.
+        """
+        return session.exec(
+            select(DedupScan)
+            .where(DedupScan.status.in_([SCAN_PENDING, SCAN_RUNNING]))
+            .order_by(DedupScan.started_at)
+        ).first()

--- a/pixlstash/tasks/missing_pixel_sha_finder.py
+++ b/pixlstash/tasks/missing_pixel_sha_finder.py
@@ -1,0 +1,29 @@
+"""Finder for pictures missing the tier-1 exact-duplicate hash."""
+
+from pixlstash.tasks.base_task_finder import SimpleMissingFinder
+from pixlstash.tasks.pixel_sha_task import PixelShaTask
+
+
+class MissingPixelShaFinder(SimpleMissingFinder):
+    """Queue :class:`PixelShaTask` for pictures whose ``pixel_sha`` is NULL.
+
+    Tier 1 of the duplicate queue groups on ``picture.pixel_sha``; a NULL there
+    is a duplicate nobody can find. Reading a file to digest it is cheap next to
+    the embedding pipeline, so this runs at one task in flight and gets out of
+    the way.
+    """
+
+    def finder_name(self) -> str:
+        return "MissingPixelShaFinder"
+
+    def max_inflight_tasks(self) -> int:
+        return 1
+
+    def _batch_size(self) -> int:
+        return PixelShaTask.BATCH_SIZE
+
+    def _fetch_candidates(self, session, limit: int) -> list:
+        return PixelShaTask.find_pictures_missing_pixel_sha(session, limit)
+
+    def _create_task(self, pictures: list):
+        return PixelShaTask(database=self._db, pictures=pictures)

--- a/pixlstash/tasks/pixel_sha_task.py
+++ b/pixlstash/tasks/pixel_sha_task.py
@@ -1,0 +1,118 @@
+"""Backfill ``Picture.pixel_sha`` — the tier-1 exact-duplicate key.
+
+Every current import path computes ``pixel_sha`` as the file is written, so this
+task exists for the rows that predate it (and for rows whose file was replaced
+under a reference folder). Tier 1 of the duplicate queue is a ``GROUP BY`` on
+that indexed column, so a NULL there is a duplicate the queue can never see —
+which is the one failure mode that makes the sidebar count untrustworthy.
+
+The digest is ``ImageUtils.calculate_hash_from_file_path``, i.e. exactly what the
+import paths write, so a backfilled row and a freshly imported row of the same
+file agree.
+"""
+
+import time
+
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models.picture import Picture
+from pixlstash.pixl_logging import get_logger
+from pixlstash.tasks.base_task import BaseTask, TaskPriority
+from pixlstash.utils.image_processing.image_utils import ImageUtils
+
+logger = get_logger(__name__)
+
+
+class PixelShaTask(BaseTask):
+    """Compute ``pixel_sha`` for a batch of pictures that have none."""
+
+    BATCH_SIZE = 64
+    SCAN_LIMIT = 512
+
+    @property
+    def priority(self) -> TaskPriority:
+        return TaskPriority.LOW
+
+    def __init__(self, database, pictures: list):
+        picture_ids = [pic.id for pic in (pictures or []) if getattr(pic, "id", None)]
+        super().__init__(
+            task_type="PixelShaTask",
+            params={"picture_ids": picture_ids, "batch_size": len(picture_ids)},
+        )
+        self._db = database
+        self._pictures = pictures or []
+
+    def _run_task(self):
+        start = time.time()
+        updates: list[tuple[int, str]] = []
+        for pic in self._pictures:
+            file_path = ImageUtils.resolve_picture_path(
+                self._db.image_root, pic.file_path
+            )
+            try:
+                digest = ImageUtils.calculate_hash_from_file_path(str(file_path))
+            except (OSError, ValueError) as exc:
+                logger.warning(
+                    "pixel_sha computation failed for picture_id=%s path=%s: %s. "
+                    "The picture stays invisible to tier-1 exact duplicate "
+                    "detection until the file is readable again.",
+                    pic.id,
+                    file_path,
+                    exc,
+                )
+                continue
+            updates.append((int(pic.id), digest))
+
+        if not updates:
+            return {"changed_count": 0, "changed": []}
+
+        changed = self._db.run_task(
+            PixelShaTask._persist_pixel_shas, updates, priority=DBPriority.LOW
+        )
+        logger.debug(
+            "PixelShaTask completed in %.2fs with %s update(s)",
+            time.time() - start,
+            len(changed or []),
+        )
+        return {"changed_count": len(changed or []), "changed": changed or []}
+
+    @staticmethod
+    def _persist_pixel_shas(session: Session, updates: list[tuple[int, str]]) -> list:
+        """Write the digests in one transaction."""
+        changed = []
+        for picture_id, digest in updates:
+            pic = session.get(Picture, picture_id)
+            if pic is None:
+                continue
+            pic.pixel_sha = digest
+            session.add(pic)
+            changed.append((Picture, picture_id, "pixel_sha", digest))
+        session.commit()
+        return changed
+
+    @staticmethod
+    def find_pictures_missing_pixel_sha(session: Session, limit: int) -> list:
+        """Return non-deleted pictures with a file but no ``pixel_sha``."""
+        return session.exec(
+            select(Picture)
+            .where(Picture.pixel_sha.is_(None))
+            .where(Picture.deleted.is_(False))
+            .where(Picture.file_path.is_not(None))
+            .limit(limit)
+        ).all()
+
+    @staticmethod
+    def count_missing_pixel_sha(session: Session) -> int:
+        """How many pictures tier 1 is still blind to."""
+        result = session.exec(
+            select(func.count())
+            .select_from(Picture)
+            .where(Picture.pixel_sha.is_(None))
+            .where(Picture.deleted.is_(False))
+            .where(Picture.file_path.is_not(None))
+        ).one()
+        if isinstance(result, (tuple, list)):
+            return result[0]
+        return result or 0

--- a/pixlstash/tasks/task_type.py
+++ b/pixlstash/tasks/task_type.py
@@ -27,6 +27,8 @@ class TaskType(str, Enum):
     TAG_HEALTH_AUTO_REBUILD = "TagHealthAutoRebuildTask"
     SCRAPHEAP_RETENTION_PURGE = "ScrapheapRetentionPurgeTask"
     THUMBNAIL_GENERATION = "ThumbnailGenerationTask"
+    PIXEL_SHA = "PixelShaTask"
+    DEDUP_SCAN = "DedupScanTask"
 
     @staticmethod
     def all():

--- a/pixlstash/utils/image_processing/image_utils.py
+++ b/pixlstash/utils/image_processing/image_utils.py
@@ -682,6 +682,32 @@ class ImageUtils:
             )
 
     @staticmethod
+    def thumbnail_cache_token(
+        thumbnail_width: Optional[int], thumbnail_height: Optional[int]
+    ) -> str:
+        """The ``?v=`` cache-buster for a picture's thumbnail URL.
+
+        Keyed on the stored bitmap's own dimensions, so any regeneration that
+        repopulates them changes the URL and the browser refetches instead of
+        painting a stale bitmap. ``"0"`` until the picture has been processed.
+
+        Single source of truth on purpose: the batch-thumbnail endpoint and the
+        duplicate queue both hand this token to the same frontend cache, and two
+        independent copies of the ``WxH`` formula would eventually disagree and
+        reintroduce the stale-thumbnail bug this token exists to fix.
+
+        Args:
+            thumbnail_width: Stored bitmap width, or ``None`` when unprocessed.
+            thumbnail_height: Stored bitmap height, or ``None`` when unprocessed.
+
+        Returns:
+            ``"<width>x<height>"``, or ``"0"`` when either dimension is missing.
+        """
+        if thumbnail_width and thumbnail_height:
+            return f"{thumbnail_width}x{thumbnail_height}"
+        return "0"
+
+    @staticmethod
     def calculate_hash_from_bytes(image_bytes: bytes) -> str:
         """Compute a content hash for raw image bytes."""
         file_size = len(image_bytes)

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -62,6 +62,8 @@ class WorkPlanner:
         )
         from pixlstash.tasks.missing_text_score_finder import MissingTextScoreFinder
         from pixlstash.tasks.missing_thumbnail_finder import MissingThumbnailFinder
+        from pixlstash.tasks.missing_pixel_sha_finder import MissingPixelShaFinder
+        from pixlstash.tasks.dedup_scan_finder import DedupScanFinder
 
         from pixlstash.utils.path_mapper import PathMapper
 
@@ -126,6 +128,12 @@ class WorkPlanner:
                 database=database,
             ),
             TaskType.THUMBNAIL_GENERATION: MissingThumbnailFinder(
+                database=database,
+            ),
+            TaskType.PIXEL_SHA: MissingPixelShaFinder(
+                database=database,
+            ),
+            TaskType.DEDUP_SCAN: DedupScanFinder(
                 database=database,
             ),
         }

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -138,6 +138,8 @@ def test_services_no_direct_db_calls():
     _direct_db_call_service_allowlist = {
         "pixlstash/services/config_service.py",  # vault-injection pattern
         "pixlstash/services/dedup_sweep_service.py",  # vault-injection pattern; read-only wrapper around plan_sweep_in_session
+        "pixlstash/services/dedup_tier_service.py",  # vault-injection pattern; thin wrappers around the *_in_session queue reads and the scan request
+        "pixlstash/services/dedup_verdict_service.py",  # vault-injection pattern; thin wrappers around the *_in_session verdict writers
         "pixlstash/services/impossible_tag_clear_service.py",  # vault-injection pattern; bulk impossible-tag clear/undo
         "pixlstash/services/picture_stats.py",  # pending session injection refactor
         "pixlstash/services/search_query_service.py",  # vault-injection pattern; DB queries for search endpoints

--- a/tests/test_dedup_tier_service.py
+++ b/tests/test_dedup_tier_service.py
@@ -1,0 +1,1061 @@
+"""Unit tests for the tiered duplicate detection service.
+
+Covers, per tier and per rule:
+
+* **tier 1 (exact)** — groups on the indexed ``pixel_sha``, refuses to group two
+  files that share a digest but differ in ``size_bytes`` (the sampled-digest
+  guard), and stays blind to the scrapheap;
+* **tier 2 (bucketed near)** — candidate buckets come from the precomputed
+  columns, comparison happens only inside a bucket, and the group's confidence is
+  its weakest link;
+* **tier 3 (embedding)** — reuses the shipped likeness edge table;
+* **the tier policy** — exact is always on, each looser tier requires the tier
+  above it, and the 0.65 floor is a hard error rather than a silent clamp;
+* **cover selection** — the design's ``px*4 + tags*3 + score*2 + RAW`` formula
+  and the oldest-capture tie-break;
+* **evidence** — matching pills and evidence-against pills, both directions;
+* **the queue** — paged by confidence descending, verdict-resolved groups never
+  re-offered, and scope-narrowed counts.
+"""
+
+import gc
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta
+
+import pytest
+from sqlmodel import select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models import Picture, PictureSet, PictureSetMember
+from pixlstash.db_models.dedup import (
+    VERDICT_KEEP_SEPARATE,
+    DedupGroup,
+    DedupVerdict,
+)
+from pixlstash.db_models.picture_likeness import PictureLikeness
+from pixlstash.db_models.tag import Tag
+from pixlstash.server import Server
+from pixlstash.services import dedup_tier_service as tiers
+from pixlstash.services import dedup_verdict_service as verdicts
+from pixlstash.services.dedup_tier_service import (
+    CandidateMember,
+    DedupScope,
+    DedupTier,
+    ScopeType,
+    TierPolicy,
+)
+
+_BASE_TIME = datetime(2026, 1, 1, 12, 0, 0)
+
+# A 64-bit dHash is 16 hex chars. These differ from ZERO by a controlled number
+# of set bits, so the Hamming distance (and therefore the similarity) is exact.
+PHASH_ZERO = "0000000000000000"
+PHASH_ONE_BIT = "0000000000000001"  # 1 bit  -> similarity 63/64 = 0.984375
+PHASH_FOUR_BITS = "000000000000000f"  # 4 bits -> similarity 60/64 = 0.9375
+PHASH_FAR = "ffffffffffffffff"  # 64 bits -> similarity 0.0
+
+
+@pytest.fixture
+def server():
+    temp_dir = tempfile.TemporaryDirectory()
+    config_path = os.path.join(temp_dir.name, "server-config.json")
+    with open(config_path, "w") as fh:
+        fh.write(json.dumps({"port": 8000, "disable_background_workers": True}))
+    Server.DEFAULT_FORCE_CPU = True
+    srv = Server(config_path)
+    try:
+        yield srv
+    finally:
+        srv.vault.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
+def _run(server, fn, *args):
+    """Run *fn(session, \\*args)* on the DB worker and return its result."""
+    return server.vault.db.run_task(fn, *args, priority=DBPriority.IMMEDIATE)
+
+
+def _seed(server, specs):
+    """Insert one picture per spec; return the ids in order.
+
+    Recognised keys: ``pixel_sha``, ``perceptual_hash``, ``size_bytes``,
+    ``width``, ``height``, ``score``, ``format``, ``file_path``, ``created_at``
+    (an offset in seconds from ``_BASE_TIME``), ``deleted``, ``tags``,
+    ``import_source_folder``, ``reference_folder_id``.
+    """
+
+    def insert(session):
+        picture_ids = []
+        for index, spec in enumerate(specs):
+            width = spec.get("width", 4000)
+            height = spec.get("height", 3000)
+            created_offset = spec.get("created_at")
+            pic = Picture(
+                file_path=spec.get("file_path", f"/vault/pic_{index}.png"),
+                format=spec.get("format", "png"),
+                width=width,
+                height=height,
+                size_bin_index=(width << 32) + height,
+                size_bytes=spec.get("size_bytes", 1000),
+                score=spec.get("score"),
+                pixel_sha=spec.get("pixel_sha"),
+                perceptual_hash=spec.get("perceptual_hash"),
+                import_source_folder=spec.get("import_source_folder"),
+                reference_folder_id=spec.get("reference_folder_id"),
+                deleted=bool(spec.get("deleted", False)),
+                created_at=(
+                    _BASE_TIME + timedelta(seconds=created_offset)
+                    if created_offset is not None
+                    else None
+                ),
+            )
+            session.add(pic)
+            session.flush()
+            for tag in spec.get("tags", []):
+                session.add(Tag(picture_id=int(pic.id), tag=tag))
+            picture_ids.append(int(pic.id))
+        session.commit()
+        return picture_ids
+
+    return _run(server, insert)
+
+
+def _member(**kwargs) -> CandidateMember:
+    """A bare :class:`CandidateMember` for the pure-function tests."""
+    defaults = {
+        "id": 1,
+        "width": 4000,
+        "height": 3000,
+        "format": "jpeg",
+        "score": 0,
+        "tag_count": 0,
+    }
+    defaults.update(kwargs)
+    return CandidateMember(**defaults)
+
+
+# ── the tier policy ───────────────────────────────────────────────────────────
+
+
+def test_exact_tier_is_always_on_and_cannot_be_switched_off():
+    assert TierPolicy().tiers == (DedupTier.EXACT,)
+    assert TierPolicy().includes(DedupTier.EXACT)
+    assert not TierPolicy().includes(DedupTier.NEAR)
+
+
+def test_each_looser_tier_requires_the_tier_above_it():
+    assert TierPolicy(near_enabled=True).tiers == (DedupTier.EXACT, DedupTier.NEAR)
+    assert TierPolicy(near_enabled=True, embedding_enabled=True).tiers == (
+        DedupTier.EXACT,
+        DedupTier.NEAR,
+        DedupTier.EMBEDDING,
+    )
+    with pytest.raises(ValueError, match="requires near_enabled"):
+        TierPolicy(embedding_enabled=True)
+
+
+def test_threshold_default_is_090_and_the_floor_is_a_hard_error():
+    assert TierPolicy().threshold == pytest.approx(0.90)
+    # Below the floor is a 400-worthy error, never a silent clamp: a low
+    # threshold produces confident-looking garbage and destroys the count.
+    with pytest.raises(ValueError, match="0.65"):
+        TierPolicy(threshold=0.5)
+    assert TierPolicy(threshold=tiers.MIN_THRESHOLD).threshold == pytest.approx(0.65)
+
+
+def test_group_size_bounds_are_validated():
+    with pytest.raises(ValueError, match="min_group_size"):
+        TierPolicy(min_group_size=1)
+    with pytest.raises(ValueError, match="max_group_size"):
+        TierPolicy(min_group_size=4, max_group_size=3)
+
+
+# ── cover selection ───────────────────────────────────────────────────────────
+
+
+def test_cover_score_is_the_designs_formula():
+    # 12 MP -> 12*4 = 48; 2 tags -> 6; score 3 -> 6; not RAW -> 0.
+    member = _member(width=4000, height=3000, tag_count=2, score=3)
+    assert member.megapixels == pytest.approx(12.0)
+    assert member.cover_score == pytest.approx(48.0 + 6.0 + 6.0)
+
+
+def test_raw_earns_the_cover_bonus_by_format_or_extension():
+    assert _member(format="ARW").is_raw
+    assert _member(format="jpeg", file_path="/shoots/A7R0912.arw").is_raw
+    assert not _member(format="jpeg", file_path="/shoots/x.jpg").is_raw
+    raw = _member(id=1, format="arw", width=1000, height=1000)
+    jpeg = _member(id=2, format="jpeg", width=1000, height=1000)
+    assert raw.cover_score - jpeg.cover_score == pytest.approx(tiers.COVER_RAW_BONUS)
+
+
+def test_cover_prefers_the_highest_score_then_the_oldest_capture():
+    big = _member(id=1, width=6000, height=4000)
+    small = _member(id=2, width=1000, height=1000, tag_count=1)
+    assert tiers.select_cover([small, big]) == 1
+
+    # Identical formula scores: the oldest capture time wins, not the newest.
+    old = _member(id=10, created_at=_BASE_TIME)
+    new = _member(id=11, created_at=_BASE_TIME + timedelta(hours=5))
+    assert old.cover_score == pytest.approx(new.cover_score)
+    assert tiers.select_cover([new, old]) == 10
+
+
+def test_tags_can_outweigh_a_slightly_larger_picture():
+    # 1 MP + 5 tags = 4 + 15 = 19 beats 4 MP with nothing = 16.
+    tagged = _member(id=1, width=1000, height=1000, tag_count=5)
+    bigger = _member(id=2, width=2000, height=2000)
+    assert tiers.select_cover([bigger, tagged]) == 1
+
+
+# ── signature ─────────────────────────────────────────────────────────────────
+
+
+def test_signature_is_order_independent_and_content_derived():
+    assert tiers.group_signature(["b", "a"]) == tiers.group_signature(["a", "b"])
+    assert tiers.group_signature(["a", "b"]) != tiers.group_signature(["a", "c"])
+
+
+def test_signature_falls_back_to_the_picture_id_when_no_hash_exists():
+    hashed = _member(id=7, pixel_sha="deadbeef", size_bytes=100)
+    unhashed = _member(id=7)
+    # The hash is never the identity on its own: it is sampled above 128 KiB, so
+    # the size travels with it (see test_content_key_carries_the_size_co_key).
+    assert hashed.content_key == "deadbeef:100"
+    assert unhashed.content_key == "id:7"
+
+
+# ── evidence ──────────────────────────────────────────────────────────────────
+
+
+def test_group_evidence_reports_both_directions():
+    members = [
+        _member(id=1, width=6000, height=4000, created_at=_BASE_TIME, format="jpeg"),
+        _member(id=2, width=1920, height=1440, created_at=_BASE_TIME, format="webp"),
+    ]
+    pills = tiers.build_group_evidence(DedupTier.NEAR, 0.96, members)
+    texts = {pill["text"]: pill["against"] for pill in pills}
+    assert texts["96% visual match"] is False
+    assert texts["Different resolution"] is True
+    assert texts["Different aspect ratio"] is True
+    assert texts["Different file format"] is True
+    assert texts["Same capture second"] is False
+
+
+def test_exact_evidence_leads_with_the_hash_and_same_dimensions():
+    members = [_member(id=1), _member(id=2)]
+    pills = tiers.build_group_evidence(DedupTier.EXACT, 1.0, members)
+    texts = [pill["text"] for pill in pills]
+    assert texts[0] == "Identical file hash"
+    assert "Same dimensions" in texts
+    assert not any(pill["against"] for pill in pills)
+
+
+def test_candidate_evidence_explains_the_preselection_both_ways():
+    best = _member(id=1, width=6000, height=4000, tag_count=6, score=5)
+    worst = _member(id=2, width=1080, height=1080)
+    members = [best, worst]
+    best_pills = tiers.build_candidate_evidence(best, members, cover_id=1)
+    worst_pills = tiers.build_candidate_evidence(worst, members, cover_id=1)
+    assert any(p["text"] == "Highest resolution" for p in best_pills)
+    assert any(p["text"] == "Preselected as cover" for p in best_pills)
+    assert any(p["against"] and "fewer pixels" in p["text"] for p in worst_pills)
+    assert any(p["against"] and "Fewer tags" in p["text"] for p in worst_pills)
+
+
+def test_reference_folder_pictures_expose_their_path_and_others_do_not():
+    managed = _member(id=1, file_path="/vault/a.png")
+    referenced = _member(id=2, file_path="/photos/a.png", reference_folder_id=3)
+    assert managed.as_dict()["file_path"] is None
+    assert referenced.as_dict()["file_path"] == "/photos/a.png"
+
+
+# ── tier 1: exact ─────────────────────────────────────────────────────────────
+
+
+def test_exact_tier_groups_on_the_indexed_hash(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 4},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "bbb", "size_bytes": 100},
+        ],
+    )
+    groups = _run(server, tiers.find_exact_groups_in_session, None)
+    assert len(groups) == 1
+    group = groups[0]
+    assert sorted(group.picture_ids) == sorted(ids[:2])
+    assert group.confidence == pytest.approx(1.0)
+    assert group.tier is DedupTier.EXACT
+    # The higher human score wins the cover under the formula.
+    assert group.cover_picture_id == ids[0]
+
+
+def test_exact_tier_refuses_to_group_on_a_digest_alone(server):
+    """The sampled-digest guard: same hash, different size is not a match.
+
+    ``pixel_sha`` samples large files rather than hashing every byte, so equal
+    file size is a required co-key. Dropping it would let the queue claim an
+    identity the digest does not actually prove.
+    """
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+        ],
+    )
+    assert _run(server, tiers.find_exact_groups_in_session, None) == []
+
+
+def test_exact_tier_ignores_the_scrapheap_and_unhashed_rows(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100, "deleted": True},
+            {"pixel_sha": None, "size_bytes": 100},
+            {"pixel_sha": None, "size_bytes": 100},
+        ],
+    )
+    assert _run(server, tiers.find_exact_groups_in_session, None) == []
+
+
+def test_exact_tier_narrows_to_a_scope(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 100},
+        ],
+    )
+
+    def add_set(session):
+        picture_set = PictureSet(name="Scope")
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        for picture_id in ids[:2]:
+            session.add(
+                PictureSetMember(set_id=int(picture_set.id), picture_id=picture_id)
+            )
+        session.commit()
+        return int(picture_set.id)
+
+    set_id = _run(server, add_set)
+    scope = DedupScope(scope_type=ScopeType.SET, scope_id=str(set_id))
+    scoped = _run(server, tiers.find_exact_groups_in_session, scope)
+    assert len(scoped) == 1
+    assert sorted(scoped[0].picture_ids) == sorted(ids[:2])
+    assert len(_run(server, tiers.find_exact_groups_in_session, None)) == 2
+
+
+# ── tier 2: bucketed near ─────────────────────────────────────────────────────
+
+
+def test_buckets_come_from_the_precomputed_columns(server):
+    _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_ONE_BIT, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_FAR, "width": 200, "height": 200},
+        ],
+    )
+    buckets = _run(server, tiers.build_near_buckets, None)
+    kinds = {bucket.kind for bucket in buckets}
+    assert "size_bin" in kinds
+    # The 200x200 picture is alone in its size bin, so that bucket is dropped:
+    # a singleton bucket is not work and must not inflate the progress total.
+    size_bins = [b for b in buckets if b.kind == "size_bin"]
+    assert len(size_bins) == 1
+    assert len(size_bins[0].picture_ids) == 2
+
+
+def test_near_pairs_are_only_compared_inside_a_bucket(server):
+    """A picture that shares no bucket is never compared, however similar it is.
+
+    The third picture has a byte-identical perceptual hash but different
+    dimensions *and* a different folder, so it shares no candidate bucket with
+    the pair. Library-wide comparison would have pulled it in; bucketed
+    comparison does not.
+    """
+    ids = _seed(
+        server,
+        [
+            # Same dimensions and folder -> same bucket, 1 bit apart.
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 100,
+                "height": 100,
+                "file_path": "/vault/a/one.png",
+            },
+            {
+                "perceptual_hash": PHASH_ONE_BIT,
+                "width": 100,
+                "height": 100,
+                "file_path": "/vault/a/two.png",
+            },
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 300,
+                "height": 300,
+                "file_path": "/vault/b/three.png",
+            },
+        ],
+    )
+    groups = _run(
+        server, tiers.find_near_groups_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert len(groups) == 1
+    assert sorted(groups[0].picture_ids) == sorted(ids[:2])
+    assert groups[0].confidence == pytest.approx(63 / 64)
+    assert groups[0].tier is DedupTier.NEAR
+
+
+def test_capture_minute_buckets_catch_a_resize(server):
+    """Different dimensions, same capture minute: still one bucket, still found."""
+    ids = _seed(
+        server,
+        [
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 4000,
+                "height": 3000,
+                "created_at": 0,
+            },
+            {
+                "perceptual_hash": PHASH_ONE_BIT,
+                "width": 2000,
+                "height": 1500,
+                "created_at": 5,
+            },
+        ],
+    )
+    groups = _run(
+        server, tiers.find_near_groups_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert len(groups) == 1
+    assert sorted(groups[0].picture_ids) == sorted(ids)
+    assert any(
+        pill["against"] and pill["text"] == "Different resolution"
+        for pill in groups[0].evidence
+    )
+
+
+def test_the_threshold_excludes_a_weaker_near_pair(server):
+    _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_FOUR_BITS, "width": 100, "height": 100},
+        ],
+    )
+    # 4 bits apart is 0.9375: above the 0.90 default, below a 0.99 threshold.
+    loose = _run(
+        server, tiers.find_near_groups_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert len(loose) == 1
+    tight = _run(
+        server,
+        tiers.find_near_groups_in_session,
+        TierPolicy(near_enabled=True, threshold=0.99),
+        None,
+    )
+    assert tight == []
+
+
+def test_a_group_is_judged_by_its_weakest_link(server):
+    """A~B at 1 bit and B~C at 4 bits is one group whose confidence is the 4-bit edge."""
+    ids = _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_ONE_BIT, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_FOUR_BITS, "width": 100, "height": 100},
+        ],
+    )
+    groups = _run(
+        server, tiers.find_near_groups_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert len(groups) == 1
+    assert sorted(groups[0].picture_ids) == sorted(ids)
+    assert groups[0].confidence == pytest.approx(60 / 64)
+
+
+def test_unparseable_perceptual_hashes_are_excluded_not_crashed(server):
+    _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": "not-a-hash-xx", "width": 100, "height": 100},
+            {"perceptual_hash": "abc", "width": 100, "height": 100},
+        ],
+    )
+    assert (
+        _run(
+            server,
+            tiers.find_near_groups_in_session,
+            TierPolicy(near_enabled=True),
+            None,
+        )
+        == []
+    )
+
+
+# ── tier 3: embedding ─────────────────────────────────────────────────────────
+
+
+def test_embedding_tier_reuses_the_shipped_likeness_table(server):
+    ids = _seed(server, [{}, {}, {}])
+
+    def link(session):
+        first, second = PictureLikeness.canon_pair(ids[0], ids[1])
+        session.add(
+            PictureLikeness(
+                picture_id_a=first, picture_id_b=second, likeness=0.97, metric="test"
+            )
+        )
+        session.commit()
+
+    _run(server, link)
+    policy = TierPolicy(near_enabled=True, embedding_enabled=True)
+    groups = _run(server, tiers.find_embedding_groups_in_session, policy, None)
+    assert len(groups) == 1
+    assert sorted(groups[0].picture_ids) == sorted(ids[:2])
+    assert groups[0].tier is DedupTier.EMBEDDING
+    assert groups[0].confidence == pytest.approx(0.97)
+
+
+# ── persistence, the queue and the counts ─────────────────────────────────────
+
+
+def _scan(server, policy=None, scope=None):
+    return _run(server, tiers.run_scan_now_in_session, policy or TierPolicy(), scope)
+
+
+def test_a_rescan_refreshes_groups_instead_of_duplicating_them(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    assert _scan(server)["unresolved_groups"] == 1
+    _scan(server)
+    rows = _run(server, lambda session: session.exec(select(DedupGroup)).all())
+    assert len(rows) == 1
+
+
+def test_the_queue_pages_by_confidence_descending(server):
+    _seed(
+        server,
+        [
+            # An exact pair (confidence 1.0). Separate folders so it does not
+            # also land in a near bucket with the pairs below.
+            {
+                "pixel_sha": "aaa",
+                "size_bytes": 100,
+                "width": 10,
+                "height": 10,
+                "file_path": "/vault/x/1.png",
+            },
+            {
+                "pixel_sha": "aaa",
+                "size_bytes": 100,
+                "width": 10,
+                "height": 10,
+                "file_path": "/vault/x/2.png",
+            },
+            # A 1-bit near pair (0.984).
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 20,
+                "height": 20,
+                "file_path": "/vault/y/1.png",
+            },
+            {
+                "perceptual_hash": PHASH_ONE_BIT,
+                "width": 20,
+                "height": 20,
+                "file_path": "/vault/y/2.png",
+            },
+            # A 4-bit near pair (0.9375), in its own folder so it stays its own
+            # group rather than chaining onto the pair above.
+            {
+                "perceptual_hash": PHASH_ZERO,
+                "width": 30,
+                "height": 30,
+                "file_path": "/vault/z/1.png",
+            },
+            {
+                "perceptual_hash": PHASH_FOUR_BITS,
+                "width": 30,
+                "height": 30,
+                "file_path": "/vault/z/2.png",
+            },
+        ],
+    )
+    policy = TierPolicy(near_enabled=True)
+    _scan(server, policy)
+    page, total, _cursor = _run(server, tiers.page_queue_in_session, policy, None, 0, 2)
+    assert total == 3
+    assert [round(group["confidence"], 4) for group in page] == [
+        1.0,
+        round(63 / 64, 4),
+    ]
+    assert page[0]["tier"] == "exact"
+    second, _total, _cursor = _run(
+        server, tiers.page_queue_in_session, policy, None, 2, 2
+    )
+    assert len(second) == 1
+    assert second[0]["confidence"] == pytest.approx(60 / 64)
+
+
+def test_the_queue_carries_the_cover_and_both_evidence_layers(server):
+    ids = _seed(
+        server,
+        [
+            {
+                "pixel_sha": "aaa",
+                "size_bytes": 100,
+                "score": 5,
+                "tags": ["portrait", "outdoor"],
+            },
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    page, _total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    group = page[0]
+    assert group["cover_picture_id"] == ids[0]
+    assert any(pill["text"] == "Identical file hash" for pill in group["why"])
+    cover = next(c for c in group["candidates"] if c["picture_id"] == ids[0])
+    assert cover["tag_count"] == 2
+    assert any(p["text"] == "Preselected as cover" for p in cover["why"])
+    assert any(p["text"].startswith("Most metadata") for p in cover["why"])
+
+
+def test_the_near_tier_is_hidden_until_it_is_switched_on(server):
+    _seed(
+        server,
+        [
+            {"perceptual_hash": PHASH_ZERO, "width": 100, "height": 100},
+            {"perceptual_hash": PHASH_ONE_BIT, "width": 100, "height": 100},
+        ],
+    )
+    near_policy = TierPolicy(near_enabled=True)
+    _scan(server, near_policy)
+    # Detected and stored, but the default policy shows only tier 1.
+    assert _run(server, tiers.count_unresolved_in_session, TierPolicy(), None) == 0
+    assert _run(server, tiers.count_unresolved_in_session, near_policy, None) == 1
+    # The per-tier counts report the switched-off tier anyway, so the user can
+    # see what enabling it would add.
+    by_tier = _run(server, tiers.count_by_tier_in_session, TierPolicy(), None)
+    assert by_tier["near"] == 1
+    assert by_tier["exact"] == 0
+
+
+def test_a_recorded_verdict_resolves_the_group_on_the_next_scan(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    page, _total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    signature = page[0]["signature"]
+
+    def record(session):
+        session.add(
+            DedupVerdict(
+                signature=signature,
+                verdict=VERDICT_KEEP_SEPARATE,
+                picture_ids="[]",
+                excluded_picture_ids="[]",
+            )
+        )
+        session.commit()
+
+    _run(server, record)
+    # A rescan re-derives the same signature and never re-asks.
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+    page, total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    assert page == [] and total == 0
+
+
+def test_a_reopened_verdict_puts_the_group_back_in_the_queue(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    page, _total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    signature = page[0]["signature"]
+
+    def record_and_reopen(session):
+        session.add(
+            DedupVerdict(
+                signature=signature,
+                verdict=VERDICT_KEEP_SEPARATE,
+                picture_ids="[]",
+                excluded_picture_ids="[]",
+                reopened_at=_BASE_TIME,
+            )
+        )
+        session.commit()
+
+    _run(server, record_and_reopen)
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+
+def test_stale_groups_are_pruned_when_their_members_go_to_the_scrapheap(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+    def soft_delete(session):
+        pic = session.get(Picture, ids[1])
+        pic.deleted = True
+        session.add(pic)
+        session.commit()
+
+    _run(server, soft_delete)
+    assert _run(server, tiers.prune_stale_groups_in_session) == 1
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+
+
+def test_scoped_counts_are_reported_per_scope(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+
+    def add_set(session):
+        picture_set = PictureSet(name="Scope")
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        for picture_id in ids[:2]:
+            session.add(
+                PictureSetMember(set_id=int(picture_set.id), picture_id=picture_id)
+            )
+        session.commit()
+        return int(picture_set.id)
+
+    set_id = _run(server, add_set)
+    scopes = [
+        DedupScope(),
+        DedupScope(scope_type=ScopeType.SET, scope_id=str(set_id)),
+    ]
+    counts = _run(server, tiers.scope_counts_in_session, scopes, None)
+    assert counts[0]["key"] == "global"
+    assert counts[0]["unresolved_groups"] == 2
+    assert counts[1]["key"] == f"set:{set_id}"
+    assert counts[1]["unresolved_groups"] == 1
+
+
+def test_a_scope_id_is_required_for_a_non_global_scope():
+    with pytest.raises(ValueError, match="scope_id is required"):
+        DedupScope(scope_type=ScopeType.PROJECT)
+    assert DedupScope(scope_type=ScopeType.GLOBAL, scope_id="ignored").key == "global"
+
+
+# ── scan progress ─────────────────────────────────────────────────────────────
+
+
+def test_requesting_a_scan_creates_one_row_per_scope_and_reuses_it(server):
+    first = _run(server, tiers.request_scan_in_session, TierPolicy(), None)
+    assert first["status"] == "pending"
+    assert first["scope_key"] == "global"
+    second = _run(
+        server, tiers.request_scan_in_session, TierPolicy(near_enabled=True), None
+    )
+    assert second["scan_id"] == first["scan_id"]
+    assert second["tiers"] == ["exact", "near"]
+
+
+def test_scan_progress_for_an_unscanned_scope_is_idle_not_an_error(server):
+    progress = _run(server, tiers.scan_progress_in_session, None)
+    assert progress["status"] == "idle"
+    assert progress["total_pictures"] == 0
+
+
+# ── R1: the group signature must be injective over groups ─────────────────────
+
+
+def test_two_groups_sharing_a_digest_but_not_a_size_stay_distinct(server):
+    """Regression for the CSO's E1: the signature needs the ``size_bytes`` co-key.
+
+    ``pixel_sha`` is a *sampled* digest above 128 KiB, which is exactly why tier 1
+    detects on ``(pixel_sha, size_bytes)``. Identity that dropped the size made
+    two distinct exact groups collapse onto one signature, and all three
+    consequences were silent: one group vanished from the queue via the
+    upsert-on-signature, a keep-separate on the survivor resolved both file sets,
+    and a stack verdict's write target depended on scan order rather than on what
+    the user saw.
+    """
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+        ],
+    )
+    groups = _run(server, tiers.find_exact_groups_in_session, None)
+    assert len(groups) == 2
+    assert sorted(sorted(g.picture_ids) for g in groups) == [
+        sorted(ids[:2]),
+        sorted(ids[2:]),
+    ]
+    # The whole point: two groups, two signatures.
+    assert len({g.signature for g in groups}) == 2
+
+    # ...and therefore two persisted rows, not one silently overwriting the other.
+    _scan(server)
+    rows = _run(
+        server,
+        lambda session: sorted(
+            (row.signature, row.member_count)
+            for row in session.exec(select(DedupGroup)).all()
+        ),
+    )
+    assert len(rows) == 2
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 2
+
+
+def test_a_verdict_on_one_group_does_not_resolve_its_same_digest_twin(server):
+    """The second half of E1: consent must not leak across file sets."""
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+            {"pixel_sha": "aaa", "size_bytes": 999},
+        ],
+    )
+    _scan(server)
+    page, total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    assert total == 2
+    _run(server, verdicts.apply_keep_separate_in_session, page[0]["signature"], None)
+    # The other group is still waiting for its own decision.
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+    remaining, _total, _cursor = _run(
+        server, tiers.page_queue_in_session, None, None, 0, 10
+    )
+    assert len(remaining) == 1
+    assert remaining[0]["signature"] == page[1]["signature"]
+
+    # And a rescan does not resurrect the decided one or silence the open one.
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+
+def test_content_key_carries_the_size_co_key():
+    """Unit-level pin on the identity format itself."""
+    member = tiers.CandidateMember(id=1, pixel_sha="aaa", size_bytes=100)
+    twin = tiers.CandidateMember(id=2, pixel_sha="aaa", size_bytes=999)
+    assert member.content_key == "aaa:100"
+    assert member.content_key != twin.content_key
+    assert tiers.group_signature([member.content_key]) != tiers.group_signature(
+        [twin.content_key]
+    )
+    # An unhashed picture still falls back to its id.
+    assert tiers.CandidateMember(id=7).content_key == "id:7"
+
+
+# ── tier precedence on upsert ────────────────────────────────────────────────
+
+
+def _group_row(server, signature):
+    return _run(
+        server,
+        lambda session: session.exec(
+            select(DedupGroup).where(DedupGroup.signature == signature)
+        ).first(),
+    )
+
+
+def test_a_near_scan_does_not_downgrade_an_exact_group(server):
+    """QA blocker 2, the two-scan repro.
+
+    A byte-identical pair is also perceptually identical, so every near-enabled
+    scan rediscovers it as a ``near`` group with the same signature. The upsert
+    wrote ``row.tier`` unconditionally, so the pair was demoted to ``near`` - and
+    a ``near`` group is invisible in the exact-only default queue *and*
+    ineligible for ``POST /dedup/auto-stack``, which only ever acts on ``exact``.
+    """
+    _seed(
+        server,
+        [
+            {
+                "pixel_sha": "same",
+                "size_bytes": 100,
+                "perceptual_hash": PHASH_ZERO,
+            },
+            {
+                "pixel_sha": "same",
+                "size_bytes": 100,
+                "perceptual_hash": PHASH_ZERO,
+            },
+        ],
+    )
+    # Scan 1: exact only.
+    _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+    rows = _run(server, lambda session: session.exec(select(DedupGroup)).all())
+    assert len(rows) == 1
+    signature = rows[0].signature
+    assert rows[0].tier == DedupTier.EXACT.value
+    exact_confidence = rows[0].confidence
+
+    # Scan 2: the user turns tier 2 on.
+    _run(
+        server,
+        tiers.run_scan_now_in_session,
+        TierPolicy(near_enabled=True),
+        None,
+    )
+    row = _group_row(server, signature)
+    assert row.tier == DedupTier.EXACT.value, "exact must never be downgraded"
+    assert row.confidence == exact_confidence
+
+    # And the pair is still where the exact-only default queue and auto-stack
+    # both look for it.
+    page, _total, _cursor = _run(
+        server, tiers.page_queue_in_session, TierPolicy(), None, 0, 10
+    )
+    assert [group["tier"] for group in page] == [DedupTier.EXACT.value]
+
+
+def test_the_upsert_takes_the_stronger_tier_in_either_arrival_order(server):
+    """Precedence is a *maximum*, not a freeze on whatever landed first.
+
+    Driven through :func:`persist_groups_in_session` directly, because a real
+    scan cannot present the same signature under two tiers in the weak-then-
+    strong order: the signature hashes the members' ``<pixel_sha>:<size_bytes>``
+    content keys, so anything tier 1 can group tier 2 also sees, and the reverse
+    change (two files becoming byte-identical) changes the content keys and
+    therefore the signature. The precedence rule still has to hold both ways, or
+    it is an ordering accident rather than a rule.
+    """
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "same", "size_bytes": 100},
+            {"pixel_sha": "same", "size_bytes": 100},
+        ],
+    )
+
+    def upsert(session, first, second):
+        members = tiers.load_candidates(session, ids)
+        ordered = [members[pid] for pid in ids]
+        for tier, confidence in (first, second):
+            tiers.persist_groups_in_session(
+                session, [tiers.assemble_group(tier, confidence, ordered)]
+            )
+        return session.exec(select(DedupGroup)).all()
+
+    strong = (DedupTier.EXACT, 1.0)
+    weak = (DedupTier.NEAR, 0.93)
+
+    rows = _run(server, upsert, strong, weak)
+    assert [row.tier for row in rows] == [DedupTier.EXACT.value]
+    assert rows[0].confidence == 1.0
+
+    rows = _run(server, upsert, weak, strong)
+    assert [row.tier for row in rows] == [DedupTier.EXACT.value]
+    assert rows[0].confidence == 1.0
+
+
+# ── keyset cursor ────────────────────────────────────────────────────────────
+
+
+def test_a_cursor_round_trips_its_position_exactly():
+    """Float equality drives the tie-break branch, so the encoding must be exact."""
+    for confidence in (1.0, 0.9, 0.65, 0.123456789012345, 0.0):
+        cursor = tiers.encode_queue_cursor(confidence, 4242)
+        assert tiers.decode_queue_cursor(cursor) == (confidence, 4242)
+
+
+def test_a_tampered_cursor_is_refused_rather_than_reinterpreted():
+    for bad in ("", "AAAA", "not base64!", tiers.encode_queue_cursor(1.0, 1)[:-4]):
+        with pytest.raises(tiers.DedupCursorError):
+            tiers.decode_queue_cursor(bad)
+    # A cursor from a future encoding version is refused, not misread.
+    import base64
+
+    forged = base64.urlsafe_b64encode(b"9|1.0|1").decode().rstrip("=")
+    with pytest.raises(tiers.DedupCursorError):
+        tiers.decode_queue_cursor(forged)
+
+
+def test_the_cursor_resumes_a_tied_confidence_run_without_gap_or_repeat(server):
+    """Every exact group ties at the same confidence; the id breaks the tie."""
+    for index in range(5):
+        _seed(
+            server,
+            [
+                {"pixel_sha": f"tie-{index}", "size_bytes": 100 + index},
+                {"pixel_sha": f"tie-{index}", "size_bytes": 100 + index},
+            ],
+        )
+    _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+
+    walked = []
+    cursor = None
+    for _ in range(10):
+        page, total, cursor = _run(
+            server, tiers.page_queue_in_session, None, None, 0, 2, cursor
+        )
+        assert total == 5
+        walked.extend(group["signature"] for group in page)
+        if cursor is None:
+            break
+    assert len(walked) == 5, walked
+    assert len(set(walked)) == 5, "a tie must not be delivered twice"
+
+
+# ── folder scope normalisation ───────────────────────────────────────────────
+
+
+def test_a_folder_scope_that_normalises_to_empty_is_refused():
+    """CSO W2: these all rstripped to "" and became a LIKE pattern of "%"."""
+    for bad in ("/", "\\", "///", "\\\\", "/\\/"):
+        with pytest.raises(ValueError):
+            DedupScope(scope_type=ScopeType.FOLDER, scope_id=bad)
+
+
+def test_a_folder_scope_is_normalised_to_one_scope_key():
+    plain = DedupScope(scope_type=ScopeType.FOLDER, scope_id="/photos/2026")
+    trailing = DedupScope(scope_type=ScopeType.FOLDER, scope_id="/photos/2026/")
+    assert plain.key == trailing.key == "folder:/photos/2026"
+    assert trailing.scope_id == "/photos/2026"

--- a/tests/test_dedup_tiers_api.py
+++ b/tests/test_dedup_tiers_api.py
@@ -1,0 +1,1178 @@
+"""API tests for the v1.9 tiered duplicate queue.
+
+Every route is declared ``OWNER_ONLY`` in ``pixlstash/authz/registry.py`` and
+enforced by the central authz gate, so these assert **both directions** per the
+CLAUDE.md security review process:
+
+* negative — a resource-scoped READ share token gets 403 on every route, via the
+  ``Authorization`` header and via the ``?token=`` query-parameter path;
+* positive — the owner cookie session reaches every route and gets a complete
+  answer (over-blocking is its own regression).
+
+Plus the contract the frontend reads: the policy is served rather than
+hardcoded, the queue pages by confidence descending with the cover preselection
+and both evidence layers, counts are live and scoped, and the verdict routes are
+non-destructive.
+
+Background workers are disabled and the pictures are inserted directly, so the
+likeness worker cannot write rows underneath the assertions.
+"""
+
+import gc
+import json
+import os
+import tempfile
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models import Picture, PictureSet, PictureSetMember
+from pixlstash.db_models.dedup import DedupScan, DedupVerdict
+from pixlstash.db_models.tag import Tag
+from pixlstash.server import Server
+from pixlstash.services import dedup_tier_service as tiers
+from pixlstash.services.dedup_tier_service import TierPolicy
+from pixlstash.routes.dedup import MAX_COUNT_SCOPES
+from pixlstash.utils.image_processing.image_utils import ImageUtils
+from tests.authz_guard import no_spa_fallback  # noqa: F401
+
+API = "/api/v1"
+POLICY_URL = f"{API}/dedup/policy"
+GROUPS_URL = f"{API}/dedup/groups"
+COUNTS_URL = f"{API}/dedup/counts"
+SCAN_URL = f"{API}/dedup/scan"
+STACK_URL = f"{API}/dedup/verdicts/stack"
+KEEP_SEPARATE_URL = f"{API}/dedup/verdicts/keep-separate"
+REOPEN_URL = f"{API}/dedup/verdicts/reopen"
+AUTO_STACK_URL = f"{API}/dedup/auto-stack"
+
+# The SPA catch-all answers unmatched GETs with 200, so a wrong URL could make a
+# positive assertion vacuous. See tests/authz_guard.py.
+pytestmark = pytest.mark.usefixtures("no_spa_fallback")
+
+
+def _run(server, fn, *args):
+    return server.vault.db.run_task(fn, *args, priority=DBPriority.IMMEDIATE)
+
+
+def _insert_pictures(server, specs):
+    def insert(session):
+        picture_ids = []
+        for index, spec in enumerate(specs):
+            pic = Picture(
+                file_path=f"/vault/dedup_{index}.png",
+                format="png",
+                width=spec.get("width", 4000),
+                height=spec.get("height", 3000),
+                size_bytes=spec.get("size_bytes", 1000),
+                score=spec.get("score"),
+                pixel_sha=spec.get("pixel_sha"),
+            )
+            session.add(pic)
+            session.flush()
+            for tag in spec.get("tags", []):
+                session.add(Tag(picture_id=int(pic.id), tag=tag))
+            picture_ids.append(int(pic.id))
+        session.commit()
+        return picture_ids
+
+    return _run(server, insert)
+
+
+def _env():
+    """Owner cookie client, one exact duplicate pair, and a set-scoped READ token.
+
+    Pictures 0 and 1 share a ``pixel_sha`` and a size, so tier 1 finds exactly
+    one group. Picture 2 is unique and never appears.
+    """
+    temp_dir = tempfile.TemporaryDirectory()
+    os.makedirs(os.path.join(temp_dir.name, "images"), exist_ok=True)
+    config_path = os.path.join(temp_dir.name, "server-config.json")
+    with open(config_path, "w") as fh:
+        fh.write(json.dumps({"port": 8000, "disable_background_workers": True}))
+    Server.DEFAULT_FORCE_CPU = True
+    server = Server(config_path)
+    client = TestClient(server.api)
+    assert (
+        client.post(
+            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        ).status_code
+        == 200
+    )
+    picture_ids = _insert_pictures(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5, "tags": ["portrait"]},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "ccc", "size_bytes": 300},
+        ],
+    )
+    set_id = client.post(f"{API}/picture_sets", json={"name": "Set A"}).json()[
+        "picture_set"
+    ]["id"]
+
+    def add_to_set(session):
+        session.add(PictureSetMember(set_id=set_id, picture_id=picture_ids[0]))
+        session.commit()
+
+    _run(server, add_to_set)
+    token = client.post(
+        f"{API}/users/me/token",
+        json={
+            "description": "set A read",
+            "scope": "READ",
+            "resource_type": "picture_set",
+            "resource_id": set_id,
+        },
+    ).json()["token"]
+    _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+    return temp_dir, client, server, picture_ids, token, set_id
+
+
+def _teardown(temp_dir, server):
+    server.vault.close()
+    temp_dir.cleanup()
+    gc.collect()
+
+
+def _signature(client) -> str:
+    body = client.get(GROUPS_URL).json()
+    assert body["groups"], body
+    return body["groups"][0]["signature"]
+
+
+# ── authorization, both directions ────────────────────────────────────────────
+
+
+def test_scoped_read_token_is_denied_on_every_route():
+    temp_dir, client, server, _ids, token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        scoped = TestClient(server.api)
+        headers = {"Authorization": f"Bearer {token}"}
+        assert scoped.get(POLICY_URL, headers=headers).status_code == 403
+        assert scoped.get(GROUPS_URL, headers=headers).status_code == 403
+        assert scoped.post(COUNTS_URL, json={}, headers=headers).status_code == 403
+        assert scoped.post(SCAN_URL, json={}, headers=headers).status_code == 403
+        assert (
+            scoped.post(
+                STACK_URL, json={"signature": signature}, headers=headers
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(
+                KEEP_SEPARATE_URL, json={"signature": signature}, headers=headers
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(
+                REOPEN_URL, json={"signature": signature}, headers=headers
+            ).status_code
+            == 403
+        )
+        assert scoped.post(AUTO_STACK_URL, json={}, headers=headers).status_code == 403
+
+        # Same via the ?token= query-param path (no Authorization header).
+        assert scoped.get(POLICY_URL, params={"token": token}).status_code == 403
+        assert scoped.get(GROUPS_URL, params={"token": token}).status_code == 403
+        assert (
+            scoped.post(COUNTS_URL, params={"token": token}, json={}).status_code == 403
+        )
+        assert (
+            scoped.post(SCAN_URL, params={"token": token}, json={}).status_code == 403
+        )
+        assert (
+            scoped.post(
+                STACK_URL, params={"token": token}, json={"signature": signature}
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(
+                KEEP_SEPARATE_URL,
+                params={"token": token},
+                json={"signature": signature},
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(
+                REOPEN_URL, params={"token": token}, json={"signature": signature}
+            ).status_code
+            == 403
+        )
+        assert (
+            scoped.post(AUTO_STACK_URL, params={"token": token}, json={}).status_code
+            == 403
+        )
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_denied_verdict_route_changed_nothing():
+    """Fail-closed, not fail-late: the 403 happens before any write."""
+    temp_dir, client, server, ids, token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        scoped = TestClient(server.api)
+        headers = {"Authorization": f"Bearer {token}"}
+        assert (
+            scoped.post(
+                STACK_URL, json={"signature": signature}, headers=headers
+            ).status_code
+            == 403
+        )
+        stacked = _run(
+            server,
+            lambda session: [session.get(Picture, pid).stack_id for pid in ids],
+        )
+        assert stacked == [None, None, None]
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_unauthenticated_is_denied():
+    temp_dir, _client, server, _ids, _token, _set_id = _env()
+    try:
+        anonymous = TestClient(server.api)
+        assert anonymous.get(POLICY_URL).status_code in (401, 403)
+        assert anonymous.get(GROUPS_URL).status_code in (401, 403)
+        assert anonymous.post(COUNTS_URL, json={}).status_code in (401, 403)
+        assert anonymous.post(SCAN_URL, json={}).status_code in (401, 403)
+        assert anonymous.post(AUTO_STACK_URL, json={}).status_code in (401, 403)
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── policy ────────────────────────────────────────────────────────────────────
+
+
+def test_owner_reads_the_tier_policy():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        response = client.get(POLICY_URL)
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["defaults"]["threshold"] == pytest.approx(0.90)
+        assert body["defaults"]["near_enabled"] is False
+        assert body["defaults"]["embedding_enabled"] is False
+        bounds = body["bounds"]
+        assert bounds["min_threshold"] == pytest.approx(0.65)
+        assert bounds["tiers"] == ["exact", "near", "embedding"]
+        assert bounds["always_on_tiers"] == ["exact"]
+        assert bounds["tier_requires"] == {
+            "exact": None,
+            "near": "exact",
+            "embedding": "near",
+        }
+        assert set(bounds["verdicts"]) == {"stacked", "keep_separate"}
+        assert "folder" in bounds["scope_types"]
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_threshold_below_the_floor_is_rejected():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        assert client.get(GROUPS_URL, params={"threshold": 0.4}).status_code == 422
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_enabling_the_embedding_tier_alone_is_rejected():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        response = client.get(GROUPS_URL, params={"embedding_enabled": True})
+        assert response.status_code == 400, response.text
+        assert "requires near_enabled" in response.json()["detail"]
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── the queue ─────────────────────────────────────────────────────────────────
+
+
+def test_the_queue_page_carries_cover_evidence_and_progress():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        response = client.get(GROUPS_URL)
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 1
+        assert body["offset"] == 0
+        assert body["policy"]["threshold"] == pytest.approx(0.90)
+        assert body["scope"]["key"] == "global"
+        # No scan row has been written by a route yet, so the banner is idle
+        # rather than an error.
+        assert body["scan"]["status"] == "idle"
+
+        group = body["groups"][0]
+        assert group["tier"] == "exact"
+        assert group["confidence"] == pytest.approx(1.0)
+        assert group["member_count"] == 2
+        assert group["cover_picture_id"] == ids[0]
+        assert any(p["text"] == "Identical file hash" for p in group["why"])
+        assert sorted(c["picture_id"] for c in group["candidates"]) == sorted(ids[:2])
+        cover = next(c for c in group["candidates"] if c["picture_id"] == ids[0])
+        assert cover["tag_count"] == 1
+        assert cover["cover_score"] > 0
+        assert any(p["text"] == "Preselected as cover" for p in cover["why"])
+        # Managed-library pictures hide their path.
+        assert all(c["file_path"] is None for c in group["candidates"])
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_the_queue_page_size_is_honoured():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        body = client.get(GROUPS_URL, params={"limit": 1, "offset": 1}).json()
+        assert body["limit"] == 1
+        assert body["offset"] == 1
+        assert body["groups"] == []
+        assert body["total"] == 1
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── counts ────────────────────────────────────────────────────────────────────
+
+
+def test_counts_report_the_badge_the_tiers_and_the_scopes():
+    temp_dir, client, server, _ids, _token, set_id = _env()
+    try:
+        response = client.post(
+            COUNTS_URL,
+            json={"scopes": [{"scope_type": "set", "scope_id": str(set_id)}]},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["unresolved_groups"] == 1
+        assert body["by_tier"] == {"exact": 1, "near": 0, "embedding": 0}
+        assert len(body["scopes"]) == 1
+        assert body["scopes"][0]["key"] == f"set:{set_id}"
+        assert body["scopes"][0]["unresolved_groups"] == 1
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_scope_without_an_id_is_rejected():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        response = client.post(COUNTS_URL, json={"scopes": [{"scope_type": "project"}]})
+        assert response.status_code == 400, response.text
+        assert "scope_id is required" in response.json()["detail"]
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── scan ──────────────────────────────────────────────────────────────────────
+
+
+def test_requesting_a_scan_returns_immediately_with_progress():
+    temp_dir, client, server, _ids, _token, set_id = _env()
+    try:
+        response = client.post(
+            SCAN_URL,
+            json={
+                "policy": {"near_enabled": True},
+                "scope": {"scope_type": "set", "scope_id": str(set_id)},
+            },
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["status"] == "pending"
+        assert body["scope_key"] == f"set:{set_id}"
+        assert body["tiers"] == ["exact", "near"]
+        # And the queue for that scope now reports the scan rather than idle.
+        queue = client.get(
+            GROUPS_URL, params={"scope_type": "set", "scope_id": str(set_id)}
+        ).json()
+        assert queue["scan"]["scope_key"] == f"set:{set_id}"
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── verdicts ──────────────────────────────────────────────────────────────────
+
+
+def test_stacking_through_the_api_applies_the_union_and_clears_the_badge():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        response = client.post(
+            STACK_URL, json={"signature": signature, "cover_picture_id": ids[0]}
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["verdict"] == "stacked"
+        assert body["cover_picture_id"] == ids[0]
+        assert sorted(body["picture_ids"]) == sorted(ids[:2])
+        assert body["stack_id"] is not None
+        assert body["metadata_union"]["tags_added"] == 1
+        assert body["metadata_union"]["scores_lifted"] == 1
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        # Nothing was deleted: a stack is a grouping row plus a cover pointer.
+        live = _run(
+            server,
+            lambda session: [
+                int(row) for row in session.exec(select(Picture.id)).all()
+            ],
+        )
+        assert sorted(live) == sorted(ids)
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_keep_separate_then_reopen_round_trips_through_the_api():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        kept = client.post(KEEP_SEPARATE_URL, json={"signature": signature})
+        assert kept.status_code == 200, kept.text
+        assert kept.json()["verdict"] == "keep_separate"
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        assert client.get(GROUPS_URL).json()["groups"] == []
+
+        reopened = client.post(REOPEN_URL, json={"signature": signature})
+        assert reopened.status_code == 200, reopened.text
+        assert reopened.json()["previous_verdict"] == "keep_separate"
+        assert reopened.json()["group_returned_to_queue"] is True
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+        # No picture changed in either direction.
+        stacked = _run(
+            server,
+            lambda session: [session.get(Picture, pid).stack_id for pid in ids],
+        )
+        assert stacked == [None, None, None]
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_scrapheaping_a_member_below_two_drops_the_group_from_the_counts():
+    """The badge follows a soft-delete immediately, not at the next scan.
+
+    prune_stale_groups only runs on a verdict or a scan, so the counts and
+    the open queue filter on LIVE membership instead of waiting for it — and
+    a restore brings the group straight back, no rescan needed.
+    """
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+
+        deleted = client.delete(f"{API}/pictures/{ids[0]}")
+        assert deleted.status_code == 200, deleted.text
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        assert client.get(GROUPS_URL).json()["groups"] == []
+
+        restored = client.post(
+            f"{API}/pictures/scrapheap/restore", json={"picture_ids": [ids[0]]}
+        )
+        assert restored.status_code == 200, restored.text
+        counts = client.post(COUNTS_URL, json={})
+        assert counts.json()["unresolved_groups"] == 1
+        assert client.get(GROUPS_URL).json()["groups"][0]["signature"] == signature
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_group_already_stacked_together_stops_posing_a_decision():
+    """Members stacked BY HAND leave the queue and the counts at once.
+
+    The grid's own stack actions never touch dedupgroup, so an exact pair the
+    user stacked from the grid stayed "unresolved" and was re-offered forever
+    (the owner's #670/#1746 report). A group where a stack would still fold
+    something in — a stack plus a loner — keeps counting.
+    """
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+
+        def stack_by_hand(session):
+            from pixlstash.db_models import PictureStack
+
+            stack = PictureStack(name=None)
+            session.add(stack)
+            session.commit()
+            session.refresh(stack)
+            for position, pid in enumerate(ids):
+                picture = session.get(Picture, pid)
+                picture.stack_id = stack.id
+                picture.stack_position = position
+                session.add(picture)
+            session.commit()
+            return stack.id
+
+        stack_id = _run(server, stack_by_hand)
+
+        # All members share one stack: no decision left, nothing offered.
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        assert client.get(GROUPS_URL).json()["groups"] == []
+
+        # Pull ONE member back out: a stack plus a loner is a decision again.
+        def unstack_one(session):
+            picture = session.get(Picture, ids[0])
+            picture.stack_id = None
+            picture.stack_position = None
+            session.add(picture)
+            session.commit()
+
+        _run(server, unstack_one)
+        assert stack_id is not None
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+        assert len(client.get(GROUPS_URL).json()["groups"]) == 1
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_the_decided_page_lists_the_verdict_and_clears_via_reopen():
+    """`GET /dedup/groups?decided=true` is the review-and-clear surface.
+
+    A decided group appears there with its live verdict and decided_at, stays
+    there under a policy that would hide it from the open queue (decisions do
+    not vanish when the threshold moves), and leaves when reopened.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        assert client.get(GROUPS_URL, params={"decided": True}).json()["groups"] == []
+
+        kept = client.post(KEEP_SEPARATE_URL, json={"signature": signature})
+        assert kept.status_code == 200, kept.text
+
+        decided = client.get(GROUPS_URL, params={"decided": True}).json()
+        assert decided["total"] == 1
+        (row,) = decided["groups"]
+        assert row["signature"] == signature
+        assert row["verdict"] == "keep_separate"
+        assert row["decided_at"] is not None
+        assert len(row["candidates"]) >= 2
+
+        # The decided page ignores the tier gate and the threshold: the open
+        # queue at the strictest policy is empty, the decision is still shown.
+        strict = client.get(
+            GROUPS_URL, params={"decided": True, "threshold": 0.99999}
+        ).json()
+        assert strict["total"] == 1
+
+        reopened = client.post(REOPEN_URL, json={"signature": signature})
+        assert reopened.status_code == 200, reopened.text
+        assert client.get(GROUPS_URL, params={"decided": True}).json()["groups"] == []
+        # The open queue lists a verdict field too, null there by construction.
+        open_page = client.get(GROUPS_URL).json()
+        assert open_page["groups"][0]["verdict"] is None
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_an_unknown_signature_is_a_400_not_a_500():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        for url in (STACK_URL, KEEP_SEPARATE_URL, REOPEN_URL):
+            response = client.post(url, json={"signature": "0" * 64})
+            assert response.status_code == 400, (url, response.text)
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── bulk auto-stack ───────────────────────────────────────────────────────────
+
+
+def test_auto_stack_defaults_to_a_dry_run():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        response = client.post(AUTO_STACK_URL, json={})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["dry_run"] is True
+        assert body["groups"] == 1
+        assert body["pictures"] == 2
+        assert body["results"] == []
+        stacked = _run(
+            server,
+            lambda session: [session.get(Picture, pid).stack_id for pid in ids],
+        )
+        assert stacked == [None, None, None]
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_auto_stack_applies_under_one_batch_id():
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        response = client.post(AUTO_STACK_URL, json={"dry_run": False})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["dry_run"] is False
+        assert body["groups"] == 1
+        assert body["batch_id"]
+        assert body["failures"] == []
+        assert {item["batch_id"] for item in body["results"]} == {body["batch_id"]}
+        stacked = _run(
+            server,
+            lambda session: [session.get(Picture, pid).stack_id for pid in ids],
+        )
+        assert stacked[0] is not None and stacked[0] == stacked[1]
+        assert stacked[2] is None
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── resource hardening ────────────────────────────────────────────────────────
+
+
+def test_a_non_numeric_scope_id_is_a_400_on_every_route():
+    """Regression for the CSO's D4.
+
+    ``picture_predicate()`` calls ``int(scope_id)`` for project / set / character.
+    Leaving that unvalidated turned a bad request into an unhandled 500 on three
+    read routes, and `POST /dedup/scan` returned 200 while **persisting** the
+    unparseable scope — a self-inflicted poison row that made every later
+    `GET /dedup/groups` for that scope 500 too. Validation now happens at the
+    boundary, before any write.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        for scope_type in ("project", "set", "character"):
+            params = {"scope_type": scope_type, "scope_id": "not-an-int"}
+            body = {"scope_type": scope_type, "scope_id": "not-an-int"}
+            assert client.get(GROUPS_URL, params=params).status_code == 400
+            assert client.post(COUNTS_URL, json={"scopes": [body]}).status_code == 400
+            assert client.post(SCAN_URL, json={"scope": body}).status_code == 400
+            assert client.post(AUTO_STACK_URL, json={"scope": body}).status_code == 400
+        # And nothing was persisted by the rejected scan requests.
+        scans = _run(server, lambda session: session.exec(select(DedupScan)).all())
+        assert scans == []
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_folder_scope_does_not_treat_wildcards_as_wildcards():
+    """A "Find duplicates in this folder" entry must not silently mean everywhere.
+
+    The folder predicate is a LIKE prefix match; unescaped, a scope_id of "%"
+    matches every path in the vault.
+    """
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        # The seeded duplicate pair lives under /vault/, so a literal "%" would
+        # match it if the metacharacter were not escaped.
+        wild = client.post(
+            COUNTS_URL, json={"scopes": [{"scope_type": "folder", "scope_id": "%"}]}
+        )
+        assert wild.status_code == 200, wild.text
+        assert wild.json()["scopes"][0]["unresolved_groups"] == 0
+
+        # The real folder still matches.
+        real = client.post(
+            COUNTS_URL,
+            json={"scopes": [{"scope_type": "folder", "scope_id": "/vault"}]},
+        )
+        assert real.json()["scopes"][0]["unresolved_groups"] == 1
+        assert len(ids) == 3
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_the_counts_scope_list_is_capped():
+    """One request must not become thousands of correlated COUNT subqueries."""
+    temp_dir, client, server, _ids, _token, set_id = _env()
+    try:
+        scopes = [{"scope_type": "set", "scope_id": str(set_id)}] * (
+            MAX_COUNT_SCOPES + 1
+        )
+        assert client.post(COUNTS_URL, json={"scopes": scopes}).status_code == 422
+        ok = client.post(COUNTS_URL, json={"scopes": scopes[:MAX_COUNT_SCOPES]})
+        assert ok.status_code == 200, ok.text
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── frontend contract additions ───────────────────────────────────────────────
+
+
+def test_every_candidate_carries_a_thumbnail_cache_token():
+    """The queue must be able to bust a stale thumbnail like the grid does."""
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        candidates = client.get(GROUPS_URL).json()["groups"][0]["candidates"]
+        # Unprocessed pictures report the "0" sentinel rather than omitting it.
+        assert all(c["thumbnail_version"] == "0" for c in candidates)
+
+        def set_thumbnail(session):
+            pic = session.get(Picture, ids[0])
+            pic.thumbnail_width = 320
+            pic.thumbnail_height = 240
+            session.add(pic)
+            session.commit()
+
+        _run(server, set_thumbnail)
+        candidates = client.get(GROUPS_URL).json()["groups"][0]["candidates"]
+        token = next(
+            c["thumbnail_version"] for c in candidates if c["picture_id"] == ids[0]
+        )
+        # Exactly the token the batch-thumbnail endpoint puts in its ?v=.
+        assert token == ImageUtils.thumbnail_cache_token(320, 240) == "320x240"
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_the_auto_stack_dry_run_carries_the_consent_aggregates():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        body = client.post(AUTO_STACK_URL, json={}).json()
+        summary = body["dry_run_summary"]
+        assert summary["groups"] == body["groups"] == 1
+        assert summary["pictures"] == body["pictures"] == 2
+        assert summary["groups_by_tier"] == {"exact": 1, "near": 0, "embedding": 0}
+        # The seeded cover carries the only tag and the only score, so it gains
+        # nothing from the union.
+        assert summary["covers_gaining_metadata"] == 0
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_partially_blocked_auto_stack_returns_its_batch_id():
+    """R2 at the HTTP boundary: a 423 mid-run must not swallow the undo handle."""
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+
+        def add_second_group_and_lock_it(session):
+            created = []
+            for _ in range(2):
+                pic = Picture(
+                    file_path=f"/vault/locked_{len(created)}.png",
+                    format="png",
+                    width=10,
+                    height=10,
+                    size_bytes=42,
+                    pixel_sha="locked",
+                )
+                session.add(pic)
+                session.flush()
+                created.append(int(pic.id))
+            picture_set = PictureSet(name="Frozen", locked=True)
+            session.add(picture_set)
+            session.commit()
+            session.refresh(picture_set)
+            session.add(
+                PictureSetMember(set_id=int(picture_set.id), picture_id=created[0])
+            )
+            session.commit()
+            return created
+
+        locked_ids = _run(server, add_second_group_and_lock_it)
+        _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+
+        response = client.post(AUTO_STACK_URL, json={"dry_run": False})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["batch_id"]
+        assert body["groups"] == 1
+        assert body["blocked"] == 1
+        assert body["failures"][0]["status_code"] == 423
+        # The unlocked group was applied, the locked one was not.
+        assert (
+            _run(server, lambda session: session.get(Picture, ids[0]).stack_id)
+            is not None
+        )
+        assert (
+            _run(server, lambda session: session.get(Picture, locked_ids[0]).stack_id)
+            is None
+        )
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── undo reopens the verdict, not only the pictures ───────────────────────────
+
+
+def _add_exact_groups(server, count, members=2, sha_prefix="extra"):
+    """Insert *count* more exact groups of *members* byte-identical pictures."""
+
+    def insert(session):
+        created = []
+        for index in range(count):
+            group = []
+            for member in range(members):
+                pic = Picture(
+                    file_path=f"/vault/{sha_prefix}_{index}_{member}.png",
+                    format="png",
+                    width=100,
+                    height=100,
+                    size_bytes=500 + index,
+                    pixel_sha=f"{sha_prefix}-{index}",
+                )
+                session.add(pic)
+                session.flush()
+                group.append(int(pic.id))
+            created.append(group)
+        session.commit()
+        return created
+
+    return _run(server, insert)
+
+
+def _rescan(server):
+    _run(server, tiers.run_scan_now_in_session, TierPolicy(), None)
+
+
+def _signatures(client) -> set:
+    return {group["signature"] for group in client.get(GROUPS_URL).json()["groups"]}
+
+
+def _verdict_row(server, signature):
+    return _run(
+        server,
+        lambda session: session.exec(
+            select(DedupVerdict).where(DedupVerdict.signature == signature)
+        ).first(),
+    )
+
+
+def test_undo_returns_the_stacked_group_to_the_queue():
+    """QA blocker 1, single verdict.
+
+    Undo restored every picture facet but left the ``DedupVerdict`` decided and
+    the ``DedupGroup`` resolved, so the group never came back to the queue, was
+    not counted, and survived a rescan (the signature still carried a live
+    verdict). The only way back was a ``POST /dedup/verdicts/reopen`` no user
+    could discover. The post-restore hook now reopens both rows inside the undo's
+    own transaction.
+    """
+    temp_dir, client, server, ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+
+        stacked = client.post(STACK_URL, json={"signature": signature})
+        assert stacked.status_code == 200, stacked.text
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        assert _signatures(client) == set()
+
+        undone = client.post(f"{API}/operations/undo", json={})
+        assert undone.status_code == 200, undone.text
+
+        # The pictures are unstacked ...
+        assert _run(
+            server, lambda session: [session.get(Picture, pid).stack_id for pid in ids]
+        ) == [None, None, None]
+        # ... and so is the decision.
+        assert _signatures(client) == {signature}
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+        verdict = _verdict_row(server, signature)
+        assert verdict is not None, "the verdict row is kept, only reopened"
+        assert verdict.reopened_at is not None
+
+        # A rescan does not re-decide it either: it is genuinely back in the queue.
+        _rescan(server)
+        assert _signatures(client) == {signature}
+
+        redone = client.post(f"{API}/operations/redo", json={})
+        assert redone.status_code == 200, redone.text
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+        assert _signatures(client) == set()
+        assert _verdict_row(server, signature).reopened_at is None
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_batch_undo_after_auto_stack_returns_every_group():
+    """QA blocker 1, QA's exact repro: bulk auto-stack then batch undo.
+
+    Every duplicate vanished from the queue permanently - one undo click, and the
+    whole vault's worth of duplicate decisions was unrecoverable without
+    hand-reopening each signature.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        _add_exact_groups(server, count=3)
+        _rescan(server)
+        before = _signatures(client)
+        assert len(before) == 4
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 4
+
+        applied = client.post(AUTO_STACK_URL, json={"dry_run": False})
+        assert applied.status_code == 200, applied.text
+        batch_id = applied.json()["batch_id"]
+        assert applied.json()["groups"] == 4
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+
+        undone = client.post(f"{API}/operations/batches/{batch_id}/undo", json={})
+        assert undone.status_code == 200, undone.text
+
+        assert _signatures(client) == before
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 4
+        # And the whole batch is redoable, back to nothing outstanding.
+        assert client.post(f"{API}/operations/redo", json={}).status_code == 200
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 0
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_an_undo_does_not_reopen_a_group_it_never_touched():
+    """The hook is scoped to the undone batch, not to every decided group."""
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        _add_exact_groups(server, count=1)
+        _rescan(server)
+        signatures = sorted(_signatures(client))
+        assert len(signatures) == 2
+        kept_separate, stacked = signatures
+
+        keep = client.post(KEEP_SEPARATE_URL, json={"signature": kept_separate})
+        assert keep.status_code == 200, keep.text
+        response = client.post(STACK_URL, json={"signature": stacked})
+        assert response.status_code == 200, response.text
+        assert _signatures(client) == set()
+
+        assert client.post(f"{API}/operations/undo", json={}).status_code == 200
+
+        # Only the stacked group came back; the keep-separate decision stands,
+        # and a rescan does not re-ask it.
+        assert _signatures(client) == {stacked}
+        _rescan(server)
+        assert _signatures(client) == {stacked}
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_an_undo_does_not_reverse_a_keep_separate_sharing_its_gesture_id():
+    """CSO R5: batch-id correlation must not over-reach the STACK verdicts.
+
+    One client gesture id across a stack and a keep-separate (exactly what the
+    gesture-batch header encourages) previously made undoing the stack silently
+    reverse the keep-separate too - a decision the product calls permanent. The
+    hook now filters on ``verdict == stacked`` and keep-separate rows store no
+    batch id at all, so both defenses are asserted here.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        _add_exact_groups(server, count=1)
+        _rescan(server)
+        signatures = sorted(_signatures(client))
+        assert len(signatures) == 2
+        kept_separate, stacked = signatures
+
+        gesture = "cli-one-gesture-r5"
+        keep = client.post(
+            KEEP_SEPARATE_URL,
+            json={"signature": kept_separate, "batch_id": gesture},
+        )
+        assert keep.status_code == 200, keep.text
+        response = client.post(
+            STACK_URL, json={"signature": stacked, "batch_id": gesture}
+        )
+        assert response.status_code == 200, response.text
+        assert _signatures(client) == set()
+
+        # Defense 1: the keep-separate row never stored the gesture id.
+        assert _verdict_row(server, kept_separate).batch_id is None
+
+        assert client.post(f"{API}/operations/undo", json={}).status_code == 200
+
+        # Defense 2: only the stacked verdict reopened; keep-separate is live.
+        assert _signatures(client) == {stacked}
+        assert _verdict_row(server, kept_separate).reopened_at is None
+        _rescan(server)
+        assert _signatures(client) == {stacked}
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── keyset paging ─────────────────────────────────────────────────────────────
+
+
+def test_a_verdict_between_pages_makes_offset_skip_and_the_cursor_not():
+    """QA 3: a decided page-1 row shifts every later row's offset by one.
+
+    Both halves are asserted: offset paging demonstrably loses a group (so the
+    test cannot pass vacuously), and the cursor delivers it.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        _add_exact_groups(server, count=3)
+        _rescan(server)
+        everything = _signatures(client)
+        assert len(everything) == 4
+
+        # Offset paging: read page 1, decide it, read page 2 at offset=2.
+        page_one = client.get(GROUPS_URL, params={"limit": 2}).json()
+        delivered = [group["signature"] for group in page_one["groups"]]
+        assert len(delivered) == 2
+        decided = client.post(STACK_URL, json={"signature": delivered[0]})
+        assert decided.status_code == 200, decided.text
+        offset_page = client.get(GROUPS_URL, params={"limit": 2, "offset": 2}).json()
+        seen_by_offset = set(delivered) | {
+            group["signature"] for group in offset_page["groups"]
+        }
+        skipped = everything - seen_by_offset
+        assert skipped, "offset paging is expected to skip after a verdict"
+
+        # Same situation, cursor paging: nothing is skipped.
+        assert page_one["next_cursor"], page_one
+        cursor_page = client.get(
+            GROUPS_URL, params={"limit": 2, "cursor": page_one["next_cursor"]}
+        ).json()
+        seen_by_cursor = set(delivered) | {
+            group["signature"] for group in cursor_page["groups"]
+        }
+        assert skipped <= seen_by_cursor
+        assert seen_by_cursor == everything
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_the_cursor_walks_every_group_when_confidences_tie():
+    """Exact groups all sit at the same confidence, so the tie-break is the id.
+
+    ``confidence < c`` alone would drop the rest of the tied run; ``<=`` would
+    repeat it forever. Walking one row at a time exercises the boundary on every
+    step.
+    """
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        _add_exact_groups(server, count=4)
+        _rescan(server)
+        everything = _signatures(client)
+        assert len(everything) == 5
+        confidences = {
+            group["confidence"] for group in client.get(GROUPS_URL).json()["groups"]
+        }
+        assert len(confidences) == 1, "the tie-break is what is under test"
+
+        walked = []
+        cursor = None
+        for _ in range(len(everything) + 2):
+            params = {"limit": 1}
+            if cursor:
+                params["cursor"] = cursor
+            body = client.get(GROUPS_URL, params=params).json()
+            walked.extend(group["signature"] for group in body["groups"])
+            cursor = body["next_cursor"]
+            if not cursor:
+                break
+        assert cursor is None, "paging must terminate"
+        assert len(walked) == len(set(walked)), "no group is delivered twice"
+        assert set(walked) == everything
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_cursor_and_offset_together_are_rejected():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        cursor = client.get(GROUPS_URL, params={"limit": 1}).json()["next_cursor"]
+        response = client.get(GROUPS_URL, params={"cursor": cursor or "x", "offset": 0})
+        assert response.status_code == 400, response.text
+        assert "mutually exclusive" in response.text
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_malformed_cursor_is_a_400_not_a_silent_restart():
+    """Silently paging from the top would hand the client page 1 forever."""
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        import base64 as _b64
+
+        non_finite = [
+            _b64.urlsafe_b64encode(f"1|{value}|0".encode()).decode().rstrip("=")
+            for value in ("inf", "-inf", "nan")
+        ]
+        # CSO R6: float() parses "inf"/"nan"; a non-finite confidence makes the
+        # keyset predicate match everything - the silent restart-from-the-top
+        # this endpoint's contract refuses.
+        for bad in ("not-base64!!", "AAAA", "MXwxLjB8", *non_finite):
+            response = client.get(GROUPS_URL, params={"cursor": bad})
+            assert response.status_code == 400, (bad, response.text)
+    finally:
+        _teardown(temp_dir, server)
+
+
+# ── batch id namespacing and folder scope normalisation ───────────────────────
+
+
+def test_a_server_shaped_batch_id_from_a_client_is_rejected():
+    """CSO M1: a verbatim body batch_id let a client impersonate a server batch."""
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        for bad in ("srv-deadbeef", "batch-42", "cli-ab", "cli-" + "a" * 200, ""):
+            response = client.post(
+                STACK_URL, json={"signature": signature, "batch_id": bad}
+            )
+            assert response.status_code == 400, (bad, response.text)
+            assert (
+                client.post(
+                    KEEP_SEPARATE_URL, json={"signature": signature, "batch_id": bad}
+                ).status_code
+                == 400
+            ), bad
+            assert (
+                client.post(
+                    AUTO_STACK_URL, json={"dry_run": False, "batch_id": bad}
+                ).status_code
+                == 400
+            ), bad
+        # Nothing was decided by any of the rejected calls.
+        assert client.post(COUNTS_URL, json={}).json()["unresolved_groups"] == 1
+
+        # A client-namespaced id is accepted and used verbatim.
+        response = client.post(
+            STACK_URL, json={"signature": signature, "batch_id": "cli-gesture-01"}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["batch_id"] == "cli-gesture-01"
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_server_minted_batch_id_is_namespaced():
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        signature = _signature(client)
+        response = client.post(STACK_URL, json={"signature": signature})
+        assert response.status_code == 200, response.text
+        assert response.json()["batch_id"].startswith("srv-")
+    finally:
+        _teardown(temp_dir, server)
+
+
+def test_a_folder_scope_that_normalises_to_nothing_is_rejected():
+    """CSO W2: "/" rstripped to "" and became a LIKE of "%" - silently global."""
+    temp_dir, client, server, _ids, _token, _set_id = _env()
+    try:
+        for bad in ("/", "\\", "///", "\\\\", "/\\/"):
+            body = {"scope_type": "folder", "scope_id": bad}
+            assert (
+                client.get(
+                    GROUPS_URL, params={"scope_type": "folder", "scope_id": bad}
+                ).status_code
+                == 400
+            ), bad
+            assert client.post(COUNTS_URL, json={"scopes": [body]}).status_code == 400
+            assert client.post(SCAN_URL, json={"scope": body}).status_code == 400
+            assert client.post(AUTO_STACK_URL, json={"scope": body}).status_code == 400
+        # No poison scan row was persisted by the rejected requests.
+        assert _run(server, lambda session: session.exec(select(DedupScan)).all()) == []
+
+        # A real folder still works, with or without a trailing separator, and
+        # both spellings are the same scope.
+        for spelling in ("/vault", "/vault/"):
+            counts = client.post(
+                COUNTS_URL,
+                json={"scopes": [{"scope_type": "folder", "scope_id": spelling}]},
+            )
+            assert counts.status_code == 200, counts.text
+            assert counts.json()["scopes"][0]["unresolved_groups"] == 1
+            assert counts.json()["scopes"][0]["key"] == "folder:/vault"
+    finally:
+        _teardown(temp_dir, server)

--- a/tests/test_dedup_verdict_service.py
+++ b/tests/test_dedup_verdict_service.py
@@ -1,0 +1,1150 @@
+"""Unit tests for applying and remembering duplicate verdicts.
+
+Covers:
+
+* **stack** — members land in one stack led by the chosen cover, excluded members
+  are untouched, and the metadata union runs (tags, sets, score);
+* **keep separate** — no picture row changes, and the decision survives a rescan;
+* **reopen** — the group comes back and the decision history is kept;
+* **bulk auto-stack** — exact tier only, one batch id across the whole run, and
+  the dry run writes nothing;
+* **the operation log (§21)** — one verdict is exactly one row (no double-record
+  through `routes/stacks.py`), undo reverses the stacking *and* the metadata
+  union, the snapshot covers stack siblings the group never named, and a whole
+  bulk run reverses with a single batch undo;
+* **the non-destructive invariant** — no verdict deletes a picture, ever;
+* **locked sets** — the metadata union is refused rather than half-applied.
+"""
+
+import gc
+import json
+import os
+import tempfile
+
+import pytest
+from sqlmodel import select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models import (
+    Picture,
+    PictureSet,
+    PictureSetMember,
+    PictureStack,
+)
+from pixlstash.db_models.dedup import (
+    VERDICT_KEEP_SEPARATE,
+    VERDICT_STACKED,
+    DedupVerdict,
+)
+from pixlstash.db_models.operation import Operation
+from pixlstash.db_models.tag import Tag
+from pixlstash.server import Server
+from pixlstash.services import dedup_tier_service as tiers
+from pixlstash.services import dedup_verdict_service as verdicts
+from pixlstash.services import operation_log_service
+from pixlstash.services.dedup_tier_service import TierPolicy
+from pixlstash.services.dedup_verdict_service import DedupVerdictError
+
+
+@pytest.fixture
+def server():
+    temp_dir = tempfile.TemporaryDirectory()
+    config_path = os.path.join(temp_dir.name, "server-config.json")
+    with open(config_path, "w") as fh:
+        fh.write(json.dumps({"port": 8000, "disable_background_workers": True}))
+    Server.DEFAULT_FORCE_CPU = True
+    srv = Server(config_path)
+    try:
+        yield srv
+    finally:
+        srv.vault.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
+def _run(server, fn, *args):
+    return server.vault.db.run_task(fn, *args, priority=DBPriority.IMMEDIATE)
+
+
+def _seed(server, specs):
+    def insert(session):
+        picture_ids = []
+        for index, spec in enumerate(specs):
+            pic = Picture(
+                file_path=spec.get("file_path", f"/vault/pic_{index}.png"),
+                format="png",
+                width=spec.get("width", 4000),
+                height=spec.get("height", 3000),
+                size_bytes=spec.get("size_bytes", 1000),
+                score=spec.get("score"),
+                pixel_sha=spec.get("pixel_sha"),
+            )
+            session.add(pic)
+            session.flush()
+            for tag in spec.get("tags", []):
+                session.add(Tag(picture_id=int(pic.id), tag=tag))
+            picture_ids.append(int(pic.id))
+        session.commit()
+        return picture_ids
+
+    return _run(server, insert)
+
+
+def _scan(server, policy=None):
+    return _run(server, tiers.run_scan_now_in_session, policy or TierPolicy(), None)
+
+
+def _one_signature(server) -> str:
+    page, _total, _cursor = _run(server, tiers.page_queue_in_session, None, None, 0, 10)
+    assert page, "expected at least one unresolved group"
+    return page[0]["signature"]
+
+
+def _picture(server, picture_id: int) -> Picture:
+    return _run(server, lambda session: session.get(Picture, picture_id))
+
+
+def _tags(server, picture_id: int) -> set[str]:
+    return _run(
+        server,
+        lambda session: {
+            str(row)
+            for row in session.exec(
+                select(Tag.tag).where(Tag.picture_id == picture_id)
+            ).all()
+        },
+    )
+
+
+# ── stack ─────────────────────────────────────────────────────────────────────
+
+
+def test_stacking_puts_the_chosen_cover_at_position_zero(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 1},
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    # Override the preselection: the user picks the *lower*-scored picture.
+    result = _run(
+        server, verdicts.apply_stack_verdict_in_session, signature, ids[0], [], None
+    )
+    assert result.verdict == VERDICT_STACKED
+    assert result.cover_picture_id == ids[0]
+    cover = _picture(server, ids[0])
+    other = _picture(server, ids[1])
+    assert cover.stack_id == other.stack_id == result.stack_id
+    assert cover.stack_position == 0
+    assert other.stack_position == 1
+
+
+def test_stacking_defaults_to_the_server_preselection(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 1},
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+        ],
+    )
+    _scan(server)
+    result = _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    # The formula's score term makes the 5-star picture the cover.
+    assert result.cover_picture_id == ids[1]
+
+
+def test_excluded_members_stay_out_and_are_recorded(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    result = _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        signature,
+        None,
+        [ids[2]],
+        None,
+    )
+    assert result.excluded_picture_ids == [ids[2]]
+    assert _picture(server, ids[2]).stack_id is None
+    row = _run(
+        server,
+        lambda session: session.exec(
+            select(DedupVerdict).where(DedupVerdict.signature == signature)
+        ).first(),
+    )
+    assert json.loads(row.excluded_picture_ids) == [ids[2]]
+
+
+def test_excluding_down_to_one_member_is_rejected(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    with pytest.raises(DedupVerdictError, match="at least two"):
+        _run(
+            server,
+            verdicts.apply_stack_verdict_in_session,
+            _one_signature(server),
+            None,
+            [ids[1]],
+            None,
+        )
+
+
+def test_a_cover_outside_the_group_is_rejected(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "bbb", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    with pytest.raises(DedupVerdictError, match="not an included member"):
+        _run(
+            server,
+            verdicts.apply_stack_verdict_in_session,
+            _one_signature(server),
+            ids[2],
+            [],
+            None,
+        )
+
+
+def test_an_unknown_signature_is_rejected(server):
+    with pytest.raises(DedupVerdictError, match="No duplicate group"):
+        _run(server, verdicts.apply_stack_verdict_in_session, "0" * 64, None, [], None)
+
+
+# ── the metadata union ────────────────────────────────────────────────────────
+
+
+def test_stacking_unions_tags_onto_every_member(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["portrait", "outdoor"]},
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["sunset"]},
+        ],
+    )
+    _scan(server)
+    result = _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    assert result.metadata_union["tags_added"] == 3
+    expected = {"portrait", "outdoor", "sunset"}
+    assert _tags(server, ids[0]) == expected
+    assert _tags(server, ids[1]) == expected
+
+
+def test_the_tag_union_skips_pipeline_sentinels(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["portrait"]},
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["__tag:wd14"]},
+        ],
+    )
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    # The sentinel is a "needs retagging" marker, not user metadata: copying it
+    # would re-queue an already-tagged picture for no reason.
+    assert _tags(server, ids[0]) == {"portrait"}
+    assert _tags(server, ids[1]) == {"__tag:wd14", "portrait"}
+
+
+def test_stacking_lifts_every_member_to_the_highest_score(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 1},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    result = _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    assert result.metadata_union["scores_lifted"] == 2
+    assert [_picture(server, pid).score for pid in ids] == [5, 5, 5]
+
+
+def test_stacking_unions_set_membership(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+
+    def add_set(session):
+        picture_set = PictureSet(name="Celebrities")
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        session.add(PictureSetMember(set_id=int(picture_set.id), picture_id=ids[0]))
+        session.commit()
+        return int(picture_set.id)
+
+    set_id = _run(server, add_set)
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    members = _run(
+        server,
+        lambda session: {
+            int(row)
+            for row in session.exec(
+                select(PictureSetMember.picture_id).where(
+                    PictureSetMember.set_id == set_id
+                )
+            ).all()
+        },
+    )
+    # A union can never break an album: the set gained a member, lost none.
+    assert members == set(ids)
+
+
+def test_the_union_is_refused_on_a_locked_set_rather_than_half_applied(server):
+    from fastapi import HTTPException
+
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["portrait"]},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+
+    def add_locked_set(session):
+        picture_set = PictureSet(name="Frozen", locked=True)
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        session.add(PictureSetMember(set_id=int(picture_set.id), picture_id=ids[0]))
+        session.commit()
+
+    _run(server, add_locked_set)
+    _scan(server)
+    with pytest.raises(HTTPException) as excinfo:
+        _run(
+            server,
+            verdicts.apply_stack_verdict_in_session,
+            _one_signature(server),
+            None,
+            [],
+            None,
+        )
+    assert excinfo.value.status_code == 423
+    assert _tags(server, ids[1]) == set()
+
+
+# ── keep separate, and the memory ─────────────────────────────────────────────
+
+
+def test_keep_separate_changes_no_picture_row(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 3},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    result = _run(
+        server, verdicts.apply_keep_separate_in_session, _one_signature(server), None
+    )
+    assert result.verdict == VERDICT_KEEP_SEPARATE
+    assert result.stack_id is None
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert _picture(server, ids[1]).score is None
+
+
+def test_a_verdict_survives_a_rescan(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    _run(server, verdicts.apply_keep_separate_in_session, _one_signature(server), None)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+    _scan(server)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+
+
+def test_reopening_returns_the_group_and_keeps_the_history(server):
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    _run(server, verdicts.apply_keep_separate_in_session, signature, None)
+    reopened = _run(server, verdicts.reopen_verdict_in_session, signature)
+    assert reopened["previous_verdict"] == VERDICT_KEEP_SEPARATE
+    assert reopened["group_returned_to_queue"] is True
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+    # The row is kept and marked, not deleted: the decision history survives.
+    row = _run(
+        server,
+        lambda session: session.exec(
+            select(DedupVerdict).where(DedupVerdict.signature == signature)
+        ).first(),
+    )
+    assert row is not None and row.reopened_at is not None
+    with pytest.raises(DedupVerdictError, match="already reopened"):
+        _run(server, verdicts.reopen_verdict_in_session, signature)
+
+
+def test_reopening_a_stack_verdict_does_not_unstack_anything(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    _run(server, verdicts.apply_stack_verdict_in_session, signature, None, [], None)
+    _run(server, verdicts.reopen_verdict_in_session, signature)
+    assert _picture(server, ids[0]).stack_id is not None
+    assert _picture(server, ids[1]).stack_id is not None
+
+
+def test_reopening_an_unknown_signature_is_rejected(server):
+    with pytest.raises(DedupVerdictError, match="No verdict recorded"):
+        _run(server, verdicts.reopen_verdict_in_session, "0" * 64)
+
+
+# ── bulk auto-stack ───────────────────────────────────────────────────────────
+
+
+def _seed_two_exact_groups(server):
+    return _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+        ],
+    )
+
+
+def test_the_dry_run_counts_and_writes_nothing(server):
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, True, None)
+    assert report["dry_run"] is True
+    assert report["groups"] == 2
+    assert report["pictures"] == 4
+    assert report["results"] == []
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 2
+
+
+def test_auto_stack_shares_one_batch_id_across_every_group(server):
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    assert report["dry_run"] is False
+    assert report["groups"] == 2
+    batch_id = report["batch_id"]
+    assert batch_id
+    assert {item["batch_id"] for item in report["results"]} == {batch_id}
+    rows = _run(server, lambda session: session.exec(select(DedupVerdict)).all())
+    assert {row.batch_id for row in rows} == {batch_id}
+    # Two groups, two stacks, every picture stacked and none deleted.
+    stacks = {_picture(server, pid).stack_id for pid in ids}
+    assert len(stacks) == 2 and None not in stacks
+    assert all(_picture(server, pid).deleted is False for pid in ids)
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 0
+
+
+def test_auto_stack_never_touches_the_near_tier(server):
+    """Only tier 1 is bulk-eligible; a near group always goes through the queue.
+
+    The near group holds two pictures of ITS OWN (no overlap with the exact
+    pair): a near group sharing the exact pair's members would stop posing a
+    decision the moment auto-stack stacked them — the pending-decision filter's
+    stack-units rule — which is correct but proves nothing about the near tier.
+    """
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+            {"pixel_sha": "ccc", "size_bytes": 300},
+        ],
+    )
+
+    def add_near_group(session):
+        pictures = session.exec(
+            select(Picture).where(Picture.pixel_sha.in_(["bbb", "ccc"]))
+        ).all()
+        members = [
+            tiers.CandidateMember(id=int(pic.id), width=10, height=10)
+            for pic in pictures
+        ]
+        group = tiers.assemble_group(tiers.DedupTier.NEAR, 0.95, members)
+        # A distinct signature so it is a second, near-tier group.
+        group.signature = "n" * 64
+        tiers.persist_groups_in_session(session, [group])
+
+    _scan(server)
+    _run(server, add_near_group)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    assert report["groups"] == 1
+    near_policy = TierPolicy(near_enabled=True)
+    assert _run(server, tiers.count_unresolved_in_session, near_policy, None) == 1
+    # And its members are untouched: no stack, no verdict, still unresolved.
+    stacked = _run(
+        server,
+        lambda session: [
+            pic.stack_id
+            for pic in session.exec(
+                select(Picture).where(Picture.pixel_sha.in_(["bbb", "ccc"]))
+            ).all()
+        ],
+    )
+    assert stacked == [None, None]
+
+
+def test_auto_stack_respects_a_limit(server):
+    _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, 1)
+    assert report["groups"] == 1
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+
+def test_no_verdict_ever_deletes_a_picture(server):
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    live = _run(
+        server,
+        lambda session: [int(row) for row in session.exec(select(Picture.id)).all()],
+    )
+    assert sorted(live) == sorted(ids)
+    assert all(_picture(server, pid).deleted is False for pid in ids)
+
+
+# ── operation log integration (§21) ───────────────────────────────────────────
+
+
+def _operations(server) -> list:
+    return _run(
+        server,
+        lambda session: list(
+            session.exec(select(Operation).order_by(Operation.id)).all()
+        ),
+    )
+
+
+def test_a_stack_verdict_records_exactly_one_operation(server):
+    """One verdict, one row. The verdict path must not double-record.
+
+    ``routes/stacks.py`` wraps itself in ``run_recorded_metadata_task``; this
+    module deliberately stacks in-session instead and records once around the
+    whole verdict, so a second row here would mean two Ctrl+Z presses to undo
+    one decision.
+    """
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    batch_id = verdicts.new_batch_id()
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        batch_id,
+    )
+    rows = _operations(server)
+    assert len(rows) == 1
+    assert rows[0].op_type == verdicts.OP_TYPE_STACK
+    assert rows[0].batch_id == batch_id
+    assert rows[0].undoable is True
+    assert "Stacked 2 duplicates" in (rows[0].summary or "")
+
+
+def test_undoing_a_stack_verdict_reverses_the_stacking(server):
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    assert _picture(server, ids[0]).stack_id is not None
+
+    _run(server, operation_log_service.undo_in_session, None)
+    # The recorded `stack` facet is written back, so both pictures leave the
+    # stack neither of them was in before the verdict.
+    assert _picture(server, ids[0]).stack_id is None
+    assert _picture(server, ids[1]).stack_id is None
+    rows = _operations(server)
+    assert len(rows) == 1 and rows[0].status == "undone"
+
+
+def test_undoing_a_stack_verdict_reverses_the_metadata_union(server):
+    """The union happens inside the snapshot, so undo restores tags and scores."""
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5, "tags": ["portrait"]},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    assert _tags(server, ids[1]) == {"portrait"}
+    assert _picture(server, ids[1]).score == 5
+
+    _run(server, operation_log_service.undo_in_session, None)
+    assert _tags(server, ids[1]) == set()
+    assert _picture(server, ids[1]).score is None
+    # The picture that already carried them keeps them.
+    assert _tags(server, ids[0]) == {"portrait"}
+    assert _picture(server, ids[0]).score == 5
+
+
+def test_the_snapshot_covers_stack_siblings_the_group_never_named(server):
+    """Folding a second stack in must be fully reversible (§21 ``expand_stacks``).
+
+    The duplicate pair is 0 and 1. Picture 0 sits in stack A with sibling 2;
+    picture 1 sits in stack B with sibling 3. The verdict's cover is 0, so stack
+    B is **folded into A** and sibling 3 — which the group never named — is
+    reparented. An undo that snapshotted only the group's own members would
+    leave 3 stranded in A with B gone.
+
+    Verified non-vacuous: with the snapshot narrowed back to ``included``, this
+    test fails on the sibling assertion.
+    """
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "yyy", "size_bytes": 800},
+            {"pixel_sha": "zzz", "size_bytes": 900},
+        ],
+    )
+
+    def pre_stack(session):
+        created = []
+        for name, members in (("A", [ids[0], ids[2]]), ("B", [ids[1], ids[3]])):
+            stack = PictureStack(name=name)
+            session.add(stack)
+            session.commit()
+            session.refresh(stack)
+            for position, picture_id in enumerate(members):
+                pic = session.get(Picture, picture_id)
+                pic.stack_id = int(stack.id)
+                pic.stack_position = position
+                session.add(pic)
+            created.append(int(stack.id))
+        session.commit()
+        return created
+
+    stack_a, stack_b = _run(server, pre_stack)
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        ids[0],
+        [],
+        None,
+    )
+    # Stack B was folded into A: all four pictures, sibling 3 included, now
+    # share one stack, and B is gone.
+    assert {_picture(server, pid).stack_id for pid in ids} == {stack_a}
+    assert _run(server, lambda session: session.get(PictureStack, stack_b)) is None
+
+    _run(server, operation_log_service.undo_in_session, None)
+    assert _picture(server, ids[0]).stack_id == stack_a
+    assert _picture(server, ids[2]).stack_id == stack_a
+    # The sibling the group never named is returned to its own stack, which the
+    # recorded `stack` facet recreates by name.
+    assert _picture(server, ids[1]).stack_id == _picture(server, ids[3]).stack_id
+    assert _picture(server, ids[1]).stack_id != stack_a
+    assert _picture(server, ids[1]).stack_id is not None
+
+
+def test_bulk_auto_stack_reverses_with_one_batch_undo(server):
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    batch_id = report["batch_id"]
+    assert report["groups"] == 2
+    rows = _operations(server)
+    # Two groups, two rows, ONE batch id.
+    assert len(rows) == 2
+    assert {row.batch_id for row in rows} == {batch_id}
+    assert all(_picture(server, pid).stack_id is not None for pid in ids)
+
+    _run(server, operation_log_service.undo_batch_in_session, batch_id)
+    # A single call reversed every stack in the run.
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert {row.status for row in _operations(server)} == {"undone"}
+
+
+def test_undoing_any_member_of_the_batch_reverts_the_whole_run(server):
+    """Batch semantics: a partially-undone bulk action cannot exist."""
+    ids = _seed_two_exact_groups(server)
+    _scan(server)
+    _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    first_id = _operations(server)[0].id
+
+    _run(server, operation_log_service.undo_in_session, first_id)
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert {row.status for row in _operations(server)} == {"undone"}
+
+
+def test_keep_separate_and_reopen_record_no_operation(server):
+    """Neither changes a reversible picture facet, so neither writes a row.
+
+    A no-op operation row would still consume a Ctrl+Z, which is worse than
+    offering no undo here: the way back from keep-separate is the explicit
+    reopen action the Stacks view shows.
+    """
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    signature = _one_signature(server)
+    _run(server, verdicts.apply_keep_separate_in_session, signature, None)
+    assert _operations(server) == []
+    _run(server, verdicts.reopen_verdict_in_session, signature)
+    assert _operations(server) == []
+
+
+# ── R2: the bulk path must never lose its undo handle ─────────────────────────
+
+
+def _lock_picture_in_a_set(server, picture_id: int, name: str = "Frozen") -> None:
+    def add_locked_set(session):
+        picture_set = PictureSet(name=name, locked=True)
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        session.add(PictureSetMember(set_id=int(picture_set.id), picture_id=picture_id))
+        session.commit()
+
+    _run(server, add_locked_set)
+
+
+def _seed_three_exact_groups(server):
+    return _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+            {"pixel_sha": "ccc", "size_bytes": 300},
+            {"pixel_sha": "ccc", "size_bytes": 300},
+        ],
+    )
+
+
+def test_a_locked_group_mid_run_does_not_abort_the_bulk_run(server):
+    """Regression for the CSO's B2.
+
+    The locked-set guards raise ``HTTPException(423)``, not
+    ``DedupVerdictError``. Catching only the latter meant a locked group in the
+    middle of a bulk run propagated out **after** earlier groups had already
+    committed — a partially applied bulk mutation whose server-minted batch id
+    the caller never received, i.e. work that happened with no undo handle in the
+    response. The run must instead skip the group, report it, and still return
+    the batch id.
+    """
+    ids = _seed_three_exact_groups(server)
+    _lock_picture_in_a_set(server, ids[2])  # a member of the middle group
+    _scan(server)
+
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+
+    # The run completed rather than raising.
+    assert report["batch_id"]
+    assert report["dry_run"] is False
+    assert report["groups"] == 2
+    assert report["blocked"] == 1
+    assert report["failed"] == 0
+
+    # Every group is accounted for under exactly one outcome.
+    assert {r["outcome"] for r in report["results"]} == {verdicts.BULK_REASON_APPLIED}
+    assert len(report["failures"]) == 1
+    failure = report["failures"][0]
+    assert failure["outcome"] == verdicts.BULK_REASON_BLOCKED
+    assert failure["status_code"] == 423
+    assert failure["error"]["code"] == "set_locked"
+
+    # The locked group is untouched; the other two are stacked.
+    assert _picture(server, ids[2]).stack_id is None
+    assert _picture(server, ids[3]).stack_id is None
+    assert _picture(server, ids[0]).stack_id is not None
+    assert _picture(server, ids[4]).stack_id is not None
+    # ...and the locked group is still in the queue, awaiting its own decision.
+    assert _run(server, tiers.count_unresolved_in_session, None, None) == 1
+
+
+def test_the_returned_batch_id_reverses_exactly_the_applied_groups(server):
+    """The undo handle from a partial run must work, and must not over-reach."""
+    ids = _seed_three_exact_groups(server)
+    _lock_picture_in_a_set(server, ids[2])
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    batch_id = report["batch_id"]
+
+    rows = _operations(server)
+    assert len(rows) == 2
+    assert {row.batch_id for row in rows} == {batch_id}
+
+    _run(server, operation_log_service.undo_batch_in_session, batch_id)
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert {row.status for row in _operations(server)} == {"undone"}
+
+
+def test_a_blocked_group_leaves_no_partial_write_of_its_own(server):
+    """The skipped iteration is rolled back, not carried into the next commit."""
+    ids = _seed_three_exact_groups(server)
+    _lock_picture_in_a_set(server, ids[2])
+    _scan(server)
+    _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+
+    # No stack row was left behind for the blocked group (_stack_members flushes
+    # a PictureStack before the lock guard runs), and no verdict was recorded.
+    stack_ids = {
+        _picture(server, pid).stack_id for pid in ids if _picture(server, pid).stack_id
+    }
+    assert len(stack_ids) == 2
+    stacks = _run(server, lambda session: session.exec(select(PictureStack)).all())
+    assert len(stacks) == 2
+    signatures = _run(
+        server,
+        lambda session: [
+            row.signature for row in session.exec(select(DedupVerdict)).all()
+        ],
+    )
+    assert len(signatures) == 2
+
+
+# ── R3: §21 origin discipline on the recording routes ─────────────────────────
+
+
+def test_a_stack_verdict_records_the_actor_and_origin(server):
+    """The service must carry through what the handler read from the request.
+
+    §21 is explicit that actor / source / origin_client_id come from the request,
+    in the handler, and are passed down — the contextvar is dead on the DB worker
+    thread. Before this, every dedup operation recorded `actor=None,
+    source="external"`, degrading the audit trail for the most far-reaching
+    mutation on the surface.
+    """
+    _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+        ],
+    )
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+        "42",
+        "ui",
+        "tab-abc",
+    )
+    row = _operations(server)[0]
+    assert row.actor == "42"
+    assert row.source == "ui"
+    assert row.origin_client_id == "tab-abc"
+
+
+def test_bulk_auto_stack_attributes_every_row_in_the_batch(server):
+    _seed_two_exact_groups(server)
+    _scan(server)
+    _run(
+        server,
+        verdicts.bulk_auto_stack_in_session,
+        None,
+        None,
+        False,
+        None,
+        "42",
+        "ui",
+        "tab-abc",
+    )
+    rows = _operations(server)
+    assert len(rows) == 2
+    assert {row.actor for row in rows} == {"42"}
+    assert {row.source for row in rows} == {"ui"}
+    assert {row.origin_client_id for row in rows} == {"tab-abc"}
+
+
+# ── R7: the scrapheaped-sibling snapshot flag is load-bearing ─────────────────
+
+
+def test_undo_restores_a_scrapheaped_stack_siblings_position(server):
+    """Regression for the CSO's C1 — pins ``include_deleted=True``.
+
+    ``normalize_stack_positions`` renumbers **every** member of an affected
+    stack, soft-deleted ones included (§21.1). If the undo snapshot expanded the
+    stack without ``include_deleted=True``, the scrapheaped sibling's renumbered
+    position would be an unrecorded change that undo could not reverse — and the
+    whole suite stayed green without it.
+    """
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "zzz", "size_bytes": 900},
+        ],
+    )
+
+    def pre_stack(session):
+        stack = PictureStack(name="with-a-scrapheaped-member")
+        session.add(stack)
+        session.commit()
+        session.refresh(stack)
+        live = session.get(Picture, ids[1])
+        live.stack_id = int(stack.id)
+        live.stack_position = 0
+        session.add(live)
+        buried = session.get(Picture, ids[2])
+        buried.stack_id = int(stack.id)
+        buried.stack_position = 5
+        buried.deleted = True
+        session.add(buried)
+        session.commit()
+
+    _run(server, pre_stack)
+    _scan(server)
+    _run(
+        server,
+        verdicts.apply_stack_verdict_in_session,
+        _one_signature(server),
+        None,
+        [],
+        None,
+    )
+    # The verdict renumbered the scrapheaped sibling along with everyone else.
+    assert _picture(server, ids[2]).stack_position != 5
+
+    _run(server, operation_log_service.undo_in_session, None)
+    buried = _picture(server, ids[2])
+    assert buried.stack_position == 5
+    assert buried.deleted is True
+
+
+# ── addendum: the auto-stack dry-run consent aggregates ───────────────────────
+
+
+def test_the_dry_run_summary_counts_covers_that_gain_metadata(server):
+    """The design's consent dialog promises a "covers gaining metadata" row.
+
+    Derived from the planned verdicts in the dry run's own snapshot — the union
+    is never executed, and nothing is written.
+    """
+    ids = _seed(
+        server,
+        [
+            # Group 1: the cover (highest score) gains a tag from its twin.
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["portrait"]},
+            # Group 2: the cover already has everything, so it gains nothing.
+            {"pixel_sha": "bbb", "size_bytes": 200, "score": 5, "tags": ["sunset"]},
+            {"pixel_sha": "bbb", "size_bytes": 200},
+        ],
+    )
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, True, None)
+    summary = report["dry_run_summary"]
+    assert summary["groups"] == 2
+    assert summary["groups_by_tier"] == {"exact": 2, "near": 0, "embedding": 0}
+    assert summary["pictures"] == 4
+    assert summary["covers_gaining_tags"] == 1
+    assert summary["covers_gaining_metadata"] == 1
+    # Aggregates agree with the top-level counts from the same snapshot.
+    assert summary["groups"] == report["groups"]
+    assert summary["pictures"] == report["pictures"]
+    # Still a dry run: nothing written, nothing tagged.
+    assert all(_picture(server, pid).stack_id is None for pid in ids)
+    assert _tags(server, ids[0]) == set()
+
+
+def test_the_dry_run_summary_counts_a_score_lift(server):
+    _seed(
+        server,
+        [
+            # The cover is chosen on tags, but a twin outranks it on score, so
+            # the union would lift the cover's score.
+            {"pixel_sha": "aaa", "size_bytes": 100, "tags": ["a", "b", "c", "d"]},
+            {"pixel_sha": "aaa", "size_bytes": 100, "score": 5},
+        ],
+    )
+    _scan(server)
+    summary = _run(server, verdicts.bulk_auto_stack_in_session, None, None, True, None)[
+        "dry_run_summary"
+    ]
+    assert summary["covers_gaining_score"] == 1
+    assert summary["covers_gaining_metadata"] == 1
+
+
+def test_an_applied_run_carries_no_dry_run_summary(server):
+    _seed_two_exact_groups(server)
+    _scan(server)
+    report = _run(server, verdicts.bulk_auto_stack_in_session, None, None, False, None)
+    assert "dry_run_summary" not in report
+
+
+def test_a_locked_co_member_of_a_folded_stack_is_refused(server):
+    """The lock guard must run BEFORE the fold, and expand through it.
+
+    ``apply_metadata_union_in_session`` only checks the group's own members, so
+    the co-members that ``_stack_members`` drags in when it folds another stack
+    are covered solely by ``enforce_stack_membership_not_locked`` running first
+    and expanding through ``expand_picture_ids_to_stacks``. That ordering is
+    load-bearing: move the lock check after the fold and a locked picture gets
+    silently reparented. Pins the CSO's B6b probe.
+    """
+    from fastapi import HTTPException
+
+    ids = _seed(
+        server,
+        [
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "aaa", "size_bytes": 100},
+            {"pixel_sha": "zzz", "size_bytes": 900},
+        ],
+    )
+
+    def pre_stack_and_lock(session):
+        # Picture 2 (a group member) shares a stack with picture 3, which is NOT
+        # in the group and is the one frozen by the locked set.
+        stack = PictureStack(name="folds-in")
+        session.add(stack)
+        session.commit()
+        session.refresh(stack)
+        for position, picture_id in enumerate([ids[1], ids[2]]):
+            pic = session.get(Picture, picture_id)
+            pic.stack_id = int(stack.id)
+            pic.stack_position = position
+            session.add(pic)
+        picture_set = PictureSet(name="Frozen", locked=True)
+        session.add(picture_set)
+        session.commit()
+        session.refresh(picture_set)
+        session.add(PictureSetMember(set_id=int(picture_set.id), picture_id=ids[2]))
+        session.commit()
+        return int(stack.id)
+
+    original_stack = _run(server, pre_stack_and_lock)
+    _scan(server)
+    with pytest.raises(HTTPException) as excinfo:
+        _run(
+            server,
+            verdicts.apply_stack_verdict_in_session,
+            _one_signature(server),
+            ids[0],
+            [],
+            None,
+        )
+    assert excinfo.value.status_code == 423
+    # Nothing moved: the group member outside the stack is still unstacked and
+    # the folded stack is intact.
+    assert _picture(server, ids[0]).stack_id is None
+    assert _picture(server, ids[1]).stack_id == original_stack
+    assert _picture(server, ids[2]).stack_id == original_stack
+    assert _operations(server) == []

--- a/tests/test_operation_log.py
+++ b/tests/test_operation_log.py
@@ -1695,3 +1695,124 @@ def test_operations_routes_have_no_inline_authz_check():
             f"{forbidden} is an inline authz check; the AuthzGate owns "
             "authorization for these routes (docs/backend_architecture.md §16.1)"
         )
+
+
+# ── post-restore hooks ────────────────────────────────────────────────────────
+
+
+def _register_recording_hook(op_type):
+    """Register a hook that records its calls, and return the call list.
+
+    The registry is module-global, so the hook is removed again by the caller's
+    ``finally`` to keep tests independent.
+    """
+    calls = []
+
+    def _hook(session, operations, direction):
+        calls.append((direction, sorted(int(op.id) for op in operations)))
+
+    operation_log_service.register_post_restore_hook(op_type, _hook)
+    return calls
+
+
+def test_a_post_restore_hook_runs_once_per_restore_with_its_whole_batch():
+    """The generic seam a feature uses to reopen what an operation also decided.
+
+    An operation can change state the recorded picture facets do not cover (the
+    v1.9 duplicate verdict is the first). Without a hook, undo restored the
+    pictures and left that decision standing. The contract asserted here is what
+    the feature relies on: called once per restore, with **every** operation of
+    its own op_type, with the direction, and never for a foreign op_type.
+    """
+    temp_dir, client, server = _setup()
+    try:
+        calls = _register_recording_hook("test.hooked")
+        other = _register_recording_hook("test.unhooked")
+        ids = [_upload(client) for _ in range(2)]
+        batch_id = operation_log_service.new_batch_id()
+
+        def _tag_one(session, picture_id, tag):
+            session.add(Tag(picture_id=picture_id, tag=tag))
+            session.commit()
+
+        for picture_id in ids:
+            operation_log_service.run_recorded_metadata_task(
+                server.vault,
+                _tag_one,
+                picture_id,
+                "hooked",
+                op_type="test.hooked",
+                picture_ids=[picture_id],
+                batch_id=batch_id,
+                summary="Hooked",
+            )
+        recorded = sorted(op["id"] for op in _operations(server, batch_id=batch_id))
+        assert len(recorded) == 2
+        assert calls == [], "recording must not fire a restore hook"
+
+        assert client.post(f"{API}/operations/undo").status_code == 200
+        assert calls == [("undo", recorded)], calls
+
+        assert client.post(f"{API}/operations/redo").status_code == 200
+        assert calls == [("undo", recorded), ("redo", recorded)], calls
+
+        # A hook registered for a different op_type never saw any of it.
+        assert other == []
+    finally:
+        operation_log_service._POST_RESTORE_HOOKS.pop("test.hooked", None)
+        operation_log_service._POST_RESTORE_HOOKS.pop("test.unhooked", None)
+        _teardown(temp_dir, server)
+
+
+def test_a_failing_post_restore_hook_aborts_the_whole_undo():
+    """The hook runs inside the restore's transaction, so it fails closed.
+
+    A hook that could fail *after* the state was committed would leave the
+    pictures restored and the feature's own state stale — exactly the split the
+    hook exists to prevent.
+    """
+    temp_dir, client, server = _setup()
+    try:
+
+        def _boom(session, operations, direction):
+            raise RuntimeError("hook refused")
+
+        operation_log_service.register_post_restore_hook("test.failing", _boom)
+        picture_id = _upload(client)
+
+        def _tag_one(session, pid, tag):
+            session.add(Tag(picture_id=pid, tag=tag))
+            session.commit()
+
+        operation_log_service.run_recorded_metadata_task(
+            server.vault,
+            _tag_one,
+            picture_id,
+            "kept",
+            op_type="test.failing",
+            picture_ids=[picture_id],
+            summary="Failing",
+        )
+        assert _tags(server, picture_id) == ["kept"]
+
+        # The TestClient re-raises an unhandled server exception rather than
+        # turning it into a 500, so the refusal surfaces here.
+        with pytest.raises(RuntimeError, match="hook refused"):
+            client.post(f"{API}/operations/undo")
+        # Nothing was written: the tag is still there and the operation is still
+        # applied, so the user can retry rather than being left half-undone.
+        assert _tags(server, picture_id) == ["kept"]
+        assert [op["status"] for op in _operations(server, op_type="test.failing")] == [
+            "applied"
+        ]
+    finally:
+        operation_log_service._POST_RESTORE_HOOKS.pop("test.failing", None)
+        _teardown(temp_dir, server)
+
+
+def test_a_server_minted_batch_id_is_namespaced():
+    """M1: an un-namespaced id is indistinguishable from a client-supplied one."""
+    assert operation_log_service.new_batch_id().startswith(
+        operation_log_service.SERVER_BATCH_ID_PREFIX
+    )
+    assert operation_log_service.new_batch_id() != operation_log_service.new_batch_id()

--- a/tests/test_picture_sets.py
+++ b/tests/test_picture_sets.py
@@ -454,6 +454,82 @@ def test_no_duplicate_reference_picture_sets():
         gc.collect()
 
 
+def test_set_view_represents_a_stack_by_its_in_set_member():
+    """A stack whose leader is OUTSIDE the set must not vanish from the set view.
+
+    Legacy stacks predating the stack-atomic invariant can leave a set holding
+    a non-leader member whose cover is not in the set; the collapsed grid then
+    rendered NEITHER picture (the owner's #670/#1746 report: six members, five
+    tiles, and no stack in sight). The listing now represents such a stack by
+    its lowest-positioned member INSIDE the id filter, stack fields intact so
+    the tile still wears its badge.
+    """
+    temp_dir, client, server = setup_server_with_temp_db()
+    try:
+        import glob
+
+        from pixlstash.db_models import Picture, PictureSetMember
+
+        image_candidates = glob.glob(
+            os.path.join(os.path.dirname(__file__), "..", "pictures", "*.png")
+        ) + glob.glob(
+            os.path.join(os.path.dirname(__file__), "..", "pictures", "*.jpg")
+        )
+        assert len(image_candidates) >= 2, "Need at least 2 test images"
+
+        def upload_image(path):
+            mime_type = "image/png" if path.lower().endswith(".png") else "image/jpeg"
+            with open(path, "rb") as f:
+                result = upload_pictures_and_wait(
+                    client,
+                    [("file", (os.path.basename(path), f, mime_type))],
+                )
+            return result["results"][0]["picture_id"]
+
+        pic_a = upload_image(image_candidates[0])
+        pic_b = upload_image(image_candidates[1])
+        stack_resp = client.post("/stacks", json={"picture_ids": [pic_a, pic_b]})
+        assert stack_resp.status_code == 200, stack_resp.text
+
+        def read_positions(session):
+            return {
+                pid: session.get(Picture, pid).stack_position
+                for pid in (pic_a, pic_b)
+            }
+
+        positions = server.vault.db.run_task(read_positions)
+        leader = pic_a if positions[pic_a] == 0 else pic_b
+        member = pic_b if leader == pic_a else pic_a
+
+        set_resp = client.post("/picture_sets", json={"name": "LegacySet"})
+        assert set_resp.status_code == 200, set_resp.text
+        set_id = set_resp.json()["picture_set"]["id"]
+
+        # Simulate the legacy shape DIRECTLY: a membership row for the
+        # non-leader only, bypassing the stack-atomic members endpoint.
+        def seed(session):
+            session.add(PictureSetMember(set_id=set_id, picture_id=member))
+            session.commit()
+
+        server.vault.db.run_task(seed)
+
+        listed = client.get(f"/pictures?set_id={set_id}&fields=grid")
+        assert listed.status_code == 200, listed.text
+        rows = listed.json()
+        assert [row["id"] for row in rows] == [member]
+        assert rows[0]["stack_id"] is not None
+
+        # The unscoped grid is untouched: the true leader represents the stack.
+        all_rows = client.get("/pictures?fields=grid").json()
+        all_ids = [row["id"] for row in all_rows]
+        assert leader in all_ids
+        assert member not in all_ids
+    finally:
+        server.vault.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
 def test_members_endpoint_expands_stack_siblings():
     """Sets are stack-atomic: adding any member of a stack adds every member.
 


### PR DESCRIPTION
The complete **Dedup → Stacks** feature (design: `design/1.9-dedup/`) in one branch and one PR: the backend lane (formerly #638, closed as superseded), the CSO authz sign-off report (#639), and the frontend lane, merged and integration-fixed together, current with develop-1.9.

## Backend — tiered detection, verdicts, queue APIs

- **Tier 1 exact**: groups on existing indexed `(pixel_sha, size_bytes)` — documented honestly as a sampled digest with the consent-dialog mitigation; `MissingPixelShaFinder` backfills NULLs. **Tier 2**: bucketed dHash XOR/popcount (size-bin / capture-minute / import-batch / folder buckets, sharded at 4000, never dropped), streamed via the task system. **Tier 3**: existing likeness edges, weakest-link confidence. Rescans keep the stronger tier.
- `TierPolicy` (exact locked on, opt-in descent, 0.90 default, 0.65 hard floor) + the design's cover formula with why-pills in both directions.
- Verdict memory (`dedupverdict` keyed on group signature) + group cache + scan rows; migration `0088` (chain 0086 → 0087 → 0088, verified linear). Cursor-based queue paging; client batch ids validated to the `cli-` namespace (400 on mismatch).
- Verdicts apply the metadata union (tags, set/project membership, score lifted; characters only in the unambiguous single-character case) and record ONE op-log operation per verdict; bulk auto-stack = one namespaced batch id = one Ctrl+Z. A post-restore hook (§21.3) reopens the verdict and group when a stack verdict is undone, so undone groups return to the queue and survive rescans correctly.
- 8 new routes, all `owner_only` with content-identity justifications; coverage matrix re-derived. **Independent CSO adversarial sign-off included** (`docs/reviews/dedup-tiers-authz-signoff.md`, from #639); its required changes are applied on this branch.

## Frontend — Duplicates destination, triage queue, Compare

- Sidebar **Duplicates** destination with live count + scan banner; virtual triage queue (one group in the DOM) with the full keyboard model (↑↓/Enter/S/C/1–9/X, auto-advance) and roving tabindex.
- **Compare view — closes #156**: field-by-field, best-value-per-column, full paths, verdicts in the footer.
- Auto-stack dialog (dry-run consent → one batch id → one Ctrl+Z receipt); keep-separate raises a sticky notice with a Reopen action.
- Stacks in the grid (badge, edge ticks, cover marker), Stacks filter segments, scoped "Find duplicates in…" context-menu entries, Likeness-Groups sort retired with a one-time migration notice.
- API layer reconciled to the shipped backend; exclusion-floor / count-drift / paging fixes; duplicate-queue e2e spec.
- ui-ux pass fixed 10 real interaction bugs pre-merge.

## Merge-conflict resolutions worth reviewing

- `operation_log_service.py`: both lanes independently introduced `SERVER_BATCH_ID_PREFIX = "srv-"`; kept one definition with a docstring naming both client entry points (the `X-Operation-Batch-Id` header and the dedup verdict body field).
- `backend_architecture.md` §21: tag-review decisions keep **§21.2** (code and tests cite that number); the dedup lane's sections renumbered to **§21.3** (post-restore hooks) and **§21.4** (batch-id namespacing, now describing both client entry points and the header-vs-body asymmetry).

## Verification (on the merged branch)

- Backend: operation-log + dedup suites green.
- Frontend: 1,392 tests green across 91 files; lint + build clean.
- `render_backend_architecture.py --check` passes (routes/events tables current).
- Known follow-ups tracked in `integration_architecture.md` §2.1 (StackExpansionStrip built but unmounted pending variable-row-height virtualization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
