### PR TITLE
Guard form submits against duplicate in-flight requests

### DIFF
--- a/docs/design/design-tokens.css
+++ b/docs/design/design-tokens.css
@@ -130,6 +130,23 @@
   --scrim-drawer: rgba(var(--v-theme-scrim), 0.28);
 
   /* ---------------------------------------------------------------------------
+     STATE OPACITY — exactly one value, because there is exactly one state that
+     may legally fade. `--opacity-disabled` names the ~38% that
+     visual-language.md §11 has always specified in prose and that AppButton
+     carried as a raw 0.38. WCAG 1.4.3 exempts an inactive control, which is why
+     the fade is allowed there and nowhere else.
+
+     There is deliberately NO `--opacity-busy`, and adding one would be a bug.
+     Group opacity composites the whole control toward its surface, so a filled
+     variant's white label falls with the fill: on the light `accent` fill it
+     measures 4.75:1 at full opacity, 3.97:1 at 0.9, 2.70:1 at 0.7 and 1.67:1 at
+     the disabled 0.38. The white-label rule (§4) only survives above ~0.97, so
+     no perceptible dim is legal. A pending control does not dim at all; it reads
+     as busy through the spinner, `cursor: progress` and `aria-busy`. See §11.
+     --------------------------------------------------------------------------- */
+  --opacity-disabled: 0.38;
+
+  /* ---------------------------------------------------------------------------
      COMPONENT DIMENSIONS — a small set of fixed component sizes that are neither
      spacing gaps nor radii, but recur across the UI and were drifting as raw
      one-offs (15px vs 7px badges; 34 / 40 / 48 / 56px action bars). Snap to these.

--- a/docs/design/visual-language.md
+++ b/docs/design/visual-language.md
@@ -590,7 +590,38 @@ These get skipped and that is exactly why a UI looks cheap.
   `on-surface` (11.1 – 12.1:1), which is what the dark theme already did. This is the
   same "`on-<x>` on a tint" trap as `on-<status>` (§4); it will keep recurring, so check
   it every time an `on-*` token appears next to an `rgba(...)` fill.
-- **Disabled:** drop to ~38% opacity of the token, never a different grey.
+- **Disabled:** drop to `--opacity-disabled` (0.38) of the token, never a
+  different grey. The fade is legal here and only here: WCAG 1.4.3 exempts an
+  inactive control, so a disabled label may sit below the contrast floor.
+- **Pending (busy):** a control that is working is disabled, but it is *not* the
+  disabled state. "Not allowed" may fade out of the reading order; "working" is
+  the only thing telling the user their click landed, so it has to stay legible.
+  **A pending control does not dim.** Group opacity composites the whole control
+  toward its surface and drags a filled variant's white label down with the fill:
+  on the light `accent` fill the label measures 4.75:1 at full opacity, 3.97:1 at
+  0.9, 2.70:1 at 0.7 and 1.67:1 at the disabled 0.38. The white-label rule (§4)
+  only survives above ~0.97, so no perceptible dim is legal and there is no
+  `--opacity-busy` token. Four things carry the state instead: the leading icon
+  swaps to the shared spinner idiom (`mdi-loading` + `mdi-spin`, the one
+  `NewReviewDialog`, `TagHealthBoard` and the overlay panels already use), the
+  cursor becomes `progress` (busy, but the rest of the surface is still live,
+  unlike disabled's `not-allowed`), the control is natively `disabled` so a
+  second click cannot fire, and it carries `aria-busy="true"`.
+  **The label does not change.** "Save" stays "Save" and never becomes
+  "Saving...". The label is the accessible name and is often the
+  `aria-keyshortcuts` target, so mutating it mid-flight renames the control under
+  a screen reader, and a longer word resizes the button and reflows the action
+  row. The spinner already says "working", so `AppButton` has no loading-text
+  prop. (`TbTagPanel`'s hand-rolled "Applying..." predates the primitive: drift
+  to converge, not precedent.) No live region on the button either, because the
+  outcome is announced by the notice surface and a second announcer would
+  double-speak, the same reason `OverlayActionReceipt` has none.
+  **The spinner keeps spinning under `prefers-reduced-motion`.** The global reset
+  in `design-tokens.css` would freeze it into a static broken ring that reads as a
+  rendering fault, and a spinner is a status readout rather than decoration, which
+  is the exception `ActionReceipt`'s countdown hairline already takes (§10).
+  Restore it with a scoped override on `::before`, where `@mdi/font` puts the
+  animation. Never by weakening the global reset.
 - **Scrollbars:** a scroll region inside a `dark-surface` panel styles its own bar,
   because the global `.is-desktop` treatment in `style.css` keys off `on-surface`
   (the light-chrome pair) and does not apply in a plain browser at all. The pattern

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -70,7 +70,8 @@ frontend/src/
 │   ├── useBreadcrumb.js         # Current-view breadcrumb trail from route + id→name maps; shared by in-grid nav and TitleBar
 │   ├── useReviewRoute.js        # URL ⇄ tag-review overlay (`?review=…`); mirrors ImageGrid's `?overlay=` mechanics (+ *.test.js)
 │   ├── useVersionCheck.js       # "New version available" check (pixlstash.dev poll); single owner gated by `enabled`
-│   └── useSidebarExpansion.js   # Which sidebar sections / projects / folders are open; localStorage-backed (+ *.test.js)
+│   ├── useSidebarExpansion.js   # Which sidebar sections / projects / folders are open; localStorage-backed (+ *.test.js)
+│   └── useSubmitGuard.js        # One in-flight submit at a time + the `pending` flag its button wears — see §10.2 (+ *.test.js)
 │
 ├── api/                         # Backend resource modules: the only place URL strings live (see §8)
 │   ├── config.js                # Per-user config blob: GET/PATCH /users/me/config
@@ -480,6 +481,8 @@ Actual file upload engine. Props: `backendUrl`, `selectedCharacterId`, `allPictu
 
 #### App* design-system layer (`widgets/`)
 The house-styled form/control primitives that wrap Vuetify with the PixlStash tokens (`styles/design-tokens.css`), so new UI composes from one consistent kit instead of raw Vuetify: `AppButton.vue` (~140 lines), `AppDialog.vue` (~165 lines), `AppInput.vue` (~95 lines), `AppSelect.vue` (~95 lines), `AppStepper.vue` (~125 lines), `AppTextarea.vue` (~60 lines), plus `FieldLabel.vue` (~15 lines) for consistent field labelling. Presentational; each takes `v-model` / props and emits the matching update events.
+
+**`AppButton loading`** (2026-07-30, issue #647): the pending state. Forces the button natively `disabled` so a create cannot be double-submitted, swaps the leading icon for `mdi-loading` + `mdi-spin`, sets `aria-busy`, and restores focus to itself when the request settles (a natively-disabled button drops focus to `<body>`, stranding a keyboard user who would otherwise have to tab all the way back). It does **not** dim and it does **not** change the label; there is no loading-text prop. Rationale and the contrast arithmetic: `docs/design/visual-language.md` §11. The behavioural half is `composables/useSubmitGuard.js` (§10.2).
 
 #### `AddToEntityControl.vue` (966 lines)
 Reusable control for assigning images to/from characters and sets. Props: `type` (`'character'`|`'set'`), `imageIds`, `selectedCharacter`, `selectedSet`. Emits: `added`, `removed`, `selected`. Used in `Toolbar`, `ImageOverlay`, `ImageGridContextMenu`.
@@ -940,6 +943,22 @@ Two rules keep the restored state honest:
 - **Re-browse what was restored.** `folderBrowseCache` is per-session, so a restored subfolder would render with no children. `fetchReferenceFolders()` calls `browseExpandedFolderPaths()` to fetch a listing for each persisted path, and `browseExpandedFolders()` does the same after the cache is dropped (folder relocate, drag-drop move).
 
 localStorage failures (private mode, disabled storage, quota) warn once per sidebar and fall back to defaults; the sections still toggle for the session.
+
+### 10.2 Submitting a form (`composables/useSubmitGuard.js`)
+
+**Any handler that creates something server-side goes through `useSubmitGuard`.** Issue #647: a create form's button stayed live while its POST was in flight, so a double-click — or an impatient second click while the server was busy captioning an import — sent the request twice and the library gained two identical people, sets, or folders. The window is invisible to the user and widest exactly when the server is slowest, which is when they are most likely to click again.
+
+```js
+const { pending: saving, run: save } = useSubmitGuard(submitCharacter);
+```
+
+Bind `pending` to the submit button (`AppButton :loading`, or `:disabled` on a hand-rolled one) and call `run` wherever the handler used to be called. Three rules:
+
+- **Guard the handler, not just the button.** The button is not the only door in: every one of these forms also submits on Enter (an `@enter` on the name field, a `@keydown.enter`, a Ctrl+Enter document listener), and key auto-repeat fires those faster than a `disabled` attribute can be painted. `run` refusing a re-entrant call is what covers the keyboard; `pending` on the button is what makes the state visible. A component that already had a `saveLoading` ref bound to `:loading` was **not** safe — `FolderEditor` had six Enter-bound fields behind one guarded button.
+- **The handler must await its own work.** `useSubmitGuard` clears `pending` when the handler settles, so a wrapper that fires an async call without awaiting it clears the flag immediately and guards nothing.
+- **Do not catch inside the guard.** It deliberately re-raises, so the form's existing `useNoticeStore` toast or inline error line still fires; `pending` clears in `finally`, which is what re-enables the button for a retry.
+
+Guarded today: `CharacterEditor`, `PictureSetEditor`, `FolderEditor`, `FolderBrowser`, `ProjectFiles` (add-URL), `LoginScreen`. `ProjectEditor` and `NewReviewDialog` predate the composable and hand-roll the same shape; converge them when next touched.
 
 ---
 

--- a/frontend/src/components/editors/CharacterEditor.vue
+++ b/frontend/src/components/editors/CharacterEditor.vue
@@ -72,6 +72,7 @@
         variant="primary"
         icon-left="check"
         :disabled="!isValid"
+        :loading="saving"
         @click="save"
       >
         Save
@@ -107,6 +108,7 @@ import {
   getReferencePictures,
 } from "../../api/characters";
 import { listPicturesByIds } from "../../api/pictures";
+import { useSubmitGuard } from "../../composables/useSubmitGuard";
 import { useNoticeStore } from "../../stores/useNoticeStore";
 import AppDialog from "../widgets/AppDialog.vue";
 import AppButton from "../widgets/AppButton.vue";
@@ -237,16 +239,21 @@ watch(
   { immediate: true },
 );
 
-function save() {
+async function submitCharacter() {
   if (!isValid.value) {
     console.error("Character data is not valid. Cannot save.");
     return;
   }
 
-  saveCharacter({
+  await saveCharacter({
     ...localCharacter.value,
   });
 }
+
+// One create at a time (#647). The button wears `saving`, and `save` refuses a
+// re-entrant call, which is what covers the two keyboard doors into this form:
+// Enter on the name field and the Ctrl+Enter listener below.
+const { pending: saving, run: save } = useSubmitGuard(submitCharacter);
 
 // Keyboard shortcuts
 function handleKeydown(event) {

--- a/frontend/src/components/editors/FolderBrowser.vue
+++ b/frontend/src/components/editors/FolderBrowser.vue
@@ -28,6 +28,7 @@
               @keydown.esc="cancelCreateFolder"
             />
             <v-btn
+              class="browse-create-btn"
               size="small"
               variant="flat"
               color="primary"
@@ -115,6 +116,7 @@ import {
   browseFilesystem,
   createFilesystemFolder,
 } from "../../api/folders";
+import { useSubmitGuard } from "../../composables/useSubmitGuard";
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -134,7 +136,6 @@ const browseError = ref("");
 const browseShowHidden = ref(false);
 const creatingFolder = ref(false);
 const newFolderName = ref("");
-const createFolderLoading = ref(false);
 const createFolderError = ref("");
 const createFolderInputRef = ref(null);
 
@@ -250,14 +251,13 @@ function cancelCreateFolder() {
   createFolderError.value = "";
 }
 
-async function createFolder() {
+async function submitNewFolder() {
   const name = newFolderName.value.trim();
   if (!name) return;
   if (name === "." || name === ".." || /[\\/]/.test(name)) {
     createFolderError.value = "Use a plain folder name.";
     return;
   }
-  createFolderLoading.value = true;
   createFolderError.value = "";
   try {
     const target = joinChildPath(browsePath.value, name);
@@ -268,10 +268,14 @@ async function createFolder() {
   } catch (error) {
     createFolderError.value =
       error?.response?.data?.detail || "Could not create folder.";
-  } finally {
-    createFolderLoading.value = false;
   }
 }
+
+// The Create button already wore `createFolderLoading`, but the name field
+// submits on Enter and stays enabled mid-flight, so a held Enter could ask the
+// filesystem for the same directory twice (#647).
+const { pending: createFolderLoading, run: createFolder } =
+  useSubmitGuard(submitNewFolder);
 </script>
 
 <style scoped>
@@ -324,6 +328,30 @@ async function createFolder() {
   color: rgb(var(--v-theme-error));
   padding: 6px 16px 0;
   font-size: 0.8rem;
+}
+
+/* Pending is not disabled (visual-language.md §11): the shared AppButton keeps
+   its label legible while busy, but this is a stock Vuetify v-btn, whose own
+   `--loading` styling sets `.v-btn__content { opacity: 0 }` — blanking "Create"
+   entirely instead of just dimming it. Restore it so this button matches the
+   pending contract the rest of #647's forms carry. */
+.browse-create-btn :deep(.v-btn--loading .v-btn__content),
+.browse-create-btn :deep(.v-btn--loading .v-btn__prepend),
+.browse-create-btn :deep(.v-btn--loading .v-btn__append) {
+  opacity: 1;
+}
+
+/* The spinner keeps spinning under reduced motion, the same fix AppButton takes
+   for its own mdi-spin icon: the global reset in design-tokens.css zeroes every
+   element's animation, which would freeze Vuetify's indeterminate spinner into a
+   static ring that reads as a rendering fault rather than "working". */
+@media (prefers-reduced-motion: reduce) {
+  .browse-create-btn :deep(.v-progress-circular--indeterminate > svg),
+  .browse-create-btn
+    :deep(.v-progress-circular--indeterminate .v-progress-circular__overlay) {
+    animation-duration: 1.4s !important;
+    animation-iteration-count: infinite !important;
+  }
 }
 
 .browse-entries {

--- a/frontend/src/components/editors/FolderEditor.vue
+++ b/frontend/src/components/editors/FolderEditor.vue
@@ -644,6 +644,7 @@ import {
   // Aliased: this component wraps it in its own debounced detectSidecars().
   detectSidecars as fetchSidecarConvention,
 } from "../../api/folders";
+import { useSubmitGuard } from "../../composables/useSubmitGuard";
 import { copyText } from "../../utils/clipboard";
 import {
   buildDockerRestartCommand,
@@ -713,7 +714,6 @@ const syncSectionOpen = ref(false);
 const detectInfo = ref("");
 const localAllowDelete = ref(false);
 const saveError = ref("");
-const saveLoading = ref(false);
 const deleteLoading = ref(false);
 const confirmingDelete = ref(false);
 const pathInputRef = ref(null);
@@ -1173,9 +1173,8 @@ function suffixForSubmit(value, def) {
   return trimmed;
 }
 
-async function save() {
+async function submitFolder() {
   if (!isValid.value) return;
-  saveLoading.value = true;
   saveError.value = "";
   try {
     let savedResponse = null;
@@ -1241,10 +1240,13 @@ async function save() {
   } catch (error) {
     saveError.value =
       error?.response?.data?.detail || `Failed to save ${props.type} folder.`;
-  } finally {
-    saveLoading.value = false;
   }
 }
+
+// The button already wore `saveLoading`, but six fields in this dialog submit on
+// Enter and none of them are disabled mid-flight, so key auto-repeat could still
+// add the same folder twice (#647). Guarding the handler closes that door too.
+const { pending: saveLoading, run: save } = useSubmitGuard(submitFolder);
 
 async function doDelete() {
   const editingFolder = activeFolder.value;
@@ -1602,5 +1604,35 @@ async function copyToClipboard(value, successMessage) {
   background: rgb(var(--v-theme-accent));
   color: rgb(var(--v-theme-on-accent));
   transition: filter 0.2s;
+}
+
+/* Pending is not disabled (visual-language.md §11): the shared AppButton keeps
+   its label legible while busy, but Save/Remove/Confirm Remove here are stock
+   Vuetify v-btn, whose own `--loading` styling sets `.v-btn__content { opacity: 0
+   }` — blanking the label entirely instead of just dimming it. Restore it so
+   these three match the pending contract the rest of #647's forms carry. */
+.btn-save :deep(.v-btn--loading .v-btn__content),
+.btn-save :deep(.v-btn--loading .v-btn__prepend),
+.btn-save :deep(.v-btn--loading .v-btn__append),
+.editor-delete-btn :deep(.v-btn--loading .v-btn__content),
+.editor-delete-btn :deep(.v-btn--loading .v-btn__prepend),
+.editor-delete-btn :deep(.v-btn--loading .v-btn__append) {
+  opacity: 1;
+}
+
+/* The spinner keeps spinning under reduced motion, the same fix AppButton takes
+   for its own mdi-spin icon: the global reset in design-tokens.css zeroes every
+   element's animation, which would freeze Vuetify's indeterminate spinner into a
+   static ring that reads as a rendering fault rather than "working". */
+@media (prefers-reduced-motion: reduce) {
+  .btn-save :deep(.v-progress-circular--indeterminate > svg),
+  .btn-save
+    :deep(.v-progress-circular--indeterminate .v-progress-circular__overlay),
+  .editor-delete-btn :deep(.v-progress-circular--indeterminate > svg),
+  .editor-delete-btn
+    :deep(.v-progress-circular--indeterminate .v-progress-circular__overlay) {
+    animation-duration: 1.4s !important;
+    animation-iteration-count: infinite !important;
+  }
 }
 </style>

--- a/frontend/src/components/editors/PictureSetEditor.vue
+++ b/frontend/src/components/editors/PictureSetEditor.vue
@@ -143,6 +143,7 @@
         variant="primary"
         icon-left="check"
         :disabled="!isValid"
+        :loading="saving"
         @click="save"
       >
         Save
@@ -158,6 +159,7 @@ import {
   createPictureSet,
   patchPictureSet,
 } from "../../api/pictureSets";
+import { useSubmitGuard } from "../../composables/useSubmitGuard";
 import { useNoticeStore } from "../../stores/useNoticeStore";
 import {
   SET_COLORS,
@@ -277,18 +279,25 @@ watch(
   { immediate: true },
 );
 
-function save() {
+async function submitSet() {
   if (!isValid.value) return;
   // A locked set only accepts an unlock: sending the other (unchanged, but
   // disabled) fields would 423 server-side. Send just id + locked so unticking
   // Locked and saving is the unlock path, and saving without unticking is a
   // no-op the server allows.
   if (isLockedSet.value) {
-    saveSetFromEditor({ id: localSet.value.id, locked: localSet.value.locked });
+    await saveSetFromEditor({
+      id: localSet.value.id,
+      locked: localSet.value.locked,
+    });
     return;
   }
-  saveSetFromEditor({ ...localSet.value });
+  await saveSetFromEditor({ ...localSet.value });
 }
+
+// One create at a time (#647): the button wears `saving`, and `save` refuses a
+// re-entrant call so the name field's Enter cannot slip a second set past it.
+const { pending: saving, run: save } = useSubmitGuard(submitSet);
 
 // Keyboard shortcuts
 function handleKeydown(event) {

--- a/frontend/src/components/panels/ProjectFiles.vue
+++ b/frontend/src/components/panels/ProjectFiles.vue
@@ -113,8 +113,12 @@
           <button
             class="pf-url-save"
             @click="addUrl"
-            :disabled="!urlInput.trim()"
+            :disabled="!urlInput.trim() || addingUrl"
+            :aria-busy="addingUrl ? 'true' : undefined"
           >
+            <v-icon size="12" :class="{ 'mdi-spin': addingUrl }">{{
+              addingUrl ? "mdi-loading" : "mdi-plus"
+            }}</v-icon>
             Add
           </button>
           <button class="pf-url-cancel" @click="showUrlForm = false">
@@ -138,6 +142,7 @@ import {
   addProjectAttachmentUrl,
   deleteProjectAttachment,
 } from "../../api/projects";
+import { useSubmitGuard } from "../../composables/useSubmitGuard";
 
 const props = defineProps({
   projectId: { type: Number, required: true },
@@ -267,7 +272,7 @@ async function deleteFile(file) {
   }
 }
 
-async function addUrl() {
+async function submitUrl() {
   const url = urlInput.value.trim();
   if (!url) return;
   const title = urlTitle.value.trim() || url;
@@ -286,6 +291,11 @@ async function addUrl() {
     uploadError.value = err?.response?.data?.detail ?? "Could not save URL.";
   }
 }
+
+// One attachment per submit (#647). The two inputs both submit on Enter and the
+// fields are only cleared after the await, so without this a second Enter or a
+// double-click on Add posts the same URL twice.
+const { pending: addingUrl, run: addUrl } = useSubmitGuard(submitUrl);
 
 function urlLabel(file) {
   const name = file.original_filename || "";
@@ -678,6 +688,9 @@ onMounted(() => {
 }
 
 .pf-url-save {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
   background: rgba(var(--v-theme-accent), 0.85);
   color: rgb(var(--v-theme-on-accent));
 }
@@ -689,6 +702,23 @@ onMounted(() => {
 .pf-url-save:disabled {
   opacity: 0.4;
   cursor: default;
+}
+
+/* Pending is not disabled: the spinner is the only thing telling the user their
+   click landed, so it must not fade with the rest (visual-language.md §11). The
+   spin also survives reduced motion — a frozen mdi-loading is a static broken
+   ring, and @mdi/font puts the animation on ::before, which is what the global
+   reset in design-tokens.css zeroes. */
+.pf-url-save:disabled[aria-busy="true"] {
+  opacity: 1;
+  cursor: progress;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pf-url-save .mdi-spin::before {
+    animation-duration: 2s !important;
+    animation-iteration-count: infinite !important;
+  }
 }
 
 .pf-url-cancel {

--- a/frontend/src/components/views/LoginScreen.vue
+++ b/frontend/src/components/views/LoginScreen.vue
@@ -49,7 +49,13 @@
           }}</v-icon>
         </button>
       </div>
-      <button class="login-button" type="submit">
+      <button
+        class="login-button"
+        type="submit"
+        :disabled="submitting"
+        :aria-busy="submitting ? 'true' : undefined"
+      >
+        <v-icon v-if="submitting" size="16" class="mdi-spin">mdi-loading</v-icon>
         {{ needsRegistration ? "Register" : "Login" }}
       </button>
       <p v-if="error" class="error">{{ error }}</p>
@@ -67,6 +73,7 @@
 <script setup>
 import { onMounted, ref } from "vue";
 import { checkLoginStatus, login } from "../../utils/apiClient";
+import { useSubmitGuard } from "../../composables/useSubmitGuard";
 import WordmarkLogo from "../WordmarkLogo.vue";
 
 defineProps({
@@ -88,7 +95,7 @@ onMounted(async () => {
   }
 });
 
-async function handleLogin() {
+async function submitLogin() {
   try {
     error.value = null;
     await login(username.value, password.value); // Call the centralised login function
@@ -97,6 +104,11 @@ async function handleLogin() {
     error.value = err.response?.data?.detail || err.message || "Login failed.";
   }
 }
+
+// A form with a submit button submits on Enter as well as on click, and the
+// registration branch of this one claims ownership of the library — so a second
+// press while the first is in flight is exactly the double-create #647 is about.
+const { pending: submitting, run: handleLogin } = useSubmitGuard(submitLogin);
 </script>
 
 <style scoped>
@@ -227,6 +239,10 @@ form {
 }
 
 .login-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
   padding: var(--space-3);
   font-size: var(--text-md);
   border: none;
@@ -234,6 +250,22 @@ form {
   background-color: rgb(var(--v-theme-primary));
   color: rgb(var(--v-theme-on-primary));
   cursor: pointer;
+}
+
+/* Pending is not disabled: the login button only ever goes disabled because a
+   request is in flight, so it keeps full strength and says "working" with the
+   spinner and the cursor rather than by fading (visual-language.md §11). The
+   spin survives reduced motion — a frozen mdi-loading reads as a broken glyph,
+   and @mdi/font puts the animation on ::before, where the global reset lands. */
+.login-button:disabled {
+  cursor: progress;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .login-button .mdi-spin::before {
+    animation-duration: 2s !important;
+    animation-iteration-count: infinite !important;
+  }
 }
 
 .error {

--- a/frontend/src/components/widgets/AppButton.test.js
+++ b/frontend/src/components/widgets/AppButton.test.js
@@ -1,0 +1,117 @@
+// AppButton — the pending (busy) state added for #647.
+//
+// A submit button that stays live while its create request is in flight lets a
+// double-click post twice. `loading` is the shared visual half of the fix
+// (`useSubmitGuard` is the behavioural half): it disables the button, marks it
+// busy for assistive tech, and swaps the leading icon for the app's spinner.
+
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+
+vi.mock("vuetify/components", () => ({
+  VIcon: { name: "v-icon", template: "<i><slot /></i>" },
+}));
+
+import AppButton from "./AppButton.vue";
+
+function mountButton(props = {}) {
+  return mount(AppButton, { props, slots: { default: "Save" } });
+}
+
+describe("AppButton loading state", () => {
+  it("is enabled and unmarked by default", () => {
+    const w = mountButton();
+    expect(w.find("button").attributes("disabled")).toBeUndefined();
+    expect(w.find("button").attributes("aria-busy")).toBeUndefined();
+  });
+
+  // The whole point: a pending button cannot be clicked a second time.
+  it("disables itself and reports busy while loading", () => {
+    const w = mountButton({ loading: true });
+    expect(w.find("button").attributes("disabled")).toBeDefined();
+    expect(w.find("button").attributes("aria-busy")).toBe("true");
+  });
+
+  it("shows the spinner in place of the leading icon while loading", () => {
+    const w = mountButton({ iconLeft: "check", loading: true });
+    const icon = w.find("i");
+    expect(icon.text()).toBe("mdi-loading");
+    expect(icon.classes()).toContain("mdi-spin");
+  });
+
+  it("shows a spinner even without a leading icon", () => {
+    const w = mountButton({ loading: true });
+    expect(w.find("i").exists()).toBe(true);
+  });
+
+  it("renders the plain icon and no spin class when idle", () => {
+    const w = mountButton({ iconLeft: "check" });
+    const icon = w.find("i");
+    expect(icon.text()).toBe("mdi-check");
+    expect(icon.classes()).not.toContain("mdi-spin");
+  });
+
+  // The label must not move under the cursor mid-click.
+  it("keeps its label while loading", () => {
+    expect(mountButton({ loading: true }).text()).toContain("Save");
+  });
+
+  it("stays disabled when disabled without loading", () => {
+    const w = mountButton({ disabled: true });
+    expect(w.find("button").attributes("disabled")).toBeDefined();
+    expect(w.find("button").attributes("aria-busy")).toBeUndefined();
+  });
+});
+
+// A natively-disabled button cannot hold focus, so going pending drops focus to
+// <body>, stranding a keyboard user far from where they were — permanently if
+// the request fails and the form stays open.
+describe("AppButton focus continuity", () => {
+  it("takes focus back when the request settles", async () => {
+    // Stands in for wherever the browser sends focus when the button disables.
+    const elsewhere = document.createElement("input");
+    document.body.appendChild(elsewhere);
+    const w = mount(AppButton, {
+      props: { loading: false },
+      slots: { default: "Save" },
+      attachTo: document.body,
+    });
+    const el = w.find("button").element;
+    el.focus();
+    expect(document.activeElement).toBe(el);
+
+    // The watcher runs pre-flush, so it records "this button had focus" before
+    // the DOM is disabled. jsdom does not drop focus off a disabled element the
+    // way a browser does, so the drop — the whole reason this exists — is
+    // emulated by moving focus away.
+    await w.setProps({ loading: true });
+    elsewhere.focus();
+    expect(document.activeElement).toBe(elsewhere);
+
+    await w.setProps({ loading: false });
+    await nextTick();
+    expect(document.activeElement).toBe(el);
+    w.unmount();
+    elsewhere.remove();
+  });
+
+  it("does not steal focus it never had", async () => {
+    const other = document.createElement("input");
+    document.body.appendChild(other);
+    const w = mount(AppButton, {
+      props: { loading: false },
+      slots: { default: "Save" },
+      attachTo: document.body,
+    });
+    other.focus();
+
+    await w.setProps({ loading: true });
+    await w.setProps({ loading: false });
+    await nextTick();
+
+    expect(document.activeElement).toBe(other);
+    w.unmount();
+    other.remove();
+  });
+});

--- a/frontend/src/components/widgets/AppButton.vue
+++ b/frontend/src/components/widgets/AppButton.vue
@@ -1,30 +1,33 @@
 <template>
   <button
+    ref="rootEl"
     type="button"
     :class="[
       'app-btn',
       `app-btn--${variant}`,
       `app-btn--${size}`,
-      { 'app-btn--icon-only': iconOnly },
+      { 'app-btn--icon-only': iconOnly, 'app-btn--loading': loading },
     ]"
-    :disabled="disabled"
+    :disabled="disabled || loading"
+    :aria-busy="loading ? 'true' : undefined"
     :title="title"
   >
     <v-icon
-      v-if="iconLeft"
+      v-if="loading || iconLeft"
       :size="size === 'sm' ? 16 : 18"
-      class="app-btn__icon"
+      :class="['app-btn__icon', { 'mdi-spin': loading }]"
     >
-      mdi-{{ iconLeft }}
+      {{ loading ? "mdi-loading" : `mdi-${iconLeft}` }}
     </v-icon>
     <span v-if="!iconOnly" class="app-btn__label"><slot /></span>
   </button>
 </template>
 
 <script setup>
+import { nextTick, ref, watch } from "vue";
 import { VIcon } from "vuetify/components";
 
-defineProps({
+const props = defineProps({
   // primary (amber accent) | primary_green (olive) | secondary (neutral) |
   // danger (error) | ghost (transparent)
   variant: { type: String, default: "secondary" },
@@ -32,8 +35,33 @@ defineProps({
   iconLeft: { type: String, default: "" },
   iconOnly: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
+  // Pending / in-flight. NOT the same thing as `disabled`: "working", not "not
+  // allowed" (visual-language.md §11). Forces the button disabled so a second
+  // click cannot fire (issue #647), swaps the leading icon for the shared
+  // spinner, and leaves the label alone. There is deliberately no loading-text
+  // prop: the label is the accessible name and must not change mid-flight.
+  loading: { type: Boolean, default: false },
   title: { type: String, default: "" },
 });
+
+const rootEl = ref(null);
+let refocusWhenDone = false;
+
+// A natively-disabled button cannot hold focus, so the browser drops focus to
+// <body>, stranding a keyboard user who would have to tab all the way back to
+// where they were once the request settles.
+watch(
+  () => props.loading,
+  (isLoading) => {
+    if (isLoading) {
+      refocusWhenDone = rootEl.value === document.activeElement;
+      return;
+    }
+    if (!refocusWhenDone) return;
+    refocusWhenDone = false;
+    nextTick(() => rootEl.value?.focus());
+  },
+);
 </script>
 
 <style scoped>
@@ -82,8 +110,22 @@ defineProps({
 }
 
 .app-btn:disabled {
-  opacity: 0.38;
+  opacity: var(--opacity-disabled);
   cursor: not-allowed;
+}
+
+/* PENDING is not DISABLED. A disabled control is "not allowed" and may legally
+   fade (WCAG 1.4.3 exempts it); a pending one is the only thing telling the user
+   their click landed, so its label has to stay legible. Group opacity cannot do
+   that on a filled variant: the whole button composites toward the surface, so
+   white on the light `accent` fill measures 4.75:1 at full opacity, 3.97:1 at
+   0.9, 2.70:1 at 0.7 and 1.67:1 at the disabled 0.38. The white-label rule
+   (visual-language.md §4) only survives above ~0.97, i.e. there is no dim that is
+   both perceptible and legal. So pending does not dim. `progress`, not
+   `not-allowed`: the button is busy, the rest of the surface is still live. */
+.app-btn--loading:disabled {
+  opacity: 1;
+  cursor: progress;
 }
 
 /* Primary — amber accent, the key action. */
@@ -136,5 +178,20 @@ defineProps({
 
 .app-btn__icon {
   flex-shrink: 0;
+}
+
+/* The spinner keeps spinning under reduced motion. It is a status readout, not
+   decoration — the same exception ActionReceipt's countdown hairline takes
+   (visual-language.md §10). The global reset in design-tokens.css zeroes
+   animation-duration and iteration-count on `*` and `*::before`, which freezes
+   this into a static broken ring that reads as a rendering fault. @mdi/font puts
+   the animation on `::before`, so that is what is restored; specificity beats the
+   universal reset even though both are !important. A 16px rotating glyph is not
+   a vestibular trigger. */
+@media (prefers-reduced-motion: reduce) {
+  .app-btn--loading .app-btn__icon.mdi-spin::before {
+    animation-duration: 2s !important;
+    animation-iteration-count: infinite !important;
+  }
 }
 </style>

--- a/frontend/src/composables/useSubmitGuard.js
+++ b/frontend/src/composables/useSubmitGuard.js
@@ -1,0 +1,54 @@
+// One in-flight submit at a time, plus the pending flag its button wears.
+//
+// The bug this exists for (#647): a create form's button stays live while its
+// POST is in flight, so a double-click — or an impatient second click while the
+// server is busy captioning an import — sends the request twice and the library
+// gains two identical people, sets, or folders. The window is invisible to the
+// user and widest exactly when the server is slowest, which is when they are
+// most likely to click again.
+//
+// Two halves, and both are needed:
+//
+//   - `pending` is what the button binds, so the second click never happens.
+//   - `run` refuses a re-entrant call anyway, because the button is not the only
+//     way in. Every one of these forms also submits on Enter (an `@enter` on the
+//     name field, a `@keydown.enter`, a Ctrl+Enter document listener), and key
+//     auto-repeat fires those faster than any disabled attribute can be painted.
+//     Guarding the handler covers both doors; guarding only the button covers
+//     one.
+//
+// It deliberately does NOT catch. A guard that swallowed the rejection would
+// hide the failure these forms already report through `useNoticeStore` or an
+// inline error line. `pending` clears in `finally`, so a failed submit re-enables
+// its button and the user can retry — which is the other half of what #647 asks
+// for.
+
+import { ref } from "vue";
+
+/**
+ * Wrap an async submit handler so it cannot overlap itself.
+ *
+ * @template {(...args: any[]) => any} T
+ * @param {T} handler - the submit work. May be sync or async; its return value
+ *   is passed through. Errors propagate to the caller unchanged.
+ * @returns {{ pending: import("vue").Ref<boolean>,
+ *   run: (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>> | undefined> }}
+ *   Bind `pending` to the submit button's `:disabled` / `:loading`, and call
+ *   `run` wherever the handler used to be called. A call made while one is
+ *   already in flight is ignored and resolves to `undefined`.
+ */
+export function useSubmitGuard(handler) {
+  const pending = ref(false);
+
+  async function run(...args) {
+    if (pending.value) return undefined;
+    pending.value = true;
+    try {
+      return await handler(...args);
+    } finally {
+      pending.value = false;
+    }
+  }
+
+  return { pending, run };
+}

--- a/frontend/src/composables/useSubmitGuard.test.js
+++ b/frontend/src/composables/useSubmitGuard.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+import { useSubmitGuard } from "./useSubmitGuard";
+
+/** A handler that resolves only when the test says so. */
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useSubmitGuard", () => {
+  it("starts idle", () => {
+    const { pending } = useSubmitGuard(() => {});
+    expect(pending.value).toBe(false);
+  });
+
+  it("is pending while the handler is in flight and idle again after", async () => {
+    const gate = deferred();
+    const { pending, run } = useSubmitGuard(() => gate.promise);
+
+    const inFlight = run();
+    expect(pending.value).toBe(true);
+
+    gate.resolve("done");
+    await expect(inFlight).resolves.toBe("done");
+    expect(pending.value).toBe(false);
+  });
+
+  // The bug itself (#647): two clicks, one create.
+  it("ignores a second call while the first is still running", async () => {
+    const gate = deferred();
+    const handler = vi.fn(() => gate.promise);
+    const { run } = useSubmitGuard(handler);
+
+    const first = run();
+    const second = run();
+    const third = run();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    await expect(second).resolves.toBeUndefined();
+    await expect(third).resolves.toBeUndefined();
+
+    gate.resolve();
+    await first;
+  });
+
+  it("lets a later call through once the first has settled", async () => {
+    const handler = vi.fn(async () => "ok");
+    const { run } = useSubmitGuard(handler);
+
+    await run();
+    await run();
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  // The other half of #647: a failed submit must re-enable its button.
+  it("clears pending and rethrows when the handler rejects", async () => {
+    const boom = new Error("500");
+    const { pending, run } = useSubmitGuard(async () => {
+      throw boom;
+    });
+
+    await expect(run()).rejects.toBe(boom);
+    expect(pending.value).toBe(false);
+  });
+
+  it("clears pending and rethrows when the handler throws synchronously", async () => {
+    const boom = new Error("bad input");
+    const { pending, run } = useSubmitGuard(() => {
+      throw boom;
+    });
+
+    await expect(run()).rejects.toBe(boom);
+    expect(pending.value).toBe(false);
+  });
+
+  it("allows a retry after a failure", async () => {
+    let attempt = 0;
+    const handler = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error("transient");
+      return "second time lucky";
+    });
+    const { run } = useSubmitGuard(handler);
+
+    await expect(run()).rejects.toThrow("transient");
+    await expect(run()).resolves.toBe("second time lucky");
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  // Templates call `run` in place of the handler, so arguments and the return
+  // value have to pass straight through — including the click event a bare
+  // `@click="run"` hands it.
+  it("forwards arguments and the resolved value", async () => {
+    const handler = vi.fn(async (a, b) => `${a}:${b}`);
+    const { run } = useSubmitGuard(handler);
+
+    await expect(run("set", 7)).resolves.toBe("set:7");
+    expect(handler).toHaveBeenCalledWith("set", 7);
+  });
+
+  it("wraps a synchronous handler too", async () => {
+    const { pending, run } = useSubmitGuard(() => 42);
+    await expect(run()).resolves.toBe(42);
+    expect(pending.value).toBe(false);
+  });
+
+  // Each form owns its own guard; one dialog submitting must not disable another.
+  it("keeps separate guards independent", async () => {
+    const gate = deferred();
+    const a = useSubmitGuard(() => gate.promise);
+    const b = useSubmitGuard(async () => "b");
+
+    const inFlight = a.run();
+    expect(a.pending.value).toBe(true);
+    expect(b.pending.value).toBe(false);
+
+    await expect(b.run()).resolves.toBe("b");
+
+    gate.resolve();
+    await inFlight;
+  });
+});

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -109,6 +109,14 @@
      the edge and the scrim is the supporting cue. */
   --scrim-drawer: rgba(var(--v-theme-scrim), 0.28);
 
+  /* STATE OPACITY — one value, and only one state may legally fade. Disabled
+     controls are exempt from WCAG 1.4.3; nothing else is. There is deliberately
+     NO `--opacity-busy`: group opacity drags a filled variant's white label down
+     with the fill (4.75:1 at full opacity, 3.97 at 0.9, 2.70 at 0.7, 1.67 at 0.38
+     on the light `accent`), so a pending control does not dim. It reads busy
+     through the spinner, `cursor: progress` and `aria-busy`. visual-language.md §11. */
+  --opacity-disabled: 0.38;
+
   /* ---------------------------------------------------------------------------
      COMPONENT DIMENSIONS — fixed component sizes (badges, action bars) that were
      drifting as raw one-offs. Count pills use `primary`/`on-primary` (contrast-


### PR DESCRIPTION
Fixes #647.

Rapid clicks (or Enter-key repeats) on a Create/Save button while the request was in flight fired the request multiple times, creating duplicate entries.

- New `useSubmitGuard` composable: wraps an async submit handler, ignores re-entrant calls, exposes a reactive `pending` flag, and always clears it on settle so a failed request re-enables the button. Errors propagate unchanged, so existing toasts/inline errors still fire.
- `AppButton` gains a `loading` prop: natively disabled, `aria-busy`, spinner icon (kept spinning under `prefers-reduced-motion`), no dim (pending is "working", not "not allowed"), and focus restored on settle.
- Applied to the six vulnerable forms: CharacterEditor (the reported case), PictureSetEditor, ProjectFiles add-URL, LoginScreen registration, FolderEditor, and FolderBrowser. The Vuetify buttons in the folder editors get scoped overrides so the label stays visible and the spinner survives reduced motion.
- Guarding the handler (not just the button) also covers Enter-key submission paths. Cancel/Escape stay live while pending.
- Unit tests for the composable and the button's loading behaviour; docs and design tokens updated.

Frontend suite passes (900 tests), lint clean, build clean.