### PR TITLE
Mark undecodable images in thumbnail and quality tasks too (#585)

### DIFF
--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -218,8 +218,8 @@
         </v-card-title>
         <v-card-text style="padding: 0 20px 4px">
           <div style="font-size: 0.875rem; opacity: 0.85; margin-bottom: 10px">
-            Leave the label empty for dense object detection, or type a phrase to
-            detect only that (e.g. "dog").
+            Leave the label empty for dense object detection, or type a phrase
+            to detect only that (e.g. "dog").
           </div>
           <v-text-field
             v-model="segmentPrompt"
@@ -231,7 +231,9 @@
           />
         </v-card-text>
         <v-card-actions style="padding: 8px 16px 16px">
-          <v-btn variant="text" @click="segmentDialogOpen = false">Cancel</v-btn>
+          <v-btn variant="text" @click="segmentDialogOpen = false"
+            >Cancel</v-btn
+          >
           <v-spacer />
           <v-btn color="primary" variant="tonal" @click="confirmSegment">
             Detect
@@ -266,7 +268,9 @@
       v-model="snapshotsWithDeletedOpen"
       :snapshots="snapshotsWithDeleted"
       :dont-show-again="userPrefsStore.hidePurgeSnapshotWarning"
-      @update:dont-show-again="userPrefsStore.setHidePurgeSnapshotWarning($event)"
+      @update:dont-show-again="
+        userPrefsStore.setHidePurgeSnapshotWarning($event)
+      "
     />
     <DeleteForeverDialog
       v-model:open="deleteForeverOpen"
@@ -681,6 +685,7 @@
               </template>
               <template v-else-if="getThumbnailSrc(img)">
                 <img
+                  v-show="!failedThumbnailIds.has(img.id)"
                   :src="getThumbnailSrc(img)"
                   class="thumbnail-img"
                   :style="getSquareCropImgStyle(img)"
@@ -694,9 +699,17 @@
                   @pointercancel="handleThumbnailPointerRelease($event)"
                   @dragstart="handleThumbnailNativeDragStart(img, $event)"
                   @dragend="handleDragEnd"
-                  @error="handleImageError"
+                  @error="handleImageError(img, $event)"
                   @load="onThumbnailLoad(img.id, $event)"
                 />
+                <div
+                  v-if="failedThumbnailIds.has(img.id)"
+                  class="thumbnail-placeholder"
+                >
+                  <v-icon class="thumbnail-broken-icon"
+                    >mdi-image-broken-variant</v-icon
+                  >
+                </div>
                 <img
                   v-if="isVideo(img)"
                   class="thumbnail-drag-preview"
@@ -1017,10 +1030,7 @@ import { useTasksStore } from "../../stores/useTasksStore";
 import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
 import { useLockedSetsStore } from "../../stores/useLockedSetsStore";
 import { useScrapheapRetentionStore } from "../../stores/useScrapheapRetentionStore";
-import {
-  useNoticeStore,
-  DEFAULT_TIMEOUTS,
-} from "../../stores/useNoticeStore";
+import { useNoticeStore, DEFAULT_TIMEOUTS } from "../../stores/useNoticeStore";
 import { useBreadcrumb } from "../../composables/useBreadcrumb";
 import { useBottomAnchor } from "../../composables/useBottomAnchor";
 import { useScopedNotice } from "../../composables/useScopedNotice";
@@ -1085,7 +1095,11 @@ import {
   removeCharacterFaces,
   removeCharacterFacesByFaceId,
 } from "../../api/characters";
-import { getPictureSet, addPictureToSet, removePictureFromSet } from "../../api/pictureSets";
+import {
+  getPictureSet,
+  addPictureToSet,
+  removePictureFromSet,
+} from "../../api/pictureSets";
 import { getSharedPictureIds, revokeTokensByResource } from "../../api/users";
 import { listTaggers } from "../../api/taggers";
 import { runTextToImage } from "../../api/comfyui";
@@ -2319,7 +2333,13 @@ function isImageRecentlyAdded(id) {
 // ============================================================
 // THUMBNAIL HELPERS
 // ============================================================
+// Thumbnails whose <img> fired @error (e.g. an undecodable source, #585):
+// the browser's native broken-image glyph is replaced with a centered icon
+// until a later successful load clears the id again.
+const failedThumbnailIds = reactive(new Set());
+
 function onThumbnailLoad(id) {
+  failedThumbnailIds.delete(id);
   thumbnailLoadedMap[id] = (thumbnailLoadedMap[id] || 0) + 1;
   const assignedAt = Number(thumbnailAssignedAtMap[id]);
   if (Number.isFinite(assignedAt) && assignedAt > 0) {
@@ -2414,9 +2434,7 @@ function getVideoThumbnailSrc(img) {
 // yet been populated falls back to cover centring until they arrive.
 function isSquareCropActive(img) {
   return (
-    !isJustifiedMode.value &&
-    !isVideo(img) &&
-    squareCropParams(img) !== null
+    !isJustifiedMode.value && !isVideo(img) && squareCropParams(img) !== null
   );
 }
 
@@ -2821,8 +2839,7 @@ const reviewOverlayOpen = computed(() => reviewSessionsStore.overlayOpen);
 // The trail logic lives in useBreadcrumb, shared with the desktop title bar.
 // In the desktop shell the breadcrumb renders in the title bar instead, so the
 // in-grid overlay below is gated on !isDesktop.
-const isDesktop =
-  typeof window !== "undefined" && !!window.pixlstashDesktop;
+const isDesktop = typeof window !== "undefined" && !!window.pixlstashDesktop;
 const { breadcrumb, navigateBreadcrumb } = useBreadcrumb();
 
 // Below 600px the centred notice card widens over the bottom-left breadcrumb, so
@@ -2887,7 +2904,10 @@ function prefetchFullImage(img) {
 // ============================================================
 // SELECTION + DRAG HELPERS
 // ============================================================
-function handleImageError(event) {
+function handleImageError(img, event) {
+  if (img?.id != null) {
+    failedThumbnailIds.add(img.id);
+  }
   const imgEl = event?.target;
   if (imgEl instanceof HTMLImageElement) {
     const src = imgEl.src || "";
@@ -3751,7 +3771,9 @@ const partialStackGroupingReason = computed(() => {
   const idSet = new Set(ids);
   const images = allGridImages.value || [];
   const byId = new Map(
-    images.filter((img) => img && img.id != null).map((img) => [String(img.id), img]),
+    images
+      .filter((img) => img && img.id != null)
+      .map((img) => [String(img.id), img]),
   );
 
   // Which stacks does the selection touch? (Members share stack_id even when
@@ -3771,7 +3793,9 @@ const partialStackGroupingReason = computed(() => {
     // An expanded stack is whole-stack only when every rendered member is
     // selected.
     const memberIds = images
-      .filter((img) => img && img.id != null && getPictureStackId(img) === stackId)
+      .filter(
+        (img) => img && img.id != null && getPictureStackId(img) === stackId,
+      )
       .map((img) => Number(img.id));
     const allSelected =
       memberIds.length > 0 && memberIds.every((mid) => idSet.has(mid));
@@ -4081,10 +4105,9 @@ async function runScrapheapSelectionPurge(idsToRemove, includeProtected) {
     );
   } catch (err) {
     console.error("Scrapheap purge failed", err);
-    noticeStore.error(
-      `Couldn't delete those pictures. ${errorDetail(err)}`,
-      { key: "scrapheap-purge" },
-    );
+    noticeStore.error(`Couldn't delete those pictures. ${errorDetail(err)}`, {
+      key: "scrapheap-purge",
+    });
   } finally {
     // The server spends the confirmation on the first attempt, so a retry must
     // go back through the preview rather than replaying a dead token.
@@ -8158,6 +8181,11 @@ function handleEmptyStateReset() {
   font-size: 28px;
   opacity: 0.7;
   animation: thumbnailPlaceholderSpin 1.1s linear infinite;
+}
+
+.thumbnail-broken-icon {
+  font-size: 48px;
+  opacity: 0.5;
 }
 
 @keyframes thumbnailPlaceholderSpin {

--- a/frontend/src/components/views/ImageOverlay.vue
+++ b/frontend/src/components/views/ImageOverlay.vue
@@ -503,16 +503,25 @@
                     </a>
                   </div>
                 </template>
-                <img
-                  v-else
-                  ref="imgRef"
-                  :src="getFullImageUrl(image)"
-                  :alt="image.description || 'Full Image'"
-                  class="overlay-img"
-                  :draggable="!isZoomed"
-                  @dragstart="handleMediaDragStart"
-                  @load="updateOverlayDims"
-                />
+                <template v-else>
+                  <img
+                    v-if="!fullImageError"
+                    ref="imgRef"
+                    :src="getFullImageUrl(image)"
+                    :alt="image.description || 'Full Image'"
+                    class="overlay-img"
+                    :draggable="!isZoomed"
+                    @dragstart="handleMediaDragStart"
+                    @load="updateOverlayDims"
+                    @error="handleFullImageError"
+                  />
+                  <div v-else class="overlay-image-error">
+                    <v-icon size="64" color="grey-lighten-1"
+                      >mdi-image-broken-variant</v-icon
+                    >
+                    <p class="overlay-image-error-msg">Could not load image</p>
+                  </div>
+                </template>
               </template>
               <template v-if="showFaceBbox && overlayReady">
                 <div v-if="faceBboxes.length === 0" class="face-bbox-empty">
@@ -786,11 +795,7 @@ import OverlayMetadataPanel from "./OverlayMetadataPanel.vue";
 import OverlayTagsPanel from "./OverlayTagsPanel.vue";
 import PluginParametersUI from "../widgets/PluginParametersUI.vue";
 import StarRatingOverlay from "../widgets/StarRatingOverlay.vue";
-import {
-  faceBoxColor,
-  getStackColor,
-  toggleScore,
-} from "../../utils/utils.js";
+import { faceBoxColor, getStackColor, toggleScore } from "../../utils/utils.js";
 import { dedupeTagList, getTagList } from "../../utils/tags.js";
 
 // Failures report through the notice surface instead of a blocking native
@@ -2929,6 +2934,13 @@ function updateOverlayDims() {
 
 watch(image, () => scheduleOverlayDimsUpdate());
 
+const fullImageError = ref(false); // full-size <img> fired @error (e.g. undecodable source)
+
+function handleFullImageError(event) {
+  console.warn("Full image load error for", event?.target?.src);
+  fullImageError.value = true;
+}
+
 function handleVideoError(event) {
   const err = event.target?.error;
   const code = err?.code ?? -1;
@@ -3512,6 +3524,7 @@ watch(
         offsetY: 0,
       };
       videoError.value = null;
+      fullImageError.value = false;
       scheduleOverlayDimsUpdate();
       fetchFaceBboxes(newId);
       fetchDetections(newId);
@@ -3522,6 +3535,7 @@ watch(
       faceBboxes.value = [];
       detectionBboxes.value = [];
       videoError.value = null;
+      fullImageError.value = false;
       comfyMetadata.value = null;
     }
   },
@@ -4304,6 +4318,26 @@ function resetOverlayCopyState() {
   font-size: var(--text-sm);
   opacity: 0.75;
   max-width: 300px;
+}
+
+.overlay-image-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-5);
+  padding: 40px;
+  border-radius: var(--radius-lg);
+  background: rgba(var(--v-theme-dark-surface), 0.8);
+  color: rgb(var(--v-theme-on-dark-surface));
+  text-align: center;
+  min-width: 280px;
+}
+
+.overlay-image-error-msg {
+  margin: 0;
+  font-size: var(--text-sm);
+  opacity: 0.75;
 }
 
 .overlay-video-download-btn {

--- a/frontend/src/components/views/OverlayFilmstrip.vue
+++ b/frontend/src/components/views/OverlayFilmstrip.vue
@@ -1,13 +1,6 @@
 <template>
-  <div
-    ref="railRef"
-    class="overlay-rail"
-    :class="{ hidden: hidden }"
-  >
-    <div
-      class="filmstrip-viewport"
-      @wheel.prevent.stop="onFilmstripWheel"
-    >
+  <div ref="railRef" class="overlay-rail" :class="{ hidden: hidden }">
+    <div class="filmstrip-viewport" @wheel.prevent.stop="onFilmstripWheel">
       <transition-group
         name="filmstrip-slide"
         tag="div"
@@ -26,12 +19,9 @@
           @click.stop="emit('select', item.index)"
           :title="item.description || 'Image'"
         >
-          <div
-            class="filmstrip-thumb-tile"
-            :style="item.stackTileStyle"
-          >
+          <div class="filmstrip-thumb-tile" :style="item.stackTileStyle">
             <img
-              v-if="item.thumbSrc"
+              v-if="item.thumbSrc && !isThumbBroken(item)"
               :class="[
                 'filmstrip-thumb-image',
                 { 'filmstrip-thumb-image-active': item.isActive },
@@ -40,6 +30,7 @@
               :alt="item.description || 'Thumbnail'"
               loading="lazy"
               draggable="false"
+              @error="onThumbError(item)"
             />
             <div
               v-else
@@ -48,25 +39,25 @@
                 { 'filmstrip-thumb-image-active': item.isActive },
               ]"
             >
-              <v-icon size="22">
-                {{ item.isVideo ? "mdi-video" : "mdi-image" }}
+              <v-icon :size="isThumbBroken(item) ? 28 : 22">
+                {{
+                  isThumbBroken(item)
+                    ? "mdi-image-broken-variant"
+                    : item.isVideo
+                      ? "mdi-video"
+                      : "mdi-image"
+                }}
               </v-icon>
             </div>
           </div>
           <div
-            v-if="
-              item.stackBadgeVisible &&
-              item.thumbSrc &&
-              item.isStackLead
-            "
+            v-if="item.stackBadgeVisible && item.thumbSrc && item.isStackLead"
             class="filmstrip-badge filmstrip-badge--top-left"
             :title="item.stackBadgeTitle"
             @click.stop="emit('toggle-expand', item)"
             @mouseenter.stop="emit('prefetch', item)"
           >
-            <v-icon size="14" :style="item.stackIconStyle"
-              >mdi-layers</v-icon
-            >
+            <v-icon size="14" :style="item.stackIconStyle">mdi-layers</v-icon>
           </div>
           <div
             v-if="item.problemBadgeVisible"
@@ -78,9 +69,7 @@
             ]"
             :title="item.problemTitle"
           >
-            <v-icon size="14" color="error"
-              >mdi-emoticon-sad-outline</v-icon
-            >
+            <v-icon size="14" color="error">mdi-emoticon-sad-outline</v-icon>
           </div>
         </button>
       </transition-group>
@@ -89,13 +78,29 @@
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { reactive, ref } from "vue";
 
 defineProps({
   items: { type: Array, default: () => [] },
   canvasStyle: { type: Object, default: () => ({}) },
   hidden: { type: Boolean, default: false },
 });
+
+// Thumbs whose <img> fired @error (e.g. an undecodable source, #585): show a
+// centered broken-image icon instead of the browser's alt-text rendering.
+const failedThumbKeys = reactive(new Set());
+
+function thumbKey(item) {
+  return item.id ?? `idx-${item.index}`;
+}
+
+function onThumbError(item) {
+  failedThumbKeys.add(thumbKey(item));
+}
+
+function isThumbBroken(item) {
+  return failedThumbKeys.has(thumbKey(item));
+}
 
 const emit = defineEmits(["select", "toggle-expand", "prefetch", "navigate"]);
 

--- a/pixlstash/tasks/missing_thumbnail_finder.py
+++ b/pixlstash/tasks/missing_thumbnail_finder.py
@@ -32,7 +32,12 @@ class MissingThumbnailFinder(BaseTaskFinder):
         limit = ThumbnailGenerationTask.BATCH_SIZE * (
             max(1, self.max_inflight_tasks()) + 1
         )
-        pictures = self._db.run_immediate_read_task(self._fetch_missing, limit)
+        # Exclude undecodable pictures (issue #585) at the query so they cannot
+        # crowd the candidate window and stall real work behind them.
+        suppressed_ids = self._db.unprocessable_images.active_suppressed_ids()
+        pictures = self._db.run_immediate_read_task(
+            lambda session: self._fetch_missing(session, limit, suppressed_ids)
+        )
         if not pictures:
             return None
 
@@ -43,13 +48,15 @@ class MissingThumbnailFinder(BaseTaskFinder):
         return ThumbnailGenerationTask(database=self._db, pictures=selected)
 
     @staticmethod
-    def _fetch_missing(session: Session, limit: int):
-        return session.exec(
+    def _fetch_missing(session: Session, limit: int, suppressed_ids=None):
+        stmt = (
             select(Picture)
             .where(Picture.thumbnail_width.is_(None))
             .where(Picture.deleted.is_(False))
             .where(Picture.file_path.is_not(None))
-            .options(selectinload(Picture.faces))
-            .order_by(Picture.id)
-            .limit(limit)
+        )
+        if suppressed_ids:
+            stmt = stmt.where(Picture.id.notin_(tuple(suppressed_ids)))
+        return session.exec(
+            stmt.options(selectinload(Picture.faces)).order_by(Picture.id).limit(limit)
         ).all()

--- a/pixlstash/tasks/quality_task.py
+++ b/pixlstash/tasks/quality_task.py
@@ -312,9 +312,26 @@ class QualityTask(BaseTask):
             )
             img = ImageUtils.load_image_or_video(file_path)
             if img is None:
-                raise ValueError(
-                    f"Cannot infer metadata for picture id={pic.id} path={pic.file_path}: file could not be loaded"
-                )
+                # Raising here aborted the whole batch (good pictures included)
+                # and left every column unset, so the finder re-selected the
+                # same corrupt picture on every sweep (#585). Mark it and move
+                # on: _compute writes sentinel quality values for unloadable
+                # images, and _filter_and_claim skips it once marked.
+                registry = getattr(self._db, "unprocessable_images", None)
+                if registry is not None:
+                    registry.mark_unprocessable(
+                        getattr(pic, "id", None),
+                        str(file_path),
+                        reason="quality source could not be decoded",
+                    )
+                else:
+                    logger.warning(
+                        "QualityTask: cannot infer metadata for picture id=%s "
+                        "path=%s: file could not be loaded",
+                        pic.id,
+                        pic.file_path,
+                    )
+                continue
 
             height, width = img.shape[:2]
             ext = os.path.splitext(pic.file_path or "")[1].lstrip(".").upper()

--- a/pixlstash/tasks/thumbnail_generation_task.py
+++ b/pixlstash/tasks/thumbnail_generation_task.py
@@ -76,11 +76,24 @@ class ThumbnailGenerationTask(BaseTask):
 
         img = ImageUtils.load_image_or_video(resolved)
         if img is None:
-            logger.warning(
-                "ThumbnailGenerationTask: failed to load source for picture %s (%s)",
-                getattr(pic, "id", None),
-                resolved,
-            )
+            # The file exists but cannot be decoded. Returning None leaves
+            # thumbnail_width NULL, which is exactly what MissingThumbnailFinder
+            # selects on — without marking, the same corrupt picture is
+            # re-selected on every sweep forever (#585). The registry logs one
+            # warning per file version and _filter_and_claim skips it.
+            registry = getattr(self._db, "unprocessable_images", None)
+            if registry is not None:
+                registry.mark_unprocessable(
+                    getattr(pic, "id", None),
+                    str(resolved),
+                    reason="thumbnail source could not be decoded",
+                )
+            else:
+                logger.warning(
+                    "ThumbnailGenerationTask: failed to load source for picture %s (%s)",
+                    getattr(pic, "id", None),
+                    resolved,
+                )
             return None
         if not isinstance(img, Image.Image):
             img = Image.fromarray(img)

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -1355,20 +1355,26 @@ class Vault:
             return result[0]
         return result or 0
 
-    @staticmethod
-    def _count_missing_thumbnails(session: Session) -> int:
+    def _count_missing_thumbnails(self, session: Session) -> int:
         """Pictures awaiting whole-frame thumbnail (re)generation.
 
         Mirrors ``MissingThumbnailFinder._fetch_missing``: keyed on
-        ``thumbnail_width IS NULL`` for live, file-backed pictures.
+        ``thumbnail_width IS NULL`` for live, file-backed pictures. Excludes
+        undecodable pictures (issue #585) so the "Upgrading thumbnails"
+        progress bar can reach 0 instead of stalling on files that can never
+        produce a thumbnail.
         """
-        result = session.exec(
+        suppressed_ids = self.db.unprocessable_images.active_suppressed_ids()
+        stmt = (
             select(func.count())
             .select_from(Picture)
             .where(Picture.thumbnail_width.is_(None))
             .where(Picture.deleted.is_(False))
             .where(Picture.file_path.is_not(None))
-        ).one()
+        )
+        if suppressed_ids:
+            stmt = stmt.where(Picture.id.notin_(tuple(suppressed_ids)))
+        result = session.exec(stmt).one()
         if isinstance(result, (tuple, list)):
             return result[0]
         return result or 0

--- a/tests/test_invalid_image_endless_retry.py
+++ b/tests/test_invalid_image_endless_retry.py
@@ -30,6 +30,8 @@ from sqlmodel import Session
 from pixlstash.db_models import Picture
 from pixlstash.tasks.image_embedding_task import ImageEmbeddingTask
 from pixlstash.tasks.missing_image_embedding_finder import MissingImageEmbeddingFinder
+from pixlstash.tasks.missing_thumbnail_finder import MissingThumbnailFinder
+from pixlstash.tasks.quality_task import QualityTask
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from pixlstash.vault import Vault
 
@@ -217,3 +219,71 @@ def test_585_filter_and_claim_never_reads_file_path(tmp_path):
         candidates = [_FilePathExplodes(1), _FilePathExplodes(2)]
         selected = finder._filter_and_claim(candidates, batch_limit=10)
         assert [c.id for c in selected] == [1, 2]
+
+
+def test_585_thumbnail_task_suppresses_corrupt_image(tmp_path):
+    """#585 follow-up: ThumbnailGenerationTask must mark undecodable sources.
+
+    Reported against v1.8.0: the original fix marked decode failures only in
+    ImageEmbeddingTask, so a corrupt picture whose thumbnail columns were NULL
+    (e.g. after the v1.8.0 thumbnail-regeneration reset) was re-selected by
+    MissingThumbnailFinder on every sweep forever.
+    """
+    corrupt_path = _write_corrupt_jpeg(tmp_path / "corrupt.jpg")
+
+    with Vault(image_root=str(tmp_path)) as vault:
+        pic_id = _seed_picture(vault, corrupt_path)
+
+        # The finder selects it (thumbnail_width is NULL) and builds a task.
+        finder = MissingThumbnailFinder(vault.db)
+        task = finder.find_task()
+        assert task is not None
+        assert task.params["picture_ids"] == [pic_id]
+
+        # The task fails to decode the source: no columns are written...
+        result = task._run_task()
+        assert result == {"changed_count": 0}
+
+        # ...but the picture is now suppressed, so after the claim is released
+        # the finder no longer re-selects it — the old endless-retry loop.
+        assert vault.db.unprocessable_images.is_suppressed(pic_id)
+        finder.on_task_complete(task, None)
+        assert finder.find_task() is None
+
+
+def test_585_quality_metadata_backfill_marks_instead_of_raising(tmp_path):
+    """#585 follow-up: an undecodable file must not abort quality backfill.
+
+    ``_backfill_missing_picture_metadata`` used to raise on the first corrupt
+    picture, killing the whole batch (good pictures included) and leaving every
+    column unset, so the finder re-selected the same batch on every sweep.
+    """
+    from PIL import Image as PILImage
+
+    corrupt_path = _write_corrupt_jpeg(tmp_path / "corrupt.jpg")
+    valid_path = str(tmp_path / "valid.jpg")
+    PILImage.new("RGB", (8, 8), "red").save(valid_path)
+
+    class _MetadatalessPic:
+        """Stands in for a Picture whose format/width/height are unset."""
+
+        def __init__(self, pid: int, file_path: str):
+            self.id = pid
+            self.file_path = file_path
+            self.format = None
+            self.width = None
+            self.height = None
+
+    corrupt_pic = _MetadatalessPic(1, corrupt_path)
+    valid_pic = _MetadatalessPic(2, valid_path)
+
+    with Vault(image_root=str(tmp_path)) as vault:
+        task = QualityTask(database=vault.db, pictures=[corrupt_pic, valid_pic])
+
+        # Corrupt picture first: the loop must survive it and reach the valid one.
+        task._backfill_missing_picture_metadata([corrupt_pic, valid_pic])
+
+        assert vault.db.unprocessable_images.is_suppressed(corrupt_pic.id)
+        assert not vault.db.unprocessable_images.is_suppressed(valid_pic.id)
+        assert (valid_pic.width, valid_pic.height) == (8, 8)
+        assert valid_pic.format == "JPG"

--- a/tests/test_invalid_image_endless_retry.py
+++ b/tests/test_invalid_image_endless_retry.py
@@ -234,21 +234,25 @@ def test_585_thumbnail_task_suppresses_corrupt_image(tmp_path):
     with Vault(image_root=str(tmp_path)) as vault:
         pic_id = _seed_picture(vault, corrupt_path)
 
-        # The finder selects it (thumbnail_width is NULL) and builds a task.
+        # The finder selects it (thumbnail_width is NULL) and builds a task,
+        # and the "Upgrading thumbnails" progress count sees it as remaining.
         finder = MissingThumbnailFinder(vault.db)
         task = finder.find_task()
         assert task is not None
         assert task.params["picture_ids"] == [pic_id]
+        assert vault.db.run_task(vault._count_missing_thumbnails) == 1
 
         # The task fails to decode the source: no columns are written...
         result = task._run_task()
         assert result == {"changed_count": 0}
 
         # ...but the picture is now suppressed, so after the claim is released
-        # the finder no longer re-selects it — the old endless-retry loop.
+        # the finder no longer re-selects it — the old endless-retry loop —
+        # and the progress count reaches 0 so the bar can complete.
         assert vault.db.unprocessable_images.is_suppressed(pic_id)
         finder.on_task_complete(task, None)
         assert finder.find_task() is None
+        assert vault.db.run_task(vault._count_missing_thumbnails) == 0
 
 
 def test_585_quality_metadata_backfill_marks_instead_of_raising(tmp_path):

--- a/tests/test_likeness_worker.py
+++ b/tests/test_likeness_worker.py
@@ -6,6 +6,7 @@ from pixlstash.pixl_logging import get_logger
 from pixlstash.server import Server
 from pixlstash.tasks.task_type import TaskType
 from pixlstash.db_models.picture import Picture
+from pixlstash.db_models.quality import Quality
 from pixlstash.db_models.picture_likeness import PictureLikeness, PictureLikenessQueue
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from sqlalchemy import func
@@ -212,14 +213,32 @@ def test_write_blob_updates_skips_hard_deleted_pictures():
         with Server(server_config_path) as server:
 
             def _seed(session):
+                # Seed pictures that look fully processed to the background
+                # pipeline. The Server runs live finders, and a picture with
+                # pending quality work gets a sentinel Quality written for its
+                # unloadable file — and update_quality resets size_bin_index
+                # as part of that, racing (and clobbering) the very column this
+                # test asserts on. Pre-filling metadata, Quality, and likeness
+                # columns keeps every finder idle so only write_blob_updates
+                # touches the rows.
                 rows = [
-                    Picture(file_path=f"lk_{i}.jpg", filename=f"lk_{i}.jpg")
+                    Picture(
+                        file_path=f"lk_{i}.jpg",
+                        filename=f"lk_{i}.jpg",
+                        format="jpg",
+                        width=64,
+                        height=64,
+                        likeness_parameters=b"\x00\x00\x00\x00",
+                        size_bin_index=1,
+                    )
                     for i in range(3)
                 ]
                 session.add_all(rows)
                 session.commit()
                 for r in rows:
                     session.refresh(r)
+                    session.add(Quality(picture_id=r.id, sharpness=1.0))
+                session.commit()
                 return [r.id for r in rows]
 
             ids = server.vault.db.run_task(_seed)


### PR DESCRIPTION
Fixes #585 (follow-up reported against v1.8.0).

## Problem

The v1.8.0 fix added the `UnprocessableImageRegistry` and made every batch finder skip suppressed pictures at the shared `_filter_and_claim` choke point — but only `ImageEmbeddingTask` ever **marked** a picture as unprocessable.

`ThumbnailGenerationTask` logged a warning on a failed decode and returned without writing any columns, so `thumbnail_width` stayed NULL and `MissingThumbnailFinder` re-selected the same corrupt picture on every sweep — the original endless-retry bug. It surfaces prominently in 1.8.0 because the upgrade resets the thumbnail columns for a one-time regeneration sweep, pushing every corrupt image in the library through this finder. Suppression via the embedding task only masks it until the next restart (the registry is in-memory by design).

`QualityTask._backfill_missing_picture_metadata` had the same shape one step worse: it **raised** on the first undecodable file, aborting the whole batch — good pictures included — and leaving every column unset for the next sweep.

## Fix

- `ThumbnailGenerationTask._resolve_columns` marks the picture in the registry when the source exists but cannot be decoded, matching the embedding task's semantics (only genuine decode failures; missing files stay with the missing-file purge finder). The registry's own one-per-file-version warning replaces the per-sweep log spam.
- `QualityTask._backfill_missing_picture_metadata` marks the picture and continues instead of raising, so the rest of the batch is processed and `_compute` writes its usual sentinel quality values for the unloadable image.

`TextScoreTask` was checked and already terminates on its own (writes a `-1.0` sentinel).

## Tests

`tests/test_invalid_image_endless_retry.py` (the #585 regression file) previously covered only the embedding path — which is how this was missed. Added:

- `test_585_thumbnail_task_suppresses_corrupt_image` — drives the real `MissingThumbnailFinder` → `ThumbnailGenerationTask` → finder loop against a corrupt file and asserts the finder stops re-selecting it.
- `test_585_quality_metadata_backfill_marks_instead_of_raising` — corrupt picture first in the batch; asserts no raise, the corrupt picture is suppressed, and the valid picture behind it still gets its metadata backfilled.

All 5 tests in the file pass, plus the thumbnail/quality-adjacent suites (49 tests) and ruff.

## Follow-up: stuck progress bar after restart

Manual testing found that after a restart the "Upgrading thumbnails" progress bar never completed: the corrupt picture was correctly re-marked and skipped, but `Vault._count_missing_thumbnails` still counted every `thumbnail_width IS NULL` row, so `remaining` stalled at the number of undecodable files. It now excludes active suppressed ids, the same way `_count_missing_image_embeddings` already did.

`MissingThumbnailFinder`'s candidate query got the same exclusion so a large run of low-id corrupt pictures cannot fill the fetch window and starve real work behind it — mirroring the embedding finder.

The thumbnail regression test now also asserts the progress count goes 1 → 0 across the suppression. Other progress counts were checked: quality/text-score terminate via sentinel values, face extraction inserts a sentinel `Face` row even for unloadable images, and embeddings were already covered.
