### PR TITLE
Move auth reads off the DB writer queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
           tests/test_anomaly_region_scope.py
           tests/test_architecture_guardrails.py
           tests/test_async_import_staging.py
+          tests/test_auth_read_path.py
           tests/test_authentication.py
           tests/test_authz_gate_step3.py
           tests/test_authz_gate_step4.py

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1244,6 +1244,30 @@ The authz refactor (§16.2) moved this class off `require_user_id` and onto decl
 
 **Loopback-tier same-host-proxy assumption (CSO Condition 2, 2026-07-21).** The `LOOPBACK_OWNER_ONLY` red line assumes there is **no same-host reverse proxy forwarding to the backend over loopback**. A hardened deployment that binds the backend to `127.0.0.1` behind a same-host nginx is the edge case: the proxy's connection to the backend *originates from loopback*, so a proxied remote client would arrive with a loopback peer IP and satisfy even the loopback tier — silently defeating the red line. An operator running that topology **MUST** set `trusted_proxies` (to the proxy's address) so the gate resolves the real client IP from `X-Forwarded-For` instead of the loopback hop; the proxy must still strip inbound `X-Forwarded-For`. The startup warning is intentionally scoped to `host=0.0.0.0` and does **not** fire on this same-host case, because it is indistinguishable at config-load time from the ordinary pure-loopback desktop deployment (backend on `127.0.0.1`, no proxy) — firing there would be a false positive on the most common, safe configuration. This assumption is therefore documented as an operator responsibility rather than enforced by a runtime check.
 
+### 16.4 How authentication reaches the database (issue #651)
+
+**Authentication reads run on the read path, never the serialised writer queue.** `VaultDatabase` has a single writer thread (§13); `run_task` enqueues onto it and `run_immediate_read_task` bypasses it entirely (opening its own `Session` under the `_EngineRWLock` read side). `DBPriority.IMMEDIATE` only wins queue *ordering* — the worker loop still runs the in-flight task's session to completion before it dequeues anything — so every authenticated request used to inherit the full duration of whatever background batch happened to be committing (amplified by the `metadata_hash` after-flush hook, which issues several queries per dirty picture inside the write transaction). The four auth reads therefore use `run_immediate_read_task`:
+
+| Read | `auth.py` |
+|---|---|
+| Owner user lookup | `get_user` |
+| Owner user by id | `get_user_for_request` |
+| Token candidate fetch (prefix-indexed) | `_token_from_value` → `fetch_candidates` |
+| Guest-session cookie → `GuestSession` row | `auth_middleware` → `_lookup_by_token` |
+
+**Writes stay on the writer queue.** Everything that mutates auth state — `ensure_user`, credential claims, `create_token`, `delete_token`, `update_token`, `revoke_tokens_for_resource` — still goes through `run_task` and is still awaited synchronously. The one exception is `last_used_at` (below).
+
+**Revocation is still immediate, and does not depend on the queue.** The property to preserve is *revoke → next request 401*. It rests on two things, neither of which is queue serialisation:
+
+1. **Commit before flush.** Every revocation path runs its `run_task` delete to completion (synchronously) and only then calls `AuthService._flush_token_cache()`. Because SQLite runs in WAL mode, a read that starts after that commit necessarily observes it — so the next lookup's candidate fetch, on the read path, cannot see a revoked row.
+2. **A revocation epoch guards the cache write.** `_token_cache` short-circuits `bcrypt.verify` for 5 minutes, and its write has *always* happened outside the writer queue. So a lookup that read the token row just before the delete committed could install that stale row just after the flush, keeping a revoked token alive for the full TTL. `_flush_token_cache` bumps `_token_cache_epoch` under `_token_cache_lock`; `_token_from_value` samples the epoch before it reads and declines to cache if it moved. The in-flight request itself still succeeds (it began before the revocation — refusing it would be over-blocking), but nothing is cached, so the next request re-reads the database and 401s.
+
+`_flush_token_cache` is the **only** supported way to invalidate the token cache. Do not clear `_token_cache` directly: that skips the epoch bump and silently reopens the window above.
+
+**`last_used_at` is fire-and-forget (accepted risk, bounded).** `_record_token_last_used` submits the refresh with `submit_task(..., priority=DBPriority.LOW)` and logs failures from a done-callback, instead of blocking the request on the writer queue. This is safe **only** because `last_used_at` is display-only: it is surfaced by `list_tokens` and the Settings account panel and is read by no authentication or authorization code path. It carries neither revocation state (that is the row's existence) nor expiry state (that is `expires_at`), both of which are re-read from the database on every cache miss. **If `last_used_at` ever becomes an input to an access decision — idle-timeout expiry, anomaly detection, anything — this must move back onto a synchronous, ordered write first.**
+
+**Restore fence.** `run_immediate_read_task` takes the read side of `_EngineRWLock`, which the restore DB-file swap fences with `exclusive_engine_access` (§18.4). Auth reads are therefore *more* strongly fenced than before, not less: during a swap they block until the new engine is in place rather than racing a disposed engine. The lock is not re-entrant, so an auth read must never be issued from inside another `run_immediate_read_task` callback — a writer waiting between the two acquisitions would deadlock. None of the current call paths nest (the authz gate's membership reads and `AuthService`'s reads are siblings, never enclosing).
+
 ---
 
 ## 17. Data Flow Pipeline

--- a/pixlstash/auth.py
+++ b/pixlstash/auth.py
@@ -284,6 +284,11 @@ class AuthService:
         self._token_cache: dict[str, tuple[UserToken, float]] = {}
         self._TOKEN_CACHE_TTL = 300.0  # seconds
         self._token_cache_lock = threading.Lock()
+        # Revocation generation counter, bumped by every _flush_token_cache().
+        # A lookup that started before a revocation must not be allowed to
+        # install its (now stale) result into the cache afterwards — see
+        # _token_from_value. Guarded by _token_cache_lock.
+        self._token_cache_epoch: int = 0
         # In-memory guest session tracking: session_id → last_active_at (monotonic seconds).
         # Entries expire after _GUEST_SESSION_INACTIVE_TTL (30 days) and are pruned lazily
         # in record_guest_activity().  When the cache reaches _guest_max_tracked_sessions
@@ -483,9 +488,16 @@ class AuthService:
             )
 
     def get_user(self) -> Optional[User]:
-        return self._db.run_task(
-            lambda session: session.exec(select(User)).first(),
-            priority=DBPriority.IMMEDIATE,
+        """Return the (single) owner user row, or None if the account row is absent.
+
+        Runs on the **read** path (``run_immediate_read_task``), not the
+        serialised writer queue. ``DBPriority.IMMEDIATE`` only reordered the
+        queue; the writer still finished the in-flight task's session first, so
+        every authenticated request paid the tail of whatever background batch
+        was committing (issue #651). See ``docs/backend_architecture.md`` §16.
+        """
+        return self._db.run_immediate_read_task(
+            lambda session: session.exec(select(User)).first()
         )
 
     def ensure_user(self) -> User:
@@ -787,6 +799,14 @@ class AuthService:
 
         Results are cached for _TOKEN_CACHE_TTL seconds to avoid a bcrypt call
         on every request (bcrypt is intentionally slow ~200 ms).
+
+        Revocation safety: the DB candidate fetch is the authority and runs on
+        the read path, so it always observes an already-committed revocation
+        (every revoke path commits *before* calling :meth:`_flush_token_cache`).
+        The only way a revoked token could survive is a lookup that read the row
+        before the delete committed and then installed it in the cache *after*
+        the flush — a 5-minute window. The epoch check around the cache write
+        below closes that.
         """
         if not token_value:
             return None
@@ -795,6 +815,7 @@ class AuthService:
         digest = hashlib.sha256(token_value.encode()).hexdigest()
         now_mono = time.monotonic()
         with self._token_cache_lock:
+            epoch_at_start = self._token_cache_epoch
             cached = self._token_cache.get(digest)
             if cached is not None:
                 token_obj, expires_mono = cached
@@ -825,36 +846,113 @@ class AuthService:
                 )
             ).all()
 
-        tokens = self._db.run_task(
-            fetch_candidates, user.id, prefix, priority=DBPriority.IMMEDIATE
-        )
+        # Read path, not the writer queue — see get_user (issue #651).
+        tokens = self._db.run_immediate_read_task(fetch_candidates, user.id, prefix)
         now = datetime.utcnow()
         for token in tokens:
             if token.expires_at is not None and token.expires_at < now:
                 continue
             if bcrypt.verify(token_value, token.token_hash):
-
-                def update_last_used(session: Session, token_id: int):
-                    db_token = session.get(UserToken, token_id)
-                    if db_token is not None:
-                        db_token.last_used_at = datetime.utcnow()
-                        session.add(db_token)
-                        session.commit()
-
-                self._db.run_task(
-                    update_last_used, token.id, priority=DBPriority.IMMEDIATE
-                )
-                # Populate cache so subsequent requests skip bcrypt.
+                self._record_token_last_used(token.id)
+                # Populate cache so subsequent requests skip bcrypt — but only
+                # if no revocation landed while we were reading/verifying. A
+                # token this lookup saw as live may have been deleted in the
+                # meantime; caching it then would keep a revoked token working
+                # for up to _TOKEN_CACHE_TTL, defeating the synchronous flush
+                # that delete_token/update_token/revoke_tokens_for_resource do.
                 with self._token_cache_lock:
-                    self._token_cache[digest] = (
-                        token,
-                        now_mono + self._TOKEN_CACHE_TTL,
-                    )
-                    # Evict entries beyond a reasonable cap to bound memory use.
-                    if len(self._token_cache) > 1000:
-                        self._token_cache.pop(next(iter(self._token_cache)))
+                    if self._token_cache_epoch == epoch_at_start:
+                        self._token_cache[digest] = (
+                            token,
+                            now_mono + self._TOKEN_CACHE_TTL,
+                        )
+                        # Evict entries beyond a reasonable cap to bound memory use.
+                        if len(self._token_cache) > 1000:
+                            self._token_cache.pop(next(iter(self._token_cache)))
+                    else:
+                        self._logger.info(
+                            "Not caching token id=%s: a token revocation raced "
+                            "this lookup. The next request re-reads the database.",
+                            token.id,
+                        )
                 return token
         return None
+
+    def _flush_token_cache(self) -> None:
+        """Drop every cached token verification and invalidate in-flight lookups.
+
+        Called by every revocation/mutation path (``delete_token``,
+        ``update_token``, ``revoke_tokens_for_resource``) *after* the change has
+        committed, so the next request re-reads the database and sees it.
+
+        Bumping ``_token_cache_epoch`` under the same lock also invalidates any
+        lookup already in flight: ``_token_from_value`` samples the epoch before
+        it reads and refuses to install its result if the epoch moved. Without
+        that, a lookup that read the token row just before the delete committed
+        could re-populate the cache just after the flush and keep a revoked
+        token authenticating for the full cache TTL.
+        """
+        with self._token_cache_lock:
+            self._token_cache.clear()
+            self._token_cache_epoch += 1
+
+    def _record_token_last_used(self, token_id: int) -> None:
+        """Queue a token's ``last_used_at`` refresh off the request's critical path.
+
+        ``last_used_at`` is a display-only hygiene signal (shown by
+        :meth:`list_tokens` and the Settings account panel); **nothing in the
+        authentication or authorization path reads it**, and it carries neither
+        revocation nor expiry state — those live in the row's existence and in
+        ``expires_at``, both of which are re-read from the database on every
+        cache miss. So it is deliberately fire-and-forget: the request no longer
+        waits for the serialised writer queue to reach it (issue #651). The cost
+        is bounded freshness on the timestamp, and a failed write is logged
+        rather than swallowed.
+
+        Args:
+            token_id: Primary key of the ``UserToken`` that just authenticated.
+        """
+
+        def update_last_used(session: Session, tid: int):
+            db_token = session.get(UserToken, tid)
+            if db_token is not None:
+                db_token.last_used_at = datetime.utcnow()
+                session.add(db_token)
+                session.commit()
+
+        future = self._db.submit_task(
+            update_last_used, token_id, priority=DBPriority.LOW
+        )
+        future.add_done_callback(
+            lambda done: self._log_last_used_result(token_id, done)
+        )
+
+    def _log_last_used_result(self, token_id: int, future) -> None:
+        """Log a failed background ``last_used_at`` refresh (never raises).
+
+        Runs as a ``Future`` done-callback on the DB writer thread, so it must
+        not propagate: an exception here would be swallowed by the executor with
+        no trace, which is exactly what this callback exists to prevent.
+        """
+        try:
+            exc = future.exception()
+        except Exception as callback_exc:
+            self._logger.warning(
+                "Could not determine the outcome of the last_used_at refresh "
+                "for token id=%s: %s. Authentication is unaffected; the "
+                "timestamp shown in Settings may be stale.",
+                token_id,
+                callback_exc,
+            )
+            return
+        if exc is not None:
+            self._logger.warning(
+                "Background last_used_at refresh failed for token id=%s: %s. "
+                "Authentication is unaffected (last_used_at is display-only), "
+                "but the timestamp shown in Settings may be stale.",
+                token_id,
+                exc,
+            )
 
     def _user_id_from_bearer(self, request: Request) -> Optional[int]:
         """Validate a Bearer token from the Authorization header and return the user id."""
@@ -1032,9 +1130,9 @@ class AuthService:
 
     def get_user_for_request(self, request: Request) -> User:
         user_id = self.require_user_id(request)
-        user = self._db.run_task(
-            lambda session: session.get(User, user_id),
-            priority=DBPriority.IMMEDIATE,
+        # Read path, not the writer queue — see get_user (issue #651).
+        user = self._db.run_immediate_read_task(
+            lambda session: session.get(User, user_id)
         )
         if user is None:
             raise HTTPException(status_code=404, detail="User not found")
@@ -1308,9 +1406,10 @@ class AuthService:
             remove_token, user_id, token_id, priority=DBPriority.IMMEDIATE
         )
         # Clear the token cache — we can't map token_id back to the digest key,
-        # so flush all entries to ensure the deleted token is not reused.
-        with self._token_cache_lock:
-            self._token_cache.clear()
+        # so flush all entries to ensure the deleted token is not reused. The
+        # delete has already committed above (run_task is synchronous), so every
+        # subsequent lookup re-reads the database and 401s.
+        self._flush_token_cache()
         return {"status": "success", "deleted_id": token_id}
 
     def update_token(self, request: Request, token_id: int, watermark: bool):
@@ -1337,8 +1436,7 @@ class AuthService:
             _update, user_id, token_id, watermark, priority=DBPriority.IMMEDIATE
         )
         # Flush the token cache so the updated watermark setting takes effect immediately.
-        with self._token_cache_lock:
-            self._token_cache.clear()
+        self._flush_token_cache()
         return {"status": "success", "id": token.id, "watermark": token.watermark}
 
     def revoke_tokens_for_resource(
@@ -1374,8 +1472,7 @@ class AuthService:
         deleted = self._db.run_task(
             _revoke, user_id, resource_type, resource_id, priority=DBPriority.IMMEDIATE
         )
-        with self._token_cache_lock:
-            self._token_cache.clear()
+        self._flush_token_cache()
         return {"status": "success", "deleted_count": deleted}
 
     def get_shared_resource_ids(self, request: Request, resource_type: str):
@@ -1769,9 +1866,16 @@ class AuthService:
                                         )
                                     ).first()
 
-                                gs = self._db.run_task(
-                                    _lookup_by_token, priority=DBPriority.IMMEDIATE
-                                )
+                                # Read path, not the writer queue (issue #651).
+                                # Unlike token auth this lookup is never cached:
+                                # every request re-reads GuestSession by
+                                # cookie_token, so a deleted/rotated row stops
+                                # resolving on the very next request with no
+                                # invalidation step to get wrong. The guest
+                                # session's own tracking (record_guest_activity,
+                                # the 30-day expiry and the eviction cap) is
+                                # in-memory and untouched by this change.
+                                gs = self._db.run_immediate_read_task(_lookup_by_token)
                                 if gs is not None:
                                     request.state.guest_session_id = gs.session_id
                                     self.record_guest_activity(gs.session_id)

--- a/tests/test_auth_read_path.py
+++ b/tests/test_auth_read_path.py
@@ -1,0 +1,493 @@
+"""Auth reads bypass the serialised DB writer queue (issue #651).
+
+Every authenticated request used to resolve its principal through
+``VaultDatabase.run_task``, i.e. the single-writer queue.  ``DBPriority.IMMEDIATE``
+only wins queue *ordering*: the worker loop still runs the in-flight task's
+session to completion first, so an API request inherited the full duration of
+whatever background batch was committing.  The auth reads (owner lookup, token
+candidate fetch, guest-session cookie lookup) now run on
+``run_immediate_read_task`` instead, and the ``last_used_at`` refresh is
+fire-and-forget.
+
+The security-critical property that must survive that move is **revoke → immediate
+401**.  Serialising through the writer queue used to be what guaranteed it; the
+replacement guarantee is two-part and is what these tests pin:
+
+1. Every revocation path commits the delete (synchronously, on the writer queue)
+   *before* it flushes the token cache, so the next lookup's read — which now runs
+   on the read path — necessarily observes the committed delete.
+2. ``_flush_token_cache`` bumps ``_token_cache_epoch``, so a lookup that read the
+   token row just *before* the delete committed cannot install its stale result
+   into the cache just *after* the flush and keep a revoked token alive for the
+   full 5-minute cache TTL.  (That window existed before this change too — the
+   cache write has always been outside the queue — so closing it is a strict
+   improvement, not a repair of something the refactor broke.)
+
+Both directions are asserted: revoked/deleted credentials are refused, and valid
+tokens, cookie sessions and guest-session cookies keep working.  Over-blocking
+would be its own regression.
+"""
+
+import hashlib
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, delete, select
+
+import pixlstash.auth as auth_module
+from pixlstash.database import DBPriority
+from pixlstash.db_models import User, UserToken
+from pixlstash.db_models.guest_session import GuestSession
+from pixlstash.server import Server
+
+# How long a simulated background batch holds the single writer thread. Long
+# enough that a request which queued behind it is unmistakable.
+SLOW_WRITE_S = 3.0
+# An auth read that bypasses the queue must return in a small fraction of that.
+# Deliberately generous (bcrypt.verify alone is ~200 ms, and CI machines are
+# loaded), while still far below SLOW_WRITE_S.
+FAST_REQUEST_S = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def server():
+    """One Server for the module — building it runs migrations and vault start-up."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with Server(f"{temp_dir}/server-config.json") as srv:
+            yield srv
+
+
+@pytest.fixture
+def owner_client(server):
+    """A TestClient logged in as the owner, starting from clean auth state."""
+
+    def _wipe(session: Session):
+        session.exec(delete(GuestSession))
+        session.exec(delete(UserToken))
+        session.exec(delete(User))
+        session.commit()
+
+    server.vault.db.run_task(_wipe)
+    server.auth.password_hash = None
+    server.auth.username = None
+    server.auth.user = None
+    server.auth.active_session_ids = {}
+    server.auth._flush_token_cache()
+    server.auth.ensure_user()
+
+    client = TestClient(server.api)
+    response = client.post(
+        "/login", json={"username": "owner651", "password": "ownerpass1"}
+    )
+    assert response.status_code == 200, response.text
+    yield client
+
+
+def _mint_read_token(owner_client) -> tuple[str, int]:
+    """Create a global READ share token and return ``(value, id)``."""
+    response = owner_client.post(
+        "/users/me/token", json={"description": "issue-651", "scope": "READ"}
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    return body["token"], body["token_id"]
+
+
+def _token_client(server) -> TestClient:
+    """A TestClient with no owner cookie, so only the Bearer token authenticates."""
+    return TestClient(server.api)
+
+
+@contextmanager
+def _writer_busy_for(db, seconds: float = SLOW_WRITE_S):
+    """Occupy the single DB writer thread with a slow committing transaction.
+
+    Mirrors a background batch commit: the worker loop runs this task's session to
+    completion before it picks up anything else, whatever the queued priority.
+    """
+    started = threading.Event()
+
+    def _slow_write(session: Session):
+        # Touch the DB so this is a real transaction, not just a sleep.
+        session.exec(select(User)).first()
+        started.set()
+        time.sleep(seconds)
+        session.commit()
+        return True
+
+    future = db.submit_task(_slow_write, priority=DBPriority.IMMEDIATE)
+    assert started.wait(timeout=30.0), "the slow writer task never started"
+    try:
+        yield
+    finally:
+        # Surface a failure in the background write rather than swallowing it.
+        assert future.result(timeout=seconds + 60.0) is True
+
+
+def _get_protected(client, token_value: str):
+    """Issue an authenticated GET and return ``(response, elapsed_seconds)``."""
+    started = time.monotonic()
+    response = client.get(
+        "/protected", headers={"Authorization": f"Bearer {token_value}"}
+    )
+    return response, time.monotonic() - started
+
+
+# ---------------------------------------------------------------------------
+# Revocation: the security-critical direction
+# ---------------------------------------------------------------------------
+
+
+def test_revoked_token_is_401_immediately_while_a_slow_write_is_in_flight(
+    server, owner_client
+):
+    """Revoke → immediate 401, with the writer thread busy on both sides of it.
+
+    This is the regression test for the TOCTOU the #651 refactor could have
+    introduced.  A revocation performed on an idle server would not exercise the
+    bug at all, so the writer is deliberately held busy while the revocation
+    lands AND while the post-revocation request is served.
+    """
+    token_value, token_id = _mint_read_token(owner_client)
+
+    # Positive control: the token authenticates, and the verification is cached.
+    response, _ = _get_protected(_token_client(server), token_value)
+    assert response.status_code == 200, response.text
+    digest = hashlib.sha256(token_value.encode()).hexdigest()
+    with server.auth._token_cache_lock:
+        assert digest in server.auth._token_cache, (
+            "the token cache was not warmed, so this test would not exercise "
+            "the cache-invalidation path at all"
+        )
+
+    # The revocation itself lands while a background batch holds the writer.
+    with _writer_busy_for(server.vault.db):
+        response = owner_client.delete(f"/users/me/token/{token_id}")
+        assert response.status_code == 200, response.text
+
+    # ...and the very next request is served while the writer is busy again.
+    with _writer_busy_for(server.vault.db):
+        response, elapsed = _get_protected(_token_client(server), token_value)
+
+    assert response.status_code == 401, (
+        f"a revoked token still authenticated: {response.status_code} {response.text}"
+    )
+    assert elapsed < FAST_REQUEST_S, (
+        f"the auth path waited {elapsed:.2f}s on the writer queue; it must not "
+        f"queue behind background writes (issue #651)"
+    )
+
+
+def test_revoking_by_resource_is_401_immediately_while_a_slow_write_is_in_flight(
+    server, owner_client
+):
+    """The sibling bulk-revoke path (``DELETE /users/me/tokens/by-resource``)."""
+    response = owner_client.post(
+        "/users/me/token",
+        json={
+            "description": "issue-651 scoped",
+            "scope": "READ",
+            "resource_type": "picture",
+            "resource_id": 4242,
+        },
+    )
+    assert response.status_code == 200, response.text
+    token_value = response.json()["token"]
+
+    # Warm the cache with a successful request.
+    response, _ = _get_protected(_token_client(server), token_value)
+    assert response.status_code == 200, response.text
+
+    response = owner_client.delete(
+        "/users/me/tokens/by-resource",
+        params={"resource_type": "picture", "resource_id": 4242},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["deleted_count"] == 1
+
+    with _writer_busy_for(server.vault.db):
+        response, elapsed = _get_protected(_token_client(server), token_value)
+
+    assert response.status_code == 401, response.text
+    assert elapsed < FAST_REQUEST_S, f"auth queued behind the writer ({elapsed:.2f}s)"
+
+
+def test_flushing_the_token_cache_bumps_the_revocation_epoch(server, owner_client):
+    """``_flush_token_cache`` must clear entries *and* invalidate in-flight lookups."""
+    auth = server.auth
+    token_value, _ = _mint_read_token(owner_client)
+    assert auth._token_from_value(token_value) is not None
+    digest = hashlib.sha256(token_value.encode()).hexdigest()
+
+    with auth._token_cache_lock:
+        assert digest in auth._token_cache
+        epoch_before = auth._token_cache_epoch
+
+    auth._flush_token_cache()
+
+    with auth._token_cache_lock:
+        assert auth._token_cache == {}
+        assert auth._token_cache_epoch == epoch_before + 1
+
+
+def test_a_lookup_racing_a_revocation_does_not_repopulate_the_cache(
+    server, owner_client
+):
+    """The epoch guard: a stale in-flight lookup must not survive the flush.
+
+    Without it, this interleaving keeps a revoked token authenticating for the
+    full ``_TOKEN_CACHE_TTL`` (5 minutes), because the cache write happens
+    outside the writer queue and so is not ordered against the revocation:
+
+        lookup: read token row  →  ...  →  write cache entry
+        revoke:                    commit delete + flush cache
+    """
+    auth = server.auth
+    token_value, _ = _mint_read_token(owner_client)
+    auth._flush_token_cache()  # force a real DB lookup, not a cache hit
+    digest = hashlib.sha256(token_value.encode()).hexdigest()
+
+    reached_verify = threading.Event()
+    may_continue = threading.Event()
+    real_bcrypt = auth_module.bcrypt
+
+    def _blocking_verify(secret, hashed):
+        matched = real_bcrypt.verify(secret, hashed)
+        if matched:
+            # We are past the DB read and about to write the cache entry.
+            reached_verify.set()
+            assert may_continue.wait(timeout=30.0)
+        return matched
+
+    result = {}
+
+    def _lookup():
+        result["token"] = auth._token_from_value(token_value)
+
+    stub = SimpleNamespace(verify=_blocking_verify, hash=real_bcrypt.hash)
+    with patch.object(auth_module, "bcrypt", stub):
+        worker = threading.Thread(target=_lookup, name="racing-token-lookup")
+        worker.start()
+        try:
+            assert reached_verify.wait(timeout=30.0)
+            # A revocation lands in the middle of the lookup.
+            auth._flush_token_cache()
+        finally:
+            may_continue.set()
+            worker.join(timeout=30.0)
+        assert not worker.is_alive()
+
+    # This request began before the revocation, so refusing it would be
+    # over-blocking; it is allowed to succeed.
+    assert result["token"] is not None
+    # But its result must NOT have been cached, so the *next* request re-reads
+    # the database and sees the revocation.
+    with auth._token_cache_lock:
+        assert digest not in auth._token_cache, (
+            "a lookup that raced a revocation repopulated the token cache; a "
+            "revoked token would keep working for the full cache TTL"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Positive direction: valid credentials must keep working, and not queue
+# ---------------------------------------------------------------------------
+
+
+def test_valid_token_authenticates_while_a_slow_write_is_in_flight(
+    server, owner_client
+):
+    """A live token still authenticates, and does not wait for the writer."""
+    token_value, _ = _mint_read_token(owner_client)
+    server.auth._flush_token_cache()  # exercise the DB lookup, not the cache
+
+    with _writer_busy_for(server.vault.db):
+        response, elapsed = _get_protected(_token_client(server), token_value)
+
+    assert response.status_code == 200, response.text
+    assert elapsed < FAST_REQUEST_S, f"auth queued behind the writer ({elapsed:.2f}s)"
+
+
+def test_cookie_session_authenticates_while_a_slow_write_is_in_flight(
+    server, owner_client
+):
+    """The owner's cookie session is unaffected and equally unqueued."""
+    with _writer_busy_for(server.vault.db):
+        started = time.monotonic()
+        response = owner_client.get("/users/me/auth")
+        elapsed = time.monotonic() - started
+
+    assert response.status_code == 200, response.text
+    assert response.json()["username"] == "owner651"
+    assert elapsed < FAST_REQUEST_S, f"auth queued behind the writer ({elapsed:.2f}s)"
+
+
+def test_auth_reads_submit_nothing_to_the_writer_queue(server, owner_client):
+    """Direct evidence: the auth read helpers no longer call ``run_task`` at all.
+
+    The spy filters on the calling thread so concurrent background work on the
+    WorkPlanner threads cannot make this flaky.
+    """
+    auth = server.auth
+    token_value, _ = _mint_read_token(owner_client)
+    auth._flush_token_cache()
+
+    db = server.vault.db
+    real_run_task = db.run_task
+    test_thread = threading.get_ident()
+    queued: list[str] = []
+
+    def _spy_run_task(func, *args, **kwargs):
+        if threading.get_ident() == test_thread:
+            queued.append(getattr(func, "__name__", repr(func)))
+        return real_run_task(func, *args, **kwargs)
+
+    user = auth.get_user()
+    assert user is not None
+    stub_request = SimpleNamespace(
+        state=SimpleNamespace(auth_user_id=user.id), cookies={}, headers={}
+    )
+
+    with patch.object(db, "run_task", _spy_run_task):
+        assert auth.get_user() is not None
+        assert auth._token_from_value(token_value) is not None
+        assert auth.get_user_for_request(stub_request).id == user.id
+
+    assert queued == [], f"auth still uses the serialised writer queue: {queued}"
+
+
+def test_last_used_at_is_still_recorded_off_the_critical_path(server, owner_client):
+    """The debounced ``last_used_at`` write still lands — just not synchronously."""
+    token_value, token_id = _mint_read_token(owner_client)
+    server.auth._flush_token_cache()
+
+    response, _ = _get_protected(_token_client(server), token_value)
+    assert response.status_code == 200, response.text
+
+    # It is fire-and-forget, so poll briefly rather than assuming it committed
+    # before the response was written.
+    def _read_last_used(session: Session):
+        row = session.get(UserToken, token_id)
+        return row.last_used_at if row is not None else None
+
+    deadline = time.monotonic() + 30.0
+    last_used = None
+    while time.monotonic() < deadline:
+        last_used = server.vault.db.run_immediate_read_task(_read_last_used)
+        if last_used is not None:
+            break
+        time.sleep(0.05)
+
+    assert last_used is not None, (
+        "last_used_at was never written; the background refresh was lost"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guest sessions — different semantics from token auth, so pinned separately
+# ---------------------------------------------------------------------------
+
+
+def _insert_guest_session(server, session_id: str, token_id: int, cookie_token: str):
+    def _insert(session: Session):
+        session.add(
+            GuestSession(
+                session_id=session_id, token_id=token_id, cookie_token=cookie_token
+            )
+        )
+        session.commit()
+
+    server.vault.db.run_task(_insert)
+
+
+def _delete_guest_session(server, session_id: str):
+    def _delete(session: Session):
+        row = session.get(GuestSession, session_id)
+        if row is not None:
+            session.delete(row)
+            session.commit()
+
+    server.vault.db.run_task(_delete)
+
+
+@contextmanager
+def _recorded_guest_activity(server):
+    """Capture the session ids the middleware resolved from the guest cookie.
+
+    ``record_guest_activity`` is called only when the cookie resolved to a live
+    ``GuestSession`` row, so it is a precise observable for the lookup.
+    """
+    seen: list[str] = []
+    real_record = server.auth.record_guest_activity
+
+    def _spy(session_id: str) -> None:
+        seen.append(session_id)
+        real_record(session_id)
+
+    with patch.object(server.auth, "record_guest_activity", _spy):
+        yield seen
+
+
+def test_guest_session_cookie_resolves_while_a_slow_write_is_in_flight(
+    server, owner_client
+):
+    """A live guest session still resolves, without queueing behind the writer."""
+    token_value, token_id = _mint_read_token(owner_client)
+    _insert_guest_session(server, "guest-651", token_id, "guest-cookie-651")
+
+    client = _token_client(server)
+    client.cookies.set("guest_session", "guest-cookie-651")
+
+    with _recorded_guest_activity(server) as seen:
+        with _writer_busy_for(server.vault.db):
+            response, elapsed = _get_protected(client, token_value)
+
+    assert response.status_code == 200, response.text
+    assert seen == ["guest-651"], f"guest cookie did not resolve (recorded: {seen})"
+    assert elapsed < FAST_REQUEST_S, (
+        f"the guest-session lookup queued behind the writer ({elapsed:.2f}s)"
+    )
+
+
+def test_deleted_guest_session_stops_resolving_immediately(server, owner_client):
+    """Guest sessions carry no cache, so removal takes effect on the next request.
+
+    This is the guest-side analogue of revoke → immediate 401: the middleware
+    re-reads ``GuestSession`` by ``cookie_token`` on every request, so there is
+    no invalidation step that the move to the read path could get wrong.
+    """
+    token_value, token_id = _mint_read_token(owner_client)
+    _insert_guest_session(server, "guest-651-gone", token_id, "guest-cookie-651-gone")
+
+    client = _token_client(server)
+    client.cookies.set("guest_session", "guest-cookie-651-gone")
+
+    with _recorded_guest_activity(server) as seen:
+        response, _ = _get_protected(client, token_value)
+    assert response.status_code == 200, response.text
+    assert seen == ["guest-651-gone"]
+
+    _delete_guest_session(server, "guest-651-gone")
+
+    with _recorded_guest_activity(server) as seen:
+        with _writer_busy_for(server.vault.db):
+            response, elapsed = _get_protected(client, token_value)
+
+    # The token itself is still valid, so the request still authenticates...
+    assert response.status_code == 200, response.text
+    # ...but the deleted guest session no longer resolves.
+    assert seen == [], f"a deleted guest session still resolved: {seen}"
+    assert elapsed < FAST_REQUEST_S, (
+        f"guest lookup queued behind the writer ({elapsed:.2f}s)"
+    )

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -49,8 +49,9 @@ def reset_auth(server):
     server.auth.username = None
     server.auth.user = None
     server.auth.active_session_ids = {}
-    with server.auth._token_cache_lock:
-        server.auth._token_cache.clear()
+    # Go through the flush helper so the revocation epoch is bumped too — a
+    # bare _token_cache.clear() skips it (see AuthService._flush_token_cache).
+    server.auth._flush_token_cache()
 
     # Re-create the User row so the rest of the server behaves as on first
     # startup (no password set yet).

--- a/tests/test_server_simple.py
+++ b/tests/test_server_simple.py
@@ -152,8 +152,9 @@ def reset_vault(server):
     server.auth.username = None
     server.auth.user = None
     server.auth.active_session_ids = {}
-    with server.auth._token_cache_lock:
-        server.auth._token_cache.clear()
+    # Go through the flush helper so the revocation epoch is bumped too — a
+    # bare _token_cache.clear() skips it (see AuthService._flush_token_cache).
+    server.auth._flush_token_cache()
     server.auth.ensure_user()
 
     yield


### PR DESCRIPTION
Tier 2 of #651. Tier 1 (engine busy timeout and page cache) is in #656.

## The problem

Every authenticated request's user lookup went through the **serialized single DB writer queue**, so it waited behind whatever background batch was committing:

- owner user lookup (`get_user`), owner user by id (`get_user_for_request`), token candidate fetch (`_token_from_value`), guest-session cookie lookup (`auth_middleware`)

`DBPriority.IMMEDIATE` only wins queue *ordering*. The worker loop still runs the in-flight task's session to completion first, and those commits are amplified by the metadata-hash hook, which issues about five queries per dirty picture inside the write transaction. Net effect on a large library: a tagger batch commit adds its full duration to every API request. That is the mechanism behind the unresponsiveness reported in #646.

## The change

Those four reads move to `run_immediate_read_task`, which bypasses the write queue and is fenced against the restore file-swap by the existing `_EngineRWLock`. The `update_last_used` write becomes asynchronous at `DBPriority.LOW` with a done-callback that logs failures. All auth **writes** stay synchronous on the writer queue.

## Why this does not weaken revocation

Queue serialization was part of what guaranteed a revoked token stops working immediately, so the replacement rests on two mechanisms that do not depend on it:

1. **Commit before flush.** Every revocation path runs its delete to completion, then flushes the token cache. WAL mode means a read starting after that commit necessarily observes it. `UserToken` is mutated or deleted in exactly three places in the tree, each immediately followed by the flush, and `resource_id` carries no foreign key, so no cascade can delete a token without going through one of them.
2. **A revocation epoch.** Implementing this surfaced a **pre-existing** race: the token cache write has always happened outside the queue, so a lookup that read a row just before a delete committed could install it just after the invalidation and keep a revoked token alive for the full five-minute TTL. `_flush_token_cache()` now bumps an epoch under the cache lock; a lookup samples the epoch before its read and declines to cache if it moved. Both interleavings are covered: an install before the flush is wiped by the clear, an install after it is refused by the epoch. `_flush_token_cache()` is now the single invalidation path.

An in-flight request that began before the revoke still completes. That is deliberate: refusing it would be over-blocking, the window is one request rather than the cache TTL, and it is unchanged from the previous design.

## Tests

`tests/test_auth_read_path.py`. The central one revokes **while a slow write holds the writer**, not on an idle server, since an idle-server test would pass against the very bug this must not introduce. Both directions are covered for all three credential types (token, cookie session, guest session): revoked is denied, valid still authenticates.

The tests were confirmed to be load-bearing by mutation rather than assertion. A surgical revert of the queue moves fails 7 of 10; neutering only the epoch check fails exactly the one test written for it.

## Review

Independently reviewed by a reviewer that did not author the change, per CLAUDE.md. Verdict: accept, no release blockers for this diff. The reviewer verified the non-reentrancy of the read lock two ways, by AST call-graph analysis over all 202 call sites and by instrumenting the lock with a per-thread depth counter across 152 tests, finding zero nested acquisitions. It also ran the timing-sensitive tests under 12 and then 40 competing CPU-bound processes, passing 10 of 10 both times.

The diff does not touch `pixlstash/authz/` at all. The gate, registry, policy and membership helpers are unchanged, no per-handler authz check was added, and the route-policy guardrail passes.

## Accepted risks

- `last_used_at` may go stale under permanent writer saturation. Verified to have zero reads that gate access: two writes and three display-only reads, backend and frontend. Documented with an explicit trigger to move it back if it ever gains a comparison.
- Backpressure on the LOW queue is looser than the old synchronous call. Bounded in practice, since only a token-cache miss enqueues anything (roughly once per token per five minutes) and an invalid token never does.

## Follow-up hardening (not in this PR)

The read lock's non-reentrancy is currently a documented invariant rather than a machine-enforced one. A per-thread depth counter that raises on nested acquisition would convert it into a machine fact, consistent with the deny-by-default principle applied to the authz gate. Worth doing because a future nested acquisition would deadlock only during a restore, the rarest and least-tested window.
