### PR TITLE
Add some missing python dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,5 @@ ultralytics==8.4.21
 psutil==7.2.2
 nvidia-ml-py==13.590.48
 zstandard==0.25.0
+watchdog==6.0.0
+python-multipart==0.0.32


### PR DESCRIPTION
`watchdog` is used by our `ReferenceFolderWatcher` to monitor for filesystem changes.  I specified the latest release (`6.0.0`) as the version.

Error without:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/pixlstash/pixlstash/app.py", line 13, in <module>
    from pixlstash.server import Server
  File "/opt/pixlstash/pixlstash/server.py", line 47, in <module>
    from pixlstash.vault import Vault
  File "/opt/pixlstash/pixlstash/vault.py", line 42, in <module>
    from .utils.reference_folder_watcher import ReferenceFolderWatcher
  File "/opt/pixlstash/pixlstash/utils/reference_folder_watcher.py", line 17, in <module>
    from watchdog.events import FileSystemEventHandler
ModuleNotFoundError: No module named 'watchdog'
```


`python-multipart` is used by `fastapi` in `post` routes.  I specified the latest release (`0.0.32`) as the version.

Error without:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/pixlstash/pixlstash/app.py", line 330, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/pixlstash/pixlstash/app.py", line 289, in main
    server = Server(server_config_path=args.server_config, path_map=path_map)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pixlstash/pixlstash/server.py", line 489, in __init__
    self._setup_routes()
  File "/opt/pixlstash/pixlstash/server.py", line 1033, in _setup_routes
    create_config_router(self),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pixlstash/pixlstash/routes/config.py", line 606, in create_router
    @router.post(
     ^^^^^^^^^^^^
  File "/opt/pixlstash/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 2788, in decorator
    self.add_api_route(
  File "/opt/pixlstash/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 2723, in add_api_route
    route = route_class(
            ^^^^^^^^^^^^
  File "/opt/pixlstash/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 1153, in __init__
    _populate_api_route_state(
  File "/opt/pixlstash/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 1056, in _populate_api_route_state
    route.dependant = get_dependant(
                      ^^^^^^^^^^^^^^
  File "/opt/pixlstash/.venv/lib/python3.12/site-packages/fastapi/dependencies/utils.py", line 311, in get_dependant
    param_details = analyze_param(
                    ^^^^^^^^^^^^^^
  File "/opt/pixlstash/.venv/lib/python3.12/site-packages/fastapi/dependencies/utils.py", line 535, in analyze_param
    ensure_multipart_is_installed()
  File "/opt/pixlstash/.venv/lib/python3.12/site-packages/fastapi/dependencies/utils.py", line 120, in ensure_multipart_is_installed
    raise RuntimeError(multipart_not_installed_error) from None
RuntimeError: Form data requires "python-multipart" to be installed. 
You can install "python-multipart" with: 

pip install python-multipart

```