### PR TITLE
ImageGrid: display preferences go store-direct (Phase 3, step 3 — part 2 of 3)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1329,9 +1329,7 @@ async function fetchConfig() {
       cfg.similarity_character ?? cfg.selected_similarity_character;
     sortStore.selectedSimilarityCharacter =
       similarityValue ?? sortStore.selectedSimilarityCharacter ?? null;
-    const newHiddenTags = Array.isArray(cfg.hidden_tags)
-      ? cfg.hidden_tags
-      : [];
+    const newHiddenTags = Array.isArray(cfg.hidden_tags) ? cfg.hidden_tags : [];
     if (
       userPrefsStore.hiddenTags.length !== newHiddenTags.length ||
       userPrefsStore.hiddenTags.some((tag, i) => tag !== newHiddenTags[i])
@@ -1379,9 +1377,7 @@ async function fetchConfig() {
       theme_mode: userPrefsStore.themeMode,
       similarity_character: sortStore.selectedSimilarityCharacter,
       stack_strictness:
-        cfg.stack_strictness != null
-          ? Number(cfg.stack_strictness)
-          : null,
+        cfg.stack_strictness != null ? Number(cfg.stack_strictness) : null,
       hidden_tags: userPrefsStore.hiddenTags,
       apply_tag_filter: userPrefsStore.applyTagFilter,
     };
@@ -2255,8 +2251,6 @@ defineExpose({
               <ImageGrid
                 v-else
                 ref="gridContainer"
-                :thumbnailSize="gridStore.thumbnailSize"
-                :sidebarVisible="sidebarStore.sidebarVisible"
                 :backendUrl="BACKEND_URL"
                 :selectedCharacter="selectionStore.selectedCharacter"
                 :selectedCharacterIds="selectionStore.selectedCharacterIds"
@@ -2271,22 +2265,11 @@ defineExpose({
                 :selectedDescending="sortStore.selectedDescending"
                 :similarityCharacter="sortStore.selectedSimilarityCharacter"
                 :stackThreshold="sortStore.stackThreshold"
-                :showStars="gridStore.showStars"
-                :gridVersion="gridStore.gridVersion"
-                :wsUpdateKey="gridStore.wsUpdateKey"
                 :wsTagUpdate="wsStore.wsTagUpdate"
                 :wsDescriptionUpdate="wsStore.wsDescriptionUpdate"
                 :wsSmartScoreUpdate="wsStore.wsSmartScoreUpdate"
                 :wsDetectionUpdate="wsStore.wsDetectionUpdate"
                 :wsPluginProgress="wsStore.wsPluginProgress"
-                :showFaceBboxes="gridStore.showFaceBboxes"
-                :showDetections="gridStore.showDetections"
-                :showProblemIcon="gridStore.showProblemIcon"
-                :penalisedTagWeights="userPrefsStore.penalisedTagWeights"
-                :showStacks="gridStore.showStacks"
-                :compactMode="gridStore.compactMode"
-                :themeMode="userPrefsStore.themeMode"
-                :dateFormat="userPrefsStore.dateFormat"
                 :allPicturesId="ALL_PICTURES_ID"
                 :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
                 :scrapheapPicturesId="SCRAPHEAP_PICTURES_ID"
@@ -2296,12 +2279,7 @@ defineExpose({
                 :setProjectIds="projectStore.setProjectIds"
                 :setDifferenceBaseId="selectionStore.setDifferenceBaseId"
                 :selectedSetNames="selectionStore.selectedSetNames"
-                :publicUrl="userPrefsStore.publicUrl"
-                :embedWatermark="userPrefsStore.embedWatermark"
                 :folderScanning="folderScanning"
-                :columns="gridStore.columns"
-                :sizeLevel="gridStore.sizeLevel"
-                :thumbnailMode="gridStore.thumbnailMode"
                 @clear-search="handleClearSearch"
                 @search-all="handleSearchAllPictures"
                 @update:selected-sort="handleUpdateSelectedSort"

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -11,9 +11,9 @@
     :detectionUpdate="props.wsDetectionUpdate"
     :hiddenTags="userPrefsStore.hiddenTags"
     :applyTagFilter="userPrefsStore.applyTagFilter"
-    :dateFormat="props.dateFormat"
-    :showStacks="props.showStacks"
-    :showProblemIcon="props.showProblemIcon"
+    :dateFormat="userPrefsStore.dateFormat"
+    :showStacks="gridStore.showStacks"
+    :showProblemIcon="gridStore.showProblemIcon"
     :availablePlugins="availablePlugins"
     :comfyuiProgress="comfyuiProgress"
     :comfyuiProgressPercent="comfyuiProgressPercent"
@@ -250,10 +250,10 @@
       resource-type="picture"
       :resource-id="contextMenuImage?.id"
       :resource-format="contextMenuImage?.format"
-      :embed-watermark="props.embedWatermark"
+      :embed-watermark="userPrefsStore.embedWatermark"
       :backend-url="props.backendUrl"
-      :public-url="props.publicUrl"
-      @update:embed-watermark="emit('update:embed-watermark', $event)"
+      :public-url="userPrefsStore.publicUrl"
+      @update:embed-watermark="userPrefsStore.embedWatermark = $event"
       @created="onSharePicCreated"
     />
     <EmptyScrapHeap
@@ -495,7 +495,7 @@
         :class="[
           'image-grid',
           {
-            'compact-mode': props.compactMode,
+            'compact-mode': gridStore.compactMode,
             'touch-select-mode': touchSelectMode,
             'image-grid--justified': isJustifiedMode,
           },
@@ -578,7 +578,7 @@
                 v-if="
                   isThumbnailReady(img.id) &&
                   img.thumbnail &&
-                  ((props.showProblemIcon && hasPenalisedTags(img)) ||
+                  ((gridStore.showProblemIcon && hasPenalisedTags(img)) ||
                     img.reference_folder_id ||
                     lockedSetsStore.isLocked(img.id) ||
                     (!isReadOnly && sharedPictureIds.has(img.id)))
@@ -586,18 +586,20 @@
                 class="thumbnail-top-left-badges"
               >
                 <div
-                  v-if="props.showProblemIcon && hasPenalisedTags(img)"
+                  v-if="gridStore.showProblemIcon && hasPenalisedTags(img)"
                   class="penalised-tag-indicator thumbnail-badge"
                   :title="penalisedTagsTitle(img)"
                 >
                   <v-icon
                     :size="badgeIconSizes.penalised"
-                    :color="penalisedTagColor(img, props.penalisedTagWeights)"
+                    :color="
+                      penalisedTagColor(img, userPrefsStore.penalisedTagWeights)
+                    "
                     >{{
                       penalisedTagIcon(
                         img,
-                        props.penalisedTagWeights,
-                        props.themeMode !== "light",
+                        userPrefsStore.penalisedTagWeights,
+                        userPrefsStore.themeMode !== "light",
                       )
                     }}</v-icon
                   >
@@ -862,7 +864,7 @@
                 class="thumbnail-top-right-badges"
               >
                 <StarRatingOverlay
-                  v-if="props.showStars"
+                  v-if="gridStore.showStars"
                   :score="
                     isReadOnly
                       ? (guestScoreMap.get(img.id) ?? img.score ?? 0)
@@ -883,7 +885,7 @@
           </div>
           <div v-if="isImageSelected(img.id)" class="selection-overlay"></div>
           <!-- Info row absolutely positioned below thumbnail -->
-          <div v-if="!props.compactMode" class="thumbnail-info-row">
+          <div v-if="!gridStore.compactMode" class="thumbnail-info-row">
             <div
               v-for="info in getThumbnailInfoItems(img)"
               :key="`${info.key}-${img.id}`"
@@ -1090,6 +1092,7 @@ import {
 } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useFilterStore } from "../../stores/useFilterStore";
+import { useGridStore } from "../../stores/useGridStore";
 import { useUserPrefsStore } from "../../stores/useUserPrefsStore";
 import { useTasksStore } from "../../stores/useTasksStore";
 import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
@@ -1220,6 +1223,12 @@ import { useGridFetch } from "../../composables/useGridFetch.js";
 import { useGridKeyboardNav } from "../../composables/useGridKeyboardNav.js";
 import { debounce } from "lodash-es";
 
+// Store-direct (Phase 3): the picture-query filter facets and the grid's own
+// display preferences are read from the stores, not mirrored in through props.
+const filterStore = useFilterStore();
+const gridStore = useGridStore();
+const userPrefsStore = useUserPrefsStore();
+
 const emit = defineEmits([
   "open-overlay",
   "update:overlay-open",
@@ -1235,7 +1244,6 @@ const emit = defineEmits([
   "update:character-multi-mode",
   "update:set-multi-mode",
   "update:set-difference-base-id",
-  "update:embed-watermark",
   "update:visible-range-label",
   "update:match-count",
   "load-pending-imports",
@@ -1250,8 +1258,6 @@ const emit = defineEmits([
 
 // Props
 const props = defineProps({
-  thumbnailSize: Number,
-  sidebarVisible: Boolean,
   backendUrl: String,
   selectedCharacter: { type: [String, Number, null], default: null },
   selectedSet: { type: [Number, String, null], default: null },
@@ -1263,26 +1269,9 @@ const props = defineProps({
   selectedDescending: Boolean,
   similarityCharacter: { type: [String, Number, null], default: null },
   stackThreshold: { type: [String, Number, null], default: null },
-  showStars: Boolean,
-  showFaceBboxes: Boolean,
-  showDetections: Boolean,
-  showProblemIcon: Boolean,
-  penalisedTagWeights: { type: Object, default: () => ({}) },
-  showStacks: { type: Boolean, default: true },
-  compactMode: { type: Boolean, default: false },
-  // 'square' (uniform grid) or 'justified' (Google-Photos-style rows of
-  // variable-width thumbnails sharing a common row height).
-  thumbnailMode: { type: String, default: "square" },
-  // Shared thumbnail-size level (0..6). Drives square column count (via
-  // gridStore.columns) and, in justified mode, the target row height.
-  sizeLevel: { type: Number, default: 3 },
-  themeMode: { type: String, default: "light" },
-  dateFormat: { type: String, default: "locale" },
   allPicturesId: String,
   unassignedPicturesId: String,
   scrapheapPicturesId: String,
-  gridVersion: { type: Number, default: 0 },
-  wsUpdateKey: { type: Number, default: 0 },
   wsTagUpdate: {
     type: Object,
     default: () => ({ key: 0, pictureIds: [] }),
@@ -1303,8 +1292,6 @@ const props = defineProps({
     type: Object,
     default: () => ({ key: 0, payload: null }),
   },
-  // "all" | "stacked" | "unstacked" | "unresolved"
-  columns: { type: Number, required: true },
   projectViewMode: { type: String, default: "global" },
   selectedProjectId: { type: Number, default: null },
   characterProjectIds: { type: Object, default: () => ({}) },
@@ -1315,8 +1302,6 @@ const props = defineProps({
   setMultiMode: { type: String, default: "intersection" },
   setDifferenceBaseId: { type: Number, default: null },
   selectedSetNames: { type: Object, default: () => ({}) },
-  publicUrl: { type: String, default: null },
-  embedWatermark: { type: Boolean, default: false },
   pendingExternalImportCount: { type: Number, default: 0 },
   sortChangedExternalCount: { type: Number, default: 0 },
 });
@@ -1477,7 +1462,7 @@ const segmentTargetIds = ref(null);
 
 // Badge size interpolated continuously across column count (1 = lg, 12+ = sm).
 const badgeSizeT = computed(() =>
-  Math.min(1, Math.max(0, ((props.columns || 1) - 1) / 11)),
+  Math.min(1, Math.max(0, ((gridStore.columns || 1) - 1) / 11)),
 );
 
 const badgeCssVars = computed(() => {
@@ -2274,7 +2259,7 @@ onUnmounted(() => {
 });
 
 watch(
-  () => props.wsUpdateKey,
+  () => gridStore.wsUpdateKey,
   (nextKey) => {
     if (!nextKey || nextKey === lastWsUpdateKey.value) return;
     lastWsUpdateKey.value = nextKey;
@@ -2600,7 +2585,7 @@ function getFaceBboxOverlays(img) {
   void selectedFaceIds.value;
   void thumbnailReadyMap[img.id];
   if (
-    !props.showFaceBboxes ||
+    !gridStore.showFaceBboxes ||
     !img.faces ||
     !img.faces.length ||
     !(img.thumbnail_width || img.width) ||
@@ -2634,7 +2619,7 @@ function getDetectionBboxOverlays(img) {
   void faceOverlayRedrawKey.value; // depend on redraw key
   void thumbnailReadyMap[img.id];
   if (
-    !props.showDetections ||
+    !gridStore.showDetections ||
     !img.detections ||
     !img.detections.length ||
     !(img.thumbnail_width || img.width) ||
@@ -2731,18 +2716,18 @@ function getThumbnailInfoItems(img) {
   } else if (selectedSort === "IMPORTED_AT" && img.imported_at) {
     items.push({
       key: "imported_at",
-      text: formatUserDate(img.imported_at, props.dateFormat),
+      text: formatUserDate(img.imported_at, userPrefsStore.dateFormat),
     });
   } else if (selectedSort.includes("DATE") && img.created_at) {
     items.push({
       key: "created_at",
-      text: formatUserDate(img.created_at, props.dateFormat),
+      text: formatUserDate(img.created_at, userPrefsStore.dateFormat),
     });
   } else if (
     selectedSort === LIKENESS_GROUPS_SORT_KEY &&
     (typeof img.stackIndex === "number" || typeof img.stack_index === "number")
   ) {
-    if (!props.showStacks) {
+    if (!gridStore.showStacks) {
       return items;
     }
     const stackIndex =
@@ -2762,7 +2747,9 @@ function formatCompactDate(dateStr) {
   const now = new Date();
   const sameYear = d.getFullYear() === now.getFullYear();
   const fmt =
-    typeof props.dateFormat === "string" ? props.dateFormat : "locale";
+    typeof userPrefsStore.dateFormat === "string"
+      ? userPrefsStore.dateFormat
+      : "locale";
   const y = d.getFullYear();
   const day = d.getDate();
   const MONTHS = [
@@ -2812,7 +2799,9 @@ function formatCompactDatetime(dateStr) {
   const now = new Date();
   const sameYear = d.getFullYear() === now.getFullYear();
   const fmt =
-    typeof props.dateFormat === "string" ? props.dateFormat : "locale";
+    typeof userPrefsStore.dateFormat === "string"
+      ? userPrefsStore.dateFormat
+      : "locale";
   const y = d.getFullYear();
   const day = d.getDate();
   const MONTHS = [
@@ -2927,10 +2916,6 @@ const visibleRangeLabel = computed(() => {
   return `${first} – ${last}`;
 });
 
-// Store-direct (Phase 3): every picture-query filter facet is read from the
-// filter store, not mirrored in through props.
-const filterStore = useFilterStore();
-const userPrefsStore = useUserPrefsStore();
 const tasksStore = useTasksStore();
 const reviewSessionsStore = useReviewSessionsStore();
 const lockedSetsStore = useLockedSetsStore();
@@ -3842,7 +3827,9 @@ const scrapheapPurgeBadges = computed(() => {
   }
   const now = purgeNowMs.value;
   const dateFormat =
-    typeof props.dateFormat === "string" ? props.dateFormat : "locale";
+    typeof userPrefsStore.dateFormat === "string"
+      ? userPrefsStore.dateFormat
+      : "locale";
   const formatDate = (iso) => formatUserDate(iso, dateFormat);
   for (const img of gridImagesToRender.value || []) {
     if (!img || img.id == null) continue;
@@ -4491,7 +4478,7 @@ function scheduleWsTagFullRefresh() {
 }
 
 watch(
-  () => props.gridVersion,
+  () => gridStore.gridVersion,
   () => {
     if (pauseGridAutoUpdates.value) {
       pendingGridRefreshAfterImport.value = true;
@@ -4651,7 +4638,7 @@ const {
 // flex-wrap lines break exactly where useJustifiedLayout computed the rows —
 // the invariant the spacer/fetch arithmetic depends on.
 const justifiedInfoRowExtra = computed(() =>
-  props.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT,
+  gridStore.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT,
 );
 
 function _justifiedItemGeometry(img, localIdx) {
@@ -4700,7 +4687,7 @@ const gridContainerStyle = computed(() => {
   }
   return {
     ...base,
-    gridTemplateColumns: `repeat(${props.columns}, minmax(0, 1fr))`,
+    gridTemplateColumns: `repeat(${gridStore.columns}, minmax(0, 1fr))`,
   };
 });
 
@@ -6135,7 +6122,7 @@ watch(
 );
 
 watch(
-  () => props.showStacks,
+  () => gridStore.showStacks,
   async (expandAllStacksEnabled) => {
     if (expandAllStacksEnabled) {
       syncExpandAllStacksFromFetchedImages();
@@ -6148,7 +6135,7 @@ watch(
 );
 
 watch(
-  () => props.columns,
+  () => gridStore.columns,
   async () => {
     updateRowHeightFromGrid();
     recalculateVisibleRange();
@@ -6161,7 +6148,7 @@ watch(
 );
 
 watch(
-  () => props.compactMode,
+  () => gridStore.compactMode,
   () => {
     updateRowHeightFromGrid();
     updateVisibleThumbnails();
@@ -6174,7 +6161,7 @@ watch(
 // the maintainer hit). Mirror the columns watch: re-measure row height, re-pack,
 // recompute the visible range, and refetch the now-visible thumbnails.
 watch(
-  () => props.thumbnailMode,
+  () => gridStore.thumbnailMode,
   async () => {
     updateRowHeightFromGrid();
     recalculateVisibleRange();
@@ -6259,7 +6246,7 @@ watch(
 );
 
 watch(
-  [() => props.showFaceBboxes, () => allGridImages.value.length],
+  [() => gridStore.showFaceBboxes, () => allGridImages.value.length],
   ([faceEnabled, length], [prevFace, prevLength]) => {
     if (!faceEnabled) return;
     if (length <= 0) return;
@@ -6271,7 +6258,7 @@ watch(
 );
 
 watch(
-  [() => props.showDetections, () => allGridImages.value.length],
+  [() => gridStore.showDetections, () => allGridImages.value.length],
   ([detEnabled, length], [prevDet, prevLength]) => {
     if (!detEnabled) return;
     if (length <= 0) return;
@@ -6371,7 +6358,7 @@ const emptyStateAlt = computed(() => {
 });
 
 const isDarkThemeActive = computed(() => {
-  const mode = String(props.themeMode || "light").toLowerCase();
+  const mode = String(userPrefsStore.themeMode || "light").toLowerCase();
   if (mode === "dark") return true;
   if (mode === "light") return false;
   if (mode === "system") {
@@ -6598,14 +6585,14 @@ async function fetchThumbnailsBatch(start, end, meta = {}) {
         }
         gridImg.faces =
           thumbObj && Array.isArray(thumbObj.faces) ? thumbObj.faces : [];
-        if (props.showFaceBboxes && gridImg.faces.length) {
+        if (gridStore.showFaceBboxes && gridImg.faces.length) {
           overlayNeedsRedraw = true;
         }
         gridImg.detections =
           thumbObj && Array.isArray(thumbObj.detections)
             ? thumbObj.detections
             : [];
-        if (props.showDetections && gridImg.detections.length) {
+        if (gridStore.showDetections && gridImg.detections.length) {
           overlayNeedsRedraw = true;
         }
         gridImg.penalised_tags =
@@ -7175,7 +7162,7 @@ function updateDescriptionForImage(imageId, description) {
 // ============================================================
 
 watch(
-  () => props.thumbnailSize,
+  () => gridStore.thumbnailSize,
   () => {
     // Recalculate visibleStart and visibleEnd after rowHeight update
     nextTick(() => {
@@ -7190,7 +7177,7 @@ watch(
       if (!el) return;
       let cardHeight = rowHeight.value;
       const scrollTop = el.scrollTop;
-      const cols = props.columns;
+      const cols = gridStore.columns;
       // First visible row (may be partially visible)
       const firstVisibleRow = scrollTop / cardHeight;
       // Last visible row (may be partially visible)
@@ -7350,7 +7337,7 @@ function gridItemTopOffset(index) {
     const top = layout.rowOffsets[row];
     return typeof top === "number" ? top : null;
   }
-  const cols = Math.max(1, props.columns || 1);
+  const cols = Math.max(1, gridStore.columns || 1);
   return Math.floor(index / cols) * rowHeight.value;
 }
 

--- a/frontend/src/composables/useGridFetch.js
+++ b/frontend/src/composables/useGridFetch.js
@@ -21,6 +21,7 @@ import {
 } from "../utils/media.js";
 import { debounce } from "lodash-es";
 import { useFilterStore } from "../stores/useFilterStore";
+import { useGridStore } from "../stores/useGridStore";
 import { useSelectionStore } from "../stores/useSelectionStore";
 import { useUserPrefsStore } from "../stores/useUserPrefsStore";
 
@@ -30,7 +31,8 @@ const LIKENESS_GROUPS_SORT_KEY = "LIKENESS_GROUPS";
  * Manages grid image fetching: fetch state, URL query building, and the
  * debounced fetch trigger.
  *
- * The filter facets of the query come from the stores directly (Phase 3);
+ * The filter facets of the query and the grid geometry come from the stores
+ * directly (Phase 3);
  * `props` still supplies the selection/sort/project fields that have not been
  * migrated yet.
  *
@@ -92,6 +94,7 @@ export function useGridFetch(
   },
 ) {
   const filterStore = useFilterStore();
+  const gridStore = useGridStore();
   const selectionStore = useSelectionStore();
   const userPrefsStore = useUserPrefsStore();
 
@@ -731,12 +734,12 @@ export function useGridFetch(
         // than rowHeight?.value, which may still hold the initial thumbnailSize
         // estimate when this runs (DOM measurement via updateRowHeightFromGrid
         // happens asynchronously and may not have fired yet).
-        const _fbCols = props.columns || 1;
+        const _fbCols = gridStore.columns || 1;
         const _fbViewH = scrollWrapper.value?.clientHeight || 0;
         const _fbViewW = scrollWrapper.value?.clientWidth || 0;
         const _fbCellH =
           _fbViewW > 0
-            ? Math.round(_fbViewW / _fbCols) + (props.compactMode ? 0 : 24)
+            ? Math.round(_fbViewW / _fbCols) + (gridStore.compactMode ? 0 : 24)
             : rowHeight?.value > 0
               ? rowHeight.value
               : 200;
@@ -986,7 +989,7 @@ export function useGridFetch(
 
         // 2. Pre-build placeholder grid — scroll area immediately reflects full size.
         const placeholderStartedAt = getNowMs();
-        const cols = props.columns || 1;
+        const cols = gridStore.columns || 1;
         // Compute window count from actual viewport capacity so visibleEnd covers
         // all initially visible items even when the viewport shows more than VIEW_WINDOW.
         // Derive cell height from clientWidth/cols (square thumbnails) rather than
@@ -996,12 +999,12 @@ export function useGridFetch(
         const _fastViewH = scrollWrapper.value?.clientHeight || 0;
         const _effectiveRowHeight0 =
           _fastViewW > 0
-            ? Math.round(_fastViewW / cols) + (props.compactMode ? 0 : 24)
+            ? Math.round(_fastViewW / cols) + (gridStore.compactMode ? 0 : 24)
             : rowHeight?.value > 0
               ? rowHeight.value
               : Math.round(
-                  Math.min(384, Math.max(128, props.thumbnailSize || 128)) +
-                    (props.compactMode ? 0 : 24),
+                  Math.min(384, Math.max(128, gridStore.thumbnailSize || 128)) +
+                    (gridStore.compactMode ? 0 : 24),
                 );
         const _viewportItemCount0 =
           _fastViewH > 0 && _effectiveRowHeight0 > 0
@@ -1279,7 +1282,7 @@ export function useGridFetch(
       if (isSetOverlapView.value) {
         totalCurrentCategoryCount.value = newImages.length;
       }
-      const cols = props.columns || 1;
+      const cols = gridStore.columns || 1;
       // Compute window count from actual viewport capacity so visibleEnd covers
       // all initially visible items even when the viewport shows more than VIEW_WINDOW.
       // Derive cell height from clientWidth/cols (square thumbnails) rather than
@@ -1289,12 +1292,12 @@ export function useGridFetch(
       const _slowViewH = scrollWrapper.value?.clientHeight || 0;
       const _effectiveRowHeight1 =
         _slowViewW > 0
-          ? Math.round(_slowViewW / cols) + (props.compactMode ? 0 : 24)
+          ? Math.round(_slowViewW / cols) + (gridStore.compactMode ? 0 : 24)
           : rowHeight?.value > 0
             ? rowHeight.value
             : Math.round(
-                Math.min(384, Math.max(128, props.thumbnailSize || 128)) +
-                  (props.compactMode ? 0 : 24),
+                Math.min(384, Math.max(128, gridStore.thumbnailSize || 128)) +
+                  (gridStore.compactMode ? 0 : 24),
               );
       const _viewportItemCount1 =
         _slowViewH > 0 && _effectiveRowHeight1 > 0

--- a/frontend/src/composables/useGridKeyboardNav.js
+++ b/frontend/src/composables/useGridKeyboardNav.js
@@ -6,6 +6,7 @@ import {
   verticalNeighborIndex,
   JUSTIFIED_ROW_GAP,
 } from "./useJustifiedLayout.js";
+import { useGridStore } from "../stores/useGridStore";
 
 /**
  * Manages keyboard navigation and keyboard-driven actions for the image grid.
@@ -56,6 +57,7 @@ export function useGridKeyboardNav(
     setScore,
   },
 ) {
+  const gridStore = useGridStore();
   // ── Scrapheap ghosts ────────────────────────────────────────────────────
   // A ghosted tile is on screen but inert: it is already in the Scrapheap and
   // is only being held there while its undo is one click away.
@@ -108,7 +110,7 @@ export function useGridKeyboardNav(
     if (scrollWrapper.value) {
       let newScrollTop = scrollWrapper.value.scrollTop;
       const total = allGridImages.value.length;
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       const totalRows = Math.ceil(total / cols);
       // Justified rows don't follow cols × rowHeight; use the packed model's
       // exact pixel height so End/PageDown reach the true bottom.
@@ -197,7 +199,7 @@ export function useGridKeyboardNav(
       event.preventDefault();
       const total = allGridImages.value.length;
       if (total === 0) return;
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       let newIdx = cursorIdx.value;
       // Which way the scan runs when the landing cell turns out to be a ghost.
       const travel =
@@ -272,7 +274,7 @@ export function useGridKeyboardNav(
       event.preventDefault();
       const total = allGridImages.value.length;
       if (total === 0) return;
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       const packedLayout = activeJustifiedLayout();
       let newIdx;
       if (packedLayout) {

--- a/frontend/src/composables/useGridKeyboardNav.test.js
+++ b/frontend/src/composables/useGridKeyboardNav.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ref } from "vue";
+import { setActivePinia, createPinia } from "pinia";
+import { useGridStore } from "../stores/useGridStore.js";
 
 // The composable imports the singleton apiClient for isReadOnly; mock it so no
 // real axios instance is constructed and read-only is deterministic.
@@ -59,7 +61,10 @@ function makeNav({
     setScore: vi.fn(),
   };
 
-  const props = { columns: 3, searchQuery: "" };
+  // The composable takes the column count from the grid store; size level 6
+  // ("huge") is the 3-column step these navigation cases are written against.
+  useGridStore().sizeLevel = 6;
+  const props = { searchQuery: "" };
   const emit = vi.fn();
   const { handleKeyDown } = useGridKeyboardNav(deps, props, emit, callbacks);
   return {
@@ -77,6 +82,8 @@ function keyEvent(overrides) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The composable reads the grid's column count from the store.
+  setActivePinia(createPinia());
 });
 
 describe("useGridKeyboardNav — review-overlay guard (F1)", () => {

--- a/frontend/src/composables/useStackOrdering.js
+++ b/frontend/src/composables/useStackOrdering.js
@@ -24,6 +24,7 @@ import {
   setStackOrder,
   removeStackMembers,
 } from "../api/stacks";
+import { useGridStore } from "../stores/useGridStore";
 
 const LIKENESS_GROUPS_SORT_KEY = "LIKENESS_GROUPS";
 
@@ -67,6 +68,7 @@ export function useStackOrdering(
     setPendingRanges,
   },
 ) {
+  const gridStore = useGridStore();
   // Stack-ordering failures report through the notice surface rather than a
   // blocking native alert() (docs/design/notice-surface.md §1). Called during
   // the host component's setup, so Pinia is active.
@@ -81,7 +83,7 @@ export function useStackOrdering(
   // ── Stack visual order map ────────────────────────────────────────────────
   const stackVisualOrderMap = computed(() => {
     const images = allGridImages.value;
-    const cols = Math.max(1, props.columns || 1);
+    const cols = Math.max(1, gridStore.columns || 1);
     const result = new Map();
     let stackAppearanceIndex = 0;
     for (let i = 0; i < images.length; i++) {
@@ -544,7 +546,7 @@ export function useStackOrdering(
     const newImages = mapGridImages(collapsed);
     allGridImages.value = newImages;
     if (visibleStart.value >= newImages.length) {
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       const windowCount = Math.max(cols, divisibleViewWindow.value || cols);
       visibleStart.value = 0;
       visibleEnd.value = Math.min(newImages.length, windowCount);

--- a/frontend/src/composables/useVirtualScroll.js
+++ b/frontend/src/composables/useVirtualScroll.js
@@ -6,6 +6,7 @@ import {
   JUSTIFIED_ROW_GAP,
 } from "./useJustifiedLayout";
 import { rowHeightForSizeLevel } from "../utils/thumbnailSizes";
+import { useGridStore } from "../stores/useGridStore";
 
 // Constants shared with ImageGrid.vue
 const MIN_THUMBNAIL_SIZE = 128;
@@ -17,7 +18,7 @@ const VIEW_WINDOW = 100;
  * Manages viewport geometry, row height, and scroll position for the virtual
  * scrolling image grid.
  *
- * Two layout modes, selected by `props.thumbnailMode`:
+ * Two layout modes, selected by `gridStore.thumbnailMode`:
  * - `'square'` (default): the original uniform grid — `cols` items per row,
  *   every row `rowHeight` px tall, `index → row` is `floor(index / cols)`.
  * - `'justified'`: Google-Photos-style rows packed by `useJustifiedLayout`.
@@ -48,12 +49,13 @@ export function useVirtualScroll(
   allGridImagesLength,
   { onVisibleRangeChange, afterRowHeightUpdate, getAspectRatios } = {},
 ) {
+  const gridStore = useGridStore();
   // ── Render buffer ──────────────────────────────────────────────────────────
   // During the initial render the buffer is 0 so the first paint is fast;
   // once the grid has rendered once the buffer expands to a full view-window
   // worth of items on each side.
   const divisibleViewWindow = computed(() => {
-    const cols = props.columns;
+    const cols = gridStore.columns;
     return Math.ceil(VIEW_WINDOW / cols) * cols;
   });
 
@@ -70,7 +72,7 @@ export function useVirtualScroll(
   // ── Justified layout ──────────────────────────────────────────────────────
   const isJustifiedMode = computed(
     () =>
-      props.thumbnailMode === "justified" &&
+      gridStore.thumbnailMode === "justified" &&
       typeof getAspectRatios === "function",
   );
 
@@ -93,13 +95,13 @@ export function useVirtualScroll(
     // resizes justified rows exactly as it resizes square columns. The min/max
     // bounds flex around the target so leftover rows can still stretch/shrink
     // to fill the container width without jumping to a fixed global size.
-    const targetRowHeight = rowHeightForSizeLevel(props.sizeLevel);
+    const targetRowHeight = rowHeightForSizeLevel(gridStore.sizeLevel);
     return packJustifiedRows({
       aspectRatios,
       containerWidth,
       targetRowHeight,
       gap: JUSTIFIED_ROW_GAP,
-      rowExtraHeight: props.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT,
+      rowExtraHeight: gridStore.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT,
       minRowHeight: Math.round(targetRowHeight * 0.7),
       maxRowHeight: Math.round(targetRowHeight * 1.4),
     });
@@ -118,34 +120,38 @@ export function useVirtualScroll(
     Math.round(
       Math.min(
         MAX_THUMBNAIL_SIZE,
-        Math.max(MIN_THUMBNAIL_SIZE, props.thumbnailSize || MIN_THUMBNAIL_SIZE),
-      ) + (props.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT),
+        Math.max(
+          MIN_THUMBNAIL_SIZE,
+          gridStore.thumbnailSize || MIN_THUMBNAIL_SIZE,
+        ),
+      ) + (gridStore.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT),
     ),
   );
 
   function getGridColumnWidth() {
-    const cols = Math.max(1, props.columns || 1);
+    const cols = Math.max(1, gridStore.columns || 1);
     const gridWidth =
-      gridContainer.value?.clientWidth ??
-      scrollWrapper.value?.clientWidth ??
-      0;
+      gridContainer.value?.clientWidth ?? scrollWrapper.value?.clientWidth ?? 0;
     if (!gridWidth) {
       return Math.min(
         MAX_THUMBNAIL_SIZE,
         Math.max(
           MIN_THUMBNAIL_SIZE,
-          props.thumbnailSize || MIN_THUMBNAIL_SIZE,
+          gridStore.thumbnailSize || MIN_THUMBNAIL_SIZE,
         ),
       );
     }
     const availableWidth = Math.max(0, gridWidth - 4);
     const rawWidth = availableWidth / cols;
-    return Math.min(MAX_THUMBNAIL_SIZE, Math.max(1, rawWidth || MIN_THUMBNAIL_SIZE));
+    return Math.min(
+      MAX_THUMBNAIL_SIZE,
+      Math.max(1, rawWidth || MIN_THUMBNAIL_SIZE),
+    );
   }
 
   function updateRowHeightFromGrid() {
     const columnWidth = getGridColumnWidth();
-    const infoHeight = props.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT;
+    const infoHeight = gridStore.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT;
     rowHeight.value = Math.round(columnWidth + infoHeight);
     if (isJustifiedMode.value) {
       remeasureJustifiedWidth();
@@ -216,7 +222,7 @@ export function useVirtualScroll(
     }
     const cardHeight = rowHeight.value;
     const scrollTop = el.scrollTop;
-    const cols = props.columns;
+    const cols = gridStore.columns;
     const firstVisibleRow = scrollTop / cardHeight;
     const lastVisibleRow = (scrollTop + el.clientHeight - 1) / cardHeight;
     return {
@@ -286,7 +292,7 @@ export function useVirtualScroll(
       // supplies JUSTIFIED_ROW_GAP px of the offset.
       return Math.max(0, layout.rowOffsets[row] - JUSTIFIED_ROW_GAP);
     }
-    const cols = props.columns;
+    const cols = gridStore.columns;
     const rowsAbove = Math.floor(renderStart.value / cols);
     return rowsAbove > 0 ? rowsAbove * rowHeight.value : 1;
   });
@@ -302,11 +308,10 @@ export function useVirtualScroll(
       const lastRow = rowOfIndex(layout.rowStarts, end - 1);
       // rowOffsets[lastRow + 1] already includes the inter-row gap that the
       // flex layout inserts between the last rendered row and the spacer.
-      const nextOffset =
-        layout.rowOffsets[lastRow + 1] ?? layout.totalHeight;
+      const nextOffset = layout.rowOffsets[lastRow + 1] ?? layout.totalHeight;
       return Math.max(0, layout.totalHeight - nextOffset);
     }
-    const cols = props.columns;
+    const cols = gridStore.columns;
     const lastRenderedRow = Math.floor((renderEnd.value - 1) / cols) + 1;
     const totalRows = Math.ceil(allGridImagesLength.value / cols);
     const rowsBelow = totalRows - lastRenderedRow;
@@ -379,7 +384,7 @@ export function useVirtualScroll(
       itemTop = layout.rowOffsets[row];
       itemBottom = itemTop + layout.rowHeights[row];
     } else {
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       const row = Math.floor(idx / cols);
       itemTop = row * rowHeight.value;
       itemBottom = itemTop + rowHeight.value;

--- a/frontend/src/composables/useVirtualScroll.test.js
+++ b/frontend/src/composables/useVirtualScroll.test.js
@@ -1,6 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ref, reactive, computed, nextTick } from "vue";
+import { setActivePinia, createPinia } from "pinia";
+import { useGridStore } from "../stores/useGridStore.js";
 import { useVirtualScroll } from "./useVirtualScroll.js";
+
+// The composable reads the grid geometry (columns, size level, thumbnail mode
+// and size, compact mode) from the grid store.
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
 
 // Justified mode packs its rows from the aspect ratios of the images that have
 // actually arrived, so `justifiedLayout` is null before the first batch and
@@ -23,13 +31,14 @@ function makeHarness() {
     clientWidth: CONTAINER_W,
     getBoundingClientRect: () => ({ width: CONTAINER_W }),
   });
-  const props = reactive({
-    columns: 6,
-    thumbnailSize: 256,
-    compactMode: false,
-    thumbnailMode: "justified",
-    sizeLevel: 3,
-  });
+  // Grid geometry lives in the store. Size level 3 is the 6-column step, which
+  // is the geometry these layout cases are written against.
+  const gridStore = useGridStore();
+  gridStore.sizeLevel = 3;
+  gridStore.thumbnailSize = 256;
+  gridStore.compactMode = false;
+  gridStore.thumbnailMode = "justified";
+  const props = reactive({});
   // The image list starts empty, exactly as it is when ImageGrid mounts.
   const aspectRatios = ref([]);
   const allGridImagesLength = computed(() => aspectRatios.value.length);


### PR DESCRIPTION
Lane A, part 2 of the ImageGrid prop migration. **Stacked on #653** — review that one first; this PR's base auto-retargets to `develop` when #653 merges.

**What moves:** thumbnail size / mode / size level, column count, compact mode, the star, face-bbox, detection, problem-icon and stack toggles, grid version and ws update key, plus theme mode, date format, penalised tag weights, public URL and the watermark preference. All now read from `gridStore` / `userPrefsStore`.

**Emit removed:** `update:embed-watermark`. The ShareDialog toggle writes `userPrefsStore.embedWatermark` directly instead of bouncing through App.vue.

**Dead props deleted:** `sidebarVisible` was declared and never read.

**The interesting part.** `useVirtualScroll`, `useGridKeyboardNav` and `useStackOrdering` are handed ImageGrid's `props` object and read `columns` / `thumbnailMode` / `thumbnailSize` / `compactMode` / `sizeLevel` off it. Deleting the props without migrating those made `props.columns` undefined, the render-window arithmetic went NaN, and the grid rendered zero cards while every unit test still passed — the unit suite has no mounted-grid coverage. e2e caught it. The three composables now call `useGridStore()` themselves and their harnesses set geometry through the store (note `gridStore.columns` is a derived getter, so the harnesses set `sizeLevel` instead).

ImageGrid is now at 31 props, down from 79.

Verified: unit suite 1656 passing, production build, and 22 e2e — the Phase 0 pins plus grid, grid-browse, overlay and sharing (the watermark path).