### PR TITLE
ImageGrid goes store-direct: display prefs + selection/sort/project/ws (Phase 3, step 3 — parts 2 and 3)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2252,33 +2252,7 @@ defineExpose({
                 v-else
                 ref="gridContainer"
                 :backendUrl="BACKEND_URL"
-                :selectedCharacter="selectionStore.selectedCharacter"
-                :selectedCharacterIds="selectionStore.selectedCharacterIds"
-                :characterMultiMode="selectionStore.characterMultiMode"
-                :selectedSet="selectionStore.selectedSet"
-                :selectedSetIds="selectionStore.selectedSetIds"
-                :setMultiMode="selectionStore.setMultiMode"
-                :searchQuery="searchStore.searchQuery"
                 :activeCategoryLabel="activeCategoryLabel"
-                :isAllPicturesActive="selectionStore.isAllPicturesActive"
-                :selectedSort="sortStore.selectedSort"
-                :selectedDescending="sortStore.selectedDescending"
-                :similarityCharacter="sortStore.selectedSimilarityCharacter"
-                :stackThreshold="sortStore.stackThreshold"
-                :wsTagUpdate="wsStore.wsTagUpdate"
-                :wsDescriptionUpdate="wsStore.wsDescriptionUpdate"
-                :wsSmartScoreUpdate="wsStore.wsSmartScoreUpdate"
-                :wsDetectionUpdate="wsStore.wsDetectionUpdate"
-                :wsPluginProgress="wsStore.wsPluginProgress"
-                :allPicturesId="ALL_PICTURES_ID"
-                :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
-                :scrapheapPicturesId="SCRAPHEAP_PICTURES_ID"
-                :projectViewMode="projectStore.projectViewMode"
-                :selectedProjectId="projectStore.selectedProjectId"
-                :characterProjectIds="projectStore.characterProjectIds"
-                :setProjectIds="projectStore.setProjectIds"
-                :setDifferenceBaseId="selectionStore.setDifferenceBaseId"
-                :selectedSetNames="selectionStore.selectedSetNames"
                 :folderScanning="folderScanning"
                 @clear-search="handleClearSearch"
                 @search-all="handleSearchAllPictures"
@@ -2295,25 +2269,8 @@ defineExpose({
                         (selectionStore.selectedSetIds = []));
                   }
                 "
-                @update:character-multi-mode="
-                  (v) => {
-                    selectionStore.setCharacterMultiMode(v);
-                  }
-                "
-                @update:set-multi-mode="
-                  (v) => {
-                    selectionStore.setSetMultiMode(v);
-                  }
-                "
-                @update:set-difference-base-id="
-                  (v) => {
-                    selectionStore.setSetDifferenceBaseId(v);
-                  }
-                "
                 @import-started="wsStore.isUploadInProgress = true"
                 @import-ended="wsStore.isUploadInProgress = false"
-                :pendingExternalImportCount="wsStore.pendingExternalImportCount"
-                :sortChangedExternalCount="wsStore.sortChangedExternalCount"
                 @load-pending-imports="loadPendingExternalImports"
                 @load-sort-changed="loadSortChangedExternal"
                 @flag-sort-changed="onFlagSortChanged"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1329,9 +1329,7 @@ async function fetchConfig() {
       cfg.similarity_character ?? cfg.selected_similarity_character;
     sortStore.selectedSimilarityCharacter =
       similarityValue ?? sortStore.selectedSimilarityCharacter ?? null;
-    const newHiddenTags = Array.isArray(cfg.hidden_tags)
-      ? cfg.hidden_tags
-      : [];
+    const newHiddenTags = Array.isArray(cfg.hidden_tags) ? cfg.hidden_tags : [];
     if (
       userPrefsStore.hiddenTags.length !== newHiddenTags.length ||
       userPrefsStore.hiddenTags.some((tag, i) => tag !== newHiddenTags[i])
@@ -1379,9 +1377,7 @@ async function fetchConfig() {
       theme_mode: userPrefsStore.themeMode,
       similarity_character: sortStore.selectedSimilarityCharacter,
       stack_strictness:
-        cfg.stack_strictness != null
-          ? Number(cfg.stack_strictness)
-          : null,
+        cfg.stack_strictness != null ? Number(cfg.stack_strictness) : null,
       hidden_tags: userPrefsStore.hiddenTags,
       apply_tag_filter: userPrefsStore.applyTagFilter,
     };
@@ -2255,8 +2251,6 @@ defineExpose({
               <ImageGrid
                 v-else
                 ref="gridContainer"
-                :thumbnailSize="gridStore.thumbnailSize"
-                :sidebarVisible="sidebarStore.sidebarVisible"
                 :backendUrl="BACKEND_URL"
                 :selectedCharacter="selectionStore.selectedCharacter"
                 :selectedCharacterIds="selectionStore.selectedCharacterIds"
@@ -2271,22 +2265,11 @@ defineExpose({
                 :selectedDescending="sortStore.selectedDescending"
                 :similarityCharacter="sortStore.selectedSimilarityCharacter"
                 :stackThreshold="sortStore.stackThreshold"
-                :showStars="gridStore.showStars"
-                :gridVersion="gridStore.gridVersion"
-                :wsUpdateKey="gridStore.wsUpdateKey"
                 :wsTagUpdate="wsStore.wsTagUpdate"
                 :wsDescriptionUpdate="wsStore.wsDescriptionUpdate"
                 :wsSmartScoreUpdate="wsStore.wsSmartScoreUpdate"
                 :wsDetectionUpdate="wsStore.wsDetectionUpdate"
                 :wsPluginProgress="wsStore.wsPluginProgress"
-                :showFaceBboxes="gridStore.showFaceBboxes"
-                :showDetections="gridStore.showDetections"
-                :showProblemIcon="gridStore.showProblemIcon"
-                :penalisedTagWeights="userPrefsStore.penalisedTagWeights"
-                :showStacks="gridStore.showStacks"
-                :compactMode="gridStore.compactMode"
-                :themeMode="userPrefsStore.themeMode"
-                :dateFormat="userPrefsStore.dateFormat"
                 :allPicturesId="ALL_PICTURES_ID"
                 :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
                 :scrapheapPicturesId="SCRAPHEAP_PICTURES_ID"
@@ -2296,12 +2279,7 @@ defineExpose({
                 :setProjectIds="projectStore.setProjectIds"
                 :setDifferenceBaseId="selectionStore.setDifferenceBaseId"
                 :selectedSetNames="selectionStore.selectedSetNames"
-                :publicUrl="userPrefsStore.publicUrl"
-                :embedWatermark="userPrefsStore.embedWatermark"
                 :folderScanning="folderScanning"
-                :columns="gridStore.columns"
-                :sizeLevel="gridStore.sizeLevel"
-                :thumbnailMode="gridStore.thumbnailMode"
                 @clear-search="handleClearSearch"
                 @search-all="handleSearchAllPictures"
                 @update:selected-sort="handleUpdateSelectedSort"

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -5,10 +5,10 @@
     :initialExpandedStackIds="overlayInitialExpandedStackIds"
     :allImages="allGridImages"
     :backendUrl="props.backendUrl"
-    :tagUpdate="props.wsTagUpdate"
-    :descriptionUpdate="props.wsDescriptionUpdate"
-    :smartScoreUpdate="props.wsSmartScoreUpdate"
-    :detectionUpdate="props.wsDetectionUpdate"
+    :tagUpdate="wsStore.wsTagUpdate"
+    :descriptionUpdate="wsStore.wsDescriptionUpdate"
+    :smartScoreUpdate="wsStore.wsSmartScoreUpdate"
+    :detectionUpdate="wsStore.wsDetectionUpdate"
     :hiddenTags="userPrefsStore.hiddenTags"
     :applyTagFilter="userPrefsStore.applyTagFilter"
     :dateFormat="userPrefsStore.dateFormat"
@@ -38,9 +38,9 @@
   <ImageImporter
     ref="imageImporterRef"
     :backendUrl="props.backendUrl"
-    :selectedCharacterId="props.selectedCharacter"
-    :allPicturesId="props.allPicturesId"
-    :unassignedPicturesId="props.unassignedPicturesId"
+    :selectedCharacterId="selectionStore.selectedCharacter"
+    :allPicturesId="ALL_PICTURES_ID"
+    :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
     @import-started="handleImportStarted"
     @import-finished="handleImagesUploaded"
     @import-cancelled="handleImportCancelled"
@@ -49,10 +49,10 @@
   <div :style="wrapperStyle" class="grid-content-area">
     <Toolbar
       :selectedCount="selectedImageIds.length"
-      :selectedCharacter="String(props.selectedCharacter)"
-      :selectedSort="props.selectedSort"
-      :allPicturesId="String(props.allPicturesId)"
-      :unassignedPicturesId="String(props.unassignedPicturesId)"
+      :selectedCharacter="String(selectionStore.selectedCharacter)"
+      :selectedSort="sortStore.selectedSort"
+      :allPicturesId="String(ALL_PICTURES_ID)"
+      :unassignedPicturesId="String(UNASSIGNED_PICTURES_ID)"
       :backend-url="props.backendUrl"
       :comfyui-configured="filterStore.comfyuiConfigured"
       @comfyui-run-grid="runComfyuiOnGridImages"
@@ -105,13 +105,13 @@
       :y="contextMenuY"
       :selected-image-ids="selectedImageIds"
       :selected-media-support="selectedMediaSupport"
-      :selected-character="String(props.selectedCharacter)"
-      :selected-set="String(props.selectedSet)"
+      :selected-character="String(selectionStore.selectedCharacter)"
+      :selected-set="String(selectionStore.selectedSet)"
       :selected-group-name="selectedGroupName"
-      :selected-sort="props.selectedSort"
-      :all-pictures-id="String(props.allPicturesId)"
-      :unassigned-pictures-id="String(props.unassignedPicturesId)"
-      :scrapheap-pictures-id="String(props.scrapheapPicturesId)"
+      :selected-sort="sortStore.selectedSort"
+      :all-pictures-id="String(ALL_PICTURES_ID)"
+      :unassigned-pictures-id="String(UNASSIGNED_PICTURES_ID)"
+      :scrapheap-pictures-id="String(SCRAPHEAP_PICTURES_ID)"
       :backend-url="props.backendUrl"
       :comfyui-configured="filterStore.comfyuiConfigured"
       :show-remove-from-stack="showRemoveFromStack"
@@ -162,10 +162,10 @@
       :x="overlayCtxX"
       :y="overlayCtxY"
       :selected-image-ids="overlayCtxSelectedIds"
-      :selected-character="String(props.selectedCharacter)"
-      :all-pictures-id="String(props.allPicturesId)"
-      :unassigned-pictures-id="String(props.unassignedPicturesId)"
-      :scrapheap-pictures-id="String(props.scrapheapPicturesId)"
+      :selected-character="String(selectionStore.selectedCharacter)"
+      :all-pictures-id="String(ALL_PICTURES_ID)"
+      :unassigned-pictures-id="String(UNASSIGNED_PICTURES_ID)"
+      :scrapheap-pictures-id="String(SCRAPHEAP_PICTURES_ID)"
       :backend-url="props.backendUrl"
       :lock-reason="overlayCtxLockReason"
       :context-image="overlayCtxImage"
@@ -292,13 +292,15 @@
       <select
         class="multi-select-toolbar__mode"
         :value="
-          isMultiCharacterView ? props.characterMultiMode : props.setMultiMode
+          isMultiCharacterView
+            ? selectionStore.characterMultiMode
+            : selectionStore.setMultiMode
         "
         @change="
           (e) =>
             isMultiCharacterView
-              ? emit('update:character-multi-mode', e.target.value)
-              : emit('update:set-multi-mode', e.target.value)
+              ? selectionStore.setCharacterMultiMode(e.target.value)
+              : selectionStore.setSetMultiMode(e.target.value)
         "
       >
         <option value="union">Union</option>
@@ -307,15 +309,19 @@
         <option value="xor">Unique (XOR)</option>
       </select>
       <template
-        v-if="!isMultiCharacterView && props.setMultiMode === 'difference'"
+        v-if="
+          !isMultiCharacterView && selectionStore.setMultiMode === 'difference'
+        "
       >
         <span class="multi-select-toolbar__separator">|</span>
         <label class="multi-select-toolbar__base-label">Base:</label>
         <select
           class="multi-select-toolbar__base"
-          :value="props.setDifferenceBaseId ?? normalizedSelectedSetIds[0]"
+          :value="
+            selectionStore.setDifferenceBaseId ?? normalizedSelectedSetIds[0]
+          "
           @change="
-            (e) => emit('update:set-difference-base-id', Number(e.target.value))
+            (e) => selectionStore.setSetDifferenceBaseId(Number(e.target.value))
           "
         >
           <option
@@ -323,7 +329,7 @@
             :key="sid"
             :value="sid"
           >
-            {{ props.selectedSetNames[sid] || `Set ${sid}` }}
+            {{ selectionStore.selectedSetNames[sid] || `Set ${sid}` }}
           </option>
         </select>
       </template>
@@ -373,7 +379,7 @@
     <ComfyUiRunner
       ref="comfyuiRunner"
       :backendUrl="props.backendUrl"
-      :wsPluginProgress="props.wsPluginProgress"
+      :wsPluginProgress="wsStore.wsPluginProgress"
       :overlayOpen="overlayOpen"
       :overlayImageId="overlayImageId"
       :allGridImages="allGridImages"
@@ -420,26 +426,26 @@
     >
       <div
         v-if="
-          props.pendingExternalImportCount > 0 ||
-          props.sortChangedExternalCount > 0
+          wsStore.pendingExternalImportCount > 0 ||
+          wsStore.sortChangedExternalCount > 0
         "
         class="pending-imports-pill-anchor"
       >
         <button
-          v-if="props.pendingExternalImportCount > 0"
+          v-if="wsStore.pendingExternalImportCount > 0"
           class="pending-imports-pill"
           data-testid="pending-imports-pill"
           @click="emit('load-pending-imports')"
         >
-          ↑ {{ props.pendingExternalImportCount }}
+          ↑ {{ wsStore.pendingExternalImportCount }}
           {{
-            props.pendingExternalImportCount === 1
+            wsStore.pendingExternalImportCount === 1
               ? "new picture"
               : "new pictures"
           }}, click to load
         </button>
         <button
-          v-if="props.sortChangedExternalCount > 0"
+          v-if="wsStore.sortChangedExternalCount > 0"
           class="pending-imports-pill"
           data-testid="sort-changed-pill"
           @click="emit('load-sort-changed')"
@@ -915,7 +921,7 @@
     <!-- Search Result Bar -->
     <SearchResultBar
       v-if="
-        (props.searchQuery && props.searchQuery.length > 0) ||
+        (searchStore.searchQuery && searchStore.searchQuery.length > 0) ||
         reverseImageSearchPictureIds.length ||
         faceLikenessSearchFaceId ||
         faceSearchCharacter
@@ -928,7 +934,7 @@
         faceLikenessSearchFaceId ||
         faceSearchCharacter
           ? true
-          : props.isAllPicturesActive
+          : selectionStore.isAllPicturesActive
       "
       :status-text="
         faceSearchCharacter
@@ -1023,9 +1029,9 @@
       :selected-expanded-count="selectedExpandedCount"
       :selected-face-count="selectedFaceIds.length"
       :selected-group-name="selectedGroupName"
-      :selected-sort="props.selectedSort"
+      :selected-sort="sortStore.selectedSort"
       :visible="showSelectionBar"
-      :scrapheap-pictures-id="String(props.scrapheapPicturesId)"
+      :scrapheap-pictures-id="String(SCRAPHEAP_PICTURES_ID)"
       :backend-url="props.backendUrl"
       :selected-image-ids="selectedImageIds"
       :selected-media-support="selectedMediaSupport"
@@ -1038,8 +1044,8 @@
       :tagger-plugins="taggerPlugins"
       :captioner-plugins="captionerPlugins"
       :all-grid-images="allGridImages"
-      :selected-character="String(props.selectedCharacter)"
-      :selected-set="String(props.selectedSet)"
+      :selected-character="String(selectionStore.selectedCharacter)"
+      :selected-set="String(selectionStore.selectedSet)"
       :impossible-sources="filterStore.impossibleSources"
       :clearing-impossible="clearingImpossibleTags"
       @clear-impossible-tags="handleClearImpossibleTags"
@@ -1222,10 +1228,25 @@ import { useStackOrdering } from "../../composables/useStackOrdering.js";
 import { useGridFetch } from "../../composables/useGridFetch.js";
 import { useGridKeyboardNav } from "../../composables/useGridKeyboardNav.js";
 import { debounce } from "lodash-es";
+import { useSelectionStore } from "../../stores/useSelectionStore";
+import { useSortStore } from "../../stores/useSortStore";
+import { useProjectStore } from "../../stores/useProjectStore";
+import { useWsStore } from "../../stores/useWsStore";
+import { useSearchStore } from "../../stores/useSearchStore";
+import {
+  ALL_PICTURES_ID,
+  SCRAPHEAP_PICTURES_ID,
+  UNASSIGNED_PICTURES_ID,
+} from "../../stores/useViewStore";
 
 // Store-direct (Phase 3): the picture-query filter facets and the grid's own
 // display preferences are read from the stores, not mirrored in through props.
 const filterStore = useFilterStore();
+const selectionStore = useSelectionStore();
+const sortStore = useSortStore();
+const projectStore = useProjectStore();
+const wsStore = useWsStore();
+const searchStore = useSearchStore();
 const gridStore = useGridStore();
 const userPrefsStore = useUserPrefsStore();
 
@@ -1241,9 +1262,6 @@ const emit = defineEmits([
   "import-started",
   "import-ended",
   "clear-multi-selection",
-  "update:character-multi-mode",
-  "update:set-multi-mode",
-  "update:set-difference-base-id",
   "update:visible-range-label",
   "update:match-count",
   "load-pending-imports",
@@ -1259,51 +1277,8 @@ const emit = defineEmits([
 // Props
 const props = defineProps({
   backendUrl: String,
-  selectedCharacter: { type: [String, Number, null], default: null },
-  selectedSet: { type: [Number, String, null], default: null },
-  selectedSetIds: { type: Array, default: () => [] },
-  searchQuery: String,
   activeCategoryLabel: { type: String, default: "Category" },
-  isAllPicturesActive: { type: Boolean, default: false },
-  selectedSort: String,
-  selectedDescending: Boolean,
-  similarityCharacter: { type: [String, Number, null], default: null },
-  stackThreshold: { type: [String, Number, null], default: null },
-  allPicturesId: String,
-  unassignedPicturesId: String,
-  scrapheapPicturesId: String,
-  wsTagUpdate: {
-    type: Object,
-    default: () => ({ key: 0, pictureIds: [] }),
-  },
-  wsDescriptionUpdate: {
-    type: Object,
-    default: () => ({ key: 0, pictureIds: [] }),
-  },
-  wsSmartScoreUpdate: {
-    type: Object,
-    default: () => ({ key: 0, pictureIds: [] }),
-  },
-  wsDetectionUpdate: {
-    type: Object,
-    default: () => ({ key: 0, pictureIds: [] }),
-  },
-  wsPluginProgress: {
-    type: Object,
-    default: () => ({ key: 0, payload: null }),
-  },
-  projectViewMode: { type: String, default: "global" },
-  selectedProjectId: { type: Number, default: null },
-  characterProjectIds: { type: Object, default: () => ({}) },
-  setProjectIds: { type: Object, default: () => ({}) },
   folderScanning: { type: Boolean, default: false },
-  selectedCharacterIds: { type: Array, default: () => [] },
-  characterMultiMode: { type: String, default: "union" },
-  setMultiMode: { type: String, default: "intersection" },
-  setDifferenceBaseId: { type: Number, default: null },
-  selectedSetNames: { type: Object, default: () => ({}) },
-  pendingExternalImportCount: { type: Number, default: 0 },
-  sortChangedExternalCount: { type: Number, default: 0 },
 });
 
 // ============================================================
@@ -1316,8 +1291,8 @@ const LIKENESS_GROUPS_SORT_KEY = "LIKENESS_GROUPS";
 const THUMBNAIL_INFO_ROW_HEIGHT = 24;
 
 const normalizedSelectedSetIds = computed(() => {
-  const idsFromProp = Array.isArray(props.selectedSetIds)
-    ? props.selectedSetIds
+  const idsFromProp = Array.isArray(selectionStore.selectedSetIds)
+    ? selectionStore.selectedSetIds
     : [];
   const normalized = idsFromProp
     .map((id) => Number(id))
@@ -1325,7 +1300,7 @@ const normalizedSelectedSetIds = computed(() => {
   if (normalized.length > 0) {
     return Array.from(new Set(normalized));
   }
-  const single = Number(props.selectedSet);
+  const single = Number(selectionStore.selectedSet);
   if (Number.isFinite(single) && single > 0) {
     return [single];
   }
@@ -1345,8 +1320,8 @@ const primarySelectedSetId = computed(() =>
 );
 
 const normalizedSelectedCharacterIds = computed(() => {
-  const ids = Array.isArray(props.selectedCharacterIds)
-    ? props.selectedCharacterIds
+  const ids = Array.isArray(selectionStore.selectedCharacterIds)
+    ? selectionStore.selectedCharacterIds
     : [];
   return ids
     .map((id) => Number(id))
@@ -1363,7 +1338,9 @@ const isMultiCharacterView = computed(
 // mode; in the global mode nothing about the query depends on project
 // membership. Used to decide whether a project assignment can change what the
 // grid shows and therefore warrants a refetch.
-const isProjectScopedView = computed(() => props.projectViewMode === "project");
+const isProjectScopedView = computed(
+  () => projectStore.projectViewMode === "project",
+);
 
 // ============================================================
 // THUMBNAIL SYSTEM STATE
@@ -1427,7 +1404,7 @@ const reverseImageSearchPictureIds = ref([]);
 const faceLikenessSearchFaceId = ref(null);
 // ── "Suggest more pictures of <person>" (#636) ────────────────────────────────
 // The person whose reference faces are the active query, or null. Distinct from
-// `props.selectedCharacter`: this search deliberately runs across the whole
+// `selectionStore.selectedCharacter`: this search deliberately runs across the whole
 // library, so it must not be mistaken for a character-scoped view.
 const faceSearchCharacter = ref(null); // { id, name }
 // The cut applied to the ranked list. Starts at the same value the backend's
@@ -1883,12 +1860,14 @@ async function runComfyuiOnGridImages({
     // set / project / character automatically.
     const contextSetId = primarySelectedSetId.value ?? undefined;
     const contextProjectId =
-      props.selectedProjectId != null ? props.selectedProjectId : undefined;
-    const rawChar = props.selectedCharacter;
+      projectStore.selectedProjectId != null
+        ? projectStore.selectedProjectId
+        : undefined;
+    const rawChar = selectionStore.selectedCharacter;
     const specialIds = [
-      props.allPicturesId,
-      props.unassignedPicturesId,
-      props.scrapheapPicturesId,
+      ALL_PICTURES_ID,
+      UNASSIGNED_PICTURES_ID,
+      SCRAPHEAP_PICTURES_ID,
     ].map((v) => String(v ?? "").toUpperCase());
     const charNum =
       rawChar != null && !specialIds.includes(String(rawChar).toUpperCase())
@@ -2006,7 +1985,7 @@ function startSmartScoreProgress(loadId, sortKey) {
   }
 
   smartScoreProgress.message =
-    props.searchQuery && props.searchQuery.trim()
+    searchStore.searchQuery && searchStore.searchQuery.trim()
       ? "Searching"
       : `Sorting by ${getSortProgressLabel(smartScoreProgressSortKey.value)}`;
   smartScoreProgressTimer = setInterval(() => {
@@ -2044,7 +2023,7 @@ function completeSmartScoreProgress(loadId, measuredDurationMs, wasSuccessful) {
     }
     setSmartScoreProgressPercent(100);
     smartScoreProgress.message =
-      props.searchQuery && props.searchQuery.trim()
+      searchStore.searchQuery && searchStore.searchQuery.trim()
         ? "Search complete"
         : `Sorted by ${getSortProgressLabel(smartScoreProgressSortKey.value)}`;
     setTimeout(() => {
@@ -2280,7 +2259,7 @@ watch(
 );
 
 watch(
-  () => props.wsTagUpdate,
+  () => wsStore.wsTagUpdate,
   (payload) => {
     if (!payload || typeof payload !== "object") return;
     const nextKey = payload.key || 0;
@@ -2334,7 +2313,7 @@ watch(
 );
 
 watch(
-  () => props.wsDescriptionUpdate,
+  () => wsStore.wsDescriptionUpdate,
   (payload) => {
     if (!payload || typeof payload !== "object") return;
     const nextKey = payload.key || 0;
@@ -2351,7 +2330,7 @@ watch(
 );
 
 watch(
-  () => props.wsPluginProgress,
+  () => wsStore.wsPluginProgress,
   (wrapped) => {
     if (!wrapped || typeof wrapped !== "object") return;
     const payload = wrapped.payload;
@@ -2678,7 +2657,7 @@ function getThumbnailInfoItems(img) {
   if (!img) return [];
   const items = [];
   const selectedSort =
-    typeof props.selectedSort === "string" ? props.selectedSort : "";
+    typeof sortStore.selectedSort === "string" ? sortStore.selectedSort : "";
 
   if (
     selectedSort.includes("CHARACTER_LIKENESS") &&
@@ -2706,7 +2685,7 @@ function getThumbnailInfoItems(img) {
   }
 
   if (
-    typeof props.searchQuery === "string" &&
+    typeof searchStore.searchQuery === "string" &&
     img.likeness_score !== undefined
   ) {
     items.push({
@@ -2873,8 +2852,11 @@ function formatCompactDatetime(dateStr) {
 // ── Visible range label (emitted to SelectionBar) ──────────────
 function getImageSortLabel(img) {
   if (!img) return null;
-  const isSearchMode = !!(props.searchQuery && props.searchQuery.trim());
-  const sort = typeof props.selectedSort === "string" ? props.selectedSort : "";
+  const isSearchMode = !!(
+    searchStore.searchQuery && searchStore.searchQuery.trim()
+  );
+  const sort =
+    typeof sortStore.selectedSort === "string" ? sortStore.selectedSort : "";
   if (isSearchMode && typeof img.likeness_score === "number")
     return `≈ ${img.likeness_score.toFixed(2)}`;
   if (sort === "IMPORTED_AT" && img.imported_at)
@@ -3119,23 +3101,27 @@ async function removeFromGroup() {
   }
   // Remove from character
   if (
-    props.selectedCharacter &&
-    props.selectedCharacter !== props.allPicturesId &&
-    props.selectedCharacter !== props.unassignedPicturesId
+    selectionStore.selectedCharacter &&
+    selectionStore.selectedCharacter !== ALL_PICTURES_ID &&
+    selectionStore.selectedCharacter !== UNASSIGNED_PICTURES_ID
   ) {
     const requests = [];
     if (pictureIds.length) {
       requests.push(
-        removeCharacterFaces(props.selectedCharacter, pictureIds, {
+        removeCharacterFaces(selectionStore.selectedCharacter, pictureIds, {
           baseUrl: backendUrl,
         }),
       );
     }
     if (faceIds.length) {
       requests.push(
-        removeCharacterFacesByFaceId(props.selectedCharacter, faceIds, {
-          baseUrl: backendUrl,
-        }),
+        removeCharacterFacesByFaceId(
+          selectionStore.selectedCharacter,
+          faceIds,
+          {
+            baseUrl: backendUrl,
+          },
+        ),
       );
     }
     if (!requests.length) return;
@@ -3168,9 +3154,9 @@ async function removeFromGroup() {
   }
   // Remove from set
   if (
-    props.selectedSet &&
-    props.selectedSet !== props.allPicturesId &&
-    props.selectedSet !== props.unassignedPicturesId
+    selectionStore.selectedSet &&
+    selectionStore.selectedSet !== ALL_PICTURES_ID &&
+    selectionStore.selectedSet !== UNASSIGNED_PICTURES_ID
   ) {
     if (!pictureIds.length) {
       clearFaceSelection();
@@ -3246,13 +3232,13 @@ async function removeFromGroup() {
       // Remove from picture set (all affected IDs in parallel).
       await Promise.all(
         [...idsToRemoveFromSet].map((id) =>
-          removePictureFromSet(props.selectedSet, id, {
+          removePictureFromSet(selectionStore.selectedSet, id, {
             baseUrl: backendUrl,
           }).catch((err) => {
             // Expected when the picture was not in the set (the selection can
             // span sets); log rather than drop it so a real failure is visible.
             console.debug(
-              `Could not remove picture ${id} from set ${props.selectedSet}`,
+              `Could not remove picture ${id} from set ${selectionStore.selectedSet}`,
               err,
             );
           }),
@@ -3339,7 +3325,7 @@ function handleOverlayAddedToSet(payload) {
   }
 
   if (
-    props.selectedCharacter === props.unassignedPicturesId &&
+    selectionStore.selectedCharacter === UNASSIGNED_PICTURES_ID &&
     !hasSetSelection.value
   ) {
     if (overlayOpen.value) {
@@ -3357,7 +3343,7 @@ function handleAddToCharacter(payload) {
     : [];
   if (!pictureIds.length) return;
   if (
-    props.selectedCharacter === props.unassignedPicturesId &&
+    selectionStore.selectedCharacter === UNASSIGNED_PICTURES_ID &&
     !hasSetSelection.value
   ) {
     removeImagesById(pictureIds);
@@ -3375,14 +3361,14 @@ function handleRemoveFromCharacter(payload) {
     : [];
   if (!pictureIds.length) return;
   const removedCharId = payload?.characterId;
-  const currentChar = props.selectedCharacter;
+  const currentChar = selectionStore.selectedCharacter;
   const isInRemovedCharView =
     removedCharId != null &&
     currentChar != null &&
     String(currentChar) === String(removedCharId) &&
-    currentChar !== props.allPicturesId &&
-    currentChar !== props.unassignedPicturesId &&
-    currentChar !== props.scrapheapPicturesId;
+    currentChar !== ALL_PICTURES_ID &&
+    currentChar !== UNASSIGNED_PICTURES_ID &&
+    currentChar !== SCRAPHEAP_PICTURES_ID;
   if (isInRemovedCharView) {
     removeImagesById(pictureIds);
     selectedImageIds.value = [];
@@ -3769,9 +3755,9 @@ async function resolveProjectSelectionPictureIds(
 // ============================================================
 const isScrapheapView = computed(() => {
   const scrapheapId = String(
-    props.scrapheapPicturesId || "SCRAPHEAP",
+    SCRAPHEAP_PICTURES_ID || "SCRAPHEAP",
   ).toUpperCase();
-  const selected = String(props.selectedCharacter || "").toUpperCase();
+  const selected = String(selectionStore.selectedCharacter || "").toUpperCase();
   return selected === scrapheapId;
 });
 
@@ -3975,20 +3961,20 @@ const selectedExpandedCount = computed(() => {
     [...visibleIds].every((id) => selectedSet.has(id));
 
   const isTopCategorySelection = [
-    String(props.allPicturesId),
-    String(props.unassignedPicturesId),
-  ].includes(String(props.selectedCharacter ?? ""));
+    String(ALL_PICTURES_ID),
+    String(UNASSIGNED_PICTURES_ID),
+  ].includes(String(selectionStore.selectedCharacter ?? ""));
 
   const isSetCategorySelection =
-    props.selectedSet !== null &&
-    props.selectedSet !== undefined &&
-    String(props.selectedSet) !== "";
+    selectionStore.selectedSet !== null &&
+    selectionStore.selectedSet !== undefined &&
+    String(selectionStore.selectedSet) !== "";
 
   const supportsAuthoritativeCategoryCount =
     isTopCategorySelection || isSetCategorySelection;
 
   const hasNoAdditionalFilters =
-    !(props.searchQuery || "").trim() &&
+    !(searchStore.searchQuery || "").trim() &&
     filterStore.mediaTypeFilter === "all" &&
     (filterStore.comfyuiModelFilter || []).length === 0 &&
     (filterStore.comfyuiLoraFilter || []).length === 0 &&
@@ -4374,13 +4360,13 @@ async function handleImagesUploaded(payload) {
   );
   if (pictureIds.length) {
     try {
-      const selectedSetId = props.selectedSet;
-      const selectedCharacterId = props.selectedCharacter;
+      const selectedSetId = selectionStore.selectedSet;
+      const selectedCharacterId = selectionStore.selectedCharacter;
       const selectedCharacterKey = String(selectedCharacterId ?? "");
       const skipCharacter = [
-        String(props.allPicturesId),
-        String(props.unassignedPicturesId),
-        String(props.scrapheapPicturesId),
+        String(ALL_PICTURES_ID),
+        String(UNASSIGNED_PICTURES_ID),
+        String(SCRAPHEAP_PICTURES_ID),
       ].includes(selectedCharacterKey);
       if (selectedSetId != null && selectedSetId !== "") {
         await Promise.all(
@@ -4568,9 +4554,9 @@ const lockedDeleteNotice = useScopedNotice(
       // reorder is not worth it. A reorder is a user action anyway, so treating
       // it as a context change is the right answer, not a false positive.
       selectedImageIds.value.join(","),
-      String(props.selectedCharacter ?? ""),
-      String(props.selectedSet ?? ""),
-      String(props.selectedProjectId ?? ""),
+      String(selectionStore.selectedCharacter ?? ""),
+      String(selectionStore.selectedSet ?? ""),
+      String(projectStore.selectedProjectId ?? ""),
       // Locked sets are few, so a per-set membership fingerprint is cheap and
       // catches an unlock, a re-lock and a membership edit alike.
       lockedSetsStore.sets
@@ -5113,13 +5099,13 @@ const selectedGroupName = ref("");
 async function updateSelectedGroupName() {
   let name = "";
   if (
-    props.selectedCharacter &&
-    props.selectedCharacter !== `${props.allPicturesId}` &&
-    props.selectedCharacter !== `${props.unassignedPicturesId}` &&
-    props.selectedCharacter !== `${props.scrapheapPicturesId}`
+    selectionStore.selectedCharacter &&
+    selectionStore.selectedCharacter !== `${ALL_PICTURES_ID}` &&
+    selectionStore.selectedCharacter !== `${UNASSIGNED_PICTURES_ID}` &&
+    selectionStore.selectedCharacter !== `${SCRAPHEAP_PICTURES_ID}`
   ) {
     try {
-      const char = await getCharacter(props.selectedCharacter, {
+      const char = await getCharacter(selectionStore.selectedCharacter, {
         baseUrl: props.backendUrl,
       });
       name = char.name || "";
@@ -5145,9 +5131,9 @@ async function updateSelectedGroupName() {
 
 watch(
   [
-    () => props.selectedCharacter,
-    () => props.selectedSet,
-    () => props.selectedSetIds,
+    () => selectionStore.selectedCharacter,
+    () => selectionStore.selectedSet,
+    () => selectionStore.selectedSetIds,
   ],
   () => {
     updateSelectedGroupName();
@@ -5236,7 +5222,7 @@ async function refreshGridImage(imageId, options = {}) {
     };
     allGridImages.value = nextImages;
   }
-  if (props.selectedSort === LIKENESS_GROUPS_SORT_KEY) {
+  if (sortStore.selectedSort === LIKENESS_GROUPS_SORT_KEY) {
     const stackIndex = getStackIndexFromItem(allGridImages.value[idx]);
     if (typeof stackIndex === "number") {
       reorderStackByScore(stackIndex);
@@ -5554,20 +5540,20 @@ function initGuestSession() {
 }
 
 function isScoreSortActive() {
-  return typeof props.selectedSort === "string"
-    ? props.selectedSort.toUpperCase() === "SCORE"
+  return typeof sortStore.selectedSort === "string"
+    ? sortStore.selectedSort.toUpperCase() === "SCORE"
     : false;
 }
 
 function isCharacterLikenessSortActive() {
-  return typeof props.selectedSort === "string"
-    ? props.selectedSort.toUpperCase() === "CHARACTER_LIKENESS"
+  return typeof sortStore.selectedSort === "string"
+    ? sortStore.selectedSort.toUpperCase() === "CHARACTER_LIKENESS"
     : false;
 }
 
 function isSmartScoreSortActive() {
-  return typeof props.selectedSort === "string"
-    ? props.selectedSort.toUpperCase().includes("SMART_SCORE")
+  return typeof sortStore.selectedSort === "string"
+    ? sortStore.selectedSort.toUpperCase().includes("SMART_SCORE")
     : false;
 }
 
@@ -5577,7 +5563,9 @@ function isSmartScoreSortActive() {
 // array it is spliced into. Nullish selectedDescending → ascending (the store
 // defaults it to a real `true`). Keep this as one computed: a lone inlined
 // `!== false` previously drifted here and mispositioned inserted cards.
-const gridSortDescending = computed(() => props.selectedDescending === true);
+const gridSortDescending = computed(
+  () => sortStore.selectedDescending === true,
+);
 
 function getGridSmartScoreValue(img) {
   if (!img) return null;
@@ -5737,7 +5725,8 @@ function repositionImageBySmartScore(imageId, smartScore, latestInfo = null) {
 // getCompactGroupLabel / sort-overlay logic). Returns a finite number used to
 // find the insert index; `id` is the implicit tiebreaker.
 function gridImageSortKey(img) {
-  const sort = typeof props.selectedSort === "string" ? props.selectedSort : "";
+  const sort =
+    typeof sortStore.selectedSort === "string" ? sortStore.selectedSort : "";
   if (sort === "IMPORTED_AT" && img?.imported_at) {
     return Date.parse(img.imported_at) || 0;
   }
@@ -6068,19 +6057,19 @@ function _resetGridState() {
 
 watch(
   [
-    () => props.selectedCharacter,
-    () => props.selectedSet,
-    () => props.selectedSetIds,
-    () => props.characterMultiMode,
-    () => props.setMultiMode,
-    () => props.setDifferenceBaseId,
-    () => props.projectViewMode,
-    () => props.selectedProjectId,
-    () => props.searchQuery,
-    () => props.selectedSort,
-    () => props.selectedDescending,
-    () => props.similarityCharacter,
-    () => props.stackThreshold,
+    () => selectionStore.selectedCharacter,
+    () => selectionStore.selectedSet,
+    () => selectionStore.selectedSetIds,
+    () => selectionStore.characterMultiMode,
+    () => selectionStore.setMultiMode,
+    () => selectionStore.setDifferenceBaseId,
+    () => projectStore.projectViewMode,
+    () => projectStore.selectedProjectId,
+    () => searchStore.searchQuery,
+    () => sortStore.selectedSort,
+    () => sortStore.selectedDescending,
+    () => sortStore.selectedSimilarityCharacter,
+    () => sortStore.stackThreshold,
   ],
   () => {
     if (scrollWrapper.value) scrollWrapper.value.scrollTop = 0;
@@ -7733,26 +7722,29 @@ async function handleAssignFaceSearchResults() {
 
 // Clear reverse image search / face search when the user starts a text search or navigates.
 watch(
-  () => props.searchQuery,
+  () => searchStore.searchQuery,
   (newVal) => {
     if (newVal && newVal.trim()) {
       resetFaceAndImageSearches();
     }
   },
 );
-watch([() => props.selectedCharacter, () => props.selectedSet], () => {
-  if (reverseImageSearchPictureIds.value?.length) {
-    reverseImageSearchPictureIds.value = [];
-  }
-  if (faceLikenessSearchFaceId.value !== null) {
-    faceLikenessSearchFaceId.value = null;
-  }
-  // The character search is NOT cleared here. It is launched from the sidebar's
-  // person menu, and opening that menu can also select the person — clearing on
-  // a selection change would cancel the search the click just asked for. It is
-  // library-wide by construction, so a view change cannot invalidate it; the
-  // Clear search button and the other search modes are its exits.
-});
+watch(
+  [() => selectionStore.selectedCharacter, () => selectionStore.selectedSet],
+  () => {
+    if (reverseImageSearchPictureIds.value?.length) {
+      reverseImageSearchPictureIds.value = [];
+    }
+    if (faceLikenessSearchFaceId.value !== null) {
+      faceLikenessSearchFaceId.value = null;
+    }
+    // The character search is NOT cleared here. It is launched from the sidebar's
+    // person menu, and opening that menu can also select the person — clearing on
+    // a selection change would cancel the search the click just asked for. It is
+    // library-wide by construction, so a view change cannot invalidate it; the
+    // Clear search button and the other search modes are its exits.
+  },
+);
 
 function handleEmptyStateReset() {
   gridReady.value = false;

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -11,9 +11,9 @@
     :detectionUpdate="props.wsDetectionUpdate"
     :hiddenTags="userPrefsStore.hiddenTags"
     :applyTagFilter="userPrefsStore.applyTagFilter"
-    :dateFormat="props.dateFormat"
-    :showStacks="props.showStacks"
-    :showProblemIcon="props.showProblemIcon"
+    :dateFormat="userPrefsStore.dateFormat"
+    :showStacks="gridStore.showStacks"
+    :showProblemIcon="gridStore.showProblemIcon"
     :availablePlugins="availablePlugins"
     :comfyuiProgress="comfyuiProgress"
     :comfyuiProgressPercent="comfyuiProgressPercent"
@@ -250,10 +250,10 @@
       resource-type="picture"
       :resource-id="contextMenuImage?.id"
       :resource-format="contextMenuImage?.format"
-      :embed-watermark="props.embedWatermark"
+      :embed-watermark="userPrefsStore.embedWatermark"
       :backend-url="props.backendUrl"
-      :public-url="props.publicUrl"
-      @update:embed-watermark="emit('update:embed-watermark', $event)"
+      :public-url="userPrefsStore.publicUrl"
+      @update:embed-watermark="userPrefsStore.embedWatermark = $event"
       @created="onSharePicCreated"
     />
     <EmptyScrapHeap
@@ -495,7 +495,7 @@
         :class="[
           'image-grid',
           {
-            'compact-mode': props.compactMode,
+            'compact-mode': gridStore.compactMode,
             'touch-select-mode': touchSelectMode,
             'image-grid--justified': isJustifiedMode,
           },
@@ -578,7 +578,7 @@
                 v-if="
                   isThumbnailReady(img.id) &&
                   img.thumbnail &&
-                  ((props.showProblemIcon && hasPenalisedTags(img)) ||
+                  ((gridStore.showProblemIcon && hasPenalisedTags(img)) ||
                     img.reference_folder_id ||
                     lockedSetsStore.isLocked(img.id) ||
                     (!isReadOnly && sharedPictureIds.has(img.id)))
@@ -586,18 +586,20 @@
                 class="thumbnail-top-left-badges"
               >
                 <div
-                  v-if="props.showProblemIcon && hasPenalisedTags(img)"
+                  v-if="gridStore.showProblemIcon && hasPenalisedTags(img)"
                   class="penalised-tag-indicator thumbnail-badge"
                   :title="penalisedTagsTitle(img)"
                 >
                   <v-icon
                     :size="badgeIconSizes.penalised"
-                    :color="penalisedTagColor(img, props.penalisedTagWeights)"
+                    :color="
+                      penalisedTagColor(img, userPrefsStore.penalisedTagWeights)
+                    "
                     >{{
                       penalisedTagIcon(
                         img,
-                        props.penalisedTagWeights,
-                        props.themeMode !== "light",
+                        userPrefsStore.penalisedTagWeights,
+                        userPrefsStore.themeMode !== "light",
                       )
                     }}</v-icon
                   >
@@ -862,7 +864,7 @@
                 class="thumbnail-top-right-badges"
               >
                 <StarRatingOverlay
-                  v-if="props.showStars"
+                  v-if="gridStore.showStars"
                   :score="
                     isReadOnly
                       ? (guestScoreMap.get(img.id) ?? img.score ?? 0)
@@ -883,7 +885,7 @@
           </div>
           <div v-if="isImageSelected(img.id)" class="selection-overlay"></div>
           <!-- Info row absolutely positioned below thumbnail -->
-          <div v-if="!props.compactMode" class="thumbnail-info-row">
+          <div v-if="!gridStore.compactMode" class="thumbnail-info-row">
             <div
               v-for="info in getThumbnailInfoItems(img)"
               :key="`${info.key}-${img.id}`"
@@ -1090,6 +1092,7 @@ import {
 } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useFilterStore } from "../../stores/useFilterStore";
+import { useGridStore } from "../../stores/useGridStore";
 import { useUserPrefsStore } from "../../stores/useUserPrefsStore";
 import { useTasksStore } from "../../stores/useTasksStore";
 import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
@@ -1220,6 +1223,12 @@ import { useGridFetch } from "../../composables/useGridFetch.js";
 import { useGridKeyboardNav } from "../../composables/useGridKeyboardNav.js";
 import { debounce } from "lodash-es";
 
+// Store-direct (Phase 3): the picture-query filter facets and the grid's own
+// display preferences are read from the stores, not mirrored in through props.
+const filterStore = useFilterStore();
+const gridStore = useGridStore();
+const userPrefsStore = useUserPrefsStore();
+
 const emit = defineEmits([
   "open-overlay",
   "update:overlay-open",
@@ -1235,7 +1244,6 @@ const emit = defineEmits([
   "update:character-multi-mode",
   "update:set-multi-mode",
   "update:set-difference-base-id",
-  "update:embed-watermark",
   "update:visible-range-label",
   "update:match-count",
   "load-pending-imports",
@@ -1250,8 +1258,6 @@ const emit = defineEmits([
 
 // Props
 const props = defineProps({
-  thumbnailSize: Number,
-  sidebarVisible: Boolean,
   backendUrl: String,
   selectedCharacter: { type: [String, Number, null], default: null },
   selectedSet: { type: [Number, String, null], default: null },
@@ -1263,26 +1269,9 @@ const props = defineProps({
   selectedDescending: Boolean,
   similarityCharacter: { type: [String, Number, null], default: null },
   stackThreshold: { type: [String, Number, null], default: null },
-  showStars: Boolean,
-  showFaceBboxes: Boolean,
-  showDetections: Boolean,
-  showProblemIcon: Boolean,
-  penalisedTagWeights: { type: Object, default: () => ({}) },
-  showStacks: { type: Boolean, default: true },
-  compactMode: { type: Boolean, default: false },
-  // 'square' (uniform grid) or 'justified' (Google-Photos-style rows of
-  // variable-width thumbnails sharing a common row height).
-  thumbnailMode: { type: String, default: "square" },
-  // Shared thumbnail-size level (0..6). Drives square column count (via
-  // gridStore.columns) and, in justified mode, the target row height.
-  sizeLevel: { type: Number, default: 3 },
-  themeMode: { type: String, default: "light" },
-  dateFormat: { type: String, default: "locale" },
   allPicturesId: String,
   unassignedPicturesId: String,
   scrapheapPicturesId: String,
-  gridVersion: { type: Number, default: 0 },
-  wsUpdateKey: { type: Number, default: 0 },
   wsTagUpdate: {
     type: Object,
     default: () => ({ key: 0, pictureIds: [] }),
@@ -1303,8 +1292,6 @@ const props = defineProps({
     type: Object,
     default: () => ({ key: 0, payload: null }),
   },
-  // "all" | "stacked" | "unstacked" | "unresolved"
-  columns: { type: Number, required: true },
   projectViewMode: { type: String, default: "global" },
   selectedProjectId: { type: Number, default: null },
   characterProjectIds: { type: Object, default: () => ({}) },
@@ -1315,8 +1302,6 @@ const props = defineProps({
   setMultiMode: { type: String, default: "intersection" },
   setDifferenceBaseId: { type: Number, default: null },
   selectedSetNames: { type: Object, default: () => ({}) },
-  publicUrl: { type: String, default: null },
-  embedWatermark: { type: Boolean, default: false },
   pendingExternalImportCount: { type: Number, default: 0 },
   sortChangedExternalCount: { type: Number, default: 0 },
 });
@@ -1477,7 +1462,7 @@ const segmentTargetIds = ref(null);
 
 // Badge size interpolated continuously across column count (1 = lg, 12+ = sm).
 const badgeSizeT = computed(() =>
-  Math.min(1, Math.max(0, ((props.columns || 1) - 1) / 11)),
+  Math.min(1, Math.max(0, ((gridStore.columns || 1) - 1) / 11)),
 );
 
 const badgeCssVars = computed(() => {
@@ -2274,7 +2259,7 @@ onUnmounted(() => {
 });
 
 watch(
-  () => props.wsUpdateKey,
+  () => gridStore.wsUpdateKey,
   (nextKey) => {
     if (!nextKey || nextKey === lastWsUpdateKey.value) return;
     lastWsUpdateKey.value = nextKey;
@@ -2600,7 +2585,7 @@ function getFaceBboxOverlays(img) {
   void selectedFaceIds.value;
   void thumbnailReadyMap[img.id];
   if (
-    !props.showFaceBboxes ||
+    !gridStore.showFaceBboxes ||
     !img.faces ||
     !img.faces.length ||
     !(img.thumbnail_width || img.width) ||
@@ -2634,7 +2619,7 @@ function getDetectionBboxOverlays(img) {
   void faceOverlayRedrawKey.value; // depend on redraw key
   void thumbnailReadyMap[img.id];
   if (
-    !props.showDetections ||
+    !gridStore.showDetections ||
     !img.detections ||
     !img.detections.length ||
     !(img.thumbnail_width || img.width) ||
@@ -2731,18 +2716,18 @@ function getThumbnailInfoItems(img) {
   } else if (selectedSort === "IMPORTED_AT" && img.imported_at) {
     items.push({
       key: "imported_at",
-      text: formatUserDate(img.imported_at, props.dateFormat),
+      text: formatUserDate(img.imported_at, userPrefsStore.dateFormat),
     });
   } else if (selectedSort.includes("DATE") && img.created_at) {
     items.push({
       key: "created_at",
-      text: formatUserDate(img.created_at, props.dateFormat),
+      text: formatUserDate(img.created_at, userPrefsStore.dateFormat),
     });
   } else if (
     selectedSort === LIKENESS_GROUPS_SORT_KEY &&
     (typeof img.stackIndex === "number" || typeof img.stack_index === "number")
   ) {
-    if (!props.showStacks) {
+    if (!gridStore.showStacks) {
       return items;
     }
     const stackIndex =
@@ -2762,7 +2747,9 @@ function formatCompactDate(dateStr) {
   const now = new Date();
   const sameYear = d.getFullYear() === now.getFullYear();
   const fmt =
-    typeof props.dateFormat === "string" ? props.dateFormat : "locale";
+    typeof userPrefsStore.dateFormat === "string"
+      ? userPrefsStore.dateFormat
+      : "locale";
   const y = d.getFullYear();
   const day = d.getDate();
   const MONTHS = [
@@ -2812,7 +2799,9 @@ function formatCompactDatetime(dateStr) {
   const now = new Date();
   const sameYear = d.getFullYear() === now.getFullYear();
   const fmt =
-    typeof props.dateFormat === "string" ? props.dateFormat : "locale";
+    typeof userPrefsStore.dateFormat === "string"
+      ? userPrefsStore.dateFormat
+      : "locale";
   const y = d.getFullYear();
   const day = d.getDate();
   const MONTHS = [
@@ -2927,10 +2916,6 @@ const visibleRangeLabel = computed(() => {
   return `${first} – ${last}`;
 });
 
-// Store-direct (Phase 3): every picture-query filter facet is read from the
-// filter store, not mirrored in through props.
-const filterStore = useFilterStore();
-const userPrefsStore = useUserPrefsStore();
 const tasksStore = useTasksStore();
 const reviewSessionsStore = useReviewSessionsStore();
 const lockedSetsStore = useLockedSetsStore();
@@ -3842,7 +3827,9 @@ const scrapheapPurgeBadges = computed(() => {
   }
   const now = purgeNowMs.value;
   const dateFormat =
-    typeof props.dateFormat === "string" ? props.dateFormat : "locale";
+    typeof userPrefsStore.dateFormat === "string"
+      ? userPrefsStore.dateFormat
+      : "locale";
   const formatDate = (iso) => formatUserDate(iso, dateFormat);
   for (const img of gridImagesToRender.value || []) {
     if (!img || img.id == null) continue;
@@ -4491,7 +4478,7 @@ function scheduleWsTagFullRefresh() {
 }
 
 watch(
-  () => props.gridVersion,
+  () => gridStore.gridVersion,
   () => {
     if (pauseGridAutoUpdates.value) {
       pendingGridRefreshAfterImport.value = true;
@@ -4651,7 +4638,7 @@ const {
 // flex-wrap lines break exactly where useJustifiedLayout computed the rows —
 // the invariant the spacer/fetch arithmetic depends on.
 const justifiedInfoRowExtra = computed(() =>
-  props.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT,
+  gridStore.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT,
 );
 
 function _justifiedItemGeometry(img, localIdx) {
@@ -4700,7 +4687,7 @@ const gridContainerStyle = computed(() => {
   }
   return {
     ...base,
-    gridTemplateColumns: `repeat(${props.columns}, minmax(0, 1fr))`,
+    gridTemplateColumns: `repeat(${gridStore.columns}, minmax(0, 1fr))`,
   };
 });
 
@@ -6135,7 +6122,7 @@ watch(
 );
 
 watch(
-  () => props.showStacks,
+  () => gridStore.showStacks,
   async (expandAllStacksEnabled) => {
     if (expandAllStacksEnabled) {
       syncExpandAllStacksFromFetchedImages();
@@ -6148,7 +6135,7 @@ watch(
 );
 
 watch(
-  () => props.columns,
+  () => gridStore.columns,
   async () => {
     updateRowHeightFromGrid();
     recalculateVisibleRange();
@@ -6161,7 +6148,7 @@ watch(
 );
 
 watch(
-  () => props.compactMode,
+  () => gridStore.compactMode,
   () => {
     updateRowHeightFromGrid();
     updateVisibleThumbnails();
@@ -6174,7 +6161,7 @@ watch(
 // the maintainer hit). Mirror the columns watch: re-measure row height, re-pack,
 // recompute the visible range, and refetch the now-visible thumbnails.
 watch(
-  () => props.thumbnailMode,
+  () => gridStore.thumbnailMode,
   async () => {
     updateRowHeightFromGrid();
     recalculateVisibleRange();
@@ -6259,7 +6246,7 @@ watch(
 );
 
 watch(
-  [() => props.showFaceBboxes, () => allGridImages.value.length],
+  [() => gridStore.showFaceBboxes, () => allGridImages.value.length],
   ([faceEnabled, length], [prevFace, prevLength]) => {
     if (!faceEnabled) return;
     if (length <= 0) return;
@@ -6271,7 +6258,7 @@ watch(
 );
 
 watch(
-  [() => props.showDetections, () => allGridImages.value.length],
+  [() => gridStore.showDetections, () => allGridImages.value.length],
   ([detEnabled, length], [prevDet, prevLength]) => {
     if (!detEnabled) return;
     if (length <= 0) return;
@@ -6371,7 +6358,7 @@ const emptyStateAlt = computed(() => {
 });
 
 const isDarkThemeActive = computed(() => {
-  const mode = String(props.themeMode || "light").toLowerCase();
+  const mode = String(userPrefsStore.themeMode || "light").toLowerCase();
   if (mode === "dark") return true;
   if (mode === "light") return false;
   if (mode === "system") {
@@ -6598,14 +6585,14 @@ async function fetchThumbnailsBatch(start, end, meta = {}) {
         }
         gridImg.faces =
           thumbObj && Array.isArray(thumbObj.faces) ? thumbObj.faces : [];
-        if (props.showFaceBboxes && gridImg.faces.length) {
+        if (gridStore.showFaceBboxes && gridImg.faces.length) {
           overlayNeedsRedraw = true;
         }
         gridImg.detections =
           thumbObj && Array.isArray(thumbObj.detections)
             ? thumbObj.detections
             : [];
-        if (props.showDetections && gridImg.detections.length) {
+        if (gridStore.showDetections && gridImg.detections.length) {
           overlayNeedsRedraw = true;
         }
         gridImg.penalised_tags =
@@ -7175,7 +7162,7 @@ function updateDescriptionForImage(imageId, description) {
 // ============================================================
 
 watch(
-  () => props.thumbnailSize,
+  () => gridStore.thumbnailSize,
   () => {
     // Recalculate visibleStart and visibleEnd after rowHeight update
     nextTick(() => {
@@ -7190,7 +7177,7 @@ watch(
       if (!el) return;
       let cardHeight = rowHeight.value;
       const scrollTop = el.scrollTop;
-      const cols = props.columns;
+      const cols = gridStore.columns;
       // First visible row (may be partially visible)
       const firstVisibleRow = scrollTop / cardHeight;
       // Last visible row (may be partially visible)
@@ -7350,7 +7337,7 @@ function gridItemTopOffset(index) {
     const top = layout.rowOffsets[row];
     return typeof top === "number" ? top : null;
   }
-  const cols = Math.max(1, props.columns || 1);
+  const cols = Math.max(1, gridStore.columns || 1);
   return Math.floor(index / cols) * rowHeight.value;
 }
 

--- a/frontend/src/components/views/ImageGridEmptyScrapheapFromSidebar.test.js
+++ b/frontend/src/components/views/ImageGridEmptyScrapheapFromSidebar.test.js
@@ -21,6 +21,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
+import { useSelectionStore } from "../../stores/useSelectionStore.js";
+import { useProjectStore } from "../../stores/useProjectStore.js";
+import { useSortStore } from "../../stores/useSortStore.js";
 import { ref, computed, nextTick } from "vue";
 
 const apiGet = vi.fn();
@@ -106,7 +109,25 @@ function previewCalls() {
   );
 }
 
-function mountGrid(props = {}) {
+// Selection, project and sort state live in the stores now; the old
+// `mountGrid({ selectedCharacter: ... })` prop overrides write them instead.
+function mountGrid(state = {}) {
+  const selectionStore = useSelectionStore();
+  const projectStore = useProjectStore();
+  const sortStore = useSortStore();
+  selectionStore.selectedCharacter = ALL_PICTURES_ID;
+  selectionStore.selectedSet = null;
+  selectionStore.selectedSetIds = [];
+  projectStore.projectViewMode = "global";
+  projectStore.selectedProjectId = null;
+  sortStore.selectedSort = "DATE";
+  sortStore.selectedDescending = true;
+  for (const [key, value] of Object.entries(state)) {
+    if (key in projectStore) projectStore[key] = value;
+    else if (key in sortStore) sortStore[key] = value;
+    else selectionStore[key] = value;
+  }
+
   return mount(ImageGrid, {
     shallow: true,
     global: {
@@ -114,20 +135,7 @@ function mountGrid(props = {}) {
         compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
       },
     },
-    props: {
-      backendUrl: "/api/v1",
-      allPicturesId: ALL_PICTURES_ID,
-      unassignedPicturesId: "UNASSIGNED",
-      scrapheapPicturesId: SCRAPHEAP_PICTURES_ID,
-      selectedCharacter: ALL_PICTURES_ID,
-      selectedSet: null,
-      selectedSetIds: [],
-      projectViewMode: "global",
-      selectedProjectId: null,
-      selectedSort: "DATE",
-      selectedDescending: true,
-      ...props,
-    },
+    props: { backendUrl: "/api/v1" },
   });
 }
 
@@ -143,7 +151,7 @@ function mountGrid(props = {}) {
  */
 async function emptyScrapheapFromSidebar(wrapper) {
   apiGet.mockReturnValue(new Promise(() => {}));
-  await wrapper.setProps({ selectedCharacter: SCRAPHEAP_PICTURES_ID });
+  useSelectionStore().selectedCharacter = SCRAPHEAP_PICTURES_ID;
   await nextTick();
   wrapper.vm.confirmEmptyScrapheap();
   await nextTick();

--- a/frontend/src/components/views/ImageGridProjectAssignRefresh.test.js
+++ b/frontend/src/components/views/ImageGridProjectAssignRefresh.test.js
@@ -17,6 +17,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
+import { useSelectionStore } from "../../stores/useSelectionStore.js";
+import { useProjectStore } from "../../stores/useProjectStore.js";
+import { useSortStore } from "../../stores/useSortStore.js";
 import { ref, computed } from "vue";
 
 // One seam for every network call: all `src/api/*` modules go through this
@@ -105,7 +108,25 @@ function gridQueryCount() {
   }).length;
 }
 
-function mountGrid(props = {}) {
+// Selection, project and sort state live in the stores now; the old
+// `mountGrid({ projectViewMode: ... })` prop overrides write them instead.
+function mountGrid(state = {}) {
+  const selectionStore = useSelectionStore();
+  const projectStore = useProjectStore();
+  const sortStore = useSortStore();
+  selectionStore.selectedCharacter = ALL_PICTURES_ID;
+  selectionStore.selectedSet = null;
+  selectionStore.selectedSetIds = [];
+  projectStore.projectViewMode = "global";
+  projectStore.selectedProjectId = null;
+  sortStore.selectedSort = "DATE";
+  sortStore.selectedDescending = true;
+  for (const [key, value] of Object.entries(state)) {
+    if (key in projectStore) projectStore[key] = value;
+    else if (key in sortStore) sortStore[key] = value;
+    else selectionStore[key] = value;
+  }
+
   return mount(ImageGrid, {
     shallow: true,
     global: {
@@ -116,20 +137,7 @@ function mountGrid(props = {}) {
         compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
       },
     },
-    props: {
-      backendUrl: "/api/v1",
-      allPicturesId: ALL_PICTURES_ID,
-      unassignedPicturesId: "UNASSIGNED",
-      scrapheapPicturesId: "SCRAPHEAP",
-      selectedCharacter: ALL_PICTURES_ID,
-      selectedSet: null,
-      selectedSetIds: [],
-      projectViewMode: "global",
-      selectedProjectId: null,
-      selectedSort: "DATE",
-      selectedDescending: true,
-      ...props,
-    },
+    props: { backendUrl: "/api/v1" },
   });
 }
 

--- a/frontend/src/composables/useGridDragDrop.js
+++ b/frontend/src/composables/useGridDragDrop.js
@@ -5,6 +5,8 @@ import {
   isVideo,
 } from "../utils/media.js";
 import { useNoticeStore } from "../stores/useNoticeStore";
+import { useSelectionStore } from "../stores/useSelectionStore";
+import { useProjectStore } from "../stores/useProjectStore";
 
 /**
  * Manages all drag-and-drop interactions in the image grid:
@@ -36,6 +38,8 @@ export function useGridDragDrop(
   },
   props,
 ) {
+  const selectionStore = useSelectionStore();
+  const projectStore = useProjectStore();
   // Drag/drop failures are reported through the notice surface rather than a
   // blocking native alert() (docs/design/notice-surface.md §1). Called during
   // the host component's setup, so Pinia is active.
@@ -191,10 +195,10 @@ export function useGridDragDrop(
     if (imageImporterRef.value && files.length) {
       imageImporterRef.value.startImport(files, {
         backendUrl: props.backendUrl,
-        selectedCharacterId: props.selectedCharacter,
+        selectedCharacterId: selectionStore.selectedCharacter,
         allPicturesId: "ALL",
         unassignedPicturesId: "UNASSIGNED",
-        projectId: props.selectedProjectId ?? null,
+        projectId: projectStore.selectedProjectId ?? null,
       });
     }
   }
@@ -209,9 +213,7 @@ export function useGridDragDrop(
     );
     const height = Math.max(
       1,
-      Math.round(
-        rect?.height || element.clientHeight || element.height || 90,
-      ),
+      Math.round(rect?.height || element.clientHeight || element.height || 90),
     );
     const computed =
       typeof window !== "undefined" && element instanceof Element

--- a/frontend/src/composables/useGridFetch.js
+++ b/frontend/src/composables/useGridFetch.js
@@ -21,6 +21,7 @@ import {
 } from "../utils/media.js";
 import { debounce } from "lodash-es";
 import { useFilterStore } from "../stores/useFilterStore";
+import { useGridStore } from "../stores/useGridStore";
 import { useSelectionStore } from "../stores/useSelectionStore";
 import { useUserPrefsStore } from "../stores/useUserPrefsStore";
 
@@ -30,7 +31,8 @@ const LIKENESS_GROUPS_SORT_KEY = "LIKENESS_GROUPS";
  * Manages grid image fetching: fetch state, URL query building, and the
  * debounced fetch trigger.
  *
- * The filter facets of the query come from the stores directly (Phase 3);
+ * The filter facets of the query and the grid geometry come from the stores
+ * directly (Phase 3);
  * `props` still supplies the selection/sort/project fields that have not been
  * migrated yet.
  *
@@ -92,6 +94,7 @@ export function useGridFetch(
   },
 ) {
   const filterStore = useFilterStore();
+  const gridStore = useGridStore();
   const selectionStore = useSelectionStore();
   const userPrefsStore = useUserPrefsStore();
 
@@ -731,12 +734,12 @@ export function useGridFetch(
         // than rowHeight?.value, which may still hold the initial thumbnailSize
         // estimate when this runs (DOM measurement via updateRowHeightFromGrid
         // happens asynchronously and may not have fired yet).
-        const _fbCols = props.columns || 1;
+        const _fbCols = gridStore.columns || 1;
         const _fbViewH = scrollWrapper.value?.clientHeight || 0;
         const _fbViewW = scrollWrapper.value?.clientWidth || 0;
         const _fbCellH =
           _fbViewW > 0
-            ? Math.round(_fbViewW / _fbCols) + (props.compactMode ? 0 : 24)
+            ? Math.round(_fbViewW / _fbCols) + (gridStore.compactMode ? 0 : 24)
             : rowHeight?.value > 0
               ? rowHeight.value
               : 200;
@@ -986,7 +989,7 @@ export function useGridFetch(
 
         // 2. Pre-build placeholder grid — scroll area immediately reflects full size.
         const placeholderStartedAt = getNowMs();
-        const cols = props.columns || 1;
+        const cols = gridStore.columns || 1;
         // Compute window count from actual viewport capacity so visibleEnd covers
         // all initially visible items even when the viewport shows more than VIEW_WINDOW.
         // Derive cell height from clientWidth/cols (square thumbnails) rather than
@@ -996,12 +999,12 @@ export function useGridFetch(
         const _fastViewH = scrollWrapper.value?.clientHeight || 0;
         const _effectiveRowHeight0 =
           _fastViewW > 0
-            ? Math.round(_fastViewW / cols) + (props.compactMode ? 0 : 24)
+            ? Math.round(_fastViewW / cols) + (gridStore.compactMode ? 0 : 24)
             : rowHeight?.value > 0
               ? rowHeight.value
               : Math.round(
-                  Math.min(384, Math.max(128, props.thumbnailSize || 128)) +
-                    (props.compactMode ? 0 : 24),
+                  Math.min(384, Math.max(128, gridStore.thumbnailSize || 128)) +
+                    (gridStore.compactMode ? 0 : 24),
                 );
         const _viewportItemCount0 =
           _fastViewH > 0 && _effectiveRowHeight0 > 0
@@ -1279,7 +1282,7 @@ export function useGridFetch(
       if (isSetOverlapView.value) {
         totalCurrentCategoryCount.value = newImages.length;
       }
-      const cols = props.columns || 1;
+      const cols = gridStore.columns || 1;
       // Compute window count from actual viewport capacity so visibleEnd covers
       // all initially visible items even when the viewport shows more than VIEW_WINDOW.
       // Derive cell height from clientWidth/cols (square thumbnails) rather than
@@ -1289,12 +1292,12 @@ export function useGridFetch(
       const _slowViewH = scrollWrapper.value?.clientHeight || 0;
       const _effectiveRowHeight1 =
         _slowViewW > 0
-          ? Math.round(_slowViewW / cols) + (props.compactMode ? 0 : 24)
+          ? Math.round(_slowViewW / cols) + (gridStore.compactMode ? 0 : 24)
           : rowHeight?.value > 0
             ? rowHeight.value
             : Math.round(
-                Math.min(384, Math.max(128, props.thumbnailSize || 128)) +
-                  (props.compactMode ? 0 : 24),
+                Math.min(384, Math.max(128, gridStore.thumbnailSize || 128)) +
+                  (gridStore.compactMode ? 0 : 24),
               );
       const _viewportItemCount1 =
         _slowViewH > 0 && _effectiveRowHeight1 > 0

--- a/frontend/src/composables/useGridFetch.js
+++ b/frontend/src/composables/useGridFetch.js
@@ -24,6 +24,14 @@ import { useFilterStore } from "../stores/useFilterStore";
 import { useGridStore } from "../stores/useGridStore";
 import { useSelectionStore } from "../stores/useSelectionStore";
 import { useUserPrefsStore } from "../stores/useUserPrefsStore";
+import { useSortStore } from "../stores/useSortStore";
+import { useProjectStore } from "../stores/useProjectStore";
+import { useSearchStore } from "../stores/useSearchStore";
+import {
+  ALL_PICTURES_ID,
+  SCRAPHEAP_PICTURES_ID,
+  UNASSIGNED_PICTURES_ID,
+} from "../stores/useViewStore";
 
 const LIKENESS_GROUPS_SORT_KEY = "LIKENESS_GROUPS";
 
@@ -93,6 +101,9 @@ export function useGridFetch(
     onGridFetchDone,
   },
 ) {
+  const sortStore = useSortStore();
+  const projectStore = useProjectStore();
+  const searchStore = useSearchStore();
   const filterStore = useFilterStore();
   const gridStore = useGridStore();
   const selectionStore = useSelectionStore();
@@ -137,46 +148,47 @@ export function useGridFetch(
   }
 
   function getActiveSortKey() {
-    if (typeof props.selectedSort !== "string") return "";
-    return props.selectedSort.trim().toUpperCase();
+    if (typeof sortStore.selectedSort !== "string") return "";
+    return sortStore.selectedSort.trim().toUpperCase();
   }
 
   function buildGridFetchKey() {
-    const selectedSetIds = Array.isArray(props.selectedSetIds)
-      ? props.selectedSetIds
+    const selectedSetIds = Array.isArray(selectionStore.selectedSetIds)
+      ? selectionStore.selectedSetIds
           .map((id) => Number(id))
           .filter((id) => Number.isFinite(id) && id > 0)
           .sort((a, b) => a - b)
       : [];
     const selectedCharacterIds = normalizedSelectedCharacterIds.value;
     return JSON.stringify({
-      selectedCharacter: props.selectedCharacter ?? null,
+      selectedCharacter: selectionStore.selectedCharacter ?? null,
       selectedCharacterIds,
       isMultiCharacterView: selectedCharacterIds.length > 1,
       characterMultiMode:
         selectedCharacterIds.length > 1
-          ? (props.characterMultiMode ?? "union")
+          ? (selectionStore.characterMultiMode ?? "union")
           : null,
-      selectedSet: props.selectedSet ?? null,
+      selectedSet: selectionStore.selectedSet ?? null,
       selectedSetIds,
       isSetOverlapView: selectedSetIds.length > 1,
       setMultiMode:
         selectedSetIds.length > 1
-          ? (props.setMultiMode ?? "intersection")
+          ? (selectionStore.setMultiMode ?? "intersection")
           : null,
       setDifferenceBaseId:
-        selectedSetIds.length > 1 && props.setMultiMode === "difference"
-          ? (props.setDifferenceBaseId ?? null)
+        selectedSetIds.length > 1 &&
+        selectionStore.setMultiMode === "difference"
+          ? (selectionStore.setDifferenceBaseId ?? null)
           : null,
-      projectViewMode: props.projectViewMode ?? "global",
-      selectedProjectId: props.selectedProjectId ?? null,
-      searchQuery: props.searchQuery ?? "",
-      selectedSort: props.selectedSort ?? "",
-      selectedDescending: props.selectedDescending ?? null,
-      stackThreshold: props.stackThreshold ?? null,
+      projectViewMode: projectStore.projectViewMode ?? "global",
+      selectedProjectId: projectStore.selectedProjectId ?? null,
+      searchQuery: searchStore.searchQuery ?? "",
+      selectedSort: sortStore.selectedSort ?? "",
+      selectedDescending: sortStore.selectedDescending ?? null,
+      stackThreshold: sortStore.stackThreshold ?? null,
       mediaTypeFilter: filterStore.mediaTypeFilter ?? "all",
       impossibleSources: filterStore.impossibleSources ?? [],
-      similarityCharacter: props.similarityCharacter ?? null,
+      similarityCharacter: sortStore.selectedSimilarityCharacter ?? null,
       comfyuiModelFilter: filterStore.comfyuiModelFilter ?? [],
       comfyuiLoraFilter: filterStore.comfyuiLoraFilter ?? [],
       referenceFolderIdFilter: referenceFolderIdFilter.value ?? null,
@@ -203,18 +215,24 @@ export function useGridFetch(
         for (const setId of normalizedSelectedSetIds.value) {
           params.append("set_ids", String(setId));
         }
-        params.append("set_mode", props.setMultiMode ?? "intersection");
+        params.append(
+          "set_mode",
+          selectionStore.setMultiMode ?? "intersection",
+        );
         if (
-          props.setMultiMode === "difference" &&
-          props.setDifferenceBaseId != null
+          selectionStore.setMultiMode === "difference" &&
+          selectionStore.setDifferenceBaseId != null
         ) {
-          params.append("base_set_id", String(props.setDifferenceBaseId));
+          params.append(
+            "base_set_id",
+            String(selectionStore.setDifferenceBaseId),
+          );
         }
-        if (props.projectViewMode === "project") {
+        if (projectStore.projectViewMode === "project") {
           // Derive effective project_id from per-set data; skip when sets span multiple projects.
           const pidSet = new Set(
             normalizedSelectedSetIds.value.map(
-              (id) => props.setProjectIds?.[id] ?? null,
+              (id) => projectStore.setProjectIds?.[id] ?? null,
             ),
           );
           if (pidSet.size === 1) {
@@ -224,11 +242,11 @@ export function useGridFetch(
         }
       } else if (primarySelectedSetId.value != null) {
         params.append("set_id", String(primarySelectedSetId.value));
-        if (props.projectViewMode === "project") {
+        if (projectStore.projectViewMode === "project") {
           params.append(
             "project_id",
-            props.selectedProjectId != null
-              ? props.selectedProjectId
+            projectStore.selectedProjectId != null
+              ? projectStore.selectedProjectId
               : "UNASSIGNED",
           );
         }
@@ -237,13 +255,16 @@ export function useGridFetch(
       for (const charId of normalizedSelectedCharacterIds.value) {
         params.append("character_ids", String(charId));
       }
-      params.append("character_mode", props.characterMultiMode ?? "union");
-      if (props.projectViewMode === "project") {
+      params.append(
+        "character_mode",
+        selectionStore.characterMultiMode ?? "union",
+      );
+      if (projectStore.projectViewMode === "project") {
         // Derive effective project_id from per-character data; if all chars share
         // the same project use it, if they span multiple projects skip the filter.
         const pidSet = new Set(
           normalizedSelectedCharacterIds.value.map(
-            (id) => props.characterProjectIds?.[id] ?? null,
+            (id) => projectStore.characterProjectIds?.[id] ?? null,
           ),
         );
         if (pidSet.size === 1) {
@@ -252,45 +273,45 @@ export function useGridFetch(
         }
       }
     } else if (
-      props.selectedCharacter !== undefined &&
-      props.selectedCharacter !== null &&
-      props.selectedCharacter !== "" &&
-      props.selectedCharacter !== props.allPicturesId
+      selectionStore.selectedCharacter !== undefined &&
+      selectionStore.selectedCharacter !== null &&
+      selectionStore.selectedCharacter !== "" &&
+      selectionStore.selectedCharacter !== ALL_PICTURES_ID
     ) {
-      if (props.selectedCharacter === String(props.scrapheapPicturesId)) {
+      if (selectionStore.selectedCharacter === String(SCRAPHEAP_PICTURES_ID)) {
         params.append("only_deleted", "true");
       } else {
-        params.append("character_id", props.selectedCharacter);
-        if (props.projectViewMode === "project") {
+        params.append("character_id", selectionStore.selectedCharacter);
+        if (projectStore.projectViewMode === "project") {
           params.append(
             "project_id",
-            props.selectedProjectId != null
-              ? props.selectedProjectId
+            projectStore.selectedProjectId != null
+              ? projectStore.selectedProjectId
               : "UNASSIGNED",
           );
         }
       }
     } else if (
-      props.selectedCharacter === props.allPicturesId &&
+      selectionStore.selectedCharacter === ALL_PICTURES_ID &&
       filterStore.unassignedOnlyFilter
     ) {
-      params.append("character_id", props.unassignedPicturesId);
-      if (props.projectViewMode === "project") {
+      params.append("character_id", UNASSIGNED_PICTURES_ID);
+      if (projectStore.projectViewMode === "project") {
         params.append(
           "project_id",
-          props.selectedProjectId != null
-            ? props.selectedProjectId
+          projectStore.selectedProjectId != null
+            ? projectStore.selectedProjectId
             : "UNASSIGNED",
         );
       }
     } else if (
-      props.selectedCharacter === props.allPicturesId &&
-      props.projectViewMode === "project"
+      selectionStore.selectedCharacter === ALL_PICTURES_ID &&
+      projectStore.projectViewMode === "project"
     ) {
       params.append(
         "project_id",
-        props.selectedProjectId != null
-          ? props.selectedProjectId
+        projectStore.selectedProjectId != null
+          ? projectStore.selectedProjectId
           : "UNASSIGNED",
       );
     }
@@ -312,26 +333,29 @@ export function useGridFetch(
     const params = new URLSearchParams();
     _appendSelectionParams(params);
     if (
-      props.selectedSort === "CHARACTER_LIKENESS" &&
-      props.similarityCharacter
+      sortStore.selectedSort === "CHARACTER_LIKENESS" &&
+      sortStore.selectedSimilarityCharacter
     ) {
-      params.append("reference_character_id", props.similarityCharacter);
+      params.append(
+        "reference_character_id",
+        sortStore.selectedSimilarityCharacter,
+      );
     }
-    if (props.searchQuery && props.searchQuery.trim()) {
-      params.append("query", props.searchQuery.trim());
+    if (searchStore.searchQuery && searchStore.searchQuery.trim()) {
+      params.append("query", searchStore.searchQuery.trim());
     } else {
-      if (props.selectedSort && props.selectedSort.trim()) {
-        params.append("sort", props.selectedSort.trim());
+      if (sortStore.selectedSort && sortStore.selectedSort.trim()) {
+        params.append("sort", sortStore.selectedSort.trim());
       }
-      if (typeof props.selectedDescending === "boolean") {
+      if (typeof sortStore.selectedDescending === "boolean") {
         params.append(
           "descending",
-          props.selectedDescending ? "true" : "false",
+          sortStore.selectedDescending ? "true" : "false",
         );
       } else {
         console.warn(
           "[ImageGrid.vue] selectedDescending is not boolean, skipping param. Type:",
-          typeof props.selectedDescending,
+          typeof sortStore.selectedDescending,
         );
       }
     }
@@ -532,9 +556,9 @@ export function useGridFetch(
         loadId,
         fetchKey,
         force,
-        selectedSort: props.selectedSort ?? null,
-        selectedCharacter: props.selectedCharacter ?? null,
-        selectedSet: props.selectedSet ?? null,
+        selectedSort: sortStore.selectedSort ?? null,
+        selectedCharacter: selectionStore.selectedCharacter ?? null,
+        selectedSet: selectionStore.selectedSet ?? null,
         visibleStart: visibleStart.value,
         visibleEnd: visibleEnd.value,
       });
@@ -551,8 +575,9 @@ export function useGridFetch(
     try {
       let images = [];
 
-      const _hasSearch = !!props.searchQuery?.trim();
-      const _isLikenessSort = props.selectedSort === LIKENESS_GROUPS_SORT_KEY;
+      const _hasSearch = !!searchStore.searchQuery?.trim();
+      const _isLikenessSort =
+        sortStore.selectedSort === LIKENESS_GROUPS_SORT_KEY;
       const _hasReverseImageSearch =
         !_hasSearch && !!reverseImageSearchPictureIds?.value?.length;
       const _hasCharacterFaceSearch =
@@ -567,7 +592,7 @@ export function useGridFetch(
 
       if (_isLikenessSort) {
         fetchMode = "likeness-groups";
-        const threshold = getStackThreshold(props.stackThreshold);
+        const threshold = getStackThreshold(sortStore.stackThreshold);
         const likenessGroupParams = buildLikenessGroupQueryParams();
         const data = await getLikenessGroups(threshold, likenessGroupParams, {
           baseUrl: props.backendUrl,
@@ -694,7 +719,7 @@ export function useGridFetch(
         fetchMode = "text-search";
         // Use /pictures/search endpoint for text search
         const params = buildPictureIdsQueryParams();
-        images = await searchPictures(props.searchQuery.trim(), {
+        images = await searchPictures(searchStore.searchQuery.trim(), {
           query: params,
           baseUrl: props.backendUrl,
         });
@@ -721,7 +746,7 @@ export function useGridFetch(
         //   3. First batch (visible area) + last batch (END cells) in parallel
         //   4. Background stream fills the middle at BG_BATCH rows per request
         const _charIds = normalizedSelectedCharacterIds.value;
-        const _selChar = props.selectedCharacter;
+        const _selChar = selectionStore.selectedCharacter;
         if (isSortedFetch && options?.showProgress === true) {
           completeSmartScoreProgress(loadId, 0, true);
         }
@@ -753,16 +778,17 @@ export function useGridFetch(
         // is not always count-neutral: CHARACTER_LIKENESS joins through Face and
         // changes the row set, so the count must run over the same query as the
         // stream or the placeholder grid ends up larger than the stream can fill.
-        const _sort = props.selectedSort?.trim();
+        const _sort = sortStore.selectedSort?.trim();
         const _desc =
-          typeof props.selectedDescending === "boolean"
-            ? props.selectedDescending
+          typeof sortStore.selectedDescending === "boolean"
+            ? sortStore.selectedDescending
             : true;
         // For CHARACTER_LIKENESS the backend also needs reference_character_id in
         // both the stream and count URLs — the reference determines the row set.
         const _refCharSuffix =
-          _sort === "CHARACTER_LIKENESS" && props.similarityCharacter
-            ? `&reference_character_id=${encodeURIComponent(props.similarityCharacter)}`
+          _sort === "CHARACTER_LIKENESS" &&
+          sortStore.selectedSimilarityCharacter
+            ? `&reference_character_id=${encodeURIComponent(sortStore.selectedSimilarityCharacter)}`
             : "";
         const _sortSuffix = _sort
           ? `&sort=${encodeURIComponent(_sort)}&descending=${_desc}${_refCharSuffix}`
@@ -775,17 +801,23 @@ export function useGridFetch(
             for (const setId of normalizedSelectedSetIds.value) {
               _charP.append("set_ids", String(setId));
             }
-            _charP.set("set_mode", props.setMultiMode ?? "intersection");
+            _charP.set(
+              "set_mode",
+              selectionStore.setMultiMode ?? "intersection",
+            );
             if (
-              props.setMultiMode === "difference" &&
-              props.setDifferenceBaseId != null
+              selectionStore.setMultiMode === "difference" &&
+              selectionStore.setDifferenceBaseId != null
             ) {
-              _charP.set("base_set_id", String(props.setDifferenceBaseId));
+              _charP.set(
+                "base_set_id",
+                String(selectionStore.setDifferenceBaseId),
+              );
             }
-            if (props.projectViewMode === "project") {
+            if (projectStore.projectViewMode === "project") {
               const _pidSet = new Set(
                 normalizedSelectedSetIds.value.map(
-                  (id) => props.setProjectIds?.[id] ?? null,
+                  (id) => projectStore.setProjectIds?.[id] ?? null,
                 ),
               );
               if (_pidSet.size === 1) {
@@ -798,22 +830,27 @@ export function useGridFetch(
             }
           } else if (primarySelectedSetId.value != null) {
             _charP.set("set_id", String(primarySelectedSetId.value));
-            if (props.projectViewMode === "project") {
+            if (projectStore.projectViewMode === "project") {
               _charP.set(
                 "project_id",
-                props.selectedProjectId != null
-                  ? String(props.selectedProjectId)
+                projectStore.selectedProjectId != null
+                  ? String(projectStore.selectedProjectId)
                   : "UNASSIGNED",
               );
             }
           }
         } else if (_charIds.length > 1) {
           for (const id of _charIds) _charP.append("character_ids", String(id));
-          _charP.set("character_mode", props.characterMultiMode ?? "union");
+          _charP.set(
+            "character_mode",
+            selectionStore.characterMultiMode ?? "union",
+          );
           // Only apply project filter when all selected characters share the same project.
-          if (props.projectViewMode === "project") {
+          if (projectStore.projectViewMode === "project") {
             const _pidSet = new Set(
-              _charIds.map((id) => props.characterProjectIds?.[id] ?? null),
+              _charIds.map(
+                (id) => projectStore.characterProjectIds?.[id] ?? null,
+              ),
             );
             if (_pidSet.size === 1) {
               const _pid = [..._pidSet][0];
@@ -823,40 +860,40 @@ export function useGridFetch(
               );
             }
           }
-        } else if (_selChar === String(props.scrapheapPicturesId)) {
+        } else if (_selChar === String(SCRAPHEAP_PICTURES_ID)) {
           _charP.set("only_deleted", "true");
         } else if (
           _selChar != null &&
           _selChar !== "" &&
-          _selChar !== props.allPicturesId
+          _selChar !== ALL_PICTURES_ID
         ) {
           _charP.set("character_id", String(_selChar));
-          if (props.projectViewMode === "project") {
+          if (projectStore.projectViewMode === "project") {
             _charP.set(
               "project_id",
-              props.selectedProjectId != null
-                ? String(props.selectedProjectId)
+              projectStore.selectedProjectId != null
+                ? String(projectStore.selectedProjectId)
                 : "UNASSIGNED",
             );
           }
         } else if (
-          _selChar === props.allPicturesId &&
+          _selChar === ALL_PICTURES_ID &&
           filterStore.unassignedOnlyFilter
         ) {
-          _charP.set("character_id", String(props.unassignedPicturesId));
-          if (props.projectViewMode === "project") {
+          _charP.set("character_id", String(UNASSIGNED_PICTURES_ID));
+          if (projectStore.projectViewMode === "project") {
             _charP.set(
               "project_id",
-              props.selectedProjectId != null
-                ? String(props.selectedProjectId)
+              projectStore.selectedProjectId != null
+                ? String(projectStore.selectedProjectId)
                 : "UNASSIGNED",
             );
           }
-        } else if (props.projectViewMode === "project") {
+        } else if (projectStore.projectViewMode === "project") {
           _charP.set(
             "project_id",
-            props.selectedProjectId != null
-              ? String(props.selectedProjectId)
+            projectStore.selectedProjectId != null
+              ? String(projectStore.selectedProjectId)
               : "UNASSIGNED",
           );
         }
@@ -1394,7 +1431,7 @@ export function useGridFetch(
   async function fetchAllPicturesCount() {
     try {
       const data = await getCharacterSummary(
-        props.allPicturesId,
+        ALL_PICTURES_ID,
         userPrefsStore.applyTagFilter ? { apply_tag_filter: true } : undefined,
         { baseUrl: props.backendUrl },
       );
@@ -1407,9 +1444,9 @@ export function useGridFetch(
       // The scoped count comes from one of two summary resources; the ladder
       // below picks which one and under what id, then a single call runs it.
       let summaryKind = "character";
-      let summaryId = props.allPicturesId;
+      let summaryId = ALL_PICTURES_ID;
       let summaryProjectId = null;
-      const selectedCharacter = String(props.selectedCharacter ?? "");
+      const selectedCharacter = String(selectionStore.selectedCharacter ?? "");
       if (isSetOverlapView.value) {
         totalCurrentCategoryCount.value =
           Number(allGridImages.value.length) || 0;
@@ -1438,21 +1475,21 @@ export function useGridFetch(
           Number(selectedSet?.picture_count) || 0;
         return;
       }
-      const inProjectView = props.projectViewMode === "project";
+      const inProjectView = projectStore.projectViewMode === "project";
       const activeProjectId =
-        props.selectedProjectId != null
-          ? props.selectedProjectId
+        projectStore.selectedProjectId != null
+          ? projectStore.selectedProjectId
           : "UNASSIGNED";
-      if (selectedCharacter === String(props.allPicturesId)) {
+      if (selectedCharacter === String(ALL_PICTURES_ID)) {
         if (inProjectView) {
           summaryKind = "project";
           summaryId = activeProjectId;
         }
-      } else if (selectedCharacter === String(props.unassignedPicturesId)) {
-        summaryId = props.unassignedPicturesId;
+      } else if (selectedCharacter === String(UNASSIGNED_PICTURES_ID)) {
+        summaryId = UNASSIGNED_PICTURES_ID;
         if (inProjectView) summaryProjectId = activeProjectId;
-      } else if (selectedCharacter === String(props.scrapheapPicturesId)) {
-        summaryId = props.scrapheapPicturesId;
+      } else if (selectedCharacter === String(SCRAPHEAP_PICTURES_ID)) {
+        summaryId = SCRAPHEAP_PICTURES_ID;
       } else if (selectedCharacter && !hasSetSelection.value) {
         summaryId = selectedCharacter;
         if (inProjectView) summaryProjectId = activeProjectId;

--- a/frontend/src/composables/useGridFetch.test.js
+++ b/frontend/src/composables/useGridFetch.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ref, reactive } from "vue";
 import { setActivePinia, createPinia } from "pinia";
+import { useSortStore } from "../stores/useSortStore.js";
 import { useGridFetch } from "./useGridFetch.js";
 import { getPictureCount, streamPictures } from "../api/pictures";
 
@@ -19,14 +20,15 @@ vi.mock("../api/pictures", () => ({
 
 // Build a minimal harness for useGridFetch. Covers the overlay-defer path
 // (returns before any network call) and the streaming path (count + stream
-// mocked above). `propOverrides` merges extra props into the harness props.
+// mocked above). Sort, selection and filter state come from the stores;
+// `storeOverrides` writes them.
 function makeHarness({
   overlayOpen = false,
   selectedSort = "DATE_TAKEN",
-  propOverrides = {},
+  storeOverrides = {},
 } = {}) {
-  // The composable reads the filter facets of the query straight from the
-  // stores, so every harness needs a live Pinia.
+  // The composable reads the query's filter, sort and selection facets
+  // straight from the stores, so every harness needs a live Pinia.
   setActivePinia(createPinia());
   const startSmartScoreProgress = vi.fn();
   const completeSmartScoreProgress = vi.fn();
@@ -63,14 +65,13 @@ function makeHarness({
     faceLikenessSearchFaceId: ref(null),
   };
 
-  const props = reactive({
-    backendUrl: "http://test",
-    selectedSort,
-    selectedCharacter: null,
-    selectedSet: null,
-    searchQuery: "",
-    ...propOverrides,
-  });
+  const sortStore = useSortStore();
+  sortStore.selectedSort = selectedSort;
+  for (const [key, value] of Object.entries(storeOverrides)) {
+    sortStore[key] = value;
+  }
+
+  const props = reactive({ backendUrl: "http://test" });
 
   const callbacks = {
     collapseStackImages: (x) => x,
@@ -121,7 +122,10 @@ describe("useGridFetch streaming path", () => {
 
     const { grid } = makeHarness({
       selectedSort: "CHARACTER_LIKENESS",
-      propOverrides: { similarityCharacter: "7", selectedDescending: true },
+      storeOverrides: {
+        selectedSimilarityCharacter: "7",
+        selectedDescending: true,
+      },
     });
 
     await grid.fetchAllGridImages({ force: true });
@@ -144,7 +148,10 @@ describe("useGridFetch streaming path", () => {
 
     const { grid, refs } = makeHarness({
       selectedSort: "CHARACTER_LIKENESS",
-      propOverrides: { similarityCharacter: "7", selectedDescending: true },
+      storeOverrides: {
+        selectedSimilarityCharacter: "7",
+        selectedDescending: true,
+      },
     });
 
     await grid.fetchAllGridImages({ force: true });

--- a/frontend/src/composables/useGridKeyboardNav.js
+++ b/frontend/src/composables/useGridKeyboardNav.js
@@ -7,6 +7,7 @@ import {
   JUSTIFIED_ROW_GAP,
 } from "./useJustifiedLayout.js";
 import { useGridStore } from "../stores/useGridStore";
+import { useSearchStore } from "../stores/useSearchStore";
 
 /**
  * Manages keyboard navigation and keyboard-driven actions for the image grid.
@@ -57,6 +58,7 @@ export function useGridKeyboardNav(
     setScore,
   },
 ) {
+  const searchStore = useSearchStore();
   const gridStore = useGridStore();
   // ── Scrapheap ghosts ────────────────────────────────────────────────────
   // A ghosted tile is on screen but inert: it is already in the Scrapheap and
@@ -86,7 +88,9 @@ export function useGridKeyboardNav(
 
   /** Drop ghosted ids from a selection about to be committed. */
   function withoutGhosts(indexedIds) {
-    return indexedIds.filter(({ index }) => !isGhosted(index)).map(({ id }) => id);
+    return indexedIds
+      .filter(({ index }) => !isGhosted(index))
+      .map(({ id }) => id);
   }
 
   /** `[start, end]` of `allGridImages` as selectable ids, ghosts skipped. */
@@ -150,7 +154,11 @@ export function useGridKeyboardNav(
       if (!(element instanceof HTMLElement)) return false;
       if (element.isContentEditable) return true;
       const tagName = element.tagName;
-      if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") {
+      if (
+        tagName === "INPUT" ||
+        tagName === "TEXTAREA" ||
+        tagName === "SELECT"
+      ) {
         return true;
       }
       if (element.getAttribute("role") === "textbox") return true;
@@ -184,7 +192,7 @@ export function useGridKeyboardNav(
       } else if (isMultiCharacterView.value || isSetOverlapView.value) {
         // No images selected — ESC closes the union/intersect/overlap bar
         emit("clear-multi-selection");
-      } else if (props.searchQuery && props.searchQuery.trim()) {
+      } else if (searchStore.searchQuery && searchStore.searchQuery.trim()) {
         // No selection active — ESC also clears search
         clearSearchQuery();
       } else {
@@ -251,7 +259,8 @@ export function useGridKeyboardNav(
             lastSelectedImageId != null
               ? allGridImages.value.findIndex(
                   (item) =>
-                    getPictureId(item?.id) === getPictureId(lastSelectedImageId),
+                    getPictureId(item?.id) ===
+                    getPictureId(lastSelectedImageId),
                 )
               : newIdx;
           const start = Math.min(anchorIndex, newIdx);

--- a/frontend/src/composables/useGridKeyboardNav.js
+++ b/frontend/src/composables/useGridKeyboardNav.js
@@ -6,6 +6,7 @@ import {
   verticalNeighborIndex,
   JUSTIFIED_ROW_GAP,
 } from "./useJustifiedLayout.js";
+import { useGridStore } from "../stores/useGridStore";
 
 /**
  * Manages keyboard navigation and keyboard-driven actions for the image grid.
@@ -56,6 +57,7 @@ export function useGridKeyboardNav(
     setScore,
   },
 ) {
+  const gridStore = useGridStore();
   // ── Scrapheap ghosts ────────────────────────────────────────────────────
   // A ghosted tile is on screen but inert: it is already in the Scrapheap and
   // is only being held there while its undo is one click away.
@@ -108,7 +110,7 @@ export function useGridKeyboardNav(
     if (scrollWrapper.value) {
       let newScrollTop = scrollWrapper.value.scrollTop;
       const total = allGridImages.value.length;
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       const totalRows = Math.ceil(total / cols);
       // Justified rows don't follow cols × rowHeight; use the packed model's
       // exact pixel height so End/PageDown reach the true bottom.
@@ -197,7 +199,7 @@ export function useGridKeyboardNav(
       event.preventDefault();
       const total = allGridImages.value.length;
       if (total === 0) return;
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       let newIdx = cursorIdx.value;
       // Which way the scan runs when the landing cell turns out to be a ghost.
       const travel =
@@ -272,7 +274,7 @@ export function useGridKeyboardNav(
       event.preventDefault();
       const total = allGridImages.value.length;
       if (total === 0) return;
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       const packedLayout = activeJustifiedLayout();
       let newIdx;
       if (packedLayout) {

--- a/frontend/src/composables/useGridKeyboardNav.test.js
+++ b/frontend/src/composables/useGridKeyboardNav.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ref } from "vue";
+import { setActivePinia, createPinia } from "pinia";
+import { useGridStore } from "../stores/useGridStore.js";
 
 // The composable imports the singleton apiClient for isReadOnly; mock it so no
 // real axios instance is constructed and read-only is deterministic.
@@ -59,7 +61,10 @@ function makeNav({
     setScore: vi.fn(),
   };
 
-  const props = { columns: 3, searchQuery: "" };
+  // The composable takes the column count from the grid store; size level 6
+  // ("huge") is the 3-column step these navigation cases are written against.
+  useGridStore().sizeLevel = 6;
+  const props = { searchQuery: "" };
   const emit = vi.fn();
   const { handleKeyDown } = useGridKeyboardNav(deps, props, emit, callbacks);
   return {
@@ -77,6 +82,8 @@ function keyEvent(overrides) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The composable reads the grid's column count from the store.
+  setActivePinia(createPinia());
 });
 
 describe("useGridKeyboardNav — review-overlay guard (F1)", () => {

--- a/frontend/src/composables/useGridKeyboardNav.test.js
+++ b/frontend/src/composables/useGridKeyboardNav.test.js
@@ -196,14 +196,7 @@ describe("useGridKeyboardNav — justified vertical navigation", () => {
     handleKeyDown(keyEvent({ key: "PageDown", shiftKey: true }));
     // Row 2's nearest-center item from center 50 is idx 5 (center 50).
     expect(deps.cursorIdx.value).toBe(5);
-    expect(deps.selectedImageIds.value).toEqual([
-      "a",
-      "b",
-      "c",
-      "d",
-      "e",
-      "f",
-    ]);
+    expect(deps.selectedImageIds.value).toEqual(["a", "b", "c", "d", "e", "f"]);
   });
 
   it("square mode keeps the uniform index ± columns arithmetic", () => {

--- a/frontend/src/composables/useStackOrdering.js
+++ b/frontend/src/composables/useStackOrdering.js
@@ -24,6 +24,7 @@ import {
   setStackOrder,
   removeStackMembers,
 } from "../api/stacks";
+import { useGridStore } from "../stores/useGridStore";
 
 const LIKENESS_GROUPS_SORT_KEY = "LIKENESS_GROUPS";
 
@@ -67,6 +68,7 @@ export function useStackOrdering(
     setPendingRanges,
   },
 ) {
+  const gridStore = useGridStore();
   // Stack-ordering failures report through the notice surface rather than a
   // blocking native alert() (docs/design/notice-surface.md §1). Called during
   // the host component's setup, so Pinia is active.
@@ -81,7 +83,7 @@ export function useStackOrdering(
   // ── Stack visual order map ────────────────────────────────────────────────
   const stackVisualOrderMap = computed(() => {
     const images = allGridImages.value;
-    const cols = Math.max(1, props.columns || 1);
+    const cols = Math.max(1, gridStore.columns || 1);
     const result = new Map();
     let stackAppearanceIndex = 0;
     for (let i = 0; i < images.length; i++) {
@@ -544,7 +546,7 @@ export function useStackOrdering(
     const newImages = mapGridImages(collapsed);
     allGridImages.value = newImages;
     if (visibleStart.value >= newImages.length) {
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       const windowCount = Math.max(cols, divisibleViewWindow.value || cols);
       visibleStart.value = 0;
       visibleEnd.value = Math.min(newImages.length, windowCount);

--- a/frontend/src/composables/useStackOrdering.js
+++ b/frontend/src/composables/useStackOrdering.js
@@ -25,6 +25,7 @@ import {
   removeStackMembers,
 } from "../api/stacks";
 import { useGridStore } from "../stores/useGridStore";
+import { useSortStore } from "../stores/useSortStore";
 
 const LIKENESS_GROUPS_SORT_KEY = "LIKENESS_GROUPS";
 
@@ -68,6 +69,7 @@ export function useStackOrdering(
     setPendingRanges,
   },
 ) {
+  const sortStore = useSortStore();
   const gridStore = useGridStore();
   // Stack-ordering failures report through the notice surface rather than a
   // blocking native alert() (docs/design/notice-surface.md §1). Called during
@@ -250,10 +252,8 @@ export function useStackOrdering(
       ? lastFetchedGridImages.value
       : [];
     if (!source.length) return [];
-    const members = source.filter(
-      (img) => getPictureStackId(img) === stackId,
-    );
-    const activeSort = String(props.selectedSort || "").toUpperCase();
+    const members = source.filter((img) => getPictureStackId(img) === stackId);
+    const activeSort = String(sortStore.selectedSort || "").toUpperCase();
     const useBackendOrder =
       !!activeSort && activeSort !== LIKENESS_GROUPS_SORT_KEY;
     return useBackendOrder ? members : sortStackMembers(members);
@@ -262,10 +262,12 @@ export function useStackOrdering(
   function cacheExpandedStackMembers(stackId, members) {
     if (!stackId || !Array.isArray(members) || members.length === 0)
       return false;
-    const activeSort = String(props.selectedSort || "").toUpperCase();
+    const activeSort = String(sortStore.selectedSort || "").toUpperCase();
     const useBackendOrder =
       !!activeSort && activeSort !== LIKENESS_GROUPS_SORT_KEY;
-    const sorted = useBackendOrder ? members.slice() : sortStackMembers(members);
+    const sorted = useBackendOrder
+      ? members.slice()
+      : sortStackMembers(members);
     const ordered = sorted
       .filter((img) => img && img.id != null)
       .map((img) =>
@@ -297,7 +299,7 @@ export function useStackOrdering(
     const entry = expandedStackMembers.value.get(stackId);
     const ids = Array.isArray(entry?.ids) ? entry.ids : [];
     const images = Array.isArray(entry?.images) ? entry.images : [];
-    const activeSort = String(props.selectedSort || "").toUpperCase();
+    const activeSort = String(sortStore.selectedSort || "").toUpperCase();
     const useBackendOrder =
       !!activeSort && activeSort !== LIKENESS_GROUPS_SORT_KEY;
     const sourceImages = ids.length
@@ -592,12 +594,12 @@ export function useStackOrdering(
       nextLoading.add(stackId);
       expandedStackLoading.value = nextLoading;
       try {
-        const activeSort = props.selectedSort ?? "";
+        const activeSort = sortStore.selectedSort ?? "";
         const isStackSort =
           !activeSort || activeSort === LIKENESS_GROUPS_SORT_KEY;
         const picsData = await listStackPictures(stackId, {
           sort: activeSort || undefined,
-          descending: props.selectedDescending,
+          descending: sortStore.selectedDescending,
           baseUrl: props.backendUrl,
         });
         const pics = Array.isArray(picsData) ? picsData : [];
@@ -672,7 +674,10 @@ export function useStackOrdering(
 
     for (const { stackId, fallbackCount, loaded } of fetchResults) {
       if (loaded !== false) {
-        const insertedCount = insertExpandedStackMembers(stackId, fallbackCount);
+        const insertedCount = insertExpandedStackMembers(
+          stackId,
+          fallbackCount,
+        );
         if (insertedCount <= 0) {
           nextExpanded.delete(stackId);
         }
@@ -718,7 +723,10 @@ export function useStackOrdering(
       const loaded = await ensureStackMembersLoaded(stackId, fallbackCount);
       if (loaded !== false && expandedStackIds.value.has(stackId)) {
         removeExpandedStackMembers(stackId);
-        const insertedCount = insertExpandedStackMembers(stackId, fallbackCount);
+        const insertedCount = insertExpandedStackMembers(
+          stackId,
+          fallbackCount,
+        );
         if (insertedCount <= 0) {
           const nextExpanded = new Set(expandedStackIds.value);
           nextExpanded.delete(stackId);
@@ -1088,7 +1096,8 @@ export function useStackOrdering(
           nextMembers.delete(stackId);
           expandedStackMembers.value = nextMembers;
           const nextExpanded = new Set(expandedStackIds.value);
-          if (nextExpanded.delete(stackId)) expandedStackIds.value = nextExpanded;
+          if (nextExpanded.delete(stackId))
+            expandedStackIds.value = nextExpanded;
         }),
       );
       clearSelection();
@@ -1150,9 +1159,7 @@ export function useStackOrdering(
           ? entry.ids.filter((id) => !removed.has(getPictureId(id)))
           : [];
         const nextImages = Array.isArray(entry.images)
-          ? entry.images.filter(
-              (img) => !removed.has(getPictureId(img?.id)),
-            )
+          ? entry.images.filter((img) => !removed.has(getPictureId(img?.id)))
           : [];
         if (nextIds.length || nextImages.length) {
           nextMembers.set(stackId, { ids: nextIds, images: nextImages });
@@ -1174,7 +1181,7 @@ export function useStackOrdering(
   }
 
   async function createStacksFromSelectedGroups() {
-    if (props.selectedSort !== LIKENESS_GROUPS_SORT_KEY) return;
+    if (sortStore.selectedSort !== LIKENESS_GROUPS_SORT_KEY) return;
     const ids = Array.isArray(selectedImageIds.value)
       ? selectedImageIds.value
       : [];
@@ -1225,9 +1232,7 @@ export function useStackOrdering(
         continue;
       }
       if (membersByStack.size === 1) {
-        const [, stackedMembers] = Array.from(
-          membersByStack.entries(),
-        )[0];
+        const [, stackedMembers] = Array.from(membersByStack.entries())[0];
         const stackedAnchorId = stackedMembers?.[0]?.id;
         const unstackedIds = memberIds.filter(
           (id) => !getPictureStackId(imageById.get(String(id))),
@@ -1316,9 +1321,7 @@ export function useStackOrdering(
     return [...stackIds];
   });
 
-  const showRemoveFromStack = computed(
-    () => selectedStackId.value !== null,
-  );
+  const showRemoveFromStack = computed(() => selectedStackId.value !== null);
 
   return {
     // State
@@ -1366,4 +1369,3 @@ export function useStackOrdering(
     createStacksFromSelectedGroups,
   };
 }
-

--- a/frontend/src/composables/useVirtualScroll.js
+++ b/frontend/src/composables/useVirtualScroll.js
@@ -6,6 +6,7 @@ import {
   JUSTIFIED_ROW_GAP,
 } from "./useJustifiedLayout";
 import { rowHeightForSizeLevel } from "../utils/thumbnailSizes";
+import { useGridStore } from "../stores/useGridStore";
 
 // Constants shared with ImageGrid.vue
 const MIN_THUMBNAIL_SIZE = 128;
@@ -17,7 +18,7 @@ const VIEW_WINDOW = 100;
  * Manages viewport geometry, row height, and scroll position for the virtual
  * scrolling image grid.
  *
- * Two layout modes, selected by `props.thumbnailMode`:
+ * Two layout modes, selected by `gridStore.thumbnailMode`:
  * - `'square'` (default): the original uniform grid — `cols` items per row,
  *   every row `rowHeight` px tall, `index → row` is `floor(index / cols)`.
  * - `'justified'`: Google-Photos-style rows packed by `useJustifiedLayout`.
@@ -48,12 +49,13 @@ export function useVirtualScroll(
   allGridImagesLength,
   { onVisibleRangeChange, afterRowHeightUpdate, getAspectRatios } = {},
 ) {
+  const gridStore = useGridStore();
   // ── Render buffer ──────────────────────────────────────────────────────────
   // During the initial render the buffer is 0 so the first paint is fast;
   // once the grid has rendered once the buffer expands to a full view-window
   // worth of items on each side.
   const divisibleViewWindow = computed(() => {
-    const cols = props.columns;
+    const cols = gridStore.columns;
     return Math.ceil(VIEW_WINDOW / cols) * cols;
   });
 
@@ -70,7 +72,7 @@ export function useVirtualScroll(
   // ── Justified layout ──────────────────────────────────────────────────────
   const isJustifiedMode = computed(
     () =>
-      props.thumbnailMode === "justified" &&
+      gridStore.thumbnailMode === "justified" &&
       typeof getAspectRatios === "function",
   );
 
@@ -93,13 +95,13 @@ export function useVirtualScroll(
     // resizes justified rows exactly as it resizes square columns. The min/max
     // bounds flex around the target so leftover rows can still stretch/shrink
     // to fill the container width without jumping to a fixed global size.
-    const targetRowHeight = rowHeightForSizeLevel(props.sizeLevel);
+    const targetRowHeight = rowHeightForSizeLevel(gridStore.sizeLevel);
     return packJustifiedRows({
       aspectRatios,
       containerWidth,
       targetRowHeight,
       gap: JUSTIFIED_ROW_GAP,
-      rowExtraHeight: props.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT,
+      rowExtraHeight: gridStore.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT,
       minRowHeight: Math.round(targetRowHeight * 0.7),
       maxRowHeight: Math.round(targetRowHeight * 1.4),
     });
@@ -118,34 +120,38 @@ export function useVirtualScroll(
     Math.round(
       Math.min(
         MAX_THUMBNAIL_SIZE,
-        Math.max(MIN_THUMBNAIL_SIZE, props.thumbnailSize || MIN_THUMBNAIL_SIZE),
-      ) + (props.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT),
+        Math.max(
+          MIN_THUMBNAIL_SIZE,
+          gridStore.thumbnailSize || MIN_THUMBNAIL_SIZE,
+        ),
+      ) + (gridStore.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT),
     ),
   );
 
   function getGridColumnWidth() {
-    const cols = Math.max(1, props.columns || 1);
+    const cols = Math.max(1, gridStore.columns || 1);
     const gridWidth =
-      gridContainer.value?.clientWidth ??
-      scrollWrapper.value?.clientWidth ??
-      0;
+      gridContainer.value?.clientWidth ?? scrollWrapper.value?.clientWidth ?? 0;
     if (!gridWidth) {
       return Math.min(
         MAX_THUMBNAIL_SIZE,
         Math.max(
           MIN_THUMBNAIL_SIZE,
-          props.thumbnailSize || MIN_THUMBNAIL_SIZE,
+          gridStore.thumbnailSize || MIN_THUMBNAIL_SIZE,
         ),
       );
     }
     const availableWidth = Math.max(0, gridWidth - 4);
     const rawWidth = availableWidth / cols;
-    return Math.min(MAX_THUMBNAIL_SIZE, Math.max(1, rawWidth || MIN_THUMBNAIL_SIZE));
+    return Math.min(
+      MAX_THUMBNAIL_SIZE,
+      Math.max(1, rawWidth || MIN_THUMBNAIL_SIZE),
+    );
   }
 
   function updateRowHeightFromGrid() {
     const columnWidth = getGridColumnWidth();
-    const infoHeight = props.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT;
+    const infoHeight = gridStore.compactMode ? 0 : THUMBNAIL_INFO_ROW_HEIGHT;
     rowHeight.value = Math.round(columnWidth + infoHeight);
     if (isJustifiedMode.value) {
       remeasureJustifiedWidth();
@@ -216,7 +222,7 @@ export function useVirtualScroll(
     }
     const cardHeight = rowHeight.value;
     const scrollTop = el.scrollTop;
-    const cols = props.columns;
+    const cols = gridStore.columns;
     const firstVisibleRow = scrollTop / cardHeight;
     const lastVisibleRow = (scrollTop + el.clientHeight - 1) / cardHeight;
     return {
@@ -286,7 +292,7 @@ export function useVirtualScroll(
       // supplies JUSTIFIED_ROW_GAP px of the offset.
       return Math.max(0, layout.rowOffsets[row] - JUSTIFIED_ROW_GAP);
     }
-    const cols = props.columns;
+    const cols = gridStore.columns;
     const rowsAbove = Math.floor(renderStart.value / cols);
     return rowsAbove > 0 ? rowsAbove * rowHeight.value : 1;
   });
@@ -302,11 +308,10 @@ export function useVirtualScroll(
       const lastRow = rowOfIndex(layout.rowStarts, end - 1);
       // rowOffsets[lastRow + 1] already includes the inter-row gap that the
       // flex layout inserts between the last rendered row and the spacer.
-      const nextOffset =
-        layout.rowOffsets[lastRow + 1] ?? layout.totalHeight;
+      const nextOffset = layout.rowOffsets[lastRow + 1] ?? layout.totalHeight;
       return Math.max(0, layout.totalHeight - nextOffset);
     }
-    const cols = props.columns;
+    const cols = gridStore.columns;
     const lastRenderedRow = Math.floor((renderEnd.value - 1) / cols) + 1;
     const totalRows = Math.ceil(allGridImagesLength.value / cols);
     const rowsBelow = totalRows - lastRenderedRow;
@@ -379,7 +384,7 @@ export function useVirtualScroll(
       itemTop = layout.rowOffsets[row];
       itemBottom = itemTop + layout.rowHeights[row];
     } else {
-      const cols = Math.max(1, props.columns || 1);
+      const cols = Math.max(1, gridStore.columns || 1);
       const row = Math.floor(idx / cols);
       itemTop = row * rowHeight.value;
       itemBottom = itemTop + rowHeight.value;

--- a/frontend/src/composables/useVirtualScroll.test.js
+++ b/frontend/src/composables/useVirtualScroll.test.js
@@ -1,6 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ref, reactive, computed, nextTick } from "vue";
+import { setActivePinia, createPinia } from "pinia";
+import { useGridStore } from "../stores/useGridStore.js";
 import { useVirtualScroll } from "./useVirtualScroll.js";
+
+// The composable reads the grid geometry (columns, size level, thumbnail mode
+// and size, compact mode) from the grid store.
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
 
 // Justified mode packs its rows from the aspect ratios of the images that have
 // actually arrived, so `justifiedLayout` is null before the first batch and
@@ -23,13 +31,14 @@ function makeHarness() {
     clientWidth: CONTAINER_W,
     getBoundingClientRect: () => ({ width: CONTAINER_W }),
   });
-  const props = reactive({
-    columns: 6,
-    thumbnailSize: 256,
-    compactMode: false,
-    thumbnailMode: "justified",
-    sizeLevel: 3,
-  });
+  // Grid geometry lives in the store. Size level 3 is the 6-column step, which
+  // is the geometry these layout cases are written against.
+  const gridStore = useGridStore();
+  gridStore.sizeLevel = 3;
+  gridStore.thumbnailSize = 256;
+  gridStore.compactMode = false;
+  gridStore.thumbnailMode = "justified";
+  const props = reactive({});
   // The image list starts empty, exactly as it is when ImageGrid mounts.
   const aspectRatios = ref([]);
   const allGridImagesLength = computed(() => aspectRatios.value.length);


### PR DESCRIPTION
Lane A, the rest of the ImageGrid prop migration. Part 1 landed as #653; **this PR now carries parts 2 and 3 together** (part 2 was #659, closed — its commit is here).

**Part 2, display preferences → `gridStore` / `userPrefsStore`:** thumbnail size / mode / size level, columns, compact mode, the star / face-bbox / detection / problem-icon / stack toggles, grid version, ws update key, theme mode, date format, penalised tag weights, public URL, watermark. The `update:embed-watermark` emit goes away (ShareDialog writes the store directly), as does `sidebarVisible`, which was declared and never read.

**Part 3, selection / sort / project / websocket → the matching stores:** character and set selection with their multi-select modes, set-difference base, set names, is-all-pictures; sort, descending, similarity character, stack threshold; project view mode, selected project, the character/set project maps; the search query; the five websocket payloads and the two external-import counters. The ALL / UNASSIGNED / SCRAPHEAP ids come from `useViewStore` instead of being handed down. Three more pure-store-write emits go: `update:character-multi-mode`, `update:set-multi-mode`, `update:set-difference-base-id`.

**Result:**

| | before | target | after |
|---|---|---|---|
| ImageGrid props | 79 | ≤10 | **3** |
| ImageGrid emits | 25 | ≤6 | 21 |

The three surviving props are genuinely parental: `backendUrl` (config), `activeCategoryLabel` and `folderScanning` (App-derived). App.vue's binding block for the grid is six lines, down from about 110.

Emits at 21 is above the plan's ≤6 — that reduction is Phase 5's `useGridActions` work (the action vocabulary), not this step's, so I have not claimed it here.

**The trap worth knowing about:** `useVirtualScroll`, `useGridKeyboardNav`, `useStackOrdering` and `useGridDragDrop` are handed ImageGrid's `props` object and read this state off it. Deleting the props without migrating them made `props.columns` undefined, the render-window arithmetic went NaN, and the grid rendered zero cards **while the whole unit suite still passed** — there is no mounted-grid coverage. e2e caught it. All four composables now call the stores themselves, and the mount harnesses set state through the stores (note `gridStore.columns` is a derived getter, so they set `sizeLevel`).

Verified: unit suite 1656 passing, production build, and the full e2e suite — 86 passed, 4 skipped.