### PR TITLE
App.vue down to 771 lines (Phase 3, step 6)

### DIFF
--- a/frontend/e2e/pages/DuplicateQueuePage.js
+++ b/frontend/e2e/pages/DuplicateQueuePage.js
@@ -39,7 +39,16 @@ export class DuplicateQueuePage {
     this.sidebarDot = this.sidebarRow.locator('.sidebar-dedup-dot')
   }
 
-  /** Open the queue by route and wait for a group (or the done state). */
+  /**
+   * Open the queue by route and wait for a group (or the done state).
+   *
+   * Waits for the row to be FOCUSED, not merely present. The queue sets its
+   * focus index when a load resolves, so there is a window where rows are
+   * painted and nothing is focused yet — and every key below acts on the
+   * focused group, so a press landing in that window does nothing at all. That
+   * window is narrow on a quiet machine and wide on a loaded CI runner, which
+   * is exactly the shape of a test that passes locally and fails in CI.
+   */
   async goto() {
     await this.page.goto('/duplicates')
     await expect(this.root).toBeVisible()
@@ -47,6 +56,8 @@ export class DuplicateQueuePage {
       .locator('.grow, .qdone')
       .first()
       .waitFor({ state: 'visible' })
+    if (await this.doneState.isVisible()) return
+    await expect(this.focusedRow).toHaveCount(1)
   }
 
   /**

--- a/frontend/e2e/specs/shortcuts-dialog.spec.js
+++ b/frontend/e2e/specs/shortcuts-dialog.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+
+// The dialog is a static table of key hints, so it has no unit coverage and
+// nothing else exercises it. This pins the two things that can actually
+// break: F1 reaching the handler, and the table rendering rows.
+
+test("shortcuts dialog opens on F1 and lists the grid shortcuts", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator(".thumbnail-card").first()).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.keyboard.press("F1");
+  const dialog = page.locator(".shortcuts-dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator(".shortcuts-table tr")).not.toHaveCount(0);
+  await expect(dialog.getByText("Open search")).toBeVisible();
+  await page.keyboard.press("F1");
+  await expect(dialog).toBeHidden();
+});

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,7 +13,6 @@ import { useReviewRoute } from "./composables/useReviewRoute";
 import { API_BASE_URL, isReadOnly, sessionContext } from "./utils/apiClient";
 import { useSelectionStore } from "./stores/useSelectionStore";
 import { useFilterStore } from "./stores/useFilterStore";
-import { useSortStore } from "./stores/useSortStore";
 import { useGridStore } from "./stores/useGridStore";
 import { useExportStore } from "./stores/useExportStore";
 import { useSidebarStore } from "./stores/useSidebarStore";
@@ -59,7 +58,6 @@ const BACKEND_URL = API_BASE_URL;
 // --- Stores ---
 const selectionStore = useSelectionStore();
 const filterStore = useFilterStore();
-const sortStore = useSortStore();
 const gridStore = useGridStore();
 const exportStore = useExportStore();
 const sidebarStore = useSidebarStore();
@@ -73,7 +71,6 @@ const tasksStore = useTasksStore();
 const operationStore = useOperationStore();
 // Owns route → view resolution (the app's single route watcher). Route pushing
 // stays here in App.vue; see stores/useViewStore.js.
-const viewStore = useViewStore();
 // Keycap labels for the shortcuts dialog. The binding accepts Ctrl and Meta
 // everywhere; only the hint is platform-specific.
 
@@ -109,7 +106,6 @@ const gridWrapperRef = ref(null);
 const shortcutsDialogOpen = ref(false);
 const updateCheckDialogOpen = ref(false);
 const photosDialogOpen = ref(false);
-const folderScanning = ref(false);
 const installType = ref("pip");
 const dockerVariant = ref("gpu");
 const loading = ref(null);
@@ -178,25 +174,13 @@ useGlobalKeydown({ gridContainer, sidebarRef, shortcutsDialogOpen });
 useWindowFileImport({ sidebarRef });
 
 const {
-  handleUpdateProjectViewMode,
-  handleUpdateSelectedProjectId,
   handleViewProject,
   handleUpdateSelectedSort,
-  handleUpdateSortOptions,
   handleStackStatsUpdate,
-  handleUpdateSimilarityCharacter,
-  handleUpdateSimilarityOptions,
-  handleUpdateHiddenTags,
-  handleUpdateApplyTagFilter,
-  handleUpdateDateFormat,
-  handleUpdateThemeMode,
   handleUpdateCheckForUpdates,
-  handleUpdateSidebarThumbnailSize,
   handleEmptyScrapheapFromSidebar,
   handleSuggestPicturesForCharacter,
   focusTasksTabPanel,
-  handleUpdateThumbnailMode,
-  handleUpdateSidebarWidth,
 } = useAppSettingsHandlers({
   gridContainer,
   statsSidebarRef,
@@ -221,7 +205,6 @@ let stopOpenSettings = null;
 // Maps the current route to a sidebar folder key ('rf-{id}' or 'if-{id}') so
 // the sidebar can highlight the correct folder on deep-link or back-navigation.
 // Parsed once, by useViewStore.
-const activeFolderKey = computed(() => viewStore.activeFolderKey);
 
 const activeCategoryLabel = computed(() => {
   if (selectionStore.selectedFolderFilter) {
@@ -306,6 +289,15 @@ async function handleLocalImport({ files, projectId } = {}) {
 }
 
 // undo affordance itself.
+// Route -> stores: install the app's single route watcher (immediately on
+// mount for deep-linking, then on every navigation). The parsing and the
+// writes live in useViewStore; the route PUSHING lives in useAppNavigation.
+useViewStore().startRouteSync(route, { watch });
+
+// A navigation retires the live undo receipt (owner decision, 2026-07-29): the
+// pill narrates something that happened on the view being left, and a receipt
+// carried into the next view reads as a fresh event there. Ctrl+Z keeps working
+// regardless - the receipt is narration, not the undo affordance itself.
 watch(
   () => route.fullPath,
   (next, prev) => {
@@ -540,65 +532,19 @@ defineExpose({
         >
           <SideBar
             ref="sidebarRef"
-            :docked="sidebarStore.effectiveDocked"
-            :selectedCharacter="selectionStore.selectedCharacter"
-            :selectedCharacterIds="selectionStore.selectedCharacterIds"
-            :allPicturesId="ALL_PICTURES_ID"
-            :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
-            :scrapheapPicturesId="SCRAPHEAP_PICTURES_ID"
-            :selectedSet="selectionStore.selectedSet"
-            :selectedSetIds="selectionStore.selectedSetIds"
-            :searchQuery="searchStore.searchQuery"
-            :selectedSort="sortStore.selectedSort"
-            :selectedDescending="sortStore.selectedDescending"
             :backendUrl="BACKEND_URL"
-            :publicUrl="userPrefsStore.publicUrl"
-            :embedWatermark="userPrefsStore.embedWatermark"
-            :selectedSimilarityCharacter="sortStore.selectedSimilarityCharacter"
-            :sidebarThumbnailSize="userPrefsStore.sidebarThumbnailSize"
-            :sidebarWidth="userPrefsStore.sidebarWidth"
-            :dateFormat="userPrefsStore.dateFormat"
-            :themeMode="userPrefsStore.themeMode"
-            :hasFolderFilter="selectionStore.selectedFolderFilter != null"
-            :activeFolderKey="activeFolderKey"
-            :externalProjectViewMode="projectStore.projectViewMode"
-            :externalSelectedProjectId="projectStore.selectedProjectId"
-            :checkForUpdates="userPrefsStore.checkForUpdates"
             :installType="installType"
             :dockerVariant="dockerVariant"
-            :showKeyboardHint="userPrefsStore.showKeyboardHint"
-            :thumbnailMode="gridStore.thumbnailMode"
-            @update:thumbnail-mode="handleUpdateThumbnailMode"
             @empty-scrapheap="handleEmptyScrapheapFromSidebar"
             @suggest-pictures-for-character="handleSuggestPicturesForCharacter"
-            @update:show-keyboard-hint="
-              userPrefsStore.showKeyboardHint = $event
-            "
-            @update:similarity-options="handleUpdateSimilarityOptions"
-            @update:sort-options="handleUpdateSortOptions"
-            @update:hidden-tags="handleUpdateHiddenTags"
-            @update:apply-tag-filter="handleUpdateApplyTagFilter"
-            @update:comfyui-configured="filterStore.comfyuiConfigured = $event"
-            @update:public-url="userPrefsStore.publicUrl = $event"
-            @update:embed-watermark="userPrefsStore.embedWatermark = $event"
-            @update:date-format="handleUpdateDateFormat"
-            @update:theme-mode="handleUpdateThemeMode"
-            @update:sidebar-thumbnail-size="handleUpdateSidebarThumbnailSize"
-            @update:sidebar-width="handleUpdateSidebarWidth"
-            @update:project-view-mode="handleUpdateProjectViewMode"
-            @update:selected-project-id="handleUpdateSelectedProjectId"
             @view-project="handleViewProject"
             @select-character="handleSelectCharacter"
-            :isDuplicatesView="isDuplicatesView"
             @select-duplicates="handleSelectDuplicates"
             @select-set="handleSelectSet"
             @select-folder="handleSelectFolder"
-            @update:folder-scanning="folderScanning = $event"
             @images-assigned-to-character="handleImagesAssignedToCharacter"
             @images-moved="handleImagesMoved"
             @faces-assigned-to-character="handleFacesAssignedToCharacter"
-            @update:selected-sort="handleUpdateSelectedSort"
-            @update:similarity-character="handleUpdateSimilarityCharacter"
             @open-import-dialog="openImportDialog"
             @update:set-error="error = $event"
             @update:set-loading="loading = $event"
@@ -703,7 +649,6 @@ defineExpose({
                 ref="gridContainer"
                 :backendUrl="BACKEND_URL"
                 :activeCategoryLabel="activeCategoryLabel"
-                :folderScanning="folderScanning"
                 @clear-search="handleClearSearch"
                 @search-all="handleSearchAllPictures"
                 @update:selected-sort="handleUpdateSelectedSort"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -31,7 +31,6 @@ import {
   UNASSIGNED_PICTURES_ID,
   useViewStore,
 } from "./stores/useViewStore";
-import { redoKeyHint, undoKeyHint } from "./utils/shortcutHints";
 import { useAppConfig } from "./composables/useAppConfig";
 import { useAppNavigation } from "./composables/useAppNavigation";
 import { useGlobalKeydown } from "./composables/useGlobalKeydown";
@@ -52,6 +51,7 @@ import ReviewSessionsOverlay from "./components/views/ReviewSessionsOverlay.vue"
 import StatsSidebar from "./components/panels/StatsSidebar.vue";
 import ThumbnailUpgradeBanner from "./components/panels/ThumbnailUpgradeBanner.vue";
 import NoticeHost from "./components/widgets/NoticeHost.vue";
+import ShortcutsDialog from "./components/widgets/ShortcutsDialog.vue";
 import { useFloatingBottomInset } from "./composables/useBottomAnchor";
 import { toPx } from "./utils/floatingBottom.js";
 const BACKEND_URL = API_BASE_URL;
@@ -76,8 +76,6 @@ const operationStore = useOperationStore();
 const viewStore = useViewStore();
 // Keycap labels for the shortcuts dialog. The binding accepts Ctrl and Meta
 // everywhere; only the hint is platform-specific.
-const undoKeyHintKeys = undoKeyHint();
-const redoKeyHintKeys = redoKeyHint();
 
 // --- Router ---
 const route = useRoute();
@@ -142,11 +140,8 @@ const {
   refreshSidebarPicturesDebounced,
 } = useSidebarRefresh({ sidebarRef });
 
-const {
-  updateIsMobile,
-  updateMaxColumns,
-  closeSidebarIfMobile,
-} = useViewportLayout({ mainAreaRef });
+const { updateIsMobile, updateMaxColumns, closeSidebarIfMobile } =
+  useViewportLayout({ mainAreaRef });
 
 // The live-updates channel. App.vue owns its lifecycle - it connects on
 // mount and disconnects on unmount - but the socket, its filter handshake and
@@ -775,136 +770,7 @@ defineExpose({
     >
       <v-icon size="20">mdi-keyboard</v-icon><span>F1</span>
     </button>
-    <v-dialog v-model="shortcutsDialogOpen" max-width="480">
-      <v-card class="shortcuts-dialog">
-        <v-card-title class="shortcuts-dialog-title"
-          >Keyboard shortcuts</v-card-title
-        >
-        <v-card-text class="shortcuts-dialog-body">
-          <table class="shortcuts-table">
-            <tbody>
-              <tr>
-                <td colspan="2" class="shortcuts-section">Grid view</td>
-              </tr>
-              <tr>
-                <td><kbd>F</kbd></td>
-                <td>Open search</td>
-              </tr>
-              <tr :class="{ 'shortcut-disabled': isReadOnly }">
-                <td><kbd>1</kbd> – <kbd>5</kbd></td>
-                <td>Set star rating on hovered / selected image(s)</td>
-              </tr>
-              <tr :class="{ 'shortcut-disabled': isReadOnly }">
-                <td><kbd>T</kbd></td>
-                <td>Tag selected images</td>
-              </tr>
-              <tr>
-                <td><kbd>Ctrl</kbd>+<kbd>A</kbd></td>
-                <td>Select all images</td>
-              </tr>
-              <tr :class="{ 'shortcut-disabled': isReadOnly }">
-                <td>
-                  <template v-for="(key, i) in undoKeyHintKeys" :key="key"
-                    ><span v-if="i > 0">+</span><kbd>{{ key }}</kbd></template
-                  >
-                </td>
-                <td>Undo the last change</td>
-              </tr>
-              <tr :class="{ 'shortcut-disabled': isReadOnly }">
-                <td>
-                  <template v-for="(key, i) in redoKeyHintKeys" :key="key"
-                    ><span v-if="i > 0">+</span><kbd>{{ key }}</kbd></template
-                  >
-                </td>
-                <td>Redo the change you just undid</td>
-              </tr>
-              <tr>
-                <td><kbd>G</kbd></td>
-                <td>Focus first visible image (start keyboard navigation)</td>
-              </tr>
-              <tr>
-                <td><kbd>←</kbd> <kbd>→</kbd> <kbd>↑</kbd> <kbd>↓</kbd></td>
-                <td>Move cursor and select image</td>
-              </tr>
-              <tr>
-                <td><kbd>Shift</kbd>+<kbd>Arrow</kbd></td>
-                <td>Extend selection</td>
-              </tr>
-              <tr>
-                <td><kbd>Ctrl</kbd>+<kbd>Arrow</kbd></td>
-                <td>Move cursor without changing selection</td>
-              </tr>
-              <tr>
-                <td><kbd>Space</kbd></td>
-                <td>Toggle selection of cursor image</td>
-              </tr>
-              <tr>
-                <td><kbd>Enter</kbd></td>
-                <td>Open cursor image</td>
-              </tr>
-              <tr :class="{ 'shortcut-disabled': isReadOnly }">
-                <td><kbd>Delete</kbd></td>
-                <td>Delete selected images</td>
-              </tr>
-              <tr>
-                <td><kbd>Esc</kbd></td>
-                <td>Clear selection</td>
-              </tr>
-              <tr>
-                <td><kbd>S</kbd></td>
-                <td>Open selection menu</td>
-              </tr>
-              <tr>
-                <td><kbd>Home</kbd> / <kbd>End</kbd></td>
-                <td>Jump to first / last image</td>
-              </tr>
-              <tr>
-                <td><kbd>Page Up</kbd> / <kbd>Page Down</kbd></td>
-                <td>Scroll image grid</td>
-              </tr>
-              <tr>
-                <td colspan="2" class="shortcuts-section">Image overlay</td>
-              </tr>
-              <tr>
-                <td><kbd>←</kbd> <kbd>→</kbd></td>
-                <td>Previous / next image</td>
-              </tr>
-              <tr :class="{ 'shortcut-disabled': isReadOnly }">
-                <td><kbd>1</kbd> – <kbd>5</kbd></td>
-                <td>Set star rating</td>
-              </tr>
-              <tr :class="{ 'shortcut-disabled': isReadOnly }">
-                <td><kbd>T</kbd></td>
-                <td>Add tag</td>
-              </tr>
-              <tr>
-                <td><kbd>Z</kbd></td>
-                <td>Toggle zoom</td>
-              </tr>
-              <tr>
-                <td><kbd>I</kbd></td>
-                <td>Toggle info panel</td>
-              </tr>
-              <tr>
-                <td><kbd>Esc</kbd></td>
-                <td>Close overlay</td>
-              </tr>
-              <tr>
-                <td colspan="2" class="shortcuts-section">General</td>
-              </tr>
-              <tr :class="{ 'shortcut-disabled': isReadOnly }">
-                <td><kbd>F2</kbd></td>
-                <td>Edit selected character or picture set</td>
-              </tr>
-              <tr>
-                <td><kbd>?</kbd> / <kbd>F1</kbd></td>
-                <td>Show / hide this dialog</td>
-              </tr>
-            </tbody>
-          </table>
-        </v-card-text>
-      </v-card>
-    </v-dialog>
+    <ShortcutsDialog v-model="shortcutsDialogOpen" />
   </v-app>
 </template>
 <style src="./App.css"></style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,7 +4,6 @@ import {
   nextTick,
   onBeforeUnmount,
   onMounted,
-  reactive,
   ref,
   watch,
 } from "vue";
@@ -17,7 +16,7 @@ import {
   isReadOnly,
   sessionContext,
 } from "./utils/apiClient";
-import { getUserConfig, patchUserConfig } from "./api/config";
+import { patchUserConfig } from "./api/config";
 import { useSelectionStore } from "./stores/useSelectionStore";
 import { useFilterStore } from "./stores/useFilterStore";
 import { useSortStore } from "./stores/useSortStore";
@@ -43,6 +42,7 @@ import {
 } from "./stores/useViewStore";
 import { redoKeyHint, undoKeyHint } from "./utils/shortcutHints";
 import { useGridRealtimeSync } from "./composables/useGridRealtimeSync";
+import { useAppConfig } from "./composables/useAppConfig";
 
 import SideBar from "./components/panels/SideBar.vue";
 import TitleBar from "./components/TitleBar.vue";
@@ -57,11 +57,6 @@ import NoticeHost from "./components/widgets/NoticeHost.vue";
 import { useFloatingBottomInset } from "./composables/useBottomAnchor";
 import { toPx } from "./utils/floatingBottom.js";
 import { isInternalImageDrag } from "./utils/media.js";
-import {
-  clampSizeLevel,
-  nearestSizeLevelForColumns,
-} from "./utils/thumbnailSizes";
-
 const BACKEND_URL = API_BASE_URL;
 
 // --- Stores ---
@@ -129,22 +124,14 @@ const loading = ref(null);
 const error = ref(null);
 
 // --- Config tracking ---
-const configLoaded = ref(false);
-const configLoading = ref(false);
-const configApplying = ref(false);
-const configSnapshot = ref({});
-const config = reactive({
-  sort: "",
-  thumbnail: 256,
-  thumbnail_mode: "square",
-  sidebar_thumbnail_size: 64,
-  show_stars: true,
-  show_face_bboxes: false,
-  show_problem_icon: true,
-  expand_all_stacks: true,
-  date_format: "locale",
-  theme_mode: "light",
-  stack_strictness: 0.92,
+// Loading the user's config and persisting UI options back lives in
+// useAppConfig; App.vue only supplies the layout re-measure that a
+// thumbnail-size change needs.
+const { fetchConfig } = useAppConfig({
+  onThumbnailSizeChanged: () => updateMaxColumns(),
+  onUpdateCheckUndecided: () => {
+    updateCheckDialogOpen.value = true;
+  },
 });
 
 // --- Layout constants ---
@@ -1224,275 +1211,6 @@ function handleUpdateSidebarWidth(value) {
   userPrefsStore.sidebarWidth = nextValue;
 }
 
-async function fetchConfig() {
-  if (isReadOnly.value) {
-    userPrefsStore.themeMode = "dark";
-    userPrefsStore.sidebarThumbnailSize = 32;
-    gridStore.showProblemIcon = true;
-    gridStore.showFaceBboxes = false;
-    gridStore.showStars = true;
-    return;
-  }
-  if (configLoading.value) return;
-  configLoading.value = true;
-  configApplying.value = true;
-  try {
-    const cfg = await getUserConfig();
-    const sortValue = cfg.sort_order ?? cfg.sort;
-    if (typeof sortValue === "string" && sortValue) {
-      sortStore.selectedSort = sortValue;
-    }
-    if (typeof cfg.show_keyboard_hint === "boolean")
-      userPrefsStore.showKeyboardHint = cfg.show_keyboard_hint;
-    if (typeof cfg.show_face_bboxes === "boolean") {
-      gridStore.showFaceBboxes = cfg.show_face_bboxes;
-    }
-    if (typeof cfg.show_problem_icon === "boolean") {
-      gridStore.showProblemIcon = cfg.show_problem_icon;
-    }
-    if (typeof cfg.expand_all_stacks === "boolean") {
-      gridStore.showStacks = cfg.expand_all_stacks;
-    } else if (typeof cfg.show_stacks === "boolean") {
-      gridStore.showStacks = cfg.show_stacks;
-    }
-    if (typeof cfg.compact_mode === "boolean") {
-      gridStore.compactMode = cfg.compact_mode;
-    }
-    if (typeof cfg.sidebar_docked === "boolean") {
-      sidebarStore.setSidebarDocked(cfg.sidebar_docked);
-    }
-    if (typeof cfg.sidebar_pinned === "boolean") {
-      sidebarStore.setSidebarPinned(cfg.sidebar_pinned);
-    }
-    if (typeof cfg.date_format === "string" && cfg.date_format) {
-      userPrefsStore.dateFormat = cfg.date_format;
-    }
-    if (typeof cfg.theme_mode === "string" && cfg.theme_mode) {
-      userPrefsStore.themeMode = cfg.theme_mode;
-    }
-    if (typeof cfg.descending === "boolean") {
-      sortStore.selectedDescending = cfg.descending;
-    }
-    if (typeof cfg.thumbnail_size_level === "number") {
-      gridStore.sizeLevel = clampSizeLevel(cfg.thumbnail_size_level);
-    } else if (typeof cfg.columns === "number") {
-      // Legacy config predating the size ladder: derive the nearest level so
-      // an old install keeps roughly the same tile size after upgrading.
-      gridStore.sizeLevel = nearestSizeLevelForColumns(cfg.columns);
-    }
-    if (cfg.thumbnail_mode === "square" || cfg.thumbnail_mode === "justified") {
-      gridStore.thumbnailMode = cfg.thumbnail_mode;
-    }
-    if (typeof cfg.sidebar_thumbnail_size === "number") {
-      userPrefsStore.sidebarThumbnailSize = cfg.sidebar_thumbnail_size;
-    }
-    if (typeof cfg.sidebar_width === "number") {
-      userPrefsStore.sidebarWidth = cfg.sidebar_width;
-    }
-    if (cfg.stack_strictness != null) {
-      sortStore.stackThreshold = String(cfg.stack_strictness);
-    }
-    config.sort_order = sortValue || sortStore.selectedSort;
-    config.descending = sortStore.selectedDescending;
-    config.columns = gridStore.columns;
-    config.thumbnail_mode = gridStore.thumbnailMode;
-    config.sidebar_thumbnail_size = userPrefsStore.sidebarThumbnailSize;
-    config.sidebar_width = userPrefsStore.sidebarWidth;
-    config.show_stars =
-      typeof cfg.show_stars === "boolean"
-        ? cfg.show_stars
-        : gridStore.showStars;
-    config.show_face_bboxes =
-      typeof cfg.show_face_bboxes === "boolean"
-        ? cfg.show_face_bboxes
-        : gridStore.showFaceBboxes;
-    config.show_problem_icon =
-      typeof cfg.show_problem_icon === "boolean"
-        ? cfg.show_problem_icon
-        : gridStore.showProblemIcon;
-    config.expand_all_stacks =
-      typeof cfg.expand_all_stacks === "boolean"
-        ? cfg.expand_all_stacks
-        : typeof cfg.show_stacks === "boolean"
-          ? cfg.show_stacks
-          : gridStore.showStacks;
-    config.compact_mode =
-      typeof cfg.compact_mode === "boolean"
-        ? cfg.compact_mode
-        : gridStore.compactMode;
-    config.sidebar_docked =
-      typeof cfg.sidebar_docked === "boolean"
-        ? cfg.sidebar_docked
-        : sidebarStore.sidebarDocked;
-    config.sidebar_pinned =
-      typeof cfg.sidebar_pinned === "boolean"
-        ? cfg.sidebar_pinned
-        : sidebarStore.sidebarPinned;
-    config.date_format = userPrefsStore.dateFormat;
-    config.theme_mode = userPrefsStore.themeMode;
-    config.stack_strictness =
-      cfg.stack_strictness != null
-        ? cfg.stack_strictness
-        : config.stack_strictness;
-    const similarityValue =
-      cfg.similarity_character ?? cfg.selected_similarity_character;
-    sortStore.selectedSimilarityCharacter =
-      similarityValue ?? sortStore.selectedSimilarityCharacter ?? null;
-    const newHiddenTags = Array.isArray(cfg.hidden_tags) ? cfg.hidden_tags : [];
-    if (
-      userPrefsStore.hiddenTags.length !== newHiddenTags.length ||
-      userPrefsStore.hiddenTags.some((tag, i) => tag !== newHiddenTags[i])
-    ) {
-      userPrefsStore.hiddenTags = newHiddenTags;
-    }
-    userPrefsStore.applyTagFilter = Boolean(cfg.apply_tag_filter);
-    const rawPt = cfg.smart_score_penalised_tags;
-    if (rawPt && typeof rawPt === "object" && !Array.isArray(rawPt)) {
-      userPrefsStore.penalisedTagWeights = Object.fromEntries(
-        Object.entries(rawPt).map(([k, v]) => [
-          String(k).trim().toLowerCase(),
-          Number(v) || 0,
-        ]),
-      );
-    } else if (Array.isArray(rawPt)) {
-      userPrefsStore.penalisedTagWeights = Object.fromEntries(
-        rawPt.map((t) => [
-          String(t || "")
-            .trim()
-            .toLowerCase(),
-          3,
-        ]),
-      );
-    } else {
-      userPrefsStore.penalisedTagWeights = {};
-    }
-    config.selectedSimilarityCharacter = sortStore.selectedSimilarityCharacter;
-    configSnapshot.value = {
-      sort: sortStore.selectedSort || "",
-      descending: sortStore.selectedDescending,
-      columns: typeof gridStore.columns === "number" ? gridStore.columns : null,
-      sidebar_thumbnail_size:
-        typeof userPrefsStore.sidebarThumbnailSize === "number"
-          ? userPrefsStore.sidebarThumbnailSize
-          : null,
-      show_keyboard_hint: userPrefsStore.showKeyboardHint,
-      show_face_bboxes: gridStore.showFaceBboxes,
-      show_problem_icon: gridStore.showProblemIcon,
-      expand_all_stacks: gridStore.showStacks,
-      compact_mode: gridStore.compactMode,
-      sidebar_docked: sidebarStore.sidebarDocked,
-      sidebar_pinned: sidebarStore.sidebarPinned,
-      date_format: userPrefsStore.dateFormat,
-      theme_mode: userPrefsStore.themeMode,
-      similarity_character: sortStore.selectedSimilarityCharacter,
-      stack_strictness:
-        cfg.stack_strictness != null ? Number(cfg.stack_strictness) : null,
-      hidden_tags: userPrefsStore.hiddenTags,
-      apply_tag_filter: userPrefsStore.applyTagFilter,
-    };
-    filterStore.comfyuiConfigured = Boolean(cfg?.comfyui_url);
-    if (typeof cfg?.public_url === "string" && cfg.public_url) {
-      userPrefsStore.publicUrl = cfg.public_url;
-    }
-    userPrefsStore.embedWatermark = Boolean(cfg?.embed_watermark);
-    userPrefsStore.hidePurgeSnapshotWarning = Boolean(
-      cfg?.hide_purge_snapshot_warning,
-    );
-    const cfu = cfg?.check_for_updates;
-    userPrefsStore.checkForUpdates =
-      cfu === true ? true : cfu === false ? false : null;
-    if (userPrefsStore.checkForUpdates === null) {
-      updateCheckDialogOpen.value = true;
-    }
-  } catch (e) {
-    console.error("Failed to fetch user config:", e);
-  } finally {
-    configApplying.value = false;
-    configLoading.value = false;
-    configLoaded.value = true;
-  }
-}
-
-async function patchConfigUIOptions() {
-  if (!configLoaded.value || configLoading.value || configApplying.value)
-    return;
-  const patch = {};
-  if (sortStore.selectedSort) patch.sort = sortStore.selectedSort;
-  patch.descending = sortStore.selectedDescending;
-  patch.thumbnail_size_level = gridStore.sizeLevel;
-  // Keep the legacy `columns` field in sync with the derived count so older
-  // clients (and anything still reading `columns`) stay consistent.
-  if (gridStore.columns) patch.columns = gridStore.columns;
-  if (userPrefsStore.sidebarThumbnailSize) {
-    patch.sidebar_thumbnail_size = userPrefsStore.sidebarThumbnailSize;
-  }
-  if (userPrefsStore.sidebarWidth) {
-    patch.sidebar_width = userPrefsStore.sidebarWidth;
-  }
-  if (typeof userPrefsStore.showKeyboardHint === "boolean")
-    patch.show_keyboard_hint = userPrefsStore.showKeyboardHint;
-  if (typeof gridStore.showFaceBboxes === "boolean") {
-    patch.show_face_bboxes = gridStore.showFaceBboxes;
-  }
-  if (typeof gridStore.showProblemIcon === "boolean") {
-    patch.show_problem_icon = gridStore.showProblemIcon;
-  }
-  if (typeof gridStore.showStacks === "boolean") {
-    patch.expand_all_stacks = gridStore.showStacks;
-  }
-  if (typeof gridStore.compactMode === "boolean") {
-    patch.compact_mode = gridStore.compactMode;
-  }
-  if (
-    gridStore.thumbnailMode === "square" ||
-    gridStore.thumbnailMode === "justified"
-  ) {
-    patch.thumbnail_mode = gridStore.thumbnailMode;
-  }
-  if (typeof sidebarStore.sidebarDocked === "boolean") {
-    patch.sidebar_docked = sidebarStore.sidebarDocked;
-  }
-  if (typeof sidebarStore.sidebarPinned === "boolean") {
-    patch.sidebar_pinned = sidebarStore.sidebarPinned;
-  }
-  if (
-    typeof userPrefsStore.dateFormat === "string" &&
-    userPrefsStore.dateFormat
-  ) {
-    patch.date_format = userPrefsStore.dateFormat;
-  }
-  if (
-    typeof userPrefsStore.themeMode === "string" &&
-    userPrefsStore.themeMode
-  ) {
-    patch.theme_mode = userPrefsStore.themeMode;
-  }
-  if (sortStore.selectedSimilarityCharacter != null) {
-    patch.similarity_character = sortStore.selectedSimilarityCharacter;
-  }
-  if (sortStore.stackThreshold != null && sortStore.stackThreshold !== "") {
-    const parsed = parseFloat(String(sortStore.stackThreshold));
-    if (Number.isFinite(parsed)) {
-      patch.stack_strictness = parsed;
-    }
-  }
-
-  const snapshot = configSnapshot.value || {};
-  const changed = Object.fromEntries(
-    Object.entries(patch).filter(([key, value]) => snapshot[key] !== value),
-  );
-  if (Object.keys(changed).length === 0) {
-    return;
-  }
-
-  try {
-    await patchUserConfig(changed);
-    configSnapshot.value = { ...snapshot, ...changed };
-  } catch (e) {
-    console.error("Error patching user config:", e);
-  }
-}
-
 /**
  * Is a modal surface (a dialog, the lightbox) currently covering the app?
  *
@@ -1766,16 +1484,6 @@ watch([() => searchStore.searchInput, () => searchStore.searchHistory], () => {
 });
 
 watch(
-  [() => sortStore.selectedSort, () => sortStore.selectedDescending],
-  () => {
-    patchConfigUIOptions();
-    // No refreshGridVersion() here: ImageGrid's selection watch already fires
-    // when selectedSort/selectedDescending props change, so calling
-    // refreshGridVersion() would produce a redundant second grid fetch.
-  },
-);
-
-watch(
   () => userPrefsStore.hiddenTags,
   () => {
     gridStore.refreshGridVersion();
@@ -1806,116 +1514,6 @@ watch(
 );
 
 watch(
-  () => gridStore.thumbnailSize,
-  () => {
-    patchConfigUIOptions();
-    updateMaxColumns();
-  },
-);
-
-watch(
-  () => userPrefsStore.showKeyboardHint,
-  () => {
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  [
-    () => gridStore.showFaceBboxes,
-    () => gridStore.showProblemIcon,
-    () => gridStore.showStacks,
-    () => gridStore.compactMode,
-  ],
-  () => {
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  [
-    () => gridStore.showFaceBboxes,
-    () => gridStore.showProblemIcon,
-    () => gridStore.showStacks,
-  ],
-  () => {},
-  { immediate: true },
-);
-
-watch(
-  () => sortStore.selectedSimilarityCharacter,
-  () => {
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  () => sortStore.stackThreshold,
-  () => {
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  () => gridStore.sizeLevel,
-  () => {
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  () => gridStore.thumbnailMode,
-  () => {
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  () => sidebarStore.sidebarDocked,
-  () => {
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  () => sidebarStore.sidebarPinned,
-  () => {
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  () => userPrefsStore.sidebarThumbnailSize,
-  () => {
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  () => userPrefsStore.sidebarWidth,
-  () => {
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
-  },
-);
-
-watch(
-  () => userPrefsStore.dateFormat,
-  () => {
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
-    gridStore.refreshGridVersion();
-  },
-);
-
-watch(
   () => gridStore.gridVersion,
   () => {
     wsStore.clearPendingExternalImportIds();
@@ -1927,8 +1525,6 @@ watch(
   () => userPrefsStore.themeMode,
   (value) => {
     theme.global.name.value = resolveThemeName(value);
-    if (!configLoaded.value) return;
-    patchConfigUIOptions();
   },
   { immediate: true },
 );

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -44,6 +44,8 @@ import { redoKeyHint, undoKeyHint } from "./utils/shortcutHints";
 import { useGridRealtimeSync } from "./composables/useGridRealtimeSync";
 import { useAppConfig } from "./composables/useAppConfig";
 import { useAppNavigation } from "./composables/useAppNavigation";
+import { useGlobalKeydown } from "./composables/useGlobalKeydown";
+import { useWindowFileImport } from "./composables/useWindowFileImport";
 
 import SideBar from "./components/panels/SideBar.vue";
 import TitleBar from "./components/TitleBar.vue";
@@ -57,7 +59,6 @@ import ThumbnailUpgradeBanner from "./components/panels/ThumbnailUpgradeBanner.v
 import NoticeHost from "./components/widgets/NoticeHost.vue";
 import { useFloatingBottomInset } from "./composables/useBottomAnchor";
 import { toPx } from "./utils/floatingBottom.js";
-import { isInternalImageDrag } from "./utils/media.js";
 const BACKEND_URL = API_BASE_URL;
 
 // --- Stores ---
@@ -142,6 +143,9 @@ const {
   onClearSearch: () => handleClearSearch(),
   onNavigated: () => closeSidebarIfMobile(),
 });
+
+useGlobalKeydown({ gridContainer, sidebarRef, shortcutsDialogOpen });
+useWindowFileImport({ sidebarRef });
 
 const { fetchConfig } = useAppConfig({
   onThumbnailSizeChanged: () => updateMaxColumns(),
@@ -619,80 +623,6 @@ async function handleLocalImport({ files, projectId } = {}) {
   sidebarRef.value?.startLocalImport?.(files, projectId ?? null);
 }
 
-function isInsideImageGrid(event) {
-  const target = event?.target;
-  if (!(target instanceof Element)) return false;
-  return Boolean(target.closest(".image-grid, .grid-scroll-wrapper"));
-}
-
-function isExternalFileDragEvent(event) {
-  const dataTransfer = event?.dataTransfer;
-  if (!dataTransfer) return false;
-  // An internal app drag (grid thumbnail → sidebar character/set/project) is
-  // never a file import — bail before the files check. On the desktop shell
-  // (Electron) such a drag ALSO populates dataTransfer.files with the dragged
-  // in-page image as a real File (the web does not), so without this guard the
-  // window-level import handler mistakes the assign-drag for an external file
-  // drop and imports the picture instead of assigning it.
-  if (isInternalImageDrag(dataTransfer)) return false;
-  const files = dataTransfer.files;
-  if (files && files.length > 0) return true;
-  const types = dataTransfer.types ? Array.from(dataTransfer.types) : [];
-  return types.includes("Files") || types.includes("application/x-moz-file");
-}
-
-function handleWindowDragOver(event) {
-  if (!isExternalFileDragEvent(event)) return;
-  // The review overlay is a modal review surface; dropping files into it
-  // must never start an import. Skip preventDefault so the drag is not shown as
-  // droppable here.
-  if (reviewSessionsStore.overlayOpen) return;
-  event.preventDefault();
-}
-
-function handleWindowDrop(event) {
-  if (!isExternalFileDragEvent(event)) return;
-  // While the review overlay is open, swallow the drop without importing
-  // (still preventDefault so the browser does not navigate to the dropped file).
-  if (reviewSessionsStore.overlayOpen) {
-    event.preventDefault();
-    return;
-  }
-  event.preventDefault();
-  if (isInsideImageGrid(event)) {
-    return;
-  }
-  const droppedFiles = Array.from(event.dataTransfer?.files || []);
-  if (!droppedFiles.length) return;
-  const projectId = sidebarRef.value?.currentProjectId ?? null;
-  sidebarRef.value?.startLocalImport?.(droppedFiles, projectId);
-}
-
-function handleWindowPaste(event) {
-  // Ignore paste events originating from editable elements (text inputs etc.)
-  const target = event.target;
-  if (
-    target instanceof HTMLInputElement ||
-    target instanceof HTMLTextAreaElement ||
-    target?.isContentEditable
-  ) {
-    return;
-  }
-  const items = Array.from(event.clipboardData?.items || []);
-  const mediaFiles = items
-    .filter(
-      (item) =>
-        item.kind === "file" &&
-        (item.type.startsWith("image/") || item.type.startsWith("video/")),
-    )
-    .map((item) => item.getAsFile())
-    .filter(Boolean);
-  if (!mediaFiles.length) return;
-  event.preventDefault();
-  const projectId = sidebarRef.value?.currentProjectId ?? null;
-  sidebarRef.value?.startLocalImport?.(mediaFiles, projectId);
-}
-
 function updateSidebarBreakpoints() {
   if (typeof window !== "undefined") {
     sidebarStore.sidebarForcedHidden =
@@ -893,148 +823,6 @@ function handleUpdateSidebarWidth(value) {
   const nextValue = Number(value);
   if (!Number.isFinite(nextValue)) return;
   userPrefsStore.sidebarWidth = nextValue;
-}
-
-/**
- * Is a modal surface (a dialog, the lightbox) currently covering the app?
- *
- * There is no shared flag for this: every dialog owns its own `open` ref, so
- * the honest single source is the scrim Vuetify renders for every active
- * overlay. Used to decline global shortcuts whose feedback would be invisible
- * behind it.
- */
-function isModalOverlayOpen() {
-  if (typeof document === "undefined") return false;
-  return document.querySelector(".v-overlay--active .v-overlay__scrim") != null;
-}
-
-function handleGlobalKeydown(e) {
-  // The review overlay is modal and owns its own keyboard handler; don't
-  // run the app/grid shortcuts (scroll, search, help) behind it.
-  if (reviewSessionsStore.overlayOpen) return;
-  // The LIGHTBOX owns the keyboard too, with its own undo binding and its own
-  // receipt. This used to be enforced implicitly by listener order — the
-  // overlay mounted before App, ran first, and stopImmediatePropagation()
-  // silenced this handler — but the Duplicates view unmounts and remounts the
-  // grid (and the overlay inside it), which re-registers their listeners
-  // AFTER this one and silently flips that order. The result was one Ctrl+Z
-  // running TWO undos: this handler's, then the overlay's, which the
-  // operation store's busy-queue happily executed as a queued second step.
-  // Ownership is therefore stated here explicitly, on the same DOM signal the
-  // overlay renders (`.image-overlay` is v-if'd on open), not on ordering.
-  if (
-    typeof document !== "undefined" &&
-    document.querySelector(".image-overlay") != null
-  ) {
-    return;
-  }
-  // Match the strictness the grid and the lightbox already use: a SELECT and an
-  // ARIA textbox are typing surfaces too, and the event target matters as much
-  // as `document.activeElement` (a Vuetify combobox moves focus around).
-  const isEditable = [e.target, document.activeElement].some(
-    (el) =>
-      el instanceof HTMLElement &&
-      (el.isContentEditable ||
-        ["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName) ||
-        el.getAttribute("role") === "textbox"),
-  );
-
-  // The auto-hide sidebar is revealed by hover (or tap), so WCAG 2.1 SC 1.4.13
-  // "Content on Hover or Focus" applies: it must be dismissible without moving
-  // the pointer. Escape is that mechanism, and for a touch user it is the only
-  // dismissal besides the scrim itself. Deliberately not preventDefault-ed, and
-  // skipped while typing, so the other Escape owners keep theirs. The sidebar
-  // context menu stops propagation from a capture-phase listener and never
-  // reaches here at all.
-  if (
-    e.key === "Escape" &&
-    !isEditable &&
-    sidebarStore.sidebarOverlay &&
-    sidebarStore.sidebarVisible
-  ) {
-    sidebarStore.hideAutoSidebar();
-  }
-
-  // Undo / redo. Global by design: the shortcut has to work with no receipt on
-  // screen, and every undo raises one, so the result is always narrated. Ctrl
-  // and Meta are both accepted (the HINT is platform-specific, the binding is
-  // not); Ctrl+Shift+Z is the macOS redo convention and is accepted everywhere.
-  //
-  // Four guards, each for its own reason:
-  //   * typing: a text field keeps its own native undo stack;
-  //   * read-only: the endpoints are owner-only anyway;
-  //   * auto-repeat: a HELD Ctrl+Z must not walk the whole stack;
-  //   * a modal DIALOG owns the screen: the receipt lives on --z-floating,
-  //     under any dialog scrim, so an undo fired from there would mutate the
-  //     library with no visible narration. That breaks the design's own "every
-  //     undo raises a receipt" invariant, so the shortcut declines rather than
-  //     acting blind.
-  //
-  // The lightbox is NOT covered by that last guard and never was:
-  // `isModalOverlayOpen()` looks for a Vuetify scrim, and `.image-overlay`
-  // renders its own. The lightbox is excluded by the explicit `.image-overlay`
-  // check at the top of this handler (listener ORDER used to do it, until the
-  // Duplicates view's grid remount flipped it — see that comment). Undo works
-  // in the lightbox through its own key handler plus `OverlayActionReceipt`,
-  // fitted to that surface's GUI per the owner's ruling.
-  if (
-    (e.ctrlKey || e.metaKey) &&
-    !e.altKey &&
-    !e.repeat &&
-    !isEditable &&
-    !isReadOnly.value &&
-    !isModalOverlayOpen()
-  ) {
-    const key = e.key?.toLowerCase();
-    if (key === "z" && !e.shiftKey) {
-      e.preventDefault();
-      operationStore.undo();
-    } else if (key === "y" || (key === "z" && e.shiftKey)) {
-      e.preventDefault();
-      operationStore.redo();
-    }
-  }
-
-  const keys = ["Home", "End", "PageUp", "PageDown"];
-  if (keys.includes(e.key) && !isEditable) {
-    // These keys drive grid scrolling only. Prevent the browser's default
-    // scroll so they don't also scroll the sidebar (or the page).
-    e.preventDefault();
-    const grid = gridContainer.value;
-    if (grid && typeof grid.onGlobalKeyPress === "function") {
-      grid.onGlobalKeyPress(e.key, e);
-    }
-  }
-  if (e.key === "f" && !e.ctrlKey && !e.metaKey && !e.altKey) {
-    if (!isEditable) {
-      e.preventDefault();
-      searchStore.requestSearchFocus();
-    }
-  }
-  if (
-    (e.key === "?" || e.key === "F1") &&
-    !e.ctrlKey &&
-    !e.metaKey &&
-    !e.altKey &&
-    !isEditable
-  ) {
-    e.preventDefault();
-    shortcutsDialogOpen.value = !shortcutsDialogOpen.value;
-  }
-  if (
-    e.key === "F2" &&
-    !e.ctrlKey &&
-    !e.metaKey &&
-    !e.altKey &&
-    !isEditable &&
-    !isReadOnly.value
-  ) {
-    const gridHasFocus = gridContainer.value?.hasCursorFocus === true;
-    if (!gridHasFocus) {
-      e.preventDefault();
-      sidebarRef.value?.openCurrentSelectionEditor?.();
-    }
-  }
 }
 
 function resolveThemeName(mode) {
@@ -1275,10 +1063,6 @@ onMounted(async () => {
   }
   updateIsMobile();
   window.addEventListener("resize", updateIsMobile);
-  window.addEventListener("keydown", handleGlobalKeydown);
-  window.addEventListener("dragover", handleWindowDragOver, true);
-  window.addEventListener("drop", handleWindowDrop, true);
-  window.addEventListener("paste", handleWindowPaste, true);
   // Desktop tray → "Settings" opens the Settings dialog directly.
   if (window.pixlstashDesktop?.onOpenSettings) {
     stopOpenSettings = window.pixlstashDesktop.onOpenSettings(() =>
@@ -1305,10 +1089,6 @@ onBeforeUnmount(() => {
   tasksStore.stopPolling();
   if (stopOpenSettings) stopOpenSettings();
   window.removeEventListener("resize", updateIsMobile);
-  window.removeEventListener("keydown", handleGlobalKeydown);
-  window.removeEventListener("dragover", handleWindowDragOver, true);
-  window.removeEventListener("drop", handleWindowDrop, true);
-  window.removeEventListener("paste", handleWindowPaste, true);
   if (mainAreaResizeObserver) {
     mainAreaResizeObserver.disconnect();
     mainAreaResizeObserver = null;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,12 +14,10 @@ import { API_BASE_URL, isReadOnly, sessionContext } from "./utils/apiClient";
 import { useSelectionStore } from "./stores/useSelectionStore";
 import { useFilterStore } from "./stores/useFilterStore";
 import { useGridStore } from "./stores/useGridStore";
-import { useExportStore } from "./stores/useExportStore";
 import { useSidebarStore } from "./stores/useSidebarStore";
 import { useUserPrefsStore } from "./stores/useUserPrefsStore";
 import { useProjectStore } from "./stores/useProjectStore";
 import { useWsStore } from "./stores/useWsStore";
-import { useSearchStore } from "./stores/useSearchStore";
 import { useReviewSessionsStore } from "./stores/useReviewSessionsStore";
 import { useSnapshotsStore } from "./stores/useSnapshotsStore";
 import { useTasksStore } from "./stores/useTasksStore";
@@ -39,6 +37,7 @@ import { useUpdatesSocket } from "./composables/useUpdatesSocket";
 import { useSidebarRefresh } from "./composables/useSidebarRefresh";
 import { useViewportLayout } from "./composables/useViewportLayout";
 import { useAppEntityActions } from "./composables/useAppEntityActions";
+import { useSearchBarSync } from "./composables/useSearchBarSync";
 
 import SideBar from "./components/panels/SideBar.vue";
 import TitleBar from "./components/TitleBar.vue";
@@ -59,12 +58,10 @@ const BACKEND_URL = API_BASE_URL;
 const selectionStore = useSelectionStore();
 const filterStore = useFilterStore();
 const gridStore = useGridStore();
-const exportStore = useExportStore();
 const sidebarStore = useSidebarStore();
 const userPrefsStore = useUserPrefsStore();
 const projectStore = useProjectStore();
 const wsStore = useWsStore();
-const searchStore = useSearchStore();
 const reviewSessionsStore = useReviewSessionsStore();
 const snapshotsStore = useSnapshotsStore();
 const tasksStore = useTasksStore();
@@ -145,7 +142,6 @@ const { updateIsMobile, updateMaxColumns, closeSidebarIfMobile } =
 const {
   connectUpdatesSocket,
   disconnectUpdatesSocket,
-  sendUpdatesFilters,
   loadPendingExternalImports,
   loadSortChangedExternal,
   onFlagSortChanged,
@@ -160,7 +156,6 @@ const {
   handleImagesAssignedToCharacter,
   handleImagesMoved,
   handleFacesAssignedToCharacter,
-  refreshExportCount,
   confirmExportZip,
   handleClearSearch,
   handleResetToAll,
@@ -168,7 +163,10 @@ const {
   gridContainer,
   refreshSidebar,
   onNavigated: () => closeSidebarIfMobile(),
+  onTagFilterChanged: () => refreshSidebarDebounced(),
 });
+
+useSearchBarSync();
 
 useGlobalKeydown({ gridContainer, sidebarRef, shortcutsDialogOpen });
 useWindowFileImport({ sidebarRef });
@@ -316,87 +314,11 @@ function resolveThemeName(mode) {
 }
 
 watch(
-  () => searchStore.searchQuery,
-  (newVal, oldVal) => {
-    if (searchStore.searchInput !== newVal) {
-      searchStore.searchInput = newVal || "";
-    }
-    if (!newVal && oldVal) {
-      gridStore.refreshGridVersion();
-    }
-  },
-);
-
-watch([() => searchStore.searchInput, () => searchStore.searchHistory], () => {
-  const needle = (searchStore.searchInput || "").trim();
-  if (!needle) {
-    searchStore.isSearchHistoryOpen = false;
-    return;
-  }
-  searchStore.isSearchHistoryOpen =
-    searchStore.filteredSearchHistory.length > 0;
-});
-
-watch(
-  () => userPrefsStore.hiddenTags,
-  () => {
-    gridStore.refreshGridVersion();
-    if (userPrefsStore.applyTagFilter) {
-      refreshSidebarDebounced();
-    }
-  },
-);
-
-watch(
-  () => userPrefsStore.applyTagFilter,
-  () => {
-    gridStore.refreshGridVersion();
-    refreshSidebarDebounced();
-  },
-);
-
-watch(
-  [
-    () => selectionStore.selectedCharacter,
-    () => selectionStore.selectedSet,
-    () => selectionStore.selectedSetIds,
-    () => searchStore.searchQuery,
-  ],
-  () => {
-    sendUpdatesFilters();
-  },
-);
-
-watch(
-  () => gridStore.gridVersion,
-  () => {
-    wsStore.clearPendingExternalImportIds();
-    wsStore.clearSortChangedExternalIds();
-  },
-);
-
-watch(
   () => userPrefsStore.themeMode,
   (value) => {
     theme.global.name.value = resolveThemeName(value);
   },
   { immediate: true },
-);
-
-watch(
-  () => exportStore.exportMenuOpen,
-  async (isOpen) => {
-    if (!isOpen) return;
-    await nextTick();
-    refreshExportCount();
-  },
-);
-
-watch(
-  () => sidebarStore.statsOpen,
-  () => {
-    updateIsMobile();
-  },
 );
 
 // --- Lifecycle ---

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,11 +10,7 @@ import {
 import { useTheme } from "vuetify";
 import { useRoute, useRouter } from "vue-router";
 import { useReviewRoute } from "./composables/useReviewRoute";
-import {
-  API_BASE_URL,
-  isReadOnly,
-  sessionContext,
-} from "./utils/apiClient";
+import { API_BASE_URL, isReadOnly, sessionContext } from "./utils/apiClient";
 import { useSelectionStore } from "./stores/useSelectionStore";
 import { useFilterStore } from "./stores/useFilterStore";
 import { useSortStore } from "./stores/useSortStore";
@@ -28,10 +24,7 @@ import { useSearchStore } from "./stores/useSearchStore";
 import { useReviewSessionsStore } from "./stores/useReviewSessionsStore";
 import { useSnapshotsStore } from "./stores/useSnapshotsStore";
 import { useTasksStore } from "./stores/useTasksStore";
-import { useLockedSetsStore } from "./stores/useLockedSetsStore";
 import { useOperationStore } from "./stores/useOperationStore";
-import { useDedupStore } from "./stores/useDedupStore";
-import { useEntityListsStore } from "./stores/useEntityListsStore";
 import {
   ALL_PICTURES_ID,
   SCRAPHEAP_PICTURES_ID,
@@ -45,6 +38,9 @@ import { useGlobalKeydown } from "./composables/useGlobalKeydown";
 import { useWindowFileImport } from "./composables/useWindowFileImport";
 import { useAppSettingsHandlers } from "./composables/useAppSettingsHandlers";
 import { useUpdatesSocket } from "./composables/useUpdatesSocket";
+import { useSidebarRefresh } from "./composables/useSidebarRefresh";
+import { useViewportLayout } from "./composables/useViewportLayout";
+import { useAppEntityActions } from "./composables/useAppEntityActions";
 
 import SideBar from "./components/panels/SideBar.vue";
 import TitleBar from "./components/TitleBar.vue";
@@ -74,10 +70,7 @@ const searchStore = useSearchStore();
 const reviewSessionsStore = useReviewSessionsStore();
 const snapshotsStore = useSnapshotsStore();
 const tasksStore = useTasksStore();
-const lockedSetsStore = useLockedSetsStore();
 const operationStore = useOperationStore();
-const dedupStore = useDedupStore();
-const entityListsStore = useEntityListsStore();
 // Owns route → view resolution (the app's single route watcher). Route pushing
 // stays here in App.vue; see stores/useViewStore.js.
 const viewStore = useViewStore();
@@ -143,6 +136,18 @@ const {
   onNavigated: () => closeSidebarIfMobile(),
 });
 
+const {
+  refreshSidebar,
+  refreshSidebarDebounced,
+  refreshSidebarPicturesDebounced,
+} = useSidebarRefresh({ sidebarRef });
+
+const {
+  updateIsMobile,
+  updateMaxColumns,
+  closeSidebarIfMobile,
+} = useViewportLayout({ mainAreaRef });
+
 // The live-updates channel. App.vue owns its lifecycle - it connects on
 // mount and disconnects on unmount - but the socket, its filter handshake and
 // the realtime-sync wiring live in the composable.
@@ -158,6 +163,20 @@ const {
   refreshSidebar: (options) => refreshSidebar(options),
   refreshSidebarPicturesDebounced: (flash) =>
     refreshSidebarPicturesDebounced(flash),
+});
+
+const {
+  handleImagesAssignedToCharacter,
+  handleImagesMoved,
+  handleFacesAssignedToCharacter,
+  refreshExportCount,
+  confirmExportZip,
+  handleClearSearch,
+  handleResetToAll,
+} = useAppEntityActions({
+  gridContainer,
+  refreshSidebar,
+  onNavigated: () => closeSidebarIfMobile(),
 });
 
 useGlobalKeydown({ gridContainer, sidebarRef, shortcutsDialogOpen });
@@ -197,21 +216,9 @@ const { fetchConfig } = useAppConfig({
   },
 });
 
-// --- Layout constants ---
-const MIN_THUMBNAIL_SIZE = 96;
-const MAX_THUMBNAIL_SIZE = 384;
-const MIN_COLUMNS = 2;
-const MAX_COLUMNS = 14;
-const SIDEBAR_HIDE_BREAKPOINT = 790;
-const STATS_HIDE_BREAKPOINT = 1280;
-const SIDEBAR_REFRESH_DEBOUNCE_MS = 150;
-const SIDEBAR_REFRESH_PICTURES_DEBOUNCE_MS = 800;
 // --- Non-reactive internals ---
 let mainAreaResizeObserver = null;
 let columnsMenuCloseTimeout = null;
-let sidebarRefreshDebounceTimeout = null;
-let sidebarRefreshPicturesDebounceTimeout = null;
-let sidebarRefreshPicturesFlash = false;
 // Unsubscribe handle for the desktop tray's "Settings" event (desktop only).
 let stopOpenSettings = null;
 
@@ -260,53 +267,6 @@ function onRestoreConfirmed() {
   refreshSidebar();
 }
 
-function refreshSidebar(options = {}) {
-  sidebarRef.value?.refreshSidebar(options);
-  // The shared character/set/project lists ride the same triggers (this is what
-  // `characters_changed` lands on). Refetch ONLY — a ws payload never writes
-  // into the cache, since `origin_client_id` is echo-matching, not authority
-  // (integration_architecture.md §8.1). The call is de-duplicated against the
-  // sidebar's own refresh above, and it also covers the case where the sidebar
-  // is unmounted but a context menu is still reading the lists.
-  entityListsStore.invalidate(undefined, { baseUrl: BACKEND_URL });
-  // The locked-sets store shares the sidebar's refresh triggers (manual emits,
-  // characters_changed, and pictures_changed via the debounced pictures path,
-  // which also fires on a lock/unlock PATCH's CHANGED_PICTURES event). The store
-  // coalesces overlapping fetches, so calling it here on every refresh is cheap.
-  lockedSetsStore.fetch();
-  // The duplicates badge rides the same triggers: an import, a stack or a
-  // verdict all move the count, and every one of them already causes a sidebar
-  // refresh. The per-scope cache goes with it, since a context menu opened
-  // afterwards must not quote a pre-change number.
-  if (!isReadOnly.value) {
-    dedupStore.invalidateScopeCounts();
-    dedupStore.refreshCounts();
-  }
-}
-
-function refreshSidebarDebounced() {
-  if (sidebarRefreshDebounceTimeout) {
-    clearTimeout(sidebarRefreshDebounceTimeout);
-  }
-  sidebarRefreshDebounceTimeout = setTimeout(() => {
-    sidebarRefreshDebounceTimeout = null;
-    refreshSidebar();
-  }, SIDEBAR_REFRESH_DEBOUNCE_MS);
-}
-
-function refreshSidebarPicturesDebounced(flash) {
-  if (flash) sidebarRefreshPicturesFlash = true;
-  if (sidebarRefreshPicturesDebounceTimeout) {
-    clearTimeout(sidebarRefreshPicturesDebounceTimeout);
-  }
-  sidebarRefreshPicturesDebounceTimeout = setTimeout(() => {
-    sidebarRefreshPicturesDebounceTimeout = null;
-    const doFlash = sidebarRefreshPicturesFlash;
-    sidebarRefreshPicturesFlash = false;
-    refreshSidebar(doFlash ? { flashCounts: true } : {});
-  }, SIDEBAR_REFRESH_PICTURES_DEBOUNCE_MS);
-}
-
 /**
  * Open the settings dialog. `tab` deep-links to a nav entry (e.g. "scrapheap"
  * from the scrapheap header's "change" link); omitted callers land on Appearance.
@@ -350,57 +310,6 @@ async function handleLocalImport({ files, projectId } = {}) {
   sidebarRef.value?.startLocalImport?.(files, projectId ?? null);
 }
 
-function updateSidebarBreakpoints() {
-  if (typeof window !== "undefined") {
-    sidebarStore.sidebarForcedHidden =
-      window.innerWidth < SIDEBAR_HIDE_BREAKPOINT;
-    sidebarStore.statsForcedHidden = window.innerWidth < STATS_HIDE_BREAKPOINT;
-  }
-}
-
-function updateIsMobile() {
-  updateSidebarBreakpoints();
-  updateMaxColumns();
-}
-
-function updateMaxColumns() {
-  // Maintain the responsive column bounds. gridStore.columns is derived from
-  // the size level and clamps itself to these bounds, so there is nothing to
-  // write back here — updating the bounds re-evaluates the derived count.
-  const width = mainAreaRef.value?.clientWidth ?? window.innerWidth ?? 0;
-  if (!width) {
-    gridStore.minColumns = MIN_COLUMNS;
-    gridStore.maxColumns = MAX_COLUMNS;
-    return;
-  }
-  const availableWidth = Math.max(0, width - 8);
-  const computedMin = Math.max(
-    1,
-    Math.ceil(availableWidth / MAX_THUMBNAIL_SIZE),
-  );
-  const computedMax = Math.max(
-    computedMin,
-    Math.floor(availableWidth / MIN_THUMBNAIL_SIZE),
-  );
-  gridStore.minColumns = Math.max(MIN_COLUMNS, computedMin);
-  gridStore.maxColumns = Math.min(MAX_COLUMNS, computedMax);
-}
-
-function closeSidebarIfMobile() {
-  if (sidebarStore.sidebarForcedHidden) {
-    sidebarStore.hideAutoSidebar();
-  }
-}
-
-// Route -> stores: install the app's single route watcher (immediately on
-// mount for deep-linking, then on every navigation). The parsing and the
-// writes live in useViewStore; App.vue keeps only the route PUSHING above.
-viewStore.startRouteSync(route, { watch });
-
-// A navigation retires the live undo receipt (owner decision, 2026-07-29):
-// the pill narrates something that happened on the view being left, and a
-// receipt carried into the next view reads as a fresh event there. Ctrl+Z
-// keeps working everywhere regardless — the receipt is narration, not the
 // undo affordance itself.
 watch(
   () => route.fullPath,
@@ -419,110 +328,6 @@ function resolveThemeName(mode) {
   return mode === "dark" ? "pixlStashDark" : "pixlStashLight";
 }
 
-async function handleImagesAssignedToCharacter({ characterId, imageIds }) {
-  const current = selectionStore.selectedCharacter;
-  // Unassigned view: assigned pictures leave the unassigned bucket — drop their
-  // tiles from the grid immediately.
-  if (current === UNASSIGNED_PICTURES_ID && !selectionStore.selectedSet) {
-    if (
-      gridContainer.value &&
-      typeof gridContainer.value.removeImagesById === "function"
-    ) {
-      gridContainer.value.removeImagesById(imageIds);
-    }
-    return;
-  }
-  // Viewing a specific character: reassigning pictures (and their whole stack)
-  // to a DIFFERENT character moves them out of this view. Refetch so they
-  // disappear right away instead of lingering until the view changes — a plain
-  // removeImagesById can't catch every stack member (a collapsed drag only
-  // carries the leader id).
-  const isSpecificCharacterView =
-    current != null &&
-    !selectionStore.selectedSet &&
-    String(current) !== String(ALL_PICTURES_ID) &&
-    String(current) !== String(UNASSIGNED_PICTURES_ID) &&
-    String(current) !== String(SCRAPHEAP_PICTURES_ID);
-  if (isSpecificCharacterView && String(current) !== String(characterId)) {
-    gridStore.refreshGridVersion();
-  }
-}
-
-function handleImagesMoved({ imageIds, kind, refresh }) {
-  if (kind === "reference-folder" || refresh) {
-    wsStore.clearSortChangedExternalIds();
-    gridStore.refreshGridVersion();
-    refreshSidebar();
-    return;
-  }
-  if (
-    selectionStore.selectedCharacter !== UNASSIGNED_PICTURES_ID ||
-    selectionStore.selectedSet
-  ) {
-    return;
-  }
-  if (
-    gridContainer.value &&
-    typeof gridContainer.value.removeImagesById === "function"
-  ) {
-    gridContainer.value.removeImagesById(imageIds);
-  }
-}
-
-function handleFacesAssignedToCharacter() {
-  if (
-    gridContainer.value &&
-    typeof gridContainer.value.clearFaceSelection === "function"
-  ) {
-    gridContainer.value.clearFaceSelection();
-  }
-}
-
-function refreshExportCount() {
-  const counts = gridContainer.value?.getExportCount?.();
-  if (!counts) return;
-  exportStore.exportSelectedCount = Number(counts.selectedCount) || 0;
-  exportStore.exportTotalCount = Number(counts.totalCount) || 0;
-}
-
-function confirmExportZip() {
-  gridContainer.value?.exportCurrentViewToZip({
-    exportType: exportStore.exportType,
-    captionMode: exportStore.exportCaptionMode,
-    tagFormat: exportStore.exportTagFormat,
-    includeCharacterName: exportStore.exportIncludeCharacterName,
-    useOriginalFileNames: exportStore.exportUseOriginalFileNames,
-    resolution: exportStore.exportResolution,
-    bboxMode: exportStore.exportBboxMode,
-  });
-  exportStore.exportMenuOpen = false;
-}
-
-// --- Review tags overlay ---
-// Visibility lives in the store so the grid toolbar can open it directly.
-
-function handleClearSearch() {
-  searchStore.searchQuery = "";
-  searchStore.searchInput = "";
-  searchStore.isSearchHistoryOpen = false;
-  gridStore.refreshGridVersion();
-}
-
-function handleResetToAll() {
-  selectionStore.selectedCharacter = ALL_PICTURES_ID;
-  selectionStore.selectedSet = null;
-  selectionStore.selectedSetIds = [];
-  selectionStore.lastSelectedCharacterLabel = "All Pictures";
-  sortStore.selectedSort = "DATE";
-  sortStore.selectedDescending = true;
-  sortStore.selectedSimilarityCharacter = null;
-  searchStore.searchQuery = "";
-  filterStore.resetFilters();
-  gridStore.refreshGridVersion();
-  closeSidebarIfMobile();
-}
-
-// --- Watchers ---
 watch(
   () => searchStore.searchQuery,
   (newVal, oldVal) => {
@@ -686,14 +491,6 @@ onBeforeUnmount(() => {
   if (columnsMenuCloseTimeout) {
     clearTimeout(columnsMenuCloseTimeout);
     columnsMenuCloseTimeout = null;
-  }
-  if (sidebarRefreshDebounceTimeout) {
-    clearTimeout(sidebarRefreshDebounceTimeout);
-    sidebarRefreshDebounceTimeout = null;
-  }
-  if (sidebarRefreshPicturesDebounceTimeout) {
-    clearTimeout(sidebarRefreshPicturesDebounceTimeout);
-    sidebarRefreshPicturesDebounceTimeout = null;
   }
 });
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -43,6 +43,7 @@ import {
 import { redoKeyHint, undoKeyHint } from "./utils/shortcutHints";
 import { useGridRealtimeSync } from "./composables/useGridRealtimeSync";
 import { useAppConfig } from "./composables/useAppConfig";
+import { useAppNavigation } from "./composables/useAppNavigation";
 
 import SideBar from "./components/panels/SideBar.vue";
 import TitleBar from "./components/TitleBar.vue";
@@ -127,6 +128,21 @@ const error = ref(null);
 // Loading the user's config and persisting UI options back lives in
 // useAppConfig; App.vue only supplies the layout re-measure that a
 // thumbnail-size change needs.
+// Sidebar entry clicks and the route pushes that follow them. Reading the
+// route back into the stores is useViewStore's job, not this one's.
+const {
+  isDuplicatesView,
+  handleSelectCharacter,
+  handleSelectSet,
+  handleSelectFolder,
+  handleSearchAllPictures,
+  handleSelectDuplicates,
+  pushAppRoute,
+} = useAppNavigation({
+  onClearSearch: () => handleClearSearch(),
+  onNavigated: () => closeSidebarIfMobile(),
+});
+
 const { fetchConfig } = useAppConfig({
   onThumbnailSizeChanged: () => updateMaxColumns(),
   onUpdateCheckUndecided: () => {
@@ -717,338 +733,6 @@ function closeSidebarIfMobile() {
   if (sidebarStore.sidebarForcedHidden) {
     sidebarStore.hideAutoSidebar();
   }
-}
-
-function SelectionPayload(payload) {
-  if (payload && typeof payload === "object") {
-    const ids = Array.isArray(payload.ids)
-      ? payload.ids
-          .map((id) => Number(id))
-          .filter((id) => Number.isFinite(id) && id > 0)
-      : [];
-    return {
-      id: payload.id ?? payload.value ?? null,
-      label: payload.label ?? payload.name ?? null,
-      ids,
-      projectIds:
-        payload.projectIds && typeof payload.projectIds === "object"
-          ? payload.projectIds
-          : {},
-      projectContext: payload.projectContext ?? null,
-    };
-  }
-  return {
-    id: payload ?? null,
-    label: null,
-    ids: [],
-    projectIds: {},
-    projectContext: null,
-  };
-}
-
-function clearSearchForCategoryChange() {
-  if (
-    (searchStore.searchQuery || "").trim() ||
-    (searchStore.searchInput || "").trim()
-  ) {
-    handleClearSearch();
-  }
-}
-
-async function handleSelectCharacter(payload) {
-  selectionStore.selectedFolderFilter = null;
-  const {
-    id: charId,
-    label,
-    ids,
-    projectIds,
-    projectContext,
-  } = SelectionPayload(payload);
-  projectStore.characterProjectIds = projectIds;
-  if (projectContext) {
-    projectStore.projectViewMode = projectContext.mode;
-    projectStore.selectedProjectId = projectContext.projectId;
-  }
-  clearSearchForCategoryChange();
-  if (charId == null) {
-    selectionStore.selectedCharacter = null;
-    await nextTick();
-    return;
-  }
-  if (label) {
-    selectionStore.lastSelectedCharacterLabel = label;
-  } else if (charId === ALL_PICTURES_ID) {
-    selectionStore.lastSelectedCharacterLabel = "All Pictures";
-  } else if (charId === UNASSIGNED_PICTURES_ID) {
-    selectionStore.lastSelectedCharacterLabel = "Unassigned Pictures";
-  } else if (charId === SCRAPHEAP_PICTURES_ID) {
-    selectionStore.lastSelectedCharacterLabel = "Scrapheap";
-  }
-  if (
-    charId === SCRAPHEAP_PICTURES_ID &&
-    sortStore.selectedSort === "LIKENESS_GROUPS"
-  ) {
-    sortStore.selectedSort = "DATE";
-  }
-  selectionStore.selectedCharacter = charId;
-  selectionStore.selectedCharacterIds = ids.length ? ids : [];
-  if (ids.length <= 1) {
-    selectionStore.setCharacterMultiMode("union");
-  }
-  if (charId !== ALL_PICTURES_ID) {
-    filterStore.unassignedOnlyFilter = false;
-  }
-  wsStore.clearPendingExternalImportIds();
-  wsStore.clearSortChangedExternalIds();
-  selectionStore.selectedSet = null;
-  selectionStore.selectedSetIds = [];
-  await nextTick();
-  closeSidebarIfMobile();
-  pushRouteForCurrentSelection();
-}
-
-async function handleSelectSet(payload) {
-  selectionStore.selectedFolderFilter = null;
-  const {
-    id: setId,
-    label,
-    ids,
-    projectIds,
-    projectContext,
-  } = SelectionPayload(payload);
-  projectStore.setProjectIds = projectIds;
-  if (projectContext) {
-    projectStore.projectViewMode = projectContext.mode;
-    projectStore.selectedProjectId = projectContext.projectId;
-  }
-  const names = payload && payload.names ? payload.names : {};
-  clearSearchForCategoryChange();
-  const nextIds = ids.length
-    ? ids
-    : setId != null
-      ? [Number(setId)].filter((id) => Number.isFinite(id) && id > 0)
-      : [];
-
-  if (!nextIds.length) {
-    const fallbackLabel =
-      projectStore.projectViewMode === "project"
-        ? "Project Pictures"
-        : "All Pictures";
-    selectionStore.selectedCharacter = ALL_PICTURES_ID;
-    selectionStore.selectedCharacterIds = [];
-    selectionStore.lastSelectedCharacterLabel = fallbackLabel;
-    selectionStore.selectedSet = null;
-    selectionStore.selectedSetIds = [];
-    await nextTick();
-    closeSidebarIfMobile();
-    return;
-  }
-  if (label && nextIds.length === 1) {
-    selectionStore.lastSelectedSetLabel = label;
-  } else if (nextIds.length > 1) {
-    selectionStore.lastSelectedSetLabel = `Set Overlap (${nextIds.length})`;
-  }
-  selectionStore.selectedSetIds = nextIds;
-  selectionStore.selectedSet = nextIds[0];
-  selectionStore.selectedCharacter = null;
-  selectionStore.selectedCharacterIds = [];
-  selectionStore.selectedSetNames = names;
-  if (
-    selectionStore.setDifferenceBaseId !== null &&
-    !nextIds.includes(selectionStore.setDifferenceBaseId)
-  ) {
-    selectionStore.setSetDifferenceBaseId(null);
-  }
-  if (nextIds.length === 1) {
-    selectionStore.setSetMultiMode("intersection");
-    selectionStore.setSetDifferenceBaseId(null);
-  }
-  closeSidebarIfMobile();
-  pushRouteForCurrentSelection();
-}
-
-function handleSearchAllPictures() {
-  selectionStore.selectedCharacter = ALL_PICTURES_ID;
-  selectionStore.selectedCharacterIds = [];
-  selectionStore.selectedSet = null;
-  selectionStore.selectedSetIds = [];
-  selectionStore.selectedFolderFilter = null;
-  selectionStore.lastSelectedCharacterLabel = "All Pictures";
-  pushAppRoute({ name: "all-pictures" });
-}
-
-function handleSelectFolder(payload) {
-  if (!payload) {
-    selectionStore.selectedFolderFilter = null;
-    pushAppRoute({ name: "all-pictures" });
-    return;
-  }
-  selectionStore.selectedFolderFilter = payload;
-  selectionStore.selectedCharacter = ALL_PICTURES_ID;
-  selectionStore.selectedCharacterIds = [];
-  selectionStore.selectedSet = null;
-  selectionStore.selectedSetIds = [];
-  pushRouteForCurrentSelection();
-}
-
-// ============================================================
-// ROUTING — URL ↔ Store sync
-// ============================================================
-
-/**
- * Push a route without cluttering history on duplicate navigations.
- * Swallows NavigationDuplicated errors (vue-router throws on same-route push).
- */
-function pushAppRoute(target) {
-  if (route.query.token) {
-    target.query = { token: route.query.token, ...target.query };
-  }
-  router.push(target).catch(() => {});
-}
-
-/**
- * Build and push the correct app route for the current store selection state.
- * Called at the end of each user-initiated navigation handler so the URL
- * always reflects what the grid is showing.
- */
-function pushRouteForCurrentSelection() {
-  const sel = selectionStore;
-  const proj = projectStore;
-
-  if (sel.selectedFolderFilter) {
-    const f = sel.selectedFolderFilter;
-    if (f.referenceFolderId != null) {
-      pushAppRoute({
-        name: "ref-folder",
-        params: { id: String(f.referenceFolderId) },
-      });
-      return;
-    }
-    if (f.importFolderId != null) {
-      pushAppRoute({
-        name: "import-folder",
-        params: { id: String(f.importFolderId) },
-      });
-      return;
-    }
-    // Path-based subfolder — no dedicated route; fall through to all-pictures.
-    pushAppRoute({ name: "all-pictures" });
-    return;
-  }
-
-  if (proj.projectViewMode === "project" && proj.selectedProjectId != null) {
-    const projId = String(proj.selectedProjectId);
-    if (sel.selectedSetIds.length > 0) {
-      const query = {};
-      if (sel.selectedSetIds.length > 1) {
-        query.ids = sel.selectedSetIds.join(",");
-        query.mode = sel.setMultiMode || "intersection";
-        if (
-          sel.setMultiMode === "difference" &&
-          sel.setDifferenceBaseId != null
-        ) {
-          query.base = String(sel.setDifferenceBaseId);
-        }
-      }
-      pushAppRoute({
-        name: "project-set",
-        params: { projectId: projId, id: String(sel.selectedSetIds[0]) },
-        query,
-      });
-      return;
-    }
-    if (
-      sel.selectedCharacter &&
-      sel.selectedCharacter !== ALL_PICTURES_ID &&
-      sel.selectedCharacter !== SCRAPHEAP_PICTURES_ID
-    ) {
-      const query = {};
-      if (sel.selectedCharacterIds.length > 1) {
-        query.ids = sel.selectedCharacterIds.join(",");
-        query.mode = sel.characterMultiMode || "union";
-      }
-      pushAppRoute({
-        name: "project-character",
-        params: { projectId: projId, id: String(sel.selectedCharacter) },
-        query,
-      });
-      return;
-    }
-    pushAppRoute({
-      name: "project",
-      params: { id: projId },
-    });
-    return;
-  }
-
-  if (sel.selectedSetIds.length > 0) {
-    const query = {};
-    if (sel.selectedSetIds.length > 1) {
-      query.ids = sel.selectedSetIds.join(",");
-      query.mode = sel.setMultiMode || "intersection";
-      if (
-        sel.setMultiMode === "difference" &&
-        sel.setDifferenceBaseId != null
-      ) {
-        query.base = String(sel.setDifferenceBaseId);
-      }
-    }
-    pushAppRoute({
-      name: "set",
-      params: { id: String(sel.selectedSetIds[0]) },
-      query,
-    });
-    return;
-  }
-
-  if (sel.selectedCharacter === SCRAPHEAP_PICTURES_ID) {
-    pushAppRoute({ name: "scrapheap" });
-    return;
-  }
-
-  if (!sel.selectedCharacter || sel.selectedCharacter === ALL_PICTURES_ID) {
-    pushAppRoute({ name: "all-pictures" });
-    return;
-  }
-
-  const query = {};
-  if (sel.selectedCharacterIds.length > 1) {
-    query.ids = sel.selectedCharacterIds.join(",");
-    query.mode = sel.characterMultiMode || "union";
-  }
-  pushAppRoute({
-    name: "character",
-    params: { id: String(sel.selectedCharacter) },
-    query,
-  });
-}
-
-// The Duplicates destination is addressed by route name, not by a sentinel in
-// the selection store: it shows no pictures, so it has no selection to express.
-const isDuplicatesView = computed(() => route.name === "duplicates");
-
-/**
- * Open the duplicate triage queue, optionally scoped to one collection object.
- *
- * The scope travels in the query rather than in a store, so a scoped queue is a
- * link the user can bookmark and reload, and a back-navigation out of one lands
- * somewhere that still makes sense.
- *
- * @param {Object} [scope]
- * @param {string} [scope.type] - "project", "set", "character" or "folder".
- * @param {number|string} [scope.id]
- * @param {string} [scope.label] - what the scope pill reads.
- * @param {string} [scope.icon] - the pill's mdi glyph.
- */
-function handleSelectDuplicates(scope = {}) {
-  const query = {};
-  if (scope.type && scope.type !== "library") {
-    query.scope = scope.type;
-    if (scope.id !== undefined && scope.id !== null) query.scope_id = scope.id;
-    if (scope.label) query.scope_label = scope.label;
-    if (scope.icon) query.scope_icon = scope.icon;
-  }
-  pushAppRoute({ name: "duplicates", query });
 }
 
 // Route -> stores: install the app's single route watcher (immediately on

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -12,11 +12,9 @@ import { useRoute, useRouter } from "vue-router";
 import { useReviewRoute } from "./composables/useReviewRoute";
 import {
   API_BASE_URL,
-  appendShareToken,
   isReadOnly,
   sessionContext,
 } from "./utils/apiClient";
-import { patchUserConfig } from "./api/config";
 import { useSelectionStore } from "./stores/useSelectionStore";
 import { useFilterStore } from "./stores/useFilterStore";
 import { useSortStore } from "./stores/useSortStore";
@@ -41,11 +39,12 @@ import {
   useViewStore,
 } from "./stores/useViewStore";
 import { redoKeyHint, undoKeyHint } from "./utils/shortcutHints";
-import { useGridRealtimeSync } from "./composables/useGridRealtimeSync";
 import { useAppConfig } from "./composables/useAppConfig";
 import { useAppNavigation } from "./composables/useAppNavigation";
 import { useGlobalKeydown } from "./composables/useGlobalKeydown";
 import { useWindowFileImport } from "./composables/useWindowFileImport";
+import { useAppSettingsHandlers } from "./composables/useAppSettingsHandlers";
+import { useUpdatesSocket } from "./composables/useUpdatesSocket";
 
 import SideBar from "./components/panels/SideBar.vue";
 import TitleBar from "./components/TitleBar.vue";
@@ -144,8 +143,52 @@ const {
   onNavigated: () => closeSidebarIfMobile(),
 });
 
+// The live-updates channel. App.vue owns its lifecycle - it connects on
+// mount and disconnects on unmount - but the socket, its filter handshake and
+// the realtime-sync wiring live in the composable.
+const {
+  connectUpdatesSocket,
+  disconnectUpdatesSocket,
+  sendUpdatesFilters,
+  loadPendingExternalImports,
+  loadSortChangedExternal,
+  onFlagSortChanged,
+} = useUpdatesSocket({
+  gridContainer,
+  refreshSidebar: (options) => refreshSidebar(options),
+  refreshSidebarPicturesDebounced: (flash) =>
+    refreshSidebarPicturesDebounced(flash),
+});
+
 useGlobalKeydown({ gridContainer, sidebarRef, shortcutsDialogOpen });
 useWindowFileImport({ sidebarRef });
+
+const {
+  handleUpdateProjectViewMode,
+  handleUpdateSelectedProjectId,
+  handleViewProject,
+  handleUpdateSelectedSort,
+  handleUpdateSortOptions,
+  handleStackStatsUpdate,
+  handleUpdateSimilarityCharacter,
+  handleUpdateSimilarityOptions,
+  handleUpdateHiddenTags,
+  handleUpdateApplyTagFilter,
+  handleUpdateDateFormat,
+  handleUpdateThemeMode,
+  handleUpdateCheckForUpdates,
+  handleUpdateSidebarThumbnailSize,
+  handleEmptyScrapheapFromSidebar,
+  handleSuggestPicturesForCharacter,
+  focusTasksTabPanel,
+  handleUpdateThumbnailMode,
+  handleUpdateSidebarWidth,
+} = useAppSettingsHandlers({
+  gridContainer,
+  statsSidebarRef,
+  onNavigated: () => closeSidebarIfMobile(),
+  pushAppRoute,
+});
 
 const { fetchConfig } = useAppConfig({
   onThumbnailSizeChanged: () => updateMaxColumns(),
@@ -163,20 +206,12 @@ const SIDEBAR_HIDE_BREAKPOINT = 790;
 const STATS_HIDE_BREAKPOINT = 1280;
 const SIDEBAR_REFRESH_DEBOUNCE_MS = 150;
 const SIDEBAR_REFRESH_PICTURES_DEBOUNCE_MS = 800;
-// Coalescing window for incoming grid-driving WS events (see
-// useGridRealtimeSync). A burst of foreign events accumulates over this window
-// and applies once per category instead of one fetch+rebuild per event.
-const GRID_WS_COALESCE_MS = 200;
-
 // --- Non-reactive internals ---
 let mainAreaResizeObserver = null;
-let updatesSocket = null;
-let updatesReconnectTimer = null;
 let columnsMenuCloseTimeout = null;
 let sidebarRefreshDebounceTimeout = null;
 let sidebarRefreshPicturesDebounceTimeout = null;
 let sidebarRefreshPicturesFlash = false;
-let gridWsCoalesceTimer = null;
 // Unsubscribe handle for the desktop tray's "Settings" event (desktop only).
 let stopOpenSettings = null;
 
@@ -218,314 +253,6 @@ const activeCategoryLabel = computed(() => {
   }
   return "All Pictures";
 });
-
-// --- WebSocket ---
-// Event types that can carry a recorded operation (the reversible metadata
-// facets of backend_architecture.md §21). `picture_imported` is deliberately
-// absent: imports are not undoable in v1.9, so they never appear in the stack.
-const OPERATION_BEARING_EVENTS = new Set([
-  "pictures_changed",
-  "tags_changed",
-  "characters_changed",
-  "descriptions_changed",
-]);
-
-function buildUpdatesSocketUrl() {
-  if (!BACKEND_URL) return "";
-  const wsBase = BACKEND_URL.replace(/^http/i, "ws");
-  // The backend authenticates the WebSocket handshake (the HTTP auth
-  // middleware does not cover WebSockets). A full session authenticates via
-  // the same-origin session cookie; a share/read-only session has no cookie,
-  // so append its READ token as ?token= the same way HTTP requests do.
-  return appendShareToken(`${wsBase}/ws/updates`);
-}
-
-// A `pictures_changed` event may carry a `fields` list naming the columns that
-// changed. When every changed field is invisible to the current sort + active
-// filters (e.g. a background `smart_score` recompute while sorting by date),
-// the grid/sidebar don't need to react at all. An event with no `fields`
-// (user edits, imports, plugin output, …) is treated as "unknown" and always
-// refreshes, preserving the previous behaviour.
-function pictureChangeFieldAffectsView(field) {
-  if (field === "smart_score") {
-    return (
-      sortStore.selectedSort === "SMART_SCORE" ||
-      filterStore.smartScoreBucketFilter != null
-    );
-  }
-  // Detections are an opt-in overlay layer, never a sort/filter field, so a
-  // detection change never affects grid membership or order — don't reload or
-  // raise the "view changed" pill for it.
-  if (field === "detections") return false;
-  // Unknown field → assume it can affect the view, so refresh to be safe.
-  return true;
-}
-
-function pictureChangeAffectsView(fields) {
-  if (!Array.isArray(fields) || fields.length === 0) return true;
-  return fields.some(pictureChangeFieldAffectsView);
-}
-
-function sendUpdatesFilters() {
-  if (!updatesSocket) return;
-  if (updatesSocket.readyState !== WebSocket.OPEN) return;
-  updatesSocket.send(
-    JSON.stringify({
-      type: "set_filters",
-      client_id: wsStore.clientId,
-      selected_character: selectionStore.selectedCharacter,
-      selected_set: selectionStore.selectedSet,
-      selected_sets: selectionStore.selectedSetIds,
-      search_query: searchStore.searchQuery,
-    }),
-  );
-}
-
-// Imperative grid API surface used by the realtime-sync composable. Each method
-// delegates to the ImageGrid template-ref's defineExpose'd methods (Tier-3
-// imperative API), no-oping safely if the grid isn't mounted yet.
-const gridApi = {
-  insertGridImagesById: (ids) =>
-    gridContainer.value?.insertGridImagesById?.(ids),
-  refreshGridImage: (id) => gridContainer.value?.refreshGridImage?.(id),
-  repositionImageByScore: (id, score) =>
-    gridContainer.value?.repositionImageByScore?.(id, score),
-  repositionImageBySmartScore: (id) =>
-    gridContainer.value?.repositionImageBySmartScore?.(id),
-  refreshSmartScoreForImage: (id) =>
-    gridContainer.value?.refreshSmartScoreForImage?.(id),
-  removeImagesById: (ids) => gridContainer.value?.removeImagesById?.(ids),
-  isImagesLoading: () => gridContainer.value?.isImagesLoading?.() ?? false,
-  isOverlayOpen: () => gridContainer.value?.isOverlayOpen?.() ?? false,
-  markOverlayDeferredRefresh: () =>
-    gridContainer.value?.markOverlayDeferredRefresh?.(),
-};
-
-function fullGridReload() {
-  gridStore.wsUpdateKey = Date.now();
-  gridStore.refreshGridVersion();
-}
-
-// Fixed-window scheduler for the realtime-sync coalescer. The composable arms
-// one flush per window (it skips schedule() while a flush is already pending),
-// so the first queued event starts a GRID_WS_COALESCE_MS timer and a
-// back-to-back burst flushes once at its end. cancel() lets onBeforeUnmount
-// drop a pending flush.
-const gridWsScheduler = {
-  schedule(flush) {
-    if (gridWsCoalesceTimer) clearTimeout(gridWsCoalesceTimer);
-    gridWsCoalesceTimer = setTimeout(() => {
-      gridWsCoalesceTimer = null;
-      flush();
-    }, GRID_WS_COALESCE_MS);
-  },
-  cancel() {
-    if (gridWsCoalesceTimer) {
-      clearTimeout(gridWsCoalesceTimer);
-      gridWsCoalesceTimer = null;
-    }
-  },
-};
-
-const gridRealtimeSync = useGridRealtimeSync({
-  getMyClientId: () => wsStore.clientId,
-  grid: gridApi,
-  wsStore,
-  pictureChangeAffectsView,
-  getSelectedSort: () => sortStore.selectedSort,
-  reload: fullGridReload,
-  refreshSidebar: (flash) => refreshSidebarPicturesDebounced(flash),
-  scheduler: gridWsScheduler,
-});
-
-function connectUpdatesSocket() {
-  if (updatesSocket) return;
-  const url = buildUpdatesSocketUrl();
-  if (!url) return;
-  const ws = new WebSocket(url);
-  updatesSocket = ws;
-
-  ws.onopen = () => {
-    sendUpdatesFilters();
-  };
-
-  ws.onmessage = (event) => {
-    let payload;
-    try {
-      payload = JSON.parse(event.data);
-    } catch {
-      return;
-    }
-    // The operation log has no WS event of its own: a metadata mutation
-    // announces itself as a picture/tag/character change, and that is the
-    // signal the undo stack may have moved. Origin is read from the event
-    // `data` (never a contextvar) and only decides whether the change may
-    // narrate itself; an external one updates the stack silently.
-    if (OPERATION_BEARING_EVENTS.has(payload?.type)) {
-      operationStore.onPictureEvent(payload);
-    }
-    const isPictureChange =
-      payload?.type === "pictures_changed" ||
-      payload?.type === "picture_imported";
-    if (isPictureChange) {
-      // LIKENESS_GROUPS reorders the whole grid wholesale, so a targeted op
-      // can't reconcile it — keep the existing wsTagUpdate signal that lets the
-      // grid re-rank in place. (Imports still flow through the normal path.)
-      const pictureIds = Array.isArray(payload.picture_ids)
-        ? payload.picture_ids
-        : [];
-      // Signal the open lightbox to re-fetch its card's smart_score. The overlay
-      // always displays the score (independent of grid sort), so this fires for
-      // any smart_score change regardless of the current sort and regardless of
-      // origin — matching on picture id + field, not origin, so it covers both
-      // origin-stamped interactive tag edits and the origin-less bulk drain that
-      // rides a penalised-tag settings change. `fields` absent = full change.
-      if (payload?.type === "pictures_changed" && pictureIds.length > 0) {
-        const changedFields = Array.isArray(payload.fields)
-          ? payload.fields
-          : [];
-        const touchesSmartScore =
-          changedFields.length === 0 || changedFields.includes("smart_score");
-        if (touchesSmartScore) {
-          const nextKey = (wsStore.wsSmartScoreUpdate?.key || 0) + 1;
-          wsStore.wsSmartScoreUpdate = { key: nextKey, pictureIds };
-        }
-        // Signal the open lightbox to re-fetch its detection boxes when a
-        // Segment run lands. The grid's card-content refresh is deferred under
-        // an open overlay (§9.1) and the overlay reads its boxes straight from
-        // the detections endpoint, so it needs its own signal. The backend
-        // always stamps this change `fields: ["detections"]`, so match on the
-        // explicit field only.
-        if (changedFields.includes("detections")) {
-          const nextKey = (wsStore.wsDetectionUpdate?.key || 0) + 1;
-          wsStore.wsDetectionUpdate = { key: nextKey, pictureIds };
-        }
-      }
-      if (
-        pictureIds.length > 0 &&
-        sortStore.selectedSort === "LIKENESS_GROUPS" &&
-        payload?.type !== "picture_imported" &&
-        pictureChangeAffectsView(payload.fields)
-      ) {
-        if (!wsStore.isUploadInProgress) {
-          refreshSidebarPicturesDebounced(true);
-        }
-        const nextKey = (wsStore.wsTagUpdate?.key || 0) + 1;
-        wsStore.wsTagUpdate = { key: nextKey, pictureIds };
-        return;
-      }
-      // Own upload in progress: the import dialog drives the grid; ignore the
-      // echo so it doesn't double-count or reload mid-upload.
-      if (wsStore.isUploadInProgress && payload?.type === "picture_imported") {
-        return;
-      }
-      // Everything else goes through the origin-aware decision table.
-      gridRealtimeSync.handleMessage(payload);
-    } else if (payload?.type === "characters_changed") {
-      refreshSidebar();
-    } else if (payload?.type === "tags_changed") {
-      const pictureIds = Array.isArray(payload.picture_ids)
-        ? payload.picture_ids
-        : [];
-      // Origin-aware: only this tab's own tag edits may refresh a tag-filtered
-      // grid in place. A tag change from outside (background tagging, another
-      // tab) must not reshuffle the user's filtered view — the grid raises a
-      // click-to-refresh pill instead (see ImageGrid's wsTagUpdate watcher).
-      // The flag rides on wsTagUpdate; the overlay still refreshes its open
-      // card's tags for any origin.
-      const isOwn = !!(
-        payload.origin_client_id &&
-        wsStore.clientId &&
-        payload.origin_client_id === wsStore.clientId
-      );
-      const nextKey = (wsStore.wsTagUpdate?.key || 0) + 1;
-      wsStore.wsTagUpdate = { key: nextKey, pictureIds, external: !isOwn };
-    } else if (payload?.type === "descriptions_changed") {
-      const pictureIds = Array.isArray(payload.picture_ids)
-        ? payload.picture_ids
-        : [];
-      const nextKey = (wsStore.wsDescriptionUpdate?.key || 0) + 1;
-      wsStore.wsDescriptionUpdate = { key: nextKey, pictureIds };
-    } else if (payload?.type === "plugin_progress") {
-      wsStore.wsPluginProgress = {
-        key: Date.now(),
-        payload,
-      };
-    } else if (payload?.type === "snapshot_created" && !isReadOnly.value) {
-      snapshotsStore.onSnapshotCreated();
-    } else if (payload?.type === "snapshot_deleted" && !isReadOnly.value) {
-      snapshotsStore.onSnapshotDeleted(payload);
-    } else if (payload?.type === "restore_started" && !isReadOnly.value) {
-      snapshotsStore.onRestoreStarted(payload);
-    } else if (payload?.type === "restore_completed" && !isReadOnly.value) {
-      snapshotsStore.onRestoreCompleted();
-      gridStore.wsUpdateKey = Date.now();
-      gridStore.refreshGridVersion();
-      refreshSidebar();
-    } else if (payload?.type === "restore_failed" && !isReadOnly.value) {
-      snapshotsStore.onRestoreFailed(payload);
-      gridStore.wsUpdateKey = Date.now();
-      gridStore.refreshGridVersion();
-      refreshSidebar();
-    }
-  };
-
-  ws.onclose = () => {
-    updatesSocket = null;
-    if (updatesReconnectTimer) {
-      clearTimeout(updatesReconnectTimer);
-    }
-    updatesReconnectTimer = setTimeout(() => {
-      updatesReconnectTimer = null;
-      connectUpdatesSocket();
-    }, 2000);
-  };
-}
-
-function disconnectUpdatesSocket() {
-  if (updatesReconnectTimer) {
-    clearTimeout(updatesReconnectTimer);
-    updatesReconnectTimer = null;
-  }
-  if (updatesSocket) {
-    updatesSocket.close();
-    updatesSocket = null;
-  }
-}
-
-function loadPendingExternalImports() {
-  const ids = wsStore.pendingExternalImportIds.slice();
-  wsStore.clearPendingExternalImportIds();
-  if (!ids.length) {
-    fullGridReload();
-    return;
-  }
-  // Splice just the new ids in place; fall back to a full reload if the grid
-  // ref isn't available (e.g. unmounted) or is mid-fetch.
-  const grid = gridContainer.value;
-  if (grid?.insertGridImagesById && !grid.isImagesLoading?.()) {
-    grid.insertGridImagesById(ids);
-  } else {
-    fullGridReload();
-  }
-}
-
-function loadSortChangedExternal() {
-  // The user opted in to the reshuffle — reconcile by refetching + re-sorting.
-  wsStore.clearSortChangedExternalIds();
-  fullGridReload();
-}
-
-// ImageGrid asks to raise the "view changed externally" pill for an external
-// tag change under an active tag filter (instead of reshuffling the filtered
-// grid under the user). Skip ids already queued in the "new pictures" pill so a
-// just-imported batch being tagged doesn't double-pill.
-function onFlagSortChanged(ids) {
-  if (!Array.isArray(ids) || !ids.length) return;
-  const pending = new Set(wsStore.pendingExternalImportIds);
-  const fresh = ids.filter((id) => !pending.has(id));
-  if (fresh.length) wsStore.addSortChangedExternalIds(fresh);
-}
 
 function onRestoreConfirmed() {
   gridStore.wsUpdateKey = Date.now();
@@ -688,143 +415,6 @@ watch(
 // into the store (used for sidebar scoping); they never push a route.
 // Grid navigation happens via explicit entry clicks (handleViewProject,
 // handleSelectCharacter, handleSelectSet, handleSelectFolder).
-function handleUpdateProjectViewMode(mode) {
-  projectStore.projectViewMode = mode;
-}
-
-function handleUpdateSelectedProjectId(id) {
-  projectStore.selectedProjectId = id;
-}
-
-// Explicit "view this project" entry click → navigate. useViewStore (watching
-// the route) sets projectViewMode/selectedProjectId from the URL, which scopes
-// the grid to the project.
-function handleViewProject(id) {
-  if (id == null) return;
-  pushAppRoute({ name: "project", params: { id: String(id) } });
-}
-
-async function handleUpdateSelectedSort({ sort, descending }) {
-  sortStore.selectedSort = sort;
-  sortStore.selectedDescending = descending;
-  closeSidebarIfMobile();
-}
-
-function handleUpdateSortOptions(options) {
-  sortStore.sortOptions = Array.isArray(options) ? options : [];
-}
-
-function handleStackStatsUpdate(payload) {
-  const expanded = Number(payload?.expanded ?? 0);
-  const total = Number(payload?.total ?? 0);
-  gridStore.expandedStackCount = Number.isFinite(expanded)
-    ? Math.max(0, expanded)
-    : 0;
-  gridStore.totalStackCount = Number.isFinite(total) ? Math.max(0, total) : 0;
-}
-
-function handleUpdateSimilarityCharacter(val) {
-  sortStore.selectedSimilarityCharacter = val;
-  gridStore.refreshGridVersion();
-  closeSidebarIfMobile();
-}
-
-function handleUpdateSimilarityOptions(options) {
-  sortStore.similarityCharacterOptions = Array.isArray(options) ? options : [];
-}
-
-function handleUpdateHiddenTags(tags) {
-  const nextTags = Array.isArray(tags) ? tags : [];
-  if (
-    userPrefsStore.hiddenTags.length === nextTags.length &&
-    userPrefsStore.hiddenTags.every((tag, index) => tag === nextTags[index])
-  ) {
-    return;
-  }
-  userPrefsStore.hiddenTags = nextTags;
-}
-
-function handleUpdateApplyTagFilter(value) {
-  const nextValue = Boolean(value);
-  if (userPrefsStore.applyTagFilter === nextValue) return;
-  userPrefsStore.applyTagFilter = nextValue;
-}
-
-function handleUpdateDateFormat(value) {
-  if (value == null) return;
-  const nextValue = String(value);
-  if (nextValue === userPrefsStore.dateFormat) return;
-  userPrefsStore.dateFormat = nextValue;
-}
-
-function handleUpdateThemeMode(value) {
-  if (value == null) return;
-  userPrefsStore.themeMode = String(value);
-}
-
-async function handleUpdateCheckForUpdates(value) {
-  userPrefsStore.checkForUpdates = value;
-  try {
-    await patchUserConfig({ check_for_updates: value });
-  } catch (e) {
-    console.error("Failed to save check_for_updates preference:", e);
-  }
-}
-
-function handleUpdateSidebarThumbnailSize(value) {
-  const nextValue = Number(value);
-  if (!Number.isFinite(nextValue)) return;
-  userPrefsStore.sidebarThumbnailSize = nextValue;
-}
-
-// The sidebar's Scrapheap context menu asks to empty the heap. The sidebar has
-// already switched the view to the scrapheap; defer to the next tick so the grid
-// is showing that view before we open its existing consent-gated empty-forever
-// confirm (whose post-confirm refetch then reconciles the right view). The grid
-// is still fetching that view at this point, by construction — the confirm is
-// deliberately not gated on that, and takes its counts from the server preview.
-function handleEmptyScrapheapFromSidebar() {
-  nextTick(() => gridContainer.value?.confirmEmptyScrapheap?.());
-}
-
-// The sidebar's person context menu asks for more pictures of that person
-// (#636). The search runs across the whole library rather than inside the
-// current view, so nothing here changes the selection or the route: the grid
-// owns the search mode and shows its own result bar.
-function handleSuggestPicturesForCharacter(character) {
-  if (character?.id == null) return;
-  nextTick(() =>
-    gridContainer.value?.suggestPicturesForCharacter?.({
-      id: character.id,
-      name: character.name,
-    }),
-  );
-}
-
-// Open the stats sidebar and focus its Tasks tab. Shared by the thumbnail-mode
-// "View progress" notice action and the ThumbnailUpgradeBanner's link, so both
-// use the same statsSidebarRef.focusTasksTab() plumbing.
-function focusTasksTabPanel() {
-  sidebarStore.statsOpen = true;
-  nextTick(() => statsSidebarRef.value?.focusTasksTab?.());
-}
-
-function handleUpdateThumbnailMode(value) {
-  if (value !== "square" && value !== "justified") return;
-  if (value === gridStore.thumbnailMode) return;
-  // Apply immediately with no regeneration: both modes render from the same
-  // stored bitmap (justified shows it whole; square crops it to the stored
-  // rectangle), so the grid re-lays-out at once. The persist watch saves it,
-  // and the radiogroup's aria-checked change is what a screen reader announces.
-  gridStore.thumbnailMode = value;
-}
-
-function handleUpdateSidebarWidth(value) {
-  const nextValue = Number(value);
-  if (!Number.isFinite(nextValue)) return;
-  userPrefsStore.sidebarWidth = nextValue;
-}
-
 function resolveThemeName(mode) {
   return mode === "dark" ? "pixlStashDark" : "pixlStashLight";
 }
@@ -1105,7 +695,6 @@ onBeforeUnmount(() => {
     clearTimeout(sidebarRefreshPicturesDebounceTimeout);
     sidebarRefreshPicturesDebounceTimeout = null;
   }
-  gridWsScheduler.cancel();
 });
 
 defineExpose({

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -49,10 +49,7 @@ import {
   movePicturesToReferenceFolder,
 } from "../../api/folders";
 import { setPicturesProject } from "../../api/pictures";
-import {
-  getSharedResourceIds,
-  revokeTokensByResource,
-} from "../../api/users";
+import { getSharedResourceIds, revokeTokensByResource } from "../../api/users";
 import { listSortMechanisms } from "../../api/session";
 import { extractSupportedImportFilesFromDataTransfer } from "../../utils/media.js";
 import {
@@ -68,7 +65,20 @@ import { useLockedSetsStore } from "../../stores/useLockedSetsStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
 import { useVersionCheck } from "../../composables/useVersionCheck";
 import { useSidebarExpansion } from "../../composables/useSidebarExpansion";
+import { useRoute } from "vue-router";
 import { useDedupStore, scopeKey } from "../../stores/useDedupStore";
+import { useSelectionStore } from "../../stores/useSelectionStore";
+import { useSortStore } from "../../stores/useSortStore";
+import { useProjectStore } from "../../stores/useProjectStore";
+import { useUserPrefsStore } from "../../stores/useUserPrefsStore";
+import { useGridStore } from "../../stores/useGridStore";
+import { useFilterStore } from "../../stores/useFilterStore";
+import {
+  ALL_PICTURES_ID,
+  SCRAPHEAP_PICTURES_ID,
+  UNASSIGNED_PICTURES_ID,
+  useViewStore,
+} from "../../stores/useViewStore";
 
 // Publishes id → name maps for the ImageGrid breadcrumb. The sidebar is the
 // authoritative name source (it fetches these lists); see useEntityNamesStore.
@@ -96,45 +106,36 @@ const isDesktop = typeof window !== "undefined" && !!window.pixlstashDesktop;
 
 const dedupStore = useDedupStore();
 
+// Store-direct (Phase 3): the sidebar reads the selection, sort, project and
+// preference state it displays straight from the stores and writes changes
+// back itself, instead of mirroring all of it through App.vue.
+const selectionStore = useSelectionStore();
+const sortStore = useSortStore();
+const projectStore = useProjectStore();
+const userPrefsStore = useUserPrefsStore();
+const gridStore = useGridStore();
+const filterStore = useFilterStore();
+const viewStore = useViewStore();
+const route = useRoute();
+
+// A folder filter and the Duplicates destination each suppress parts of the
+// entity lists, so both are derived once here.
+const hasFolderFilter = computed(
+  () => selectionStore.selectedFolderFilter != null,
+);
+// Duplicates is addressed by route name, not by a selection sentinel: it shows
+// no pictures, so there is no selection to express.
+const isDuplicatesView = computed(() => route.name === "duplicates");
+
 const props = defineProps({
-  docked: { type: Boolean, default: false },
-  selectedCharacter: { type: [String, Number, null], default: null },
-  allPicturesId: { type: String, required: true },
-  unassignedPicturesId: { type: String, required: true },
-  scrapheapPicturesId: { type: String, required: true },
-  // The Duplicates destination is addressed by route, not by a selection
-  // sentinel, so its active state arrives as its own flag.
-  isDuplicatesView: { type: Boolean, default: false },
-  selectedSet: { type: [Number, null], default: null },
-  selectedSetIds: { type: Array, default: () => [] },
-  selectedCharacterIds: { type: Array, default: () => [] },
-  searchQuery: { type: String, default: "" },
-  selectedSort: { type: String, default: "" },
-  selectedDescending: { type: Boolean, default: false },
-  selectedSimilarityCharacter: { type: [String, Number, null], default: null },
   backendUrl: { type: String, required: true },
-  publicUrl: { type: String, default: null },
-  embedWatermark: { type: Boolean, default: false },
-  sidebarThumbnailSize: { type: Number, default: 48 },
-  sidebarWidth: { type: Number, default: 240 },
-  dateFormat: { type: String, default: "locale" },
-  themeMode: { type: String, default: "light" },
-  hasFolderFilter: { type: Boolean, default: false },
-  activeFolderKey: { type: String, default: null },
-  externalProjectViewMode: { type: String, default: null },
-  externalSelectedProjectId: { type: Number, default: null },
-  checkForUpdates: { type: Boolean, default: null },
   installType: { type: String, default: "pip" },
   dockerVariant: { type: String, default: "gpu" },
-  showKeyboardHint: { type: Boolean, default: true },
-  thumbnailMode: { type: String, default: "square" },
 });
 
 const emit = defineEmits([
   "select-duplicates",
   "select-character",
-  "update:selected-sort",
-  "update:search-query",
   "select-set",
   "import-finished",
   "set-error",
@@ -143,29 +144,12 @@ const emit = defineEmits([
   "faces-assigned-to-character",
   "images-moved",
   "search-images",
-  "update:similarity-character",
-  "update:similarity-options",
-  "update:sidebar-thumbnail-size",
-  "update:sidebar-width",
-  "update:date-format",
-  "update:theme-mode",
-  "update:thumbnail-mode",
   "empty-scrapheap",
   "suggest-pictures-for-character",
-  "update:sort-options",
-  "update:hidden-tags",
-  "update:apply-tag-filter",
-  "update:comfyui-configured",
-  "update:public-url",
-  "update:embed-watermark",
   "open-import-dialog",
-  "update:project-view-mode",
-  "update:selected-project-id",
   "view-project",
   "update:check-for-updates",
-  "update:show-keyboard-hint",
   "select-folder",
-  "update:folder-scanning",
 ]);
 
 // "New version available" alert. Disabled on the desktop shell, where the title
@@ -181,7 +165,7 @@ const {
   dismissUpdateAlert,
 } = useVersionCheck(
   () => props.installType,
-  () => props.checkForUpdates,
+  () => userPrefsStore.checkForUpdates,
   !isDesktop,
 );
 
@@ -239,9 +223,9 @@ const sortOptions = ref([]);
 // --- Character & Sidebar State ---
 const characters = computed(() => entityLists.characters);
 const categoryCounts = ref({
-  [props.allPicturesId]: 0,
-  [props.unassignedPicturesId]: 0,
-  [props.scrapheapPicturesId]: 0,
+  [ALL_PICTURES_ID]: 0,
+  [UNASSIGNED_PICTURES_ID]: 0,
+  [SCRAPHEAP_PICTURES_ID]: 0,
 });
 // Counts keyed by project id (number) or UNASSIGNED_PROJECT_KEY (unassigned in project mode)
 const UNASSIGNED_PROJECT_KEY = "UNASSIGNED";
@@ -586,7 +570,7 @@ async function referenceFolderDeleted() {
   selectedFolderKey.value = null;
   selectedFolderReferenceId.value = null;
   emit("select-folder", null);
-  emit("update:folder-scanning", false);
+  sidebarStore.folderScanning = false;
   await fetchReferenceFolders();
 }
 
@@ -612,7 +596,7 @@ async function importFolderSaved() {
         importFolderId: newFolder.id,
         label: newFolder.label || newFolder.folder,
       });
-      emit("update:folder-scanning", Boolean(newFolder.last_checked == null));
+      sidebarStore.folderScanning = Boolean(newFolder.last_checked == null);
       return;
     }
   }
@@ -627,7 +611,7 @@ async function importFolderSaved() {
     selectedFolderKey.value = null;
     selectedFolderReferenceId.value = null;
     emit("select-folder", null);
-    emit("update:folder-scanning", false);
+    sidebarStore.folderScanning = false;
     return;
   }
   emit("select-folder", {
@@ -647,7 +631,7 @@ async function importFolderDeleted() {
     selectedFolderKey.value = null;
     selectedFolderReferenceId.value = null;
     emit("select-folder", null);
-    emit("update:folder-scanning", false);
+    sidebarStore.folderScanning = false;
   }
   await fetchImportFolders();
 }
@@ -693,7 +677,7 @@ const selectedFolderScanning = computed(() => {
 });
 
 watch(selectedFolderScanning, (val) => {
-  emit("update:folder-scanning", val);
+  sidebarStore.folderScanning = val;
 });
 
 const collapsedProjectBtnTitle = computed(() => {
@@ -838,7 +822,7 @@ function handleFolderNodeSelect(key, payload) {
   }
   emit("select-folder", payload);
   // Emit immediately on selection so ImageGrid updates before next poll tick.
-  emit("update:folder-scanning", selectedFolderScanning.value);
+  sidebarStore.folderScanning = selectedFolderScanning.value;
 }
 
 async function handleFolderNodeToggle(path) {
@@ -1137,7 +1121,11 @@ function createSet() {
 }
 
 function toggleProjectMenu() {
-  if (!projectMenuOpen.value && props.docked && collapsedProjectBtnRef.value) {
+  if (
+    !projectMenuOpen.value &&
+    sidebarStore.effectiveDocked &&
+    collapsedProjectBtnRef.value
+  ) {
     const rect = collapsedProjectBtnRef.value.getBoundingClientRect();
     collapsedProjectMenuPos.value = _flyoutPos(rect);
     if (
@@ -1301,13 +1289,14 @@ const sortedCharacters = computed(() => {
 
 const selectedCharacterObj = computed(() => {
   if (
-    props.selectedCharacter &&
-    props.selectedCharacter !== props.allPicturesId &&
-    props.selectedCharacter !== props.unassignedPicturesId &&
-    props.selectedCharacter !== props.scrapheapPicturesId
+    selectionStore.selectedCharacter &&
+    selectionStore.selectedCharacter !== ALL_PICTURES_ID &&
+    selectionStore.selectedCharacter !== UNASSIGNED_PICTURES_ID &&
+    selectionStore.selectedCharacter !== SCRAPHEAP_PICTURES_ID
   ) {
     const char =
-      characters.value.find((c) => c.id === props.selectedCharacter) || null;
+      characters.value.find((c) => c.id === selectionStore.selectedCharacter) ||
+      null;
     if (char && typeof char.name === "string" && char.name.length > 0) {
       return {
         ...char,
@@ -1321,9 +1310,10 @@ const selectedCharacterObj = computed(() => {
 
 const selectedSetObj = computed(() => {
   const primarySetId =
-    Array.isArray(props.selectedSetIds) && props.selectedSetIds.length
-      ? props.selectedSetIds[0]
-      : props.selectedSet;
+    Array.isArray(selectionStore.selectedSetIds) &&
+    selectionStore.selectedSetIds.length
+      ? selectionStore.selectedSetIds[0]
+      : selectionStore.selectedSet;
   if (!primarySetId) return null;
   return pictureSets.value.find((pset) => pset.id === primarySetId) || null;
 });
@@ -1331,7 +1321,10 @@ const selectedSetObj = computed(() => {
 const selectedSetIdSet = computed(
   () =>
     new Set(
-      (Array.isArray(props.selectedSetIds) ? props.selectedSetIds : [])
+      (Array.isArray(selectionStore.selectedSetIds)
+        ? selectionStore.selectedSetIds
+        : []
+      )
         .map((id) => Number(id))
         .filter((id) => Number.isFinite(id) && id > 0),
     ),
@@ -1342,8 +1335,8 @@ const hasSingleSelectedSet = computed(() => selectedSetIdSet.value.size === 1);
 const selectedCharacterIdSet = computed(
   () =>
     new Set(
-      (Array.isArray(props.selectedCharacterIds)
-        ? props.selectedCharacterIds
+      (Array.isArray(selectionStore.selectedCharacterIds)
+        ? selectionStore.selectedCharacterIds
         : []
       )
         .map((id) => Number(id))
@@ -1446,24 +1439,31 @@ const similarityCharacterOptions = computed(() => {
 watch(
   similarityCharacterOptions,
   (options) => {
-    emit("update:similarity-options", options);
+    sortStore.setSimilarityCharacterOptions(options);
   },
   { immediate: true },
 );
 
 const similarityCharacterModel = computed({
-  get: () => props.selectedSimilarityCharacter,
-  set: (value) => emit("update:similarity-character", value ?? null),
+  get: () => sortStore.selectedSimilarityCharacter,
+  // Changing the reference person changes what the similarity sort means, so
+  // the grid has to repaint; and on a narrow window the choice is made, so the
+  // auto-hidden sidebar gets out of the way.
+  set: (value) => {
+    sortStore.selectedSimilarityCharacter = value ?? null;
+    gridStore.refreshGridVersion();
+    if (sidebarStore.sidebarForcedHidden) sidebarStore.hideAutoSidebar();
+  },
 });
 
 const sidebarThumbnailSizeModel = computed({
-  get: () => props.sidebarThumbnailSize ?? 48,
+  get: () => userPrefsStore.sidebarThumbnailSize ?? 48,
   set: (value) => {
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) return;
     const clamped = Math.min(64, Math.max(16, parsed));
     const snapped = Math.round(clamped / 4) * 4;
-    emit("update:sidebar-thumbnail-size", snapped);
+    userPrefsStore.setSidebarThumbnailSize(snapped);
   },
 });
 
@@ -1474,7 +1474,8 @@ const _dockRowH = computed(() => sidebarThumbnailSizeModel.value + 4);
 const _DOCK_DIV = 3; // divider height (1px + 2px margins)
 const _addBtn = computed(() => (isReadOnly.value ? 0 : 1)); // extra [+] row when editable
 const setsCollapsed = computed(() => {
-  if (!props.docked || sidebarPrimaryTab.value === "folders") return false;
+  if (!sidebarStore.effectiveDocked || sidebarPrimaryTab.value === "folders")
+    return false;
   const h = _dockRowH.value;
   const charCount = visibleCharacters.value.length;
   const setCount = visibleSets.value.length;
@@ -1486,7 +1487,8 @@ const setsCollapsed = computed(() => {
   return fixedH + charH + setDividerH + allSetsH > dockedScrollHeight.value;
 });
 const charsCollapsed = computed(() => {
-  if (!props.docked || sidebarPrimaryTab.value === "folders") return false;
+  if (!sidebarStore.effectiveDocked || sidebarPrimaryTab.value === "folders")
+    return false;
   if (!setsCollapsed.value) return false;
   const h = _dockRowH.value;
   const charCount = visibleCharacters.value.length;
@@ -1506,18 +1508,18 @@ const sidebarFolderChildIconSize = computed(() =>
 );
 
 const dateFormatModel = computed({
-  get: () => props.dateFormat ?? "locale",
-  set: (value) => emit("update:date-format", value ?? "locale"),
+  get: () => userPrefsStore.dateFormat ?? "locale",
+  set: (value) => userPrefsStore.setDateFormat(value ?? "locale"),
 });
 
 const themeModeModel = computed({
-  get: () => props.themeMode ?? "light",
-  set: (value) => emit("update:theme-mode", value ?? "light"),
+  get: () => userPrefsStore.themeMode ?? "light",
+  set: (value) => userPrefsStore.setThemeMode(value ?? "light"),
 });
 
 const showKeyboardHintModel = computed({
-  get: () => props.showKeyboardHint ?? true,
-  set: (value) => emit("update:show-keyboard-hint", value ?? true),
+  get: () => userPrefsStore.showKeyboardHint ?? true,
+  set: (value) => (userPrefsStore.showKeyboardHint = value ?? true),
 });
 
 const sidebarThumbnailSizeLarge = computed(
@@ -1542,11 +1544,11 @@ const clampSidebarWidth = (v) =>
 
 // Persisted width; the setter emits up to the store/backend.
 const sidebarWidthModel = computed({
-  get: () => props.sidebarWidth ?? 240,
+  get: () => userPrefsStore.sidebarWidth ?? 240,
   set: (value) => {
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) return;
-    emit("update:sidebar-width", clampSidebarWidth(parsed));
+    userPrefsStore.setSidebarWidth(clampSidebarWidth(parsed));
   },
 });
 
@@ -1558,7 +1560,7 @@ const sidebarDragWidth = ref(null);
 // drop them. Uses the live drag width while resizing, the saved width otherwise.
 const sidebarIsNarrow = computed(
   () =>
-    !props.docked &&
+    !sidebarStore.effectiveDocked &&
     (sidebarDragWidth.value ?? sidebarWidthModel.value ?? 240) < 150,
 );
 
@@ -1569,7 +1571,7 @@ const sidebarThumbStyle = computed(() => {
   };
   // Apply the resized width only when expanded; docked width is driven by the
   // thumbnail size in CSS, so leave it to the stylesheet there.
-  if (!props.docked) {
+  if (!sidebarStore.effectiveDocked) {
     const w = sidebarDragWidth.value ?? sidebarWidthModel.value;
     style.width = `${w}px`;
   }
@@ -1599,7 +1601,7 @@ function onSidebarResizeEnd() {
 }
 
 function onSidebarResizeStart(e) {
-  if (props.docked) return;
+  if (sidebarStore.effectiveDocked) return;
   e.preventDefault();
   const rect = sidebarRootRef.value?.getBoundingClientRect();
   _resizeStartWidth = rect ? rect.width : sidebarWidthModel.value;
@@ -1612,7 +1614,7 @@ function onSidebarResizeStart(e) {
 }
 
 function onSidebarResizeKey(e) {
-  if (props.docked) return;
+  if (sidebarStore.effectiveDocked) return;
   const step = e.shiftKey ? 24 : 8;
   if (e.key === "ArrowLeft") {
     sidebarWidthModel.value = sidebarWidthModel.value - step;
@@ -1623,14 +1625,22 @@ function onSidebarResizeKey(e) {
   }
 }
 
-const reactiveSelectedDescending = ref(props.selectedDescending);
+const reactiveSelectedDescending = ref(sortStore.selectedDescending);
 
 watch(
-  () => props.selectedDescending,
+  () => sortStore.selectedDescending,
   (newValue) => {
     reactiveSelectedDescending.value = newValue;
   },
 );
+
+// Changing the sort from the sidebar also closes an auto-hidden sidebar: on a
+// narrow window the user has just made their choice and wants to see the grid.
+function applySort(sort, descending) {
+  sortStore.selectedSort = sort;
+  sortStore.selectedDescending = descending;
+  if (sidebarStore.sidebarForcedHidden) sidebarStore.hideAutoSidebar();
+}
 
 const descendingModel = computed({
   get: () => {
@@ -1638,17 +1648,14 @@ const descendingModel = computed({
   },
   set: (value) => {
     reactiveSelectedDescending.value = value;
-    emit("update:selected-sort", { sort: sortModel.value, descending: value });
+    applySort(sortModel.value, value);
   },
 });
 
 const sortModel = computed({
-  get: () => props.selectedSort,
+  get: () => sortStore.selectedSort,
   set: (value) =>
-    emit("update:selected-sort", {
-      sort: value != null ? String(value) : "",
-      descending: descendingModel.value,
-    }),
+    applySort(value != null ? String(value) : "", descendingModel.value),
 });
 
 // --- Character Editor Dialog Functions ---
@@ -1686,13 +1693,13 @@ function openSettingsDialog(tab = "") {
 function selectCharacter(id, label = null, event = null) {
   clearCountNew(id);
   const isSpecial =
-    id === props.allPicturesId ||
-    id === props.unassignedPicturesId ||
-    id === props.scrapheapPicturesId;
+    id === ALL_PICTURES_ID ||
+    id === UNASSIGNED_PICTURES_ID ||
+    id === SCRAPHEAP_PICTURES_ID;
   const isMultiToggle = !isSpecial && Boolean(event?.ctrlKey || event?.metaKey);
 
   if (!isMultiToggle) {
-    if (id === props.allPicturesId) {
+    if (id === ALL_PICTURES_ID) {
       allPicturesLastMode.value = projectViewMode.value;
       allPicturesLastProjectId.value = selectedProjectId.value;
     }
@@ -1703,7 +1710,7 @@ function selectCharacter(id, label = null, event = null) {
     // Compute the full project context so App.vue can apply everything
     // atomically without relying on any pre-existing store state.
     let projectContext;
-    if (id === props.allPicturesId) {
+    if (id === ALL_PICTURES_ID) {
       // "All Pictures" keeps whatever project scope was active when clicked.
       projectContext = {
         mode: projectViewMode.value,
@@ -1769,7 +1776,7 @@ function selectCharacter(id, label = null, event = null) {
   const nextIds = Array.from(currentIds).sort((a, b) => a - b);
   if (!nextIds.length) {
     emit("select-character", {
-      id: props.allPicturesId,
+      id: ALL_PICTURES_ID,
       label: null,
       ids: [],
       projectIds: {},
@@ -1778,7 +1785,7 @@ function selectCharacter(id, label = null, event = null) {
   }
 
   // Keep the primary view unchanged on ctrl-click
-  const primaryId = props.selectedCharacter ?? nextIds[0];
+  const primaryId = selectionStore.selectedCharacter ?? nextIds[0];
   const multiProjectIds = {};
   for (const cid of nextIds) {
     const c = characters.value.find((ch) => ch.id === cid);
@@ -1854,10 +1861,10 @@ function selectSet(setId, label = null, event = null) {
 }
 
 async function deleteCharacter() {
-  if (!props.selectedCharacter) return;
+  if (!selectionStore.selectedCharacter) return;
   if (!window.confirm("Delete this character?")) return;
   try {
-    await apiDeleteCharacter(props.selectedCharacter);
+    await apiDeleteCharacter(selectionStore.selectedCharacter);
     // The list is shared state now: the server is asked again rather than the
     // row being spliced out locally.
     await fetchCharacters();
@@ -1972,7 +1979,7 @@ async function deleteImportFolderById(id) {
       selectedFolderKey.value = null;
       selectedFolderReferenceId.value = null;
       emit("select-folder", null);
-      emit("update:folder-scanning", false);
+      sidebarStore.folderScanning = false;
     }
     await fetchImportFolders();
   } catch (e) {
@@ -1988,10 +1995,22 @@ async function deleteImportFolderById(id) {
 
 /** Context-menu target types that can be scoped for a duplicate scan. */
 const DEDUP_SCOPE_TYPES = {
-  character: { scope: "character", icon: "mdi-account-box-outline", noun: "for" },
+  character: {
+    scope: "character",
+    icon: "mdi-account-box-outline",
+    noun: "for",
+  },
   set: { scope: "set", icon: "mdi-folder-multiple-image", noun: "in this set" },
-  project: { scope: "project", icon: "mdi-briefcase-outline", noun: "in this project" },
-  folder: { scope: "folder", icon: "mdi-folder-outline", noun: "in this folder" },
+  project: {
+    scope: "project",
+    icon: "mdi-briefcase-outline",
+    noun: "in this project",
+  },
+  folder: {
+    scope: "folder",
+    icon: "mdi-folder-outline",
+    noun: "in this folder",
+  },
 };
 
 /**
@@ -2182,7 +2201,7 @@ function closeSidebarCtxMenu() {
 // The sidebar row already owns this count, so we read it here rather than reach
 // into the grid's `scrapheapEmptyDisabled`.
 const scrapheapIsEmpty = computed(
-  () => !categoryCounts.value[props.scrapheapPicturesId],
+  () => !categoryCounts.value[SCRAPHEAP_PICTURES_ID],
 );
 
 // Empty Scrapheap from the sidebar context menu. Navigate into the scrapheap
@@ -2191,7 +2210,7 @@ const scrapheapIsEmpty = computed(
 function emptyScrapheapFromCtx() {
   if (scrapheapIsEmpty.value) return;
   closeSidebarCtxMenu();
-  selectCharacter(props.scrapheapPicturesId, "Scrapheap");
+  selectCharacter(SCRAPHEAP_PICTURES_ID, "Scrapheap");
   emit("empty-scrapheap");
 }
 
@@ -2399,7 +2418,7 @@ function dragLeaveSetItem() {
 
 function isCountSelected(id) {
   if (!id) return false;
-  return props.selectedCharacter === id;
+  return selectionStore.selectedCharacter === id;
 }
 
 /**
@@ -2411,12 +2430,12 @@ function isCountSelected(id) {
  * guards travel together.
  */
 const selectionOwnsHighlight = computed(
-  () => !props.hasFolderFilter && !props.isDuplicatesView,
+  () => !hasFolderFilter.value && !isDuplicatesView.value,
 );
 
 const isAllPicturesRowActive = computed(() => {
   if (!selectionOwnsHighlight.value) return false;
-  if (props.selectedCharacter !== props.allPicturesId) return false;
+  if (selectionStore.selectedCharacter !== ALL_PICTURES_ID) return false;
   if (selectedSetIdSet.value.size > 0) return false;
   return true;
 });
@@ -2460,10 +2479,10 @@ async function fetchSidebarData() {
   // Fetch total image count for END key logic
   try {
     // All images summary
-    const data = await getCharacterSummary(props.allPicturesId, undefined, {
+    const data = await getCharacterSummary(ALL_PICTURES_ID, undefined, {
       baseUrl: props.backendUrl,
     });
-    setCategoryCount(props.allPicturesId, data.image_count, shouldFlash);
+    setCategoryCount(ALL_PICTURES_ID, data.image_count, shouldFlash);
   } catch (e) {
     console.warn("Error fetching all images summary:", e);
   }
@@ -2479,21 +2498,19 @@ async function fetchSidebarData() {
           }
         : undefined;
     const data = await getCharacterSummary(
-      props.unassignedPicturesId,
+      UNASSIGNED_PICTURES_ID,
       unassignedParams,
       { baseUrl: props.backendUrl },
     );
-    setCategoryCount(props.unassignedPicturesId, data.image_count, shouldFlash);
+    setCategoryCount(UNASSIGNED_PICTURES_ID, data.image_count, shouldFlash);
   } catch (e) {
     console.warn("Error fetching unassigned images summary:", e);
   }
   try {
-    const data = await getCharacterSummary(
-      props.scrapheapPicturesId,
-      undefined,
-      { baseUrl: props.backendUrl },
-    );
-    setCategoryCount(props.scrapheapPicturesId, data.image_count, shouldFlash);
+    const data = await getCharacterSummary(SCRAPHEAP_PICTURES_ID, undefined, {
+      baseUrl: props.backendUrl,
+    });
+    setCategoryCount(SCRAPHEAP_PICTURES_ID, data.image_count, shouldFlash);
   } catch (e) {
     console.warn("Error fetching scrapheap images summary:", e);
   }
@@ -2623,11 +2640,11 @@ async function fetchSortOptions() {
         ? sortOptions.value[0].value
         : null;
     }
-    emit("update:sort-options", sortOptions.value);
+    sortStore.setSortOptions(sortOptions.value);
   } catch (e) {
     console.error("Error fetching sort options:", e);
     sortOptions.value = [];
-    emit("update:sort-options", []);
+    sortStore.setSortOptions([]);
   }
 }
 
@@ -3169,15 +3186,15 @@ onMounted(() => {
     // _initializing suppresses the watchers so this one-time restore does NOT
     // emit navigation events back to App.vue.
     if (
-      props.externalProjectViewMode != null ||
-      props.externalSelectedProjectId != null
+      projectStore.projectViewMode != null ||
+      projectStore.selectedProjectId != null
     ) {
       _initializing = true;
-      if (props.externalProjectViewMode != null)
-        projectViewMode.value = props.externalProjectViewMode;
-      if (props.externalSelectedProjectId != null) {
-        lastUsedProjectId.value = props.externalSelectedProjectId;
-        selectedProjectId.value = props.externalSelectedProjectId;
+      if (projectStore.projectViewMode != null)
+        projectViewMode.value = projectStore.projectViewMode;
+      if (projectStore.selectedProjectId != null) {
+        lastUsedProjectId.value = projectStore.selectedProjectId;
+        selectedProjectId.value = projectStore.selectedProjectId;
       }
       nextTick(() => {
         _initializing = false;
@@ -3352,7 +3369,7 @@ watch(
 );
 
 watch(
-  [() => sortedCharacters.value, () => props.selectedSort],
+  [() => sortedCharacters.value, () => sortStore.selectedSort],
   ([chars, selectedSort]) => {
     const hasCharacters = Array.isArray(chars) && chars.length > 0;
     if (!hasCharacters && selectedSort === SIMILARITY_SORT_KEY) {
@@ -3371,7 +3388,7 @@ watch(
 );
 
 watch(
-  () => props.selectedCharacter,
+  () => selectionStore.selectedCharacter,
   (nextId) => {
     clearCountNew(nextId);
   },
@@ -3413,7 +3430,7 @@ watch(selectedProjectId, (v) => {
 // this handles every subsequent route change. (Switching the Projects tab does
 // NOT change the prop, so the stateless browse-scope is preserved.)
 watch(
-  () => props.externalSelectedProjectId,
+  () => projectStore.selectedProjectId,
   (v) => {
     if (_initializing) return;
     const next = v ?? null;
@@ -3426,7 +3443,7 @@ watch(
 // the matching key via the activeFolderKey prop so we can switch to the
 // folders tab and emit the correct filter payload.
 watch(
-  () => props.activeFolderKey,
+  () => viewStore.activeFolderKey,
   async (newKey, oldKey) => {
     if (!newKey) {
       // Route left a folder view — clear the sidebar's folder highlight.
@@ -3443,7 +3460,7 @@ watch(
     await fetchImportFolders();
 
     // Guard: user may have navigated away while fetches were in flight.
-    if (props.activeFolderKey !== newKey) return;
+    if (viewStore.activeFolderKey !== newKey) return;
 
     if (newKey.startsWith("rf-")) {
       const id = parseInt(newKey.slice(3), 10);
@@ -3697,9 +3714,9 @@ defineExpose({
   <ImageImporter
     ref="imageImporterRef"
     :backend-url="props.backendUrl"
-    :selected-character-id="props.selectedCharacter"
-    :all-pictures-id="props.allPicturesId"
-    :unassigned-pictures-id="props.unassignedPicturesId"
+    :selected-character-id="selectionStore.selectedCharacter"
+    :all-pictures-id="ALL_PICTURES_ID"
+    :unassigned-pictures-id="UNASSIGNED_PICTURES_ID"
     @import-finished="handleImportFinished"
   />
   <CharacterEditor
@@ -3734,17 +3751,19 @@ defineExpose({
     v-model:sidebar-thumbnail-size="sidebarThumbnailSizeModel"
     v-model:date-format="dateFormatModel"
     v-model:theme-mode="themeModeModel"
-    :checkForUpdates="props.checkForUpdates"
+    :checkForUpdates="userPrefsStore.checkForUpdates"
     v-model:show-keyboard-hint="showKeyboardHintModel"
-    :thumbnail-mode="props.thumbnailMode"
-    @update:thumbnail-mode="(value) => emit('update:thumbnail-mode', value)"
+    :thumbnail-mode="gridStore.thumbnailMode"
+    @update:thumbnail-mode="(value) => gridStore.setThumbnailMode(value)"
     :initial-tab="settingsDialogInitialTab"
-    @update:hidden-tags="(value) => emit('update:hidden-tags', value)"
-    @update:apply-tag-filter="(value) => emit('update:apply-tag-filter', value)"
-    @update:comfyui-configured="
-      (value) => emit('update:comfyui-configured', value)
+    @update:hidden-tags="(value) => userPrefsStore.setHiddenTags(value)"
+    @update:apply-tag-filter="
+      (value) => userPrefsStore.setApplyTagFilter(value)
     "
-    @update:public-url="(value) => emit('update:public-url', value)"
+    @update:comfyui-configured="
+      (value) => (filterStore.comfyuiConfigured = value)
+    "
+    @update:public-url="(value) => (userPrefsStore.publicUrl = value)"
     @update:check-for-updates="
       (value) => emit('update:check-for-updates', value)
     "
@@ -3899,14 +3918,14 @@ defineExpose({
     ref="sidebarRootRef"
     class="sidebar"
     :class="{
-      'sidebar-docked': props.docked,
+      'sidebar-docked': sidebarStore.effectiveDocked,
       'sidebar--narrow': sidebarIsNarrow,
     }"
     :style="sidebarThumbStyle"
   >
     <!-- Drag the right edge to resize the expanded sidebar (hidden when docked). -->
     <div
-      v-if="!props.docked"
+      v-if="!sidebarStore.effectiveDocked"
       class="sidebar-resize-handle"
       role="separator"
       aria-orientation="vertical"
@@ -3939,7 +3958,7 @@ defineExpose({
             class="sidebar-brand-logo"
           />
         </a>
-        <div v-if="!props.docked" class="sidebar-brand-text">
+        <div v-if="!sidebarStore.effectiveDocked" class="sidebar-brand-text">
           <WordmarkLogo class="sidebar-brand-title" />
           <div
             v-if="updateAvailable && !updateDismissed"
@@ -3968,7 +3987,7 @@ defineExpose({
       </div>
     </div>
     <div
-      v-if="props.docked"
+      v-if="sidebarStore.effectiveDocked"
       class="sidebar-collapsed-project-wrap"
       ref="projectMenuRef"
       @contextmenu.prevent="openSidebarCtxMenu('empty', null, $event)"
@@ -3994,7 +4013,7 @@ defineExpose({
       </div>
       <Teleport to="body">
         <div
-          v-if="projectMenuOpen && props.docked"
+          v-if="projectMenuOpen && sidebarStore.effectiveDocked"
           ref="collapsedProjectMenuRef"
           class="sidebar-collapsed-project-menu"
           :style="{
@@ -4013,7 +4032,7 @@ defineExpose({
             @mouseenter="scheduleCloseProjectSubMenu"
             @click="
               selectLibraryTab('global');
-              selectCharacter(props.allPicturesId, 'All Pictures');
+              selectCharacter(ALL_PICTURES_ID, 'All Pictures');
               projectMenuOpen = false;
             "
           >
@@ -4064,7 +4083,11 @@ defineExpose({
       <!-- Flyout submenu -->
       <Teleport to="body">
         <div
-          v-if="projectMenuSection && projectMenuOpen && props.docked"
+          v-if="
+            projectMenuSection &&
+            projectMenuOpen &&
+            sidebarStore.effectiveDocked
+          "
           ref="collapsedProjectSubMenuRef"
           class="sidebar-collapsed-project-submenu"
           :style="{
@@ -4095,8 +4118,8 @@ defineExpose({
               class="sidebar-project-menu-item"
               :class="{
                 active:
-                  props.externalProjectViewMode === 'project' &&
-                  props.externalSelectedProjectId === p.id,
+                  projectStore.projectViewMode === 'project' &&
+                  projectStore.selectedProjectId === p.id,
               }"
               @click="
                 selectLibraryTab('project');
@@ -4137,7 +4160,7 @@ defineExpose({
                 active:
                   sidebarPrimaryTab === 'folders' &&
                   selectedFolderKey === 'rf-' + rf.id &&
-                  !props.isDuplicatesView,
+                  !isDuplicatesView,
               }"
               @click="
                 selectFoldersTab();
@@ -4169,7 +4192,7 @@ defineExpose({
                 active:
                   sidebarPrimaryTab === 'folders' &&
                   selectedFolderKey === 'if-' + imf.id &&
-                  !props.isDuplicatesView,
+                  !isDuplicatesView,
               }"
               @click="
                 selectFoldersTab();
@@ -4238,7 +4261,7 @@ defineExpose({
       ref="dockedScrollRef"
       @contextmenu.self.prevent="openSidebarCtxMenu('empty', null, $event)"
     >
-      <template v-if="props.docked">
+      <template v-if="sidebarStore.effectiveDocked">
         <!-- Catch-all: any right-click that reaches the list (blank gaps, the
              margins beside the centered rows, the spacer) opens the view menu.
              Item rows below use `.stop` on their own context menus so they never
@@ -4260,7 +4283,7 @@ defineExpose({
                 { active: isAllPicturesRowActive },
               ]"
               title="All Pictures"
-              @click="selectCharacter(props.allPicturesId, 'All Pictures')"
+              @click="selectCharacter(ALL_PICTURES_ID, 'All Pictures')"
               @contextmenu.prevent.stop="
                 openSidebarCtxMenu('all-pictures', null, $event)
               "
@@ -4288,7 +4311,7 @@ defineExpose({
                 'sidebar-collapsed-row',
                 {
                   active:
-                    props.selectedCharacter === char.id &&
+                    selectionStore.selectedCharacter === char.id &&
                     selectionOwnsHighlight,
                 },
               ]"
@@ -4298,7 +4321,7 @@ defineExpose({
                   'sidebar-collapsed-item',
                   {
                     active:
-                      props.selectedCharacter === char.id &&
+                      selectionStore.selectedCharacter === char.id &&
                       selectionOwnsHighlight,
                   },
                 ]"
@@ -4439,7 +4462,7 @@ defineExpose({
                     'sidebar-collapsed-flyout-item',
                     {
                       active:
-                        props.selectedCharacter === char.id &&
+                        selectionStore.selectedCharacter === char.id &&
                         selectionOwnsHighlight,
                     },
                   ]"
@@ -4765,13 +4788,10 @@ defineExpose({
                reports pending work. -->
           <div
             v-if="!isReadOnly"
-            :class="['sidebar-collapsed-row', { active: props.isDuplicatesView }]"
+            :class="['sidebar-collapsed-row', { active: isDuplicatesView }]"
           >
             <div
-              :class="[
-                'sidebar-collapsed-item',
-                { active: props.isDuplicatesView },
-              ]"
+              :class="['sidebar-collapsed-item', { active: isDuplicatesView }]"
               title="Duplicates"
               @click="emit('select-duplicates', {})"
             >
@@ -4794,7 +4814,7 @@ defineExpose({
               'sidebar-collapsed-row',
               {
                 active:
-                  props.selectedCharacter === props.scrapheapPicturesId &&
+                  selectionStore.selectedCharacter === SCRAPHEAP_PICTURES_ID &&
                   selectionOwnsHighlight,
               },
             ]"
@@ -4805,12 +4825,12 @@ defineExpose({
                 'sidebar-collapsed-item--scrapheap',
                 {
                   active:
-                    props.selectedCharacter === props.scrapheapPicturesId &&
-                    selectionOwnsHighlight,
+                    selectionStore.selectedCharacter ===
+                      SCRAPHEAP_PICTURES_ID && selectionOwnsHighlight,
                 },
               ]"
               title="Scrapheap"
-              @click="selectCharacter(props.scrapheapPicturesId, 'Scrapheap')"
+              @click="selectCharacter(SCRAPHEAP_PICTURES_ID, 'Scrapheap')"
               @contextmenu.prevent.stop="
                 openSidebarCtxMenu('scrapheap', null, $event)
               "
@@ -5176,9 +5196,7 @@ defineExpose({
                   'sidebar-list-item',
                   { active: isAllPicturesRowActive },
                 ]"
-                @click="
-                  selectCharacter(props.allPicturesId, allPicturesRowLabel)
-                "
+                @click="selectCharacter(ALL_PICTURES_ID, allPicturesRowLabel)"
                 @contextmenu.prevent="
                   openSidebarCtxMenu('all-pictures', null, $event)
                 "
@@ -5190,7 +5208,7 @@ defineExpose({
                   allPicturesRowLabel
                 }}</span>
                 <span class="sidebar-list-count">{{
-                  categoryCounts[props.allPicturesId] ?? ""
+                  categoryCounts[ALL_PICTURES_ID] ?? ""
                 }}</span>
               </div>
             </div>
@@ -5201,10 +5219,7 @@ defineExpose({
                  unstacked stay a filter. -->
             <div v-if="!isReadOnly" class="sidebar-all-pictures-row">
               <div
-                :class="[
-                  'sidebar-list-item',
-                  { active: props.isDuplicatesView },
-                ]"
+                :class="['sidebar-list-item', { active: isDuplicatesView }]"
                 @click="emit('select-duplicates', {})"
               >
                 <span class="sidebar-list-icon sidebar-list-icon--toplevel"
@@ -5237,11 +5252,11 @@ defineExpose({
                   'sidebar-list-item',
                   {
                     active:
-                      props.selectedCharacter === props.scrapheapPicturesId &&
-                      selectionOwnsHighlight,
+                      selectionStore.selectedCharacter ===
+                        SCRAPHEAP_PICTURES_ID && selectionOwnsHighlight,
                   },
                 ]"
-                @click="selectCharacter(props.scrapheapPicturesId, 'Scrapheap')"
+                @click="selectCharacter(SCRAPHEAP_PICTURES_ID, 'Scrapheap')"
                 @contextmenu.prevent="
                   openSidebarCtxMenu('scrapheap', null, $event)
                 "
@@ -5251,7 +5266,7 @@ defineExpose({
                 >
                 <span class="sidebar-list-label">Scrapheap</span>
                 <span class="sidebar-list-count">{{
-                  categoryCounts[props.scrapheapPicturesId] || ""
+                  categoryCounts[SCRAPHEAP_PICTURES_ID] || ""
                 }}</span>
               </div>
             </div>
@@ -5281,7 +5296,7 @@ defineExpose({
                     v-if="selectedCharacterIdSet.size > 1"
                     class="clear-selection-inline"
                     @click.stop="
-                      selectCharacter(props.allPicturesId, 'All Pictures')
+                      selectCharacter(ALL_PICTURES_ID, 'All Pictures')
                     "
                     title="Clear character selection"
                   >
@@ -5301,10 +5316,11 @@ defineExpose({
                   <v-icon
                     v-if="
                       !isReadOnly &&
-                      props.selectedCharacter &&
-                      props.selectedCharacter !== props.allPicturesId &&
-                      props.selectedCharacter !== props.unassignedPicturesId &&
-                      props.selectedCharacter !== props.scrapheapPicturesId
+                      selectionStore.selectedCharacter &&
+                      selectionStore.selectedCharacter !== ALL_PICTURES_ID &&
+                      selectionStore.selectedCharacter !==
+                        UNASSIGNED_PICTURES_ID &&
+                      selectionStore.selectedCharacter !== SCRAPHEAP_PICTURES_ID
                     "
                     class="delete-character-inline"
                     color="white"
@@ -5635,9 +5651,9 @@ defineExpose({
                     'sidebar-project-tree-row',
                     {
                       active:
-                        props.externalProjectViewMode === 'project' &&
-                        props.externalSelectedProjectId === p.id &&
-                        props.selectedCharacter === props.allPicturesId &&
+                        projectStore.projectViewMode === 'project' &&
+                        projectStore.selectedProjectId === p.id &&
+                        selectionStore.selectedCharacter === ALL_PICTURES_ID &&
                         selectedSetIdSet.size === 0 &&
                         selectionOwnsHighlight,
                       droppable: dragOverProjectId === p.id,
@@ -6218,9 +6234,7 @@ defineExpose({
         <button
           class="sidebar-ctx-item sidebar-ctx-item--danger"
           :disabled="isReadOnly || scrapheapIsEmpty"
-          :title="
-            scrapheapIsEmpty ? 'Scrapheap is already empty' : undefined
-          "
+          :title="scrapheapIsEmpty ? 'Scrapheap is already empty' : undefined"
           :aria-disabled="isReadOnly || scrapheapIsEmpty"
           @click="emptyScrapheapFromCtx()"
         >
@@ -6249,19 +6263,19 @@ defineExpose({
           @click="findDuplicatesIn('character', sidebarCtxCharacter)"
         >
           <v-icon size="15" class="sidebar-ctx-icon">{{
-            duplicateCountFor('character', sidebarCtxCharacter) === 0
+            duplicateCountFor("character", sidebarCtxCharacter) === 0
               ? "mdi-check"
               : "mdi-content-duplicate"
           }}</v-icon>
           <span class="sidebar-ctx-label">{{
-            duplicateCountFor('character', sidebarCtxCharacter) === 0
+            duplicateCountFor("character", sidebarCtxCharacter) === 0
               ? "No duplicates for this person"
               : "Find duplicates for this person"
           }}</span>
           <span
             v-if="duplicateCountFor('character', sidebarCtxCharacter)"
             class="sidebar-ctx-count"
-            >{{ duplicateCountFor('character', sidebarCtxCharacter) }}</span
+            >{{ duplicateCountFor("character", sidebarCtxCharacter) }}</span
           >
         </button>
         <div v-if="!isReadOnly" class="sidebar-ctx-divider"></div>
@@ -6342,19 +6356,19 @@ defineExpose({
           @click="findDuplicatesIn('set', sidebarCtxSet)"
         >
           <v-icon size="15" class="sidebar-ctx-icon">{{
-            duplicateCountFor('set', sidebarCtxSet) === 0
+            duplicateCountFor("set", sidebarCtxSet) === 0
               ? "mdi-check"
               : "mdi-content-duplicate"
           }}</v-icon>
           <span class="sidebar-ctx-label">{{
-            duplicateCountFor('set', sidebarCtxSet) === 0
+            duplicateCountFor("set", sidebarCtxSet) === 0
               ? "No duplicates in this set"
               : "Find duplicates in this set"
           }}</span>
           <span
             v-if="duplicateCountFor('set', sidebarCtxSet)"
             class="sidebar-ctx-count"
-            >{{ duplicateCountFor('set', sidebarCtxSet) }}</span
+            >{{ duplicateCountFor("set", sidebarCtxSet) }}</span
           >
         </button>
         <div v-if="!isReadOnly" class="sidebar-ctx-divider"></div>
@@ -6564,19 +6578,19 @@ defineExpose({
           @click="findDuplicatesIn('project', sidebarCtxProject)"
         >
           <v-icon size="15" class="sidebar-ctx-icon">{{
-            duplicateCountFor('project', sidebarCtxProject) === 0
+            duplicateCountFor("project", sidebarCtxProject) === 0
               ? "mdi-check"
               : "mdi-content-duplicate"
           }}</v-icon>
           <span class="sidebar-ctx-label">{{
-            duplicateCountFor('project', sidebarCtxProject) === 0
+            duplicateCountFor("project", sidebarCtxProject) === 0
               ? "No duplicates in this project"
               : "Find duplicates in this project"
           }}</span>
           <span
             v-if="duplicateCountFor('project', sidebarCtxProject)"
             class="sidebar-ctx-count"
-            >{{ duplicateCountFor('project', sidebarCtxProject) }}</span
+            >{{ duplicateCountFor("project", sidebarCtxProject) }}</span
           >
         </button>
         <div v-if="!isReadOnly" class="sidebar-ctx-divider"></div>
@@ -6659,22 +6673,25 @@ defineExpose({
           @click="findDuplicatesIn('folder', sidebarCtxFolder)"
         >
           <v-icon size="15" class="sidebar-ctx-icon">{{
-            duplicateCountFor('folder', sidebarCtxFolder) === 0
+            duplicateCountFor("folder", sidebarCtxFolder) === 0
               ? "mdi-check"
               : "mdi-content-duplicate"
           }}</v-icon>
           <span class="sidebar-ctx-label">{{
-            duplicateCountFor('folder', sidebarCtxFolder) === 0
+            duplicateCountFor("folder", sidebarCtxFolder) === 0
               ? "No duplicates in this folder"
               : "Find duplicates in this folder"
           }}</span>
           <span
             v-if="duplicateCountFor('folder', sidebarCtxFolder)"
             class="sidebar-ctx-count"
-            >{{ duplicateCountFor('folder', sidebarCtxFolder) }}</span
+            >{{ duplicateCountFor("folder", sidebarCtxFolder) }}</span
           >
         </button>
-        <div v-if="!isReadOnly && !sidebarCtxFolderScopePath" class="sidebar-ctx-divider"></div>
+        <div
+          v-if="!isReadOnly && !sidebarCtxFolderScopePath"
+          class="sidebar-ctx-divider"
+        ></div>
         <button
           v-if="!inDocker && !sidebarCtxFolderScopePath"
           class="sidebar-ctx-item"
@@ -6836,10 +6853,10 @@ defineExpose({
     :resource-type="shareDialogPending?.resourceType"
     :resource-id="shareDialogPending?.resourceId"
     :resource-label="shareDialogPending?.label"
-    :embed-watermark="props.embedWatermark"
+    :embed-watermark="userPrefsStore.embedWatermark"
     :backend-url="props.backendUrl"
-    :public-url="props.publicUrl"
-    @update:embed-watermark="emit('update:embed-watermark', $event)"
+    :public-url="userPrefsStore.publicUrl"
+    @update:embed-watermark="userPrefsStore.embedWatermark = $event"
   />
 
   <!-- ── Revoke all shares confirm dialog ──────────────────────── -->

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -1099,6 +1099,7 @@ import {
 import { useRoute, useRouter } from "vue-router";
 import { useFilterStore } from "../../stores/useFilterStore";
 import { useGridStore } from "../../stores/useGridStore";
+import { useSidebarStore } from "../../stores/useSidebarStore";
 import { useUserPrefsStore } from "../../stores/useUserPrefsStore";
 import { useTasksStore } from "../../stores/useTasksStore";
 import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
@@ -1248,6 +1249,7 @@ const projectStore = useProjectStore();
 const wsStore = useWsStore();
 const searchStore = useSearchStore();
 const gridStore = useGridStore();
+const sidebarStore = useSidebarStore();
 const userPrefsStore = useUserPrefsStore();
 
 const emit = defineEmits([
@@ -1278,7 +1280,6 @@ const emit = defineEmits([
 const props = defineProps({
   backendUrl: String,
   activeCategoryLabel: { type: String, default: "Category" },
-  folderScanning: { type: Boolean, default: false },
 });
 
 // ============================================================
@@ -6295,7 +6296,7 @@ const emptyStateDelayPassed = ref(false);
 let emptyStateDelayTimer = null;
 
 const showEmptyState = computed(() => {
-  if (props.folderScanning) return false;
+  if (sidebarStore.folderScanning) return false;
   return (
     gridReady.value &&
     !imagesLoading.value &&
@@ -6306,7 +6307,9 @@ const showEmptyState = computed(() => {
 
 const showFolderScanningState = computed(() => {
   return (
-    props.folderScanning && gridReady.value && filteredGridCount.value === 0
+    sidebarStore.folderScanning &&
+    gridReady.value &&
+    filteredGridCount.value === 0
   );
 });
 
@@ -6373,7 +6376,7 @@ watch([imagesLoading, filteredGridCount], ([loading, count]) => {
     emptyStateDelayTimer = null;
   }
 
-  if (loading || count > 0 || props.folderScanning) {
+  if (loading || count > 0 || sidebarStore.folderScanning) {
     emptyStateDelayPassed.value = false;
     return;
   }
@@ -6383,7 +6386,7 @@ watch([imagesLoading, filteredGridCount], ([loading, count]) => {
     if (
       !imagesLoading.value &&
       filteredGridCount.value === 0 &&
-      !props.folderScanning
+      !sidebarStore.folderScanning
     ) {
       emptyStateDelayPassed.value = true;
     }
@@ -6393,7 +6396,7 @@ watch([imagesLoading, filteredGridCount], ([loading, count]) => {
 // When scanning ends the grid will reload; reset the delay so the
 // empty state only shows after images have had a chance to arrive.
 watch(
-  () => props.folderScanning,
+  () => sidebarStore.folderScanning,
   (scanning) => {
     if (!scanning) {
       if (emptyStateDelayTimer) {

--- a/frontend/src/components/widgets/ShortcutsDialog.vue
+++ b/frontend/src/components/widgets/ShortcutsDialog.vue
@@ -1,0 +1,153 @@
+<script setup>
+import { computed } from "vue";
+import { isReadOnly } from "../../utils/apiClient";
+import { redoKeyHint, undoKeyHint } from "../../utils/shortcutHints";
+
+// The undo/redo chords differ per platform, so the table renders whatever the
+// hint helper reports rather than hard-coding Ctrl.
+const undoKeyHintKeys = undoKeyHint();
+const redoKeyHintKeys = redoKeyHint();
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+});
+const emit = defineEmits(["update:modelValue"]);
+
+const open = computed({
+  get: () => props.modelValue,
+  set: (value) => emit("update:modelValue", value),
+});
+</script>
+
+<template>
+  <v-dialog v-model="open" max-width="480">
+    <v-card class="shortcuts-dialog">
+      <v-card-title class="shortcuts-dialog-title"
+        >Keyboard shortcuts</v-card-title
+      >
+      <v-card-text class="shortcuts-dialog-body">
+        <table class="shortcuts-table">
+          <tbody>
+            <tr>
+              <td colspan="2" class="shortcuts-section">Grid view</td>
+            </tr>
+            <tr>
+              <td><kbd>F</kbd></td>
+              <td>Open search</td>
+            </tr>
+            <tr :class="{ 'shortcut-disabled': isReadOnly }">
+              <td><kbd>1</kbd> – <kbd>5</kbd></td>
+              <td>Set star rating on hovered / selected image(s)</td>
+            </tr>
+            <tr :class="{ 'shortcut-disabled': isReadOnly }">
+              <td><kbd>T</kbd></td>
+              <td>Tag selected images</td>
+            </tr>
+            <tr>
+              <td><kbd>Ctrl</kbd>+<kbd>A</kbd></td>
+              <td>Select all images</td>
+            </tr>
+            <tr :class="{ 'shortcut-disabled': isReadOnly }">
+              <td>
+                <template v-for="(key, i) in undoKeyHintKeys" :key="key"
+                  ><span v-if="i > 0">+</span><kbd>{{ key }}</kbd></template
+                >
+              </td>
+              <td>Undo the last change</td>
+            </tr>
+            <tr :class="{ 'shortcut-disabled': isReadOnly }">
+              <td>
+                <template v-for="(key, i) in redoKeyHintKeys" :key="key"
+                  ><span v-if="i > 0">+</span><kbd>{{ key }}</kbd></template
+                >
+              </td>
+              <td>Redo the change you just undid</td>
+            </tr>
+            <tr>
+              <td><kbd>G</kbd></td>
+              <td>Focus first visible image (start keyboard navigation)</td>
+            </tr>
+            <tr>
+              <td><kbd>←</kbd> <kbd>→</kbd> <kbd>↑</kbd> <kbd>↓</kbd></td>
+              <td>Move cursor and select image</td>
+            </tr>
+            <tr>
+              <td><kbd>Shift</kbd>+<kbd>Arrow</kbd></td>
+              <td>Extend selection</td>
+            </tr>
+            <tr>
+              <td><kbd>Ctrl</kbd>+<kbd>Arrow</kbd></td>
+              <td>Move cursor without changing selection</td>
+            </tr>
+            <tr>
+              <td><kbd>Space</kbd></td>
+              <td>Toggle selection of cursor image</td>
+            </tr>
+            <tr>
+              <td><kbd>Enter</kbd></td>
+              <td>Open cursor image</td>
+            </tr>
+            <tr :class="{ 'shortcut-disabled': isReadOnly }">
+              <td><kbd>Delete</kbd></td>
+              <td>Delete selected images</td>
+            </tr>
+            <tr>
+              <td><kbd>Esc</kbd></td>
+              <td>Clear selection</td>
+            </tr>
+            <tr>
+              <td><kbd>S</kbd></td>
+              <td>Open selection menu</td>
+            </tr>
+            <tr>
+              <td><kbd>Home</kbd> / <kbd>End</kbd></td>
+              <td>Jump to first / last image</td>
+            </tr>
+            <tr>
+              <td><kbd>Page Up</kbd> / <kbd>Page Down</kbd></td>
+              <td>Scroll image grid</td>
+            </tr>
+            <tr>
+              <td colspan="2" class="shortcuts-section">Image overlay</td>
+            </tr>
+            <tr>
+              <td><kbd>←</kbd> <kbd>→</kbd></td>
+              <td>Previous / next image</td>
+            </tr>
+            <tr :class="{ 'shortcut-disabled': isReadOnly }">
+              <td><kbd>1</kbd> – <kbd>5</kbd></td>
+              <td>Set star rating</td>
+            </tr>
+            <tr :class="{ 'shortcut-disabled': isReadOnly }">
+              <td><kbd>T</kbd></td>
+              <td>Add tag</td>
+            </tr>
+            <tr>
+              <td><kbd>Z</kbd></td>
+              <td>Toggle zoom</td>
+            </tr>
+            <tr>
+              <td><kbd>I</kbd></td>
+              <td>Toggle info panel</td>
+            </tr>
+            <tr>
+              <td><kbd>Esc</kbd></td>
+              <td>Close overlay</td>
+            </tr>
+            <tr>
+              <td colspan="2" class="shortcuts-section">General</td>
+            </tr>
+            <tr :class="{ 'shortcut-disabled': isReadOnly }">
+              <td><kbd>F2</kbd></td>
+              <td>Edit selected character or picture set</td>
+            </tr>
+            <tr>
+              <td><kbd>?</kbd> / <kbd>F1</kbd></td>
+              <td>Show / hide this dialog</td>
+            </tr>
+          </tbody>
+        </table>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>

--- a/frontend/src/composables/useAppConfig.js
+++ b/frontend/src/composables/useAppConfig.js
@@ -1,0 +1,402 @@
+import { reactive, ref, watch } from "vue";
+import { isReadOnly } from "../utils/apiClient";
+import { getUserConfig, patchUserConfig } from "../api/config";
+import {
+  clampSizeLevel,
+  nearestSizeLevelForColumns,
+} from "../utils/thumbnailSizes";
+import { useUserPrefsStore } from "../stores/useUserPrefsStore";
+import { useGridStore } from "../stores/useGridStore";
+import { useSortStore } from "../stores/useSortStore";
+import { useFilterStore } from "../stores/useFilterStore";
+import { useSidebarStore } from "../stores/useSidebarStore";
+
+/**
+ * The user's server-side config: load it once on start, and write UI options
+ * back whenever one of them changes.
+ *
+ * `configApplying` is what keeps the two halves from fighting: fetchConfig sets
+ * it while it pushes the loaded values into the stores, so the persistence
+ * watchers those writes trigger see it and stay quiet instead of PATCHing the
+ * server with what it just told us.
+ *
+ * Read-only sessions never call the endpoint at all; they take the demo
+ * defaults and nothing is ever persisted.
+ *
+ * @param {object} hooks
+ * @param {Function} hooks.onThumbnailSizeChanged - re-measure the column
+ *   ceiling after a thumbnail-size change (a layout concern App.vue owns).
+ * @param {Function} hooks.onUpdateCheckUndecided - the user has never
+ *   answered the update-check question, so App.vue should ask.
+ */
+export function useAppConfig({
+  onThumbnailSizeChanged,
+  onUpdateCheckUndecided,
+} = {}) {
+  const userPrefsStore = useUserPrefsStore();
+  const gridStore = useGridStore();
+  const sortStore = useSortStore();
+  const filterStore = useFilterStore();
+  const sidebarStore = useSidebarStore();
+
+  // The last config the server gave us, and the shape the PATCH is built
+  // against. Kept here so nothing outside this composable can drift from it.
+  const configSnapshot = ref({});
+  const config = reactive({
+    sort: "",
+    thumbnail: 256,
+    thumbnail_mode: "square",
+    sidebar_thumbnail_size: 64,
+    show_stars: true,
+    show_face_bboxes: false,
+    show_problem_icon: true,
+    expand_all_stacks: true,
+    date_format: "locale",
+    theme_mode: "light",
+    stack_strictness: 0.92,
+  });
+
+  const configLoaded = ref(false);
+  const configLoading = ref(false);
+  const configApplying = ref(false);
+
+  async function fetchConfig() {
+    if (isReadOnly.value) {
+      userPrefsStore.themeMode = "dark";
+      userPrefsStore.sidebarThumbnailSize = 32;
+      gridStore.showProblemIcon = true;
+      gridStore.showFaceBboxes = false;
+      gridStore.showStars = true;
+      return;
+    }
+    if (configLoading.value) return;
+    configLoading.value = true;
+    configApplying.value = true;
+    try {
+      const cfg = await getUserConfig();
+      const sortValue = cfg.sort_order ?? cfg.sort;
+      if (typeof sortValue === "string" && sortValue) {
+        sortStore.selectedSort = sortValue;
+      }
+      if (typeof cfg.show_keyboard_hint === "boolean")
+        userPrefsStore.showKeyboardHint = cfg.show_keyboard_hint;
+      if (typeof cfg.show_face_bboxes === "boolean") {
+        gridStore.showFaceBboxes = cfg.show_face_bboxes;
+      }
+      if (typeof cfg.show_problem_icon === "boolean") {
+        gridStore.showProblemIcon = cfg.show_problem_icon;
+      }
+      if (typeof cfg.expand_all_stacks === "boolean") {
+        gridStore.showStacks = cfg.expand_all_stacks;
+      } else if (typeof cfg.show_stacks === "boolean") {
+        gridStore.showStacks = cfg.show_stacks;
+      }
+      if (typeof cfg.compact_mode === "boolean") {
+        gridStore.compactMode = cfg.compact_mode;
+      }
+      if (typeof cfg.sidebar_docked === "boolean") {
+        sidebarStore.setSidebarDocked(cfg.sidebar_docked);
+      }
+      if (typeof cfg.sidebar_pinned === "boolean") {
+        sidebarStore.setSidebarPinned(cfg.sidebar_pinned);
+      }
+      if (typeof cfg.date_format === "string" && cfg.date_format) {
+        userPrefsStore.dateFormat = cfg.date_format;
+      }
+      if (typeof cfg.theme_mode === "string" && cfg.theme_mode) {
+        userPrefsStore.themeMode = cfg.theme_mode;
+      }
+      if (typeof cfg.descending === "boolean") {
+        sortStore.selectedDescending = cfg.descending;
+      }
+      if (typeof cfg.thumbnail_size_level === "number") {
+        gridStore.sizeLevel = clampSizeLevel(cfg.thumbnail_size_level);
+      } else if (typeof cfg.columns === "number") {
+        // Legacy config predating the size ladder: derive the nearest level so
+        // an old install keeps roughly the same tile size after upgrading.
+        gridStore.sizeLevel = nearestSizeLevelForColumns(cfg.columns);
+      }
+      if (
+        cfg.thumbnail_mode === "square" ||
+        cfg.thumbnail_mode === "justified"
+      ) {
+        gridStore.thumbnailMode = cfg.thumbnail_mode;
+      }
+      if (typeof cfg.sidebar_thumbnail_size === "number") {
+        userPrefsStore.sidebarThumbnailSize = cfg.sidebar_thumbnail_size;
+      }
+      if (typeof cfg.sidebar_width === "number") {
+        userPrefsStore.sidebarWidth = cfg.sidebar_width;
+      }
+      if (cfg.stack_strictness != null) {
+        sortStore.stackThreshold = String(cfg.stack_strictness);
+      }
+      config.sort_order = sortValue || sortStore.selectedSort;
+      config.descending = sortStore.selectedDescending;
+      config.columns = gridStore.columns;
+      config.thumbnail_mode = gridStore.thumbnailMode;
+      config.sidebar_thumbnail_size = userPrefsStore.sidebarThumbnailSize;
+      config.sidebar_width = userPrefsStore.sidebarWidth;
+      config.show_stars =
+        typeof cfg.show_stars === "boolean"
+          ? cfg.show_stars
+          : gridStore.showStars;
+      config.show_face_bboxes =
+        typeof cfg.show_face_bboxes === "boolean"
+          ? cfg.show_face_bboxes
+          : gridStore.showFaceBboxes;
+      config.show_problem_icon =
+        typeof cfg.show_problem_icon === "boolean"
+          ? cfg.show_problem_icon
+          : gridStore.showProblemIcon;
+      config.expand_all_stacks =
+        typeof cfg.expand_all_stacks === "boolean"
+          ? cfg.expand_all_stacks
+          : typeof cfg.show_stacks === "boolean"
+            ? cfg.show_stacks
+            : gridStore.showStacks;
+      config.compact_mode =
+        typeof cfg.compact_mode === "boolean"
+          ? cfg.compact_mode
+          : gridStore.compactMode;
+      config.sidebar_docked =
+        typeof cfg.sidebar_docked === "boolean"
+          ? cfg.sidebar_docked
+          : sidebarStore.sidebarDocked;
+      config.sidebar_pinned =
+        typeof cfg.sidebar_pinned === "boolean"
+          ? cfg.sidebar_pinned
+          : sidebarStore.sidebarPinned;
+      config.date_format = userPrefsStore.dateFormat;
+      config.theme_mode = userPrefsStore.themeMode;
+      config.stack_strictness =
+        cfg.stack_strictness != null
+          ? cfg.stack_strictness
+          : config.stack_strictness;
+      const similarityValue =
+        cfg.similarity_character ?? cfg.selected_similarity_character;
+      sortStore.selectedSimilarityCharacter =
+        similarityValue ?? sortStore.selectedSimilarityCharacter ?? null;
+      const newHiddenTags = Array.isArray(cfg.hidden_tags)
+        ? cfg.hidden_tags
+        : [];
+      if (
+        userPrefsStore.hiddenTags.length !== newHiddenTags.length ||
+        userPrefsStore.hiddenTags.some((tag, i) => tag !== newHiddenTags[i])
+      ) {
+        userPrefsStore.hiddenTags = newHiddenTags;
+      }
+      userPrefsStore.applyTagFilter = Boolean(cfg.apply_tag_filter);
+      const rawPt = cfg.smart_score_penalised_tags;
+      if (rawPt && typeof rawPt === "object" && !Array.isArray(rawPt)) {
+        userPrefsStore.penalisedTagWeights = Object.fromEntries(
+          Object.entries(rawPt).map(([k, v]) => [
+            String(k).trim().toLowerCase(),
+            Number(v) || 0,
+          ]),
+        );
+      } else if (Array.isArray(rawPt)) {
+        userPrefsStore.penalisedTagWeights = Object.fromEntries(
+          rawPt.map((t) => [
+            String(t || "")
+              .trim()
+              .toLowerCase(),
+            3,
+          ]),
+        );
+      } else {
+        userPrefsStore.penalisedTagWeights = {};
+      }
+      config.selectedSimilarityCharacter =
+        sortStore.selectedSimilarityCharacter;
+      configSnapshot.value = {
+        sort: sortStore.selectedSort || "",
+        descending: sortStore.selectedDescending,
+        columns:
+          typeof gridStore.columns === "number" ? gridStore.columns : null,
+        sidebar_thumbnail_size:
+          typeof userPrefsStore.sidebarThumbnailSize === "number"
+            ? userPrefsStore.sidebarThumbnailSize
+            : null,
+        show_keyboard_hint: userPrefsStore.showKeyboardHint,
+        show_face_bboxes: gridStore.showFaceBboxes,
+        show_problem_icon: gridStore.showProblemIcon,
+        expand_all_stacks: gridStore.showStacks,
+        compact_mode: gridStore.compactMode,
+        sidebar_docked: sidebarStore.sidebarDocked,
+        sidebar_pinned: sidebarStore.sidebarPinned,
+        date_format: userPrefsStore.dateFormat,
+        theme_mode: userPrefsStore.themeMode,
+        similarity_character: sortStore.selectedSimilarityCharacter,
+        stack_strictness:
+          cfg.stack_strictness != null ? Number(cfg.stack_strictness) : null,
+        hidden_tags: userPrefsStore.hiddenTags,
+        apply_tag_filter: userPrefsStore.applyTagFilter,
+      };
+      filterStore.comfyuiConfigured = Boolean(cfg?.comfyui_url);
+      if (typeof cfg?.public_url === "string" && cfg.public_url) {
+        userPrefsStore.publicUrl = cfg.public_url;
+      }
+      userPrefsStore.embedWatermark = Boolean(cfg?.embed_watermark);
+      userPrefsStore.hidePurgeSnapshotWarning = Boolean(
+        cfg?.hide_purge_snapshot_warning,
+      );
+      const cfu = cfg?.check_for_updates;
+      userPrefsStore.checkForUpdates =
+        cfu === true ? true : cfu === false ? false : null;
+      if (userPrefsStore.checkForUpdates === null) {
+        onUpdateCheckUndecided?.();
+      }
+    } catch (e) {
+      console.error("Failed to fetch user config:", e);
+    } finally {
+      configApplying.value = false;
+      configLoading.value = false;
+      configLoaded.value = true;
+    }
+  }
+
+  async function patchConfigUIOptions() {
+    if (!configLoaded.value || configLoading.value || configApplying.value)
+      return;
+    const patch = {};
+    if (sortStore.selectedSort) patch.sort = sortStore.selectedSort;
+    patch.descending = sortStore.selectedDescending;
+    patch.thumbnail_size_level = gridStore.sizeLevel;
+    // Keep the legacy `columns` field in sync with the derived count so older
+    // clients (and anything still reading `columns`) stay consistent.
+    if (gridStore.columns) patch.columns = gridStore.columns;
+    if (userPrefsStore.sidebarThumbnailSize) {
+      patch.sidebar_thumbnail_size = userPrefsStore.sidebarThumbnailSize;
+    }
+    if (userPrefsStore.sidebarWidth) {
+      patch.sidebar_width = userPrefsStore.sidebarWidth;
+    }
+    if (typeof userPrefsStore.showKeyboardHint === "boolean")
+      patch.show_keyboard_hint = userPrefsStore.showKeyboardHint;
+    if (typeof gridStore.showFaceBboxes === "boolean") {
+      patch.show_face_bboxes = gridStore.showFaceBboxes;
+    }
+    if (typeof gridStore.showProblemIcon === "boolean") {
+      patch.show_problem_icon = gridStore.showProblemIcon;
+    }
+    if (typeof gridStore.showStacks === "boolean") {
+      patch.expand_all_stacks = gridStore.showStacks;
+    }
+    if (typeof gridStore.compactMode === "boolean") {
+      patch.compact_mode = gridStore.compactMode;
+    }
+    if (
+      gridStore.thumbnailMode === "square" ||
+      gridStore.thumbnailMode === "justified"
+    ) {
+      patch.thumbnail_mode = gridStore.thumbnailMode;
+    }
+    if (typeof sidebarStore.sidebarDocked === "boolean") {
+      patch.sidebar_docked = sidebarStore.sidebarDocked;
+    }
+    if (typeof sidebarStore.sidebarPinned === "boolean") {
+      patch.sidebar_pinned = sidebarStore.sidebarPinned;
+    }
+    if (
+      typeof userPrefsStore.dateFormat === "string" &&
+      userPrefsStore.dateFormat
+    ) {
+      patch.date_format = userPrefsStore.dateFormat;
+    }
+    if (
+      typeof userPrefsStore.themeMode === "string" &&
+      userPrefsStore.themeMode
+    ) {
+      patch.theme_mode = userPrefsStore.themeMode;
+    }
+    if (sortStore.selectedSimilarityCharacter != null) {
+      patch.similarity_character = sortStore.selectedSimilarityCharacter;
+    }
+    if (sortStore.stackThreshold != null && sortStore.stackThreshold !== "") {
+      const parsed = parseFloat(String(sortStore.stackThreshold));
+      if (Number.isFinite(parsed)) {
+        patch.stack_strictness = parsed;
+      }
+    }
+
+    const snapshot = configSnapshot.value || {};
+    const changed = Object.fromEntries(
+      Object.entries(patch).filter(([key, value]) => snapshot[key] !== value),
+    );
+    if (Object.keys(changed).length === 0) {
+      return;
+    }
+
+    try {
+      await patchUserConfig(changed);
+      configSnapshot.value = { ...snapshot, ...changed };
+    } catch (e) {
+      console.error("Error patching user config:", e);
+    }
+  }
+
+  // Persist a UI option whenever it changes. Every one of these is gated on
+  // configLoaded so the initial store writes from fetchConfig do not echo
+  // straight back to the server.
+  function persist() {
+    if (!configLoaded.value) return;
+    patchConfigUIOptions();
+  }
+
+  watch(
+    () => gridStore.thumbnailSize,
+    () => {
+      patchConfigUIOptions();
+      onThumbnailSizeChanged?.();
+    },
+  );
+  watch(
+    [() => sortStore.selectedSort, () => sortStore.selectedDescending],
+    () => {
+      patchConfigUIOptions();
+      // No refreshGridVersion() here: the grid's own selection watch already
+      // fires on a sort change, so bumping the version would cost a second
+      // redundant fetch.
+    },
+  );
+  watch(() => userPrefsStore.themeMode, persist);
+  watch(() => userPrefsStore.showKeyboardHint, persist);
+  watch(
+    [
+      () => gridStore.showFaceBboxes,
+      () => gridStore.showProblemIcon,
+      () => gridStore.showStacks,
+      () => gridStore.compactMode,
+    ],
+    () => patchConfigUIOptions(),
+  );
+  watch(
+    () => sortStore.selectedSimilarityCharacter,
+    () => patchConfigUIOptions(),
+  );
+  watch(() => sortStore.stackThreshold, persist);
+  watch(() => gridStore.sizeLevel, persist);
+  watch(() => gridStore.thumbnailMode, persist);
+  watch(() => sidebarStore.sidebarDocked, persist);
+  watch(() => sidebarStore.sidebarPinned, persist);
+  watch(() => userPrefsStore.sidebarThumbnailSize, persist);
+  watch(() => userPrefsStore.sidebarWidth, persist);
+  watch(
+    () => userPrefsStore.dateFormat,
+    () => {
+      if (!configLoaded.value) return;
+      patchConfigUIOptions();
+      // The grid renders dates per row, so a format change has to repaint it.
+      gridStore.refreshGridVersion();
+    },
+  );
+
+  return {
+    configLoaded,
+    configLoading,
+    configApplying,
+    fetchConfig,
+    patchConfigUIOptions,
+  };
+}

--- a/frontend/src/composables/useAppEntityActions.js
+++ b/frontend/src/composables/useAppEntityActions.js
@@ -1,3 +1,5 @@
+import { nextTick, watch } from "vue";
+import { useUserPrefsStore } from "../stores/useUserPrefsStore";
 import { useSelectionStore } from "../stores/useSelectionStore";
 import { useSearchStore } from "../stores/useSearchStore";
 import { useSortStore } from "../stores/useSortStore";
@@ -23,18 +25,22 @@ import {
  * @param {object} deps
  * @param {import("vue").Ref} deps.gridContainer
  * @param {Function} deps.refreshSidebar
+ * @param {Function} deps.onTagFilterChanged - debounced sidebar refresh for a
+ *   tag-visibility change.
  * @param {Function} deps.onNavigated
  */
 export function useAppEntityActions({
   gridContainer,
   refreshSidebar,
   onNavigated,
+  onTagFilterChanged,
 }) {
   const selectionStore = useSelectionStore();
   const searchStore = useSearchStore();
   const sortStore = useSortStore();
   const gridStore = useGridStore();
   const exportStore = useExportStore();
+  const userPrefsStore = useUserPrefsStore();
   const filterStore = useFilterStore();
   const wsStore = useWsStore();
 
@@ -142,6 +148,35 @@ export function useAppEntityActions({
   }
 
   // --- Watchers ---
+
+  // Opening the export menu is when its count has to be right; computing it
+  // eagerly would cost a request per selection change.
+  watch(
+    () => exportStore.exportMenuOpen,
+    async (isOpen) => {
+      if (!isOpen) return;
+      await nextTick();
+      refreshExportCount();
+    },
+  );
+
+  // Hiding tags, or turning the tag filter on, changes which pictures the grid
+  // and the sidebar counts should show.
+  watch(
+    () => userPrefsStore.hiddenTags,
+    () => {
+      gridStore.refreshGridVersion();
+      if (userPrefsStore.applyTagFilter) onTagFilterChanged?.();
+    },
+  );
+
+  watch(
+    () => userPrefsStore.applyTagFilter,
+    () => {
+      gridStore.refreshGridVersion();
+      onTagFilterChanged?.();
+    },
+  );
 
   return {
     handleImagesAssignedToCharacter,

--- a/frontend/src/composables/useAppEntityActions.js
+++ b/frontend/src/composables/useAppEntityActions.js
@@ -1,0 +1,155 @@
+import { useSelectionStore } from "../stores/useSelectionStore";
+import { useSearchStore } from "../stores/useSearchStore";
+import { useSortStore } from "../stores/useSortStore";
+import { useGridStore } from "../stores/useGridStore";
+import { useExportStore } from "../stores/useExportStore";
+import { useFilterStore } from "../stores/useFilterStore";
+import { useWsStore } from "../stores/useWsStore";
+import {
+  ALL_PICTURES_ID,
+  SCRAPHEAP_PICTURES_ID,
+  UNASSIGNED_PICTURES_ID,
+} from "../stores/useViewStore";
+
+/**
+ * What happens after a picture-level action that changes more than the grid:
+ * assigning images to a person, moving them between folders, confirming an
+ * export, or clearing the search back to All Pictures.
+ *
+ * Each of these has to reconcile two surfaces - the grid and the sidebar's
+ * counts - which is why they sit together rather than in the components that
+ * trigger them.
+ *
+ * @param {object} deps
+ * @param {import("vue").Ref} deps.gridContainer
+ * @param {Function} deps.refreshSidebar
+ * @param {Function} deps.onNavigated
+ */
+export function useAppEntityActions({
+  gridContainer,
+  refreshSidebar,
+  onNavigated,
+}) {
+  const selectionStore = useSelectionStore();
+  const searchStore = useSearchStore();
+  const sortStore = useSortStore();
+  const gridStore = useGridStore();
+  const exportStore = useExportStore();
+  const filterStore = useFilterStore();
+  const wsStore = useWsStore();
+
+  async function handleImagesAssignedToCharacter({ characterId, imageIds }) {
+    const current = selectionStore.selectedCharacter;
+    // Unassigned view: assigned pictures leave the unassigned bucket — drop their
+    // tiles from the grid immediately.
+    if (current === UNASSIGNED_PICTURES_ID && !selectionStore.selectedSet) {
+      if (
+        gridContainer.value &&
+        typeof gridContainer.value.removeImagesById === "function"
+      ) {
+        gridContainer.value.removeImagesById(imageIds);
+      }
+      return;
+    }
+    // Viewing a specific character: reassigning pictures (and their whole stack)
+    // to a DIFFERENT character moves them out of this view. Refetch so they
+    // disappear right away instead of lingering until the view changes — a plain
+    // removeImagesById can't catch every stack member (a collapsed drag only
+    // carries the leader id).
+    const isSpecificCharacterView =
+      current != null &&
+      !selectionStore.selectedSet &&
+      String(current) !== String(ALL_PICTURES_ID) &&
+      String(current) !== String(UNASSIGNED_PICTURES_ID) &&
+      String(current) !== String(SCRAPHEAP_PICTURES_ID);
+    if (isSpecificCharacterView && String(current) !== String(characterId)) {
+      gridStore.refreshGridVersion();
+    }
+  }
+
+  function handleImagesMoved({ imageIds, kind, refresh }) {
+    if (kind === "reference-folder" || refresh) {
+      wsStore.clearSortChangedExternalIds();
+      gridStore.refreshGridVersion();
+      refreshSidebar();
+      return;
+    }
+    if (
+      selectionStore.selectedCharacter !== UNASSIGNED_PICTURES_ID ||
+      selectionStore.selectedSet
+    ) {
+      return;
+    }
+    if (
+      gridContainer.value &&
+      typeof gridContainer.value.removeImagesById === "function"
+    ) {
+      gridContainer.value.removeImagesById(imageIds);
+    }
+  }
+
+  function handleFacesAssignedToCharacter() {
+    if (
+      gridContainer.value &&
+      typeof gridContainer.value.clearFaceSelection === "function"
+    ) {
+      gridContainer.value.clearFaceSelection();
+    }
+  }
+
+  function refreshExportCount() {
+    const counts = gridContainer.value?.getExportCount?.();
+    if (!counts) return;
+    exportStore.exportSelectedCount = Number(counts.selectedCount) || 0;
+    exportStore.exportTotalCount = Number(counts.totalCount) || 0;
+  }
+
+  function confirmExportZip() {
+    gridContainer.value?.exportCurrentViewToZip({
+      exportType: exportStore.exportType,
+      captionMode: exportStore.exportCaptionMode,
+      tagFormat: exportStore.exportTagFormat,
+      includeCharacterName: exportStore.exportIncludeCharacterName,
+      useOriginalFileNames: exportStore.exportUseOriginalFileNames,
+      resolution: exportStore.exportResolution,
+      bboxMode: exportStore.exportBboxMode,
+    });
+    exportStore.exportMenuOpen = false;
+  }
+
+  // --- Review tags overlay ---
+  // Visibility lives in the store so the grid toolbar can open it directly.
+
+  function handleClearSearch() {
+    searchStore.searchQuery = "";
+    searchStore.searchInput = "";
+    searchStore.isSearchHistoryOpen = false;
+    gridStore.refreshGridVersion();
+  }
+
+  function handleResetToAll() {
+    selectionStore.selectedCharacter = ALL_PICTURES_ID;
+    selectionStore.selectedSet = null;
+    selectionStore.selectedSetIds = [];
+    selectionStore.lastSelectedCharacterLabel = "All Pictures";
+    sortStore.selectedSort = "DATE";
+    sortStore.selectedDescending = true;
+    sortStore.selectedSimilarityCharacter = null;
+    searchStore.searchQuery = "";
+    filterStore.resetFilters();
+    gridStore.refreshGridVersion();
+    onNavigated?.();
+  }
+
+  // --- Watchers ---
+
+  return {
+    handleImagesAssignedToCharacter,
+    handleImagesMoved,
+    handleFacesAssignedToCharacter,
+    refreshExportCount,
+    confirmExportZip,
+    handleClearSearch,
+    handleResetToAll,
+  };
+}

--- a/frontend/src/composables/useAppNavigation.js
+++ b/frontend/src/composables/useAppNavigation.js
@@ -1,0 +1,384 @@
+import { computed, nextTick } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useSelectionStore } from "../stores/useSelectionStore";
+import { useProjectStore } from "../stores/useProjectStore";
+import { useSearchStore } from "../stores/useSearchStore";
+import { useSortStore } from "../stores/useSortStore";
+import { useFilterStore } from "../stores/useFilterStore";
+import { useWsStore } from "../stores/useWsStore";
+import {
+  ALL_PICTURES_ID,
+  SCRAPHEAP_PICTURES_ID,
+  UNASSIGNED_PICTURES_ID,
+} from "../stores/useViewStore";
+
+/**
+ * The app's navigation handlers: the sidebar's entry clicks, and the route
+ * pushes that follow them.
+ *
+ * The direction matters. Reading the route back into the stores belongs to
+ * useViewStore, which owns the app's single route watcher; everything here is
+ * the other way round - a user gesture updates the selection stores and then
+ * pushes the URL that expresses it. Keeping the two apart is what makes "the
+ * route is the single source of truth for what the grid shows" hold.
+ *
+ * @param {object} hooks
+ * @param {Function} hooks.onClearSearch - clear the active search (App.vue owns
+ *   the search bar's own state).
+ * @param {Function} hooks.onNavigated - called after a user-initiated
+ *   navigation, so the mobile sidebar can close itself.
+ */
+export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
+  const route = useRoute();
+  const router = useRouter();
+  const selectionStore = useSelectionStore();
+  const projectStore = useProjectStore();
+  const searchStore = useSearchStore();
+  const sortStore = useSortStore();
+  const filterStore = useFilterStore();
+  const wsStore = useWsStore();
+
+  function SelectionPayload(payload) {
+    if (payload && typeof payload === "object") {
+      const ids = Array.isArray(payload.ids)
+        ? payload.ids
+            .map((id) => Number(id))
+            .filter((id) => Number.isFinite(id) && id > 0)
+        : [];
+      return {
+        id: payload.id ?? payload.value ?? null,
+        label: payload.label ?? payload.name ?? null,
+        ids,
+        projectIds:
+          payload.projectIds && typeof payload.projectIds === "object"
+            ? payload.projectIds
+            : {},
+        projectContext: payload.projectContext ?? null,
+      };
+    }
+    return {
+      id: payload ?? null,
+      label: null,
+      ids: [],
+      projectIds: {},
+      projectContext: null,
+    };
+  }
+
+  function clearSearchForCategoryChange() {
+    if (
+      (searchStore.searchQuery || "").trim() ||
+      (searchStore.searchInput || "").trim()
+    ) {
+      onClearSearch?.();
+    }
+  }
+
+  async function handleSelectCharacter(payload) {
+    selectionStore.selectedFolderFilter = null;
+    const {
+      id: charId,
+      label,
+      ids,
+      projectIds,
+      projectContext,
+    } = SelectionPayload(payload);
+    projectStore.characterProjectIds = projectIds;
+    if (projectContext) {
+      projectStore.projectViewMode = projectContext.mode;
+      projectStore.selectedProjectId = projectContext.projectId;
+    }
+    clearSearchForCategoryChange();
+    if (charId == null) {
+      selectionStore.selectedCharacter = null;
+      await nextTick();
+      return;
+    }
+    if (label) {
+      selectionStore.lastSelectedCharacterLabel = label;
+    } else if (charId === ALL_PICTURES_ID) {
+      selectionStore.lastSelectedCharacterLabel = "All Pictures";
+    } else if (charId === UNASSIGNED_PICTURES_ID) {
+      selectionStore.lastSelectedCharacterLabel = "Unassigned Pictures";
+    } else if (charId === SCRAPHEAP_PICTURES_ID) {
+      selectionStore.lastSelectedCharacterLabel = "Scrapheap";
+    }
+    if (
+      charId === SCRAPHEAP_PICTURES_ID &&
+      sortStore.selectedSort === "LIKENESS_GROUPS"
+    ) {
+      sortStore.selectedSort = "DATE";
+    }
+    selectionStore.selectedCharacter = charId;
+    selectionStore.selectedCharacterIds = ids.length ? ids : [];
+    if (ids.length <= 1) {
+      selectionStore.setCharacterMultiMode("union");
+    }
+    if (charId !== ALL_PICTURES_ID) {
+      filterStore.unassignedOnlyFilter = false;
+    }
+    wsStore.clearPendingExternalImportIds();
+    wsStore.clearSortChangedExternalIds();
+    selectionStore.selectedSet = null;
+    selectionStore.selectedSetIds = [];
+    await nextTick();
+    onNavigated?.();
+    pushRouteForCurrentSelection();
+  }
+
+  async function handleSelectSet(payload) {
+    selectionStore.selectedFolderFilter = null;
+    const {
+      id: setId,
+      label,
+      ids,
+      projectIds,
+      projectContext,
+    } = SelectionPayload(payload);
+    projectStore.setProjectIds = projectIds;
+    if (projectContext) {
+      projectStore.projectViewMode = projectContext.mode;
+      projectStore.selectedProjectId = projectContext.projectId;
+    }
+    const names = payload && payload.names ? payload.names : {};
+    clearSearchForCategoryChange();
+    const nextIds = ids.length
+      ? ids
+      : setId != null
+        ? [Number(setId)].filter((id) => Number.isFinite(id) && id > 0)
+        : [];
+
+    if (!nextIds.length) {
+      const fallbackLabel =
+        projectStore.projectViewMode === "project"
+          ? "Project Pictures"
+          : "All Pictures";
+      selectionStore.selectedCharacter = ALL_PICTURES_ID;
+      selectionStore.selectedCharacterIds = [];
+      selectionStore.lastSelectedCharacterLabel = fallbackLabel;
+      selectionStore.selectedSet = null;
+      selectionStore.selectedSetIds = [];
+      await nextTick();
+      onNavigated?.();
+      return;
+    }
+    if (label && nextIds.length === 1) {
+      selectionStore.lastSelectedSetLabel = label;
+    } else if (nextIds.length > 1) {
+      selectionStore.lastSelectedSetLabel = `Set Overlap (${nextIds.length})`;
+    }
+    selectionStore.selectedSetIds = nextIds;
+    selectionStore.selectedSet = nextIds[0];
+    selectionStore.selectedCharacter = null;
+    selectionStore.selectedCharacterIds = [];
+    selectionStore.selectedSetNames = names;
+    if (
+      selectionStore.setDifferenceBaseId !== null &&
+      !nextIds.includes(selectionStore.setDifferenceBaseId)
+    ) {
+      selectionStore.setSetDifferenceBaseId(null);
+    }
+    if (nextIds.length === 1) {
+      selectionStore.setSetMultiMode("intersection");
+      selectionStore.setSetDifferenceBaseId(null);
+    }
+    onNavigated?.();
+    pushRouteForCurrentSelection();
+  }
+
+  function handleSearchAllPictures() {
+    selectionStore.selectedCharacter = ALL_PICTURES_ID;
+    selectionStore.selectedCharacterIds = [];
+    selectionStore.selectedSet = null;
+    selectionStore.selectedSetIds = [];
+    selectionStore.selectedFolderFilter = null;
+    selectionStore.lastSelectedCharacterLabel = "All Pictures";
+    pushAppRoute({ name: "all-pictures" });
+  }
+
+  function handleSelectFolder(payload) {
+    if (!payload) {
+      selectionStore.selectedFolderFilter = null;
+      pushAppRoute({ name: "all-pictures" });
+      return;
+    }
+    selectionStore.selectedFolderFilter = payload;
+    selectionStore.selectedCharacter = ALL_PICTURES_ID;
+    selectionStore.selectedCharacterIds = [];
+    selectionStore.selectedSet = null;
+    selectionStore.selectedSetIds = [];
+    pushRouteForCurrentSelection();
+  }
+
+  // ============================================================
+  // ROUTING — URL ↔ Store sync
+  // ============================================================
+
+  /**
+   * Push a route without cluttering history on duplicate navigations.
+   * Swallows NavigationDuplicated errors (vue-router throws on same-route push).
+   */
+  function pushAppRoute(target) {
+    if (route.query.token) {
+      target.query = { token: route.query.token, ...target.query };
+    }
+    router.push(target).catch(() => {});
+  }
+
+  /**
+   * Build and push the correct app route for the current store selection state.
+   * Called at the end of each user-initiated navigation handler so the URL
+   * always reflects what the grid is showing.
+   */
+  function pushRouteForCurrentSelection() {
+    const sel = selectionStore;
+    const proj = projectStore;
+
+    if (sel.selectedFolderFilter) {
+      const f = sel.selectedFolderFilter;
+      if (f.referenceFolderId != null) {
+        pushAppRoute({
+          name: "ref-folder",
+          params: { id: String(f.referenceFolderId) },
+        });
+        return;
+      }
+      if (f.importFolderId != null) {
+        pushAppRoute({
+          name: "import-folder",
+          params: { id: String(f.importFolderId) },
+        });
+        return;
+      }
+      // Path-based subfolder — no dedicated route; fall through to all-pictures.
+      pushAppRoute({ name: "all-pictures" });
+      return;
+    }
+
+    if (proj.projectViewMode === "project" && proj.selectedProjectId != null) {
+      const projId = String(proj.selectedProjectId);
+      if (sel.selectedSetIds.length > 0) {
+        const query = {};
+        if (sel.selectedSetIds.length > 1) {
+          query.ids = sel.selectedSetIds.join(",");
+          query.mode = sel.setMultiMode || "intersection";
+          if (
+            sel.setMultiMode === "difference" &&
+            sel.setDifferenceBaseId != null
+          ) {
+            query.base = String(sel.setDifferenceBaseId);
+          }
+        }
+        pushAppRoute({
+          name: "project-set",
+          params: { projectId: projId, id: String(sel.selectedSetIds[0]) },
+          query,
+        });
+        return;
+      }
+      if (
+        sel.selectedCharacter &&
+        sel.selectedCharacter !== ALL_PICTURES_ID &&
+        sel.selectedCharacter !== SCRAPHEAP_PICTURES_ID
+      ) {
+        const query = {};
+        if (sel.selectedCharacterIds.length > 1) {
+          query.ids = sel.selectedCharacterIds.join(",");
+          query.mode = sel.characterMultiMode || "union";
+        }
+        pushAppRoute({
+          name: "project-character",
+          params: { projectId: projId, id: String(sel.selectedCharacter) },
+          query,
+        });
+        return;
+      }
+      pushAppRoute({
+        name: "project",
+        params: { id: projId },
+      });
+      return;
+    }
+
+    if (sel.selectedSetIds.length > 0) {
+      const query = {};
+      if (sel.selectedSetIds.length > 1) {
+        query.ids = sel.selectedSetIds.join(",");
+        query.mode = sel.setMultiMode || "intersection";
+        if (
+          sel.setMultiMode === "difference" &&
+          sel.setDifferenceBaseId != null
+        ) {
+          query.base = String(sel.setDifferenceBaseId);
+        }
+      }
+      pushAppRoute({
+        name: "set",
+        params: { id: String(sel.selectedSetIds[0]) },
+        query,
+      });
+      return;
+    }
+
+    if (sel.selectedCharacter === SCRAPHEAP_PICTURES_ID) {
+      pushAppRoute({ name: "scrapheap" });
+      return;
+    }
+
+    if (!sel.selectedCharacter || sel.selectedCharacter === ALL_PICTURES_ID) {
+      pushAppRoute({ name: "all-pictures" });
+      return;
+    }
+
+    const query = {};
+    if (sel.selectedCharacterIds.length > 1) {
+      query.ids = sel.selectedCharacterIds.join(",");
+      query.mode = sel.characterMultiMode || "union";
+    }
+    pushAppRoute({
+      name: "character",
+      params: { id: String(sel.selectedCharacter) },
+      query,
+    });
+  }
+
+  // The Duplicates destination is addressed by route name, not by a sentinel in
+  // the selection store: it shows no pictures, so it has no selection to express.
+  const isDuplicatesView = computed(() => route.name === "duplicates");
+
+  /**
+   * Open the duplicate triage queue, optionally scoped to one collection object.
+   *
+   * The scope travels in the query rather than in a store, so a scoped queue is a
+   * link the user can bookmark and reload, and a back-navigation out of one lands
+   * somewhere that still makes sense.
+   *
+   * @param {Object} [scope]
+   * @param {string} [scope.type] - "project", "set", "character" or "folder".
+   * @param {number|string} [scope.id]
+   * @param {string} [scope.label] - what the scope pill reads.
+   * @param {string} [scope.icon] - the pill's mdi glyph.
+   */
+  function handleSelectDuplicates(scope = {}) {
+    const query = {};
+    if (scope.type && scope.type !== "library") {
+      query.scope = scope.type;
+      if (scope.id !== undefined && scope.id !== null)
+        query.scope_id = scope.id;
+      if (scope.label) query.scope_label = scope.label;
+      if (scope.icon) query.scope_icon = scope.icon;
+    }
+    pushAppRoute({ name: "duplicates", query });
+  }
+
+  return {
+    isDuplicatesView,
+    handleSelectCharacter,
+    handleSelectSet,
+    handleSelectFolder,
+    handleSearchAllPictures,
+    handleSelectDuplicates,
+    pushAppRoute,
+    pushRouteForCurrentSelection,
+  };
+}

--- a/frontend/src/composables/useAppSettingsHandlers.js
+++ b/frontend/src/composables/useAppSettingsHandlers.js
@@ -1,0 +1,200 @@
+import { nextTick } from "vue";
+import { patchUserConfig } from "../api/config";
+import { useGridStore } from "../stores/useGridStore";
+import { useSortStore } from "../stores/useSortStore";
+import { useProjectStore } from "../stores/useProjectStore";
+import { useSidebarStore } from "../stores/useSidebarStore";
+import { useUserPrefsStore } from "../stores/useUserPrefsStore";
+
+/**
+ * The handlers behind the sidebar's and settings dialog's controls.
+ *
+ * They are deliberately thin: each one validates its input and writes the
+ * store, and the config composable's watchers do the persisting. Nothing here
+ * pushes a route - the project-mode and project-picker handlers in particular
+ * only mirror their value into the store, because switching the sidebar's
+ * scope must not move the grid (the route is what does that).
+ *
+ * @param {object} deps
+ * @param {import("vue").Ref} deps.gridContainer - the grid, for the few
+ *   actions it exposes imperatively.
+ * @param {import("vue").Ref} deps.statsSidebarRef - the stats panel, for the
+ *   Tasks-tab deep link.
+ * @param {Function} deps.onNavigated - close the mobile sidebar after an
+ *   action that moves the view.
+ * @param {Function} deps.pushAppRoute - navigate (viewing a project is the
+ *   one control here that does move the grid).
+ */
+export function useAppSettingsHandlers({
+  gridContainer,
+  statsSidebarRef,
+  onNavigated,
+  pushAppRoute,
+}) {
+  const gridStore = useGridStore();
+  const sortStore = useSortStore();
+  const projectStore = useProjectStore();
+  const sidebarStore = useSidebarStore();
+  const userPrefsStore = useUserPrefsStore();
+
+  function handleUpdateProjectViewMode(mode) {
+    projectStore.projectViewMode = mode;
+  }
+
+  function handleUpdateSelectedProjectId(id) {
+    projectStore.selectedProjectId = id;
+  }
+
+  // Explicit "view this project" entry click → navigate. useViewStore (watching
+  // the route) sets projectViewMode/selectedProjectId from the URL, which scopes
+  // the grid to the project.
+  function handleViewProject(id) {
+    if (id == null) return;
+    pushAppRoute({ name: "project", params: { id: String(id) } });
+  }
+
+  async function handleUpdateSelectedSort({ sort, descending }) {
+    sortStore.selectedSort = sort;
+    sortStore.selectedDescending = descending;
+    onNavigated?.();
+  }
+
+  function handleUpdateSortOptions(options) {
+    sortStore.sortOptions = Array.isArray(options) ? options : [];
+  }
+
+  function handleStackStatsUpdate(payload) {
+    const expanded = Number(payload?.expanded ?? 0);
+    const total = Number(payload?.total ?? 0);
+    gridStore.expandedStackCount = Number.isFinite(expanded)
+      ? Math.max(0, expanded)
+      : 0;
+    gridStore.totalStackCount = Number.isFinite(total) ? Math.max(0, total) : 0;
+  }
+
+  function handleUpdateSimilarityCharacter(val) {
+    sortStore.selectedSimilarityCharacter = val;
+    gridStore.refreshGridVersion();
+    onNavigated?.();
+  }
+
+  function handleUpdateSimilarityOptions(options) {
+    sortStore.similarityCharacterOptions = Array.isArray(options)
+      ? options
+      : [];
+  }
+
+  function handleUpdateHiddenTags(tags) {
+    const nextTags = Array.isArray(tags) ? tags : [];
+    if (
+      userPrefsStore.hiddenTags.length === nextTags.length &&
+      userPrefsStore.hiddenTags.every((tag, index) => tag === nextTags[index])
+    ) {
+      return;
+    }
+    userPrefsStore.hiddenTags = nextTags;
+  }
+
+  function handleUpdateApplyTagFilter(value) {
+    const nextValue = Boolean(value);
+    if (userPrefsStore.applyTagFilter === nextValue) return;
+    userPrefsStore.applyTagFilter = nextValue;
+  }
+
+  function handleUpdateDateFormat(value) {
+    if (value == null) return;
+    const nextValue = String(value);
+    if (nextValue === userPrefsStore.dateFormat) return;
+    userPrefsStore.dateFormat = nextValue;
+  }
+
+  function handleUpdateThemeMode(value) {
+    if (value == null) return;
+    userPrefsStore.themeMode = String(value);
+  }
+
+  async function handleUpdateCheckForUpdates(value) {
+    userPrefsStore.checkForUpdates = value;
+    try {
+      await patchUserConfig({ check_for_updates: value });
+    } catch (e) {
+      console.error("Failed to save check_for_updates preference:", e);
+    }
+  }
+
+  function handleUpdateSidebarThumbnailSize(value) {
+    const nextValue = Number(value);
+    if (!Number.isFinite(nextValue)) return;
+    userPrefsStore.sidebarThumbnailSize = nextValue;
+  }
+
+  // The sidebar's Scrapheap context menu asks to empty the heap. The sidebar has
+  // already switched the view to the scrapheap; defer to the next tick so the grid
+  // is showing that view before we open its existing consent-gated empty-forever
+  // confirm (whose post-confirm refetch then reconciles the right view). The grid
+  // is still fetching that view at this point, by construction — the confirm is
+  // deliberately not gated on that, and takes its counts from the server preview.
+  function handleEmptyScrapheapFromSidebar() {
+    nextTick(() => gridContainer.value?.confirmEmptyScrapheap?.());
+  }
+
+  // The sidebar's person context menu asks for more pictures of that person
+  // (#636). The search runs across the whole library rather than inside the
+  // current view, so nothing here changes the selection or the route: the grid
+  // owns the search mode and shows its own result bar.
+  function handleSuggestPicturesForCharacter(character) {
+    if (character?.id == null) return;
+    nextTick(() =>
+      gridContainer.value?.suggestPicturesForCharacter?.({
+        id: character.id,
+        name: character.name,
+      }),
+    );
+  }
+
+  // Open the stats sidebar and focus its Tasks tab. Shared by the thumbnail-mode
+  // "View progress" notice action and the ThumbnailUpgradeBanner's link, so both
+  // use the same statsSidebarRef.focusTasksTab() plumbing.
+  function focusTasksTabPanel() {
+    sidebarStore.statsOpen = true;
+    nextTick(() => statsSidebarRef.value?.focusTasksTab?.());
+  }
+
+  function handleUpdateThumbnailMode(value) {
+    if (value !== "square" && value !== "justified") return;
+    if (value === gridStore.thumbnailMode) return;
+    // Apply immediately with no regeneration: both modes render from the same
+    // stored bitmap (justified shows it whole; square crops it to the stored
+    // rectangle), so the grid re-lays-out at once. The persist watch saves it,
+    // and the radiogroup's aria-checked change is what a screen reader announces.
+    gridStore.thumbnailMode = value;
+  }
+
+  function handleUpdateSidebarWidth(value) {
+    const nextValue = Number(value);
+    if (!Number.isFinite(nextValue)) return;
+    userPrefsStore.sidebarWidth = nextValue;
+  }
+
+  return {
+    handleUpdateProjectViewMode,
+    handleUpdateSelectedProjectId,
+    handleViewProject,
+    handleUpdateSelectedSort,
+    handleUpdateSortOptions,
+    handleStackStatsUpdate,
+    handleUpdateSimilarityCharacter,
+    handleUpdateSimilarityOptions,
+    handleUpdateHiddenTags,
+    handleUpdateApplyTagFilter,
+    handleUpdateDateFormat,
+    handleUpdateThemeMode,
+    handleUpdateCheckForUpdates,
+    handleUpdateSidebarThumbnailSize,
+    handleEmptyScrapheapFromSidebar,
+    handleSuggestPicturesForCharacter,
+    focusTasksTabPanel,
+    handleUpdateThumbnailMode,
+    handleUpdateSidebarWidth,
+  };
+}

--- a/frontend/src/composables/useAppSettingsHandlers.js
+++ b/frontend/src/composables/useAppSettingsHandlers.js
@@ -35,8 +35,6 @@ export function useAppSettingsHandlers({
   const sidebarStore = useSidebarStore();
   const userPrefsStore = useUserPrefsStore();
 
-
-
   // Explicit "view this project" entry click → navigate. useViewStore (watching
   // the route) sets projectViewMode/selectedProjectId from the URL, which scopes
   // the grid to the project.
@@ -51,7 +49,6 @@ export function useAppSettingsHandlers({
     onNavigated?.();
   }
 
-
   function handleStackStatsUpdate(payload) {
     const expanded = Number(payload?.expanded ?? 0);
     const total = Number(payload?.total ?? 0);
@@ -61,12 +58,6 @@ export function useAppSettingsHandlers({
     gridStore.totalStackCount = Number.isFinite(total) ? Math.max(0, total) : 0;
   }
 
-
-
-
-
-
-
   async function handleUpdateCheckForUpdates(value) {
     userPrefsStore.checkForUpdates = value;
     try {
@@ -75,7 +66,6 @@ export function useAppSettingsHandlers({
       console.error("Failed to save check_for_updates preference:", e);
     }
   }
-
 
   // The sidebar's Scrapheap context menu asks to empty the heap. The sidebar has
   // already switched the view to the scrapheap; defer to the next tick so the grid
@@ -108,8 +98,6 @@ export function useAppSettingsHandlers({
     sidebarStore.statsOpen = true;
     nextTick(() => statsSidebarRef.value?.focusTasksTab?.());
   }
-
-
 
   return {
     handleViewProject,

--- a/frontend/src/composables/useAppSettingsHandlers.js
+++ b/frontend/src/composables/useAppSettingsHandlers.js
@@ -2,7 +2,6 @@ import { nextTick } from "vue";
 import { patchUserConfig } from "../api/config";
 import { useGridStore } from "../stores/useGridStore";
 import { useSortStore } from "../stores/useSortStore";
-import { useProjectStore } from "../stores/useProjectStore";
 import { useSidebarStore } from "../stores/useSidebarStore";
 import { useUserPrefsStore } from "../stores/useUserPrefsStore";
 
@@ -33,17 +32,10 @@ export function useAppSettingsHandlers({
 }) {
   const gridStore = useGridStore();
   const sortStore = useSortStore();
-  const projectStore = useProjectStore();
   const sidebarStore = useSidebarStore();
   const userPrefsStore = useUserPrefsStore();
 
-  function handleUpdateProjectViewMode(mode) {
-    projectStore.projectViewMode = mode;
-  }
 
-  function handleUpdateSelectedProjectId(id) {
-    projectStore.selectedProjectId = id;
-  }
 
   // Explicit "view this project" entry click → navigate. useViewStore (watching
   // the route) sets projectViewMode/selectedProjectId from the URL, which scopes
@@ -59,9 +51,6 @@ export function useAppSettingsHandlers({
     onNavigated?.();
   }
 
-  function handleUpdateSortOptions(options) {
-    sortStore.sortOptions = Array.isArray(options) ? options : [];
-  }
 
   function handleStackStatsUpdate(payload) {
     const expanded = Number(payload?.expanded ?? 0);
@@ -72,46 +61,11 @@ export function useAppSettingsHandlers({
     gridStore.totalStackCount = Number.isFinite(total) ? Math.max(0, total) : 0;
   }
 
-  function handleUpdateSimilarityCharacter(val) {
-    sortStore.selectedSimilarityCharacter = val;
-    gridStore.refreshGridVersion();
-    onNavigated?.();
-  }
 
-  function handleUpdateSimilarityOptions(options) {
-    sortStore.similarityCharacterOptions = Array.isArray(options)
-      ? options
-      : [];
-  }
 
-  function handleUpdateHiddenTags(tags) {
-    const nextTags = Array.isArray(tags) ? tags : [];
-    if (
-      userPrefsStore.hiddenTags.length === nextTags.length &&
-      userPrefsStore.hiddenTags.every((tag, index) => tag === nextTags[index])
-    ) {
-      return;
-    }
-    userPrefsStore.hiddenTags = nextTags;
-  }
 
-  function handleUpdateApplyTagFilter(value) {
-    const nextValue = Boolean(value);
-    if (userPrefsStore.applyTagFilter === nextValue) return;
-    userPrefsStore.applyTagFilter = nextValue;
-  }
 
-  function handleUpdateDateFormat(value) {
-    if (value == null) return;
-    const nextValue = String(value);
-    if (nextValue === userPrefsStore.dateFormat) return;
-    userPrefsStore.dateFormat = nextValue;
-  }
 
-  function handleUpdateThemeMode(value) {
-    if (value == null) return;
-    userPrefsStore.themeMode = String(value);
-  }
 
   async function handleUpdateCheckForUpdates(value) {
     userPrefsStore.checkForUpdates = value;
@@ -122,11 +76,6 @@ export function useAppSettingsHandlers({
     }
   }
 
-  function handleUpdateSidebarThumbnailSize(value) {
-    const nextValue = Number(value);
-    if (!Number.isFinite(nextValue)) return;
-    userPrefsStore.sidebarThumbnailSize = nextValue;
-  }
 
   // The sidebar's Scrapheap context menu asks to empty the heap. The sidebar has
   // already switched the view to the scrapheap; defer to the next tick so the grid
@@ -160,41 +109,15 @@ export function useAppSettingsHandlers({
     nextTick(() => statsSidebarRef.value?.focusTasksTab?.());
   }
 
-  function handleUpdateThumbnailMode(value) {
-    if (value !== "square" && value !== "justified") return;
-    if (value === gridStore.thumbnailMode) return;
-    // Apply immediately with no regeneration: both modes render from the same
-    // stored bitmap (justified shows it whole; square crops it to the stored
-    // rectangle), so the grid re-lays-out at once. The persist watch saves it,
-    // and the radiogroup's aria-checked change is what a screen reader announces.
-    gridStore.thumbnailMode = value;
-  }
 
-  function handleUpdateSidebarWidth(value) {
-    const nextValue = Number(value);
-    if (!Number.isFinite(nextValue)) return;
-    userPrefsStore.sidebarWidth = nextValue;
-  }
 
   return {
-    handleUpdateProjectViewMode,
-    handleUpdateSelectedProjectId,
     handleViewProject,
     handleUpdateSelectedSort,
-    handleUpdateSortOptions,
     handleStackStatsUpdate,
-    handleUpdateSimilarityCharacter,
-    handleUpdateSimilarityOptions,
-    handleUpdateHiddenTags,
-    handleUpdateApplyTagFilter,
-    handleUpdateDateFormat,
-    handleUpdateThemeMode,
     handleUpdateCheckForUpdates,
-    handleUpdateSidebarThumbnailSize,
     handleEmptyScrapheapFromSidebar,
     handleSuggestPicturesForCharacter,
     focusTasksTabPanel,
-    handleUpdateThumbnailMode,
-    handleUpdateSidebarWidth,
   };
 }

--- a/frontend/src/composables/useBreadcrumb.js
+++ b/frontend/src/composables/useBreadcrumb.js
@@ -25,9 +25,9 @@ export function useBreadcrumb() {
     const charName = (id) =>
       isMulti
         ? "Multiple People"
-        : entityNames.characterNames[id] ?? `Character ${id}`;
+        : (entityNames.characterNames[id] ?? `Character ${id}`);
     const setName = (id) =>
-      isMulti ? "Multiple Sets" : entityNames.setNames[id] ?? `Set ${id}`;
+      isMulti ? "Multiple Sets" : (entityNames.setNames[id] ?? `Set ${id}`);
     const projName = (id) => entityNames.projectNames[id] ?? `Project ${id}`;
     // Root scope crumb names the sidebar bar/tab the view belongs to. These are
     // scope *labels*, not destinations — plain text, not links. Only an

--- a/frontend/src/composables/useGlobalKeydown.js
+++ b/frontend/src/composables/useGlobalKeydown.js
@@ -1,0 +1,178 @@
+import { onMounted, onUnmounted } from "vue";
+import { isReadOnly } from "../utils/apiClient";
+import { useReviewSessionsStore } from "../stores/useReviewSessionsStore";
+import { useOperationStore } from "../stores/useOperationStore";
+import { useSearchStore } from "../stores/useSearchStore";
+import { useSidebarStore } from "../stores/useSidebarStore";
+
+/**
+ * The app-wide keyboard shortcuts: undo/redo, search focus, sidebar and grid
+ * navigation.
+ *
+ * Every modal surface owns its own keyboard handling, so this handler declines
+ * whenever one is up rather than competing with it.
+ *
+ * @param {object} deps
+ * @param {import("vue").Ref} deps.gridContainer - the grid, for the shortcuts
+ *   it exposes imperatively.
+ * @param {import("vue").Ref} deps.sidebarRef - the sidebar, same.
+ * @param {import("vue").Ref} deps.shortcutsDialogOpen - the keyboard-help
+ *   dialog, which its own shortcut toggles.
+ */
+export function useGlobalKeydown({
+  gridContainer,
+  sidebarRef,
+  shortcutsDialogOpen,
+}) {
+  const reviewSessionsStore = useReviewSessionsStore();
+  const operationStore = useOperationStore();
+  const searchStore = useSearchStore();
+  const sidebarStore = useSidebarStore();
+
+  /**
+   * Is a modal surface (a dialog, the lightbox) currently covering the app?
+   *
+   * There is no shared flag for this: every dialog owns its own `open` ref, so
+   * the honest single source is the scrim Vuetify renders for every active
+   * overlay. Used to decline global shortcuts whose feedback would be invisible
+   * behind it.
+   */
+  function isModalOverlayOpen() {
+    if (typeof document === "undefined") return false;
+    return (
+      document.querySelector(".v-overlay--active .v-overlay__scrim") != null
+    );
+  }
+
+  function handleGlobalKeydown(e) {
+    // The review overlay is modal and owns its own keyboard handler; don't
+    // run the app/grid shortcuts (scroll, search, help) behind it.
+    if (reviewSessionsStore.overlayOpen) return;
+    // The LIGHTBOX owns the keyboard too, with its own undo binding and its own
+    // receipt. This used to be enforced implicitly by listener order — the
+    // overlay mounted before App, ran first, and stopImmediatePropagation()
+    // silenced this handler — but the Duplicates view unmounts and remounts the
+    // grid (and the overlay inside it), which re-registers their listeners
+    // AFTER this one and silently flips that order. The result was one Ctrl+Z
+    // running TWO undos: this handler's, then the overlay's, which the
+    // operation store's busy-queue happily executed as a queued second step.
+    // Ownership is therefore stated here explicitly, on the same DOM signal the
+    // overlay renders (`.image-overlay` is v-if'd on open), not on ordering.
+    if (
+      typeof document !== "undefined" &&
+      document.querySelector(".image-overlay") != null
+    ) {
+      return;
+    }
+    // Match the strictness the grid and the lightbox already use: a SELECT and an
+    // ARIA textbox are typing surfaces too, and the event target matters as much
+    // as `document.activeElement` (a Vuetify combobox moves focus around).
+    const isEditable = [e.target, document.activeElement].some(
+      (el) =>
+        el instanceof HTMLElement &&
+        (el.isContentEditable ||
+          ["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName) ||
+          el.getAttribute("role") === "textbox"),
+    );
+
+    // The auto-hide sidebar is revealed by hover (or tap), so WCAG 2.1 SC 1.4.13
+    // "Content on Hover or Focus" applies: it must be dismissible without moving
+    // the pointer. Escape is that mechanism, and for a touch user it is the only
+    // dismissal besides the scrim itself. Deliberately not preventDefault-ed, and
+    // skipped while typing, so the other Escape owners keep theirs. The sidebar
+    // context menu stops propagation from a capture-phase listener and never
+    // reaches here at all.
+    if (
+      e.key === "Escape" &&
+      !isEditable &&
+      sidebarStore.sidebarOverlay &&
+      sidebarStore.sidebarVisible
+    ) {
+      sidebarStore.hideAutoSidebar();
+    }
+
+    // Undo / redo. Global by design: the shortcut has to work with no receipt on
+    // screen, and every undo raises one, so the result is always narrated. Ctrl
+    // and Meta are both accepted (the HINT is platform-specific, the binding is
+    // not); Ctrl+Shift+Z is the macOS redo convention and is accepted everywhere.
+    //
+    // Four guards, each for its own reason:
+    //   * typing: a text field keeps its own native undo stack;
+    //   * read-only: the endpoints are owner-only anyway;
+    //   * auto-repeat: a HELD Ctrl+Z must not walk the whole stack;
+    //   * a modal DIALOG owns the screen: the receipt lives on --z-floating,
+    //     under any dialog scrim, so an undo fired from there would mutate the
+    //     library with no visible narration. That breaks the design's own "every
+    //     undo raises a receipt" invariant, so the shortcut declines rather than
+    //     acting blind.
+    //
+    // The lightbox is NOT covered by that last guard and never was:
+    // `isModalOverlayOpen()` looks for a Vuetify scrim, and `.image-overlay`
+    // renders its own. The lightbox is excluded by the explicit `.image-overlay`
+    // check at the top of this handler (listener ORDER used to do it, until the
+    // Duplicates view's grid remount flipped it — see that comment). Undo works
+    // in the lightbox through its own key handler plus `OverlayActionReceipt`,
+    // fitted to that surface's GUI per the owner's ruling.
+    if (
+      (e.ctrlKey || e.metaKey) &&
+      !e.altKey &&
+      !e.repeat &&
+      !isEditable &&
+      !isReadOnly.value &&
+      !isModalOverlayOpen()
+    ) {
+      const key = e.key?.toLowerCase();
+      if (key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        operationStore.undo();
+      } else if (key === "y" || (key === "z" && e.shiftKey)) {
+        e.preventDefault();
+        operationStore.redo();
+      }
+    }
+
+    const keys = ["Home", "End", "PageUp", "PageDown"];
+    if (keys.includes(e.key) && !isEditable) {
+      // These keys drive grid scrolling only. Prevent the browser's default
+      // scroll so they don't also scroll the sidebar (or the page).
+      e.preventDefault();
+      const grid = gridContainer.value;
+      if (grid && typeof grid.onGlobalKeyPress === "function") {
+        grid.onGlobalKeyPress(e.key, e);
+      }
+    }
+    if (e.key === "f" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (!isEditable) {
+        e.preventDefault();
+        searchStore.requestSearchFocus();
+      }
+    }
+    if (
+      (e.key === "?" || e.key === "F1") &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      !e.altKey &&
+      !isEditable
+    ) {
+      e.preventDefault();
+      shortcutsDialogOpen.value = !shortcutsDialogOpen.value;
+    }
+    if (
+      e.key === "F2" &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      !e.altKey &&
+      !isEditable &&
+      !isReadOnly.value
+    ) {
+      const gridHasFocus = gridContainer.value?.hasCursorFocus === true;
+      if (!gridHasFocus) {
+        e.preventDefault();
+        sidebarRef.value?.openCurrentSelectionEditor?.();
+      }
+    }
+  }
+
+  onMounted(() => window.addEventListener("keydown", handleGlobalKeydown));
+  onUnmounted(() => window.removeEventListener("keydown", handleGlobalKeydown));
+}

--- a/frontend/src/composables/useReviewRoute.js
+++ b/frontend/src/composables/useReviewRoute.js
@@ -192,7 +192,8 @@ export function useReviewRoute(route, router, store, { watch }) {
       // redundant /tag_health request). `pendingRestoreViewId` is consumed by
       // load() once the session lists have landed — only then can an id be
       // resolved to a session vs an archived receipt vs nothing.
-      if (!scopeEquals(store.healthScope, scope)) store.healthScope = { ...scope };
+      if (!scopeEquals(store.healthScope, scope))
+        store.healthScope = { ...scope };
       store.pendingRestoreViewId = reviewId;
       store.overlayOpen = true;
       return;

--- a/frontend/src/composables/useReviewRoute.test.js
+++ b/frontend/src/composables/useReviewRoute.test.js
@@ -98,7 +98,16 @@ describe("parseReviewQuery", () => {
   });
 
   it("opens on the board for every non-id value", () => {
-    for (const raw of ["", "board", "true", "nonsense", "0", "-3", "1.5", null]) {
+    for (const raw of [
+      "",
+      "board",
+      "true",
+      "nonsense",
+      "0",
+      "-3",
+      "1.5",
+      null,
+    ]) {
       const parsed = parseReviewQuery({ review: raw });
       expect(parsed.open, `review=${raw}`).toBe(true);
       expect(parsed.reviewId, `review=${raw}`).toBe(null);
@@ -126,8 +135,8 @@ describe("parseReviewQuery", () => {
 
   it("accepts UNASSIGNED for the character dimension", () => {
     expect(
-      parseReviewQuery({ review: "board", review_character: "UNASSIGNED" }).scope
-        .characterId,
+      parseReviewQuery({ review: "board", review_character: "UNASSIGNED" })
+        .scope.characterId,
     ).toBe("UNASSIGNED");
   });
 
@@ -158,9 +167,9 @@ describe("buildReviewQuery", () => {
   });
 
   it("encodes the board", () => {
-    expect(buildReviewQuery({}, { open: true, view: { type: "board" } })).toEqual(
-      { review: REVIEW_BOARD },
-    );
+    expect(
+      buildReviewQuery({}, { open: true, view: { type: "board" } }),
+    ).toEqual({ review: REVIEW_BOARD });
   });
 
   it("encodes a session and an archived receipt by id", () => {
@@ -472,9 +481,8 @@ describe("useReviewSessionsStore.load — URL restore", () => {
   it("resolves, then clears, pendingRestoreViewId", async () => {
     const { setActivePinia, createPinia } = await import("pinia");
     const { apiClient } = await import("../utils/apiClient");
-    const { useReviewSessionsStore } = await import(
-      "../stores/useReviewSessionsStore"
-    );
+    const { useReviewSessionsStore } =
+      await import("../stores/useReviewSessionsStore");
     setActivePinia(createPinia());
     apiClient.get.mockImplementation((url, opts) => {
       if (url === "/reviews" && opts?.params?.status === "OPEN") {
@@ -494,9 +502,8 @@ describe("useReviewSessionsStore.load — URL restore", () => {
   it("falls back to the board for an unknown id", async () => {
     const { setActivePinia, createPinia } = await import("pinia");
     const { apiClient } = await import("../utils/apiClient");
-    const { useReviewSessionsStore } = await import(
-      "../stores/useReviewSessionsStore"
-    );
+    const { useReviewSessionsStore } =
+      await import("../stores/useReviewSessionsStore");
     setActivePinia(createPinia());
     apiClient.get.mockResolvedValue({ data: [] });
     apiClient.post.mockResolvedValue({ data: {} });

--- a/frontend/src/composables/useSearchBarSync.js
+++ b/frontend/src/composables/useSearchBarSync.js
@@ -1,0 +1,42 @@
+import { watch } from "vue";
+import { useSearchStore } from "../stores/useSearchStore";
+import { useGridStore } from "../stores/useGridStore";
+
+/**
+ * Keep the search bar's input in step with the committed query, and decide
+ * when the history dropdown should be showing.
+ *
+ * The two are separate on purpose: `searchQuery` is what the grid fetched
+ * against, `searchInput` is what the user is typing. They only converge when
+ * the query changes from somewhere else (a cleared search, a restored route).
+ */
+export function useSearchBarSync() {
+  const searchStore = useSearchStore();
+  const gridStore = useGridStore();
+
+  watch(
+    () => searchStore.searchQuery,
+    (newVal, oldVal) => {
+      if (searchStore.searchInput !== newVal) {
+        searchStore.searchInput = newVal || "";
+      }
+      // Clearing a search widens the result set, so the grid has to repaint.
+      if (!newVal && oldVal) {
+        gridStore.refreshGridVersion();
+      }
+    },
+  );
+
+  watch(
+    [() => searchStore.searchInput, () => searchStore.searchHistory],
+    () => {
+      const needle = (searchStore.searchInput || "").trim();
+      if (!needle) {
+        searchStore.isSearchHistoryOpen = false;
+        return;
+      }
+      searchStore.isSearchHistoryOpen =
+        searchStore.filteredSearchHistory.length > 0;
+    },
+  );
+}

--- a/frontend/src/composables/useSidebarRefresh.js
+++ b/frontend/src/composables/useSidebarRefresh.js
@@ -1,0 +1,93 @@
+import { onUnmounted } from "vue";
+import { API_BASE_URL, isReadOnly } from "../utils/apiClient";
+import { useDedupStore } from "../stores/useDedupStore";
+import { useEntityListsStore } from "../stores/useEntityListsStore";
+import { useLockedSetsStore } from "../stores/useLockedSetsStore";
+
+const SIDEBAR_REFRESH_DEBOUNCE_MS = 150;
+const SIDEBAR_REFRESH_PICTURES_DEBOUNCE_MS = 800;
+
+/**
+ * Debounced sidebar refreshes.
+ *
+ * A burst of websocket events would otherwise refetch the sidebar's entity
+ * lists once per event; these coalesce that into one refresh. The pictures
+ * variant is debounced far longer because it is the expensive one, and it
+ * carries a flash flag so the refresh that lands can highlight what changed.
+ *
+ * @param {object} deps
+ * @param {import("vue").Ref} deps.sidebarRef - the sidebar's template ref.
+ */
+export function useSidebarRefresh({ sidebarRef }) {
+  const dedupStore = useDedupStore();
+  const entityListsStore = useEntityListsStore();
+  const lockedSetsStore = useLockedSetsStore();
+
+  let sidebarRefreshDebounceTimeout = null;
+  let sidebarRefreshPicturesDebounceTimeout = null;
+  let sidebarRefreshPicturesFlash = false;
+
+  function refreshSidebar(options = {}) {
+    sidebarRef.value?.refreshSidebar(options);
+    // The shared character/set/project lists ride the same triggers (this is what
+    // `characters_changed` lands on). Refetch ONLY — a ws payload never writes
+    // into the cache, since `origin_client_id` is echo-matching, not authority
+    // (integration_architecture.md §8.1). The call is de-duplicated against the
+    // sidebar's own refresh above, and it also covers the case where the sidebar
+    // is unmounted but a context menu is still reading the lists.
+    entityListsStore.invalidate(undefined, { baseUrl: API_BASE_URL });
+    // The locked-sets store shares the sidebar's refresh triggers (manual emits,
+    // characters_changed, and pictures_changed via the debounced pictures path,
+    // which also fires on a lock/unlock PATCH's CHANGED_PICTURES event). The store
+    // coalesces overlapping fetches, so calling it here on every refresh is cheap.
+    lockedSetsStore.fetch();
+    // The duplicates badge rides the same triggers: an import, a stack or a
+    // verdict all move the count, and every one of them already causes a sidebar
+    // refresh. The per-scope cache goes with it, since a context menu opened
+    // afterwards must not quote a pre-change number.
+    if (!isReadOnly.value) {
+      dedupStore.invalidateScopeCounts();
+      dedupStore.refreshCounts();
+    }
+  }
+
+  function refreshSidebarDebounced() {
+    if (sidebarRefreshDebounceTimeout) {
+      clearTimeout(sidebarRefreshDebounceTimeout);
+    }
+    sidebarRefreshDebounceTimeout = setTimeout(() => {
+      sidebarRefreshDebounceTimeout = null;
+      refreshSidebar();
+    }, SIDEBAR_REFRESH_DEBOUNCE_MS);
+  }
+
+  function refreshSidebarPicturesDebounced(flash) {
+    if (flash) sidebarRefreshPicturesFlash = true;
+    if (sidebarRefreshPicturesDebounceTimeout) {
+      clearTimeout(sidebarRefreshPicturesDebounceTimeout);
+    }
+    sidebarRefreshPicturesDebounceTimeout = setTimeout(() => {
+      sidebarRefreshPicturesDebounceTimeout = null;
+      const doFlash = sidebarRefreshPicturesFlash;
+      sidebarRefreshPicturesFlash = false;
+      refreshSidebar(doFlash ? { flashCounts: true } : {});
+    }, SIDEBAR_REFRESH_PICTURES_DEBOUNCE_MS);
+  }
+
+  onUnmounted(() => {
+    if (sidebarRefreshDebounceTimeout) {
+      clearTimeout(sidebarRefreshDebounceTimeout);
+      sidebarRefreshDebounceTimeout = null;
+    }
+    if (sidebarRefreshPicturesDebounceTimeout) {
+      clearTimeout(sidebarRefreshPicturesDebounceTimeout);
+      sidebarRefreshPicturesDebounceTimeout = null;
+    }
+  });
+
+  return {
+    refreshSidebar,
+    refreshSidebarDebounced,
+    refreshSidebarPicturesDebounced,
+  };
+}

--- a/frontend/src/composables/useUpdatesSocket.js
+++ b/frontend/src/composables/useUpdatesSocket.js
@@ -1,0 +1,381 @@
+import { onUnmounted } from "vue";
+import {
+  API_BASE_URL,
+  appendShareToken,
+  isReadOnly,
+} from "../utils/apiClient";
+import { useGridRealtimeSync } from "./useGridRealtimeSync";
+import { useWsStore } from "../stores/useWsStore";
+import { useGridStore } from "../stores/useGridStore";
+import { useSortStore } from "../stores/useSortStore";
+import { useFilterStore } from "../stores/useFilterStore";
+import { useSelectionStore } from "../stores/useSelectionStore";
+import { useSearchStore } from "../stores/useSearchStore";
+import { useOperationStore } from "../stores/useOperationStore";
+import { useSnapshotsStore } from "../stores/useSnapshotsStore";
+
+const BACKEND_URL = API_BASE_URL;
+
+// Coalescing window for incoming grid-driving WS events. A burst of foreign
+// events accumulates over this window and applies once per category instead of
+// one fetch-and-rebuild per event.
+const GRID_WS_COALESCE_MS = 200;
+
+/**
+ * The live-updates channel: the /updates WebSocket, the filter handshake that
+ * tells the backend which events this client cares about, and the reconnect
+ * loop.
+ *
+ * Applying an event to the grid is useGridRealtimeSync's job; this composable
+ * owns the socket around it, and hands it an imperative grid surface plus the
+ * coalescing scheduler.
+ *
+ * @param {object} deps
+ * @param {import("vue").Ref} deps.gridContainer - the grid's template ref.
+ * @param {Function} deps.refreshSidebar
+ * @param {Function} deps.refreshSidebarPicturesDebounced
+ */
+export function useUpdatesSocket({
+  gridContainer,
+  refreshSidebar,
+  refreshSidebarPicturesDebounced,
+}) {
+  const wsStore = useWsStore();
+  const gridStore = useGridStore();
+  const sortStore = useSortStore();
+  const filterStore = useFilterStore();
+  const selectionStore = useSelectionStore();
+  const searchStore = useSearchStore();
+  const operationStore = useOperationStore();
+  const snapshotsStore = useSnapshotsStore();
+
+  let updatesSocket = null;
+  let updatesReconnectTimer = null;
+  let gridWsCoalesceTimer = null;
+
+  // --- WebSocket ---
+  // Event types that can carry a recorded operation (the reversible metadata
+  // facets of backend_architecture.md §21). `picture_imported` is deliberately
+  // absent: imports are not undoable in v1.9, so they never appear in the stack.
+  const OPERATION_BEARING_EVENTS = new Set([
+    "pictures_changed",
+    "tags_changed",
+    "characters_changed",
+    "descriptions_changed",
+  ]);
+
+  function buildUpdatesSocketUrl() {
+    if (!BACKEND_URL) return "";
+    const wsBase = BACKEND_URL.replace(/^http/i, "ws");
+    // The backend authenticates the WebSocket handshake (the HTTP auth
+    // middleware does not cover WebSockets). A full session authenticates via
+    // the same-origin session cookie; a share/read-only session has no cookie,
+    // so append its READ token as ?token= the same way HTTP requests do.
+    return appendShareToken(`${wsBase}/ws/updates`);
+  }
+
+  // A `pictures_changed` event may carry a `fields` list naming the columns that
+  // changed. When every changed field is invisible to the current sort + active
+  // filters (e.g. a background `smart_score` recompute while sorting by date),
+  // the grid/sidebar don't need to react at all. An event with no `fields`
+  // (user edits, imports, plugin output, …) is treated as "unknown" and always
+  // refreshes, preserving the previous behaviour.
+  function pictureChangeFieldAffectsView(field) {
+    if (field === "smart_score") {
+      return (
+        sortStore.selectedSort === "SMART_SCORE" ||
+        filterStore.smartScoreBucketFilter != null
+      );
+    }
+    // Detections are an opt-in overlay layer, never a sort/filter field, so a
+    // detection change never affects grid membership or order — don't reload or
+    // raise the "view changed" pill for it.
+    if (field === "detections") return false;
+    // Unknown field → assume it can affect the view, so refresh to be safe.
+    return true;
+  }
+
+  function pictureChangeAffectsView(fields) {
+    if (!Array.isArray(fields) || fields.length === 0) return true;
+    return fields.some(pictureChangeFieldAffectsView);
+  }
+
+  function sendUpdatesFilters() {
+    if (!updatesSocket) return;
+    if (updatesSocket.readyState !== WebSocket.OPEN) return;
+    updatesSocket.send(
+      JSON.stringify({
+        type: "set_filters",
+        client_id: wsStore.clientId,
+        selected_character: selectionStore.selectedCharacter,
+        selected_set: selectionStore.selectedSet,
+        selected_sets: selectionStore.selectedSetIds,
+        search_query: searchStore.searchQuery,
+      }),
+    );
+  }
+
+  // Imperative grid API surface used by the realtime-sync composable. Each method
+  // delegates to the ImageGrid template-ref's defineExpose'd methods (Tier-3
+  // imperative API), no-oping safely if the grid isn't mounted yet.
+  const gridApi = {
+    insertGridImagesById: (ids) =>
+      gridContainer.value?.insertGridImagesById?.(ids),
+    refreshGridImage: (id) => gridContainer.value?.refreshGridImage?.(id),
+    repositionImageByScore: (id, score) =>
+      gridContainer.value?.repositionImageByScore?.(id, score),
+    repositionImageBySmartScore: (id) =>
+      gridContainer.value?.repositionImageBySmartScore?.(id),
+    refreshSmartScoreForImage: (id) =>
+      gridContainer.value?.refreshSmartScoreForImage?.(id),
+    removeImagesById: (ids) => gridContainer.value?.removeImagesById?.(ids),
+    isImagesLoading: () => gridContainer.value?.isImagesLoading?.() ?? false,
+    isOverlayOpen: () => gridContainer.value?.isOverlayOpen?.() ?? false,
+    markOverlayDeferredRefresh: () =>
+      gridContainer.value?.markOverlayDeferredRefresh?.(),
+  };
+
+  function fullGridReload() {
+    gridStore.wsUpdateKey = Date.now();
+    gridStore.refreshGridVersion();
+  }
+
+  // Fixed-window scheduler for the realtime-sync coalescer. The composable arms
+  // one flush per window (it skips schedule() while a flush is already pending),
+  // so the first queued event starts a GRID_WS_COALESCE_MS timer and a
+  // back-to-back burst flushes once at its end. cancel() lets onBeforeUnmount
+  // drop a pending flush.
+  const gridWsScheduler = {
+    schedule(flush) {
+      if (gridWsCoalesceTimer) clearTimeout(gridWsCoalesceTimer);
+      gridWsCoalesceTimer = setTimeout(() => {
+        gridWsCoalesceTimer = null;
+        flush();
+      }, GRID_WS_COALESCE_MS);
+    },
+    cancel() {
+      if (gridWsCoalesceTimer) {
+        clearTimeout(gridWsCoalesceTimer);
+        gridWsCoalesceTimer = null;
+      }
+    },
+  };
+
+  const gridRealtimeSync = useGridRealtimeSync({
+    getMyClientId: () => wsStore.clientId,
+    grid: gridApi,
+    wsStore,
+    pictureChangeAffectsView,
+    getSelectedSort: () => sortStore.selectedSort,
+    reload: fullGridReload,
+    refreshSidebar: (flash) => refreshSidebarPicturesDebounced(flash),
+    scheduler: gridWsScheduler,
+  });
+
+  function connectUpdatesSocket() {
+    if (updatesSocket) return;
+    const url = buildUpdatesSocketUrl();
+    if (!url) return;
+    const ws = new WebSocket(url);
+    updatesSocket = ws;
+
+    ws.onopen = () => {
+      sendUpdatesFilters();
+    };
+
+    ws.onmessage = (event) => {
+      let payload;
+      try {
+        payload = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+      // The operation log has no WS event of its own: a metadata mutation
+      // announces itself as a picture/tag/character change, and that is the
+      // signal the undo stack may have moved. Origin is read from the event
+      // `data` (never a contextvar) and only decides whether the change may
+      // narrate itself; an external one updates the stack silently.
+      if (OPERATION_BEARING_EVENTS.has(payload?.type)) {
+        operationStore.onPictureEvent(payload);
+      }
+      const isPictureChange =
+        payload?.type === "pictures_changed" ||
+        payload?.type === "picture_imported";
+      if (isPictureChange) {
+        // LIKENESS_GROUPS reorders the whole grid wholesale, so a targeted op
+        // can't reconcile it — keep the existing wsTagUpdate signal that lets the
+        // grid re-rank in place. (Imports still flow through the normal path.)
+        const pictureIds = Array.isArray(payload.picture_ids)
+          ? payload.picture_ids
+          : [];
+        // Signal the open lightbox to re-fetch its card's smart_score. The overlay
+        // always displays the score (independent of grid sort), so this fires for
+        // any smart_score change regardless of the current sort and regardless of
+        // origin — matching on picture id + field, not origin, so it covers both
+        // origin-stamped interactive tag edits and the origin-less bulk drain that
+        // rides a penalised-tag settings change. `fields` absent = full change.
+        if (payload?.type === "pictures_changed" && pictureIds.length > 0) {
+          const changedFields = Array.isArray(payload.fields)
+            ? payload.fields
+            : [];
+          const touchesSmartScore =
+            changedFields.length === 0 || changedFields.includes("smart_score");
+          if (touchesSmartScore) {
+            const nextKey = (wsStore.wsSmartScoreUpdate?.key || 0) + 1;
+            wsStore.wsSmartScoreUpdate = { key: nextKey, pictureIds };
+          }
+          // Signal the open lightbox to re-fetch its detection boxes when a
+          // Segment run lands. The grid's card-content refresh is deferred under
+          // an open overlay (§9.1) and the overlay reads its boxes straight from
+          // the detections endpoint, so it needs its own signal. The backend
+          // always stamps this change `fields: ["detections"]`, so match on the
+          // explicit field only.
+          if (changedFields.includes("detections")) {
+            const nextKey = (wsStore.wsDetectionUpdate?.key || 0) + 1;
+            wsStore.wsDetectionUpdate = { key: nextKey, pictureIds };
+          }
+        }
+        if (
+          pictureIds.length > 0 &&
+          sortStore.selectedSort === "LIKENESS_GROUPS" &&
+          payload?.type !== "picture_imported" &&
+          pictureChangeAffectsView(payload.fields)
+        ) {
+          if (!wsStore.isUploadInProgress) {
+            refreshSidebarPicturesDebounced(true);
+          }
+          const nextKey = (wsStore.wsTagUpdate?.key || 0) + 1;
+          wsStore.wsTagUpdate = { key: nextKey, pictureIds };
+          return;
+        }
+        // Own upload in progress: the import dialog drives the grid; ignore the
+        // echo so it doesn't double-count or reload mid-upload.
+        if (
+          wsStore.isUploadInProgress &&
+          payload?.type === "picture_imported"
+        ) {
+          return;
+        }
+        // Everything else goes through the origin-aware decision table.
+        gridRealtimeSync.handleMessage(payload);
+      } else if (payload?.type === "characters_changed") {
+        refreshSidebar();
+      } else if (payload?.type === "tags_changed") {
+        const pictureIds = Array.isArray(payload.picture_ids)
+          ? payload.picture_ids
+          : [];
+        // Origin-aware: only this tab's own tag edits may refresh a tag-filtered
+        // grid in place. A tag change from outside (background tagging, another
+        // tab) must not reshuffle the user's filtered view — the grid raises a
+        // click-to-refresh pill instead (see ImageGrid's wsTagUpdate watcher).
+        // The flag rides on wsTagUpdate; the overlay still refreshes its open
+        // card's tags for any origin.
+        const isOwn = !!(
+          payload.origin_client_id &&
+          wsStore.clientId &&
+          payload.origin_client_id === wsStore.clientId
+        );
+        const nextKey = (wsStore.wsTagUpdate?.key || 0) + 1;
+        wsStore.wsTagUpdate = { key: nextKey, pictureIds, external: !isOwn };
+      } else if (payload?.type === "descriptions_changed") {
+        const pictureIds = Array.isArray(payload.picture_ids)
+          ? payload.picture_ids
+          : [];
+        const nextKey = (wsStore.wsDescriptionUpdate?.key || 0) + 1;
+        wsStore.wsDescriptionUpdate = { key: nextKey, pictureIds };
+      } else if (payload?.type === "plugin_progress") {
+        wsStore.wsPluginProgress = {
+          key: Date.now(),
+          payload,
+        };
+      } else if (payload?.type === "snapshot_created" && !isReadOnly.value) {
+        snapshotsStore.onSnapshotCreated();
+      } else if (payload?.type === "snapshot_deleted" && !isReadOnly.value) {
+        snapshotsStore.onSnapshotDeleted(payload);
+      } else if (payload?.type === "restore_started" && !isReadOnly.value) {
+        snapshotsStore.onRestoreStarted(payload);
+      } else if (payload?.type === "restore_completed" && !isReadOnly.value) {
+        snapshotsStore.onRestoreCompleted();
+        gridStore.wsUpdateKey = Date.now();
+        gridStore.refreshGridVersion();
+        refreshSidebar();
+      } else if (payload?.type === "restore_failed" && !isReadOnly.value) {
+        snapshotsStore.onRestoreFailed(payload);
+        gridStore.wsUpdateKey = Date.now();
+        gridStore.refreshGridVersion();
+        refreshSidebar();
+      }
+    };
+
+    ws.onclose = () => {
+      updatesSocket = null;
+      if (updatesReconnectTimer) {
+        clearTimeout(updatesReconnectTimer);
+      }
+      updatesReconnectTimer = setTimeout(() => {
+        updatesReconnectTimer = null;
+        connectUpdatesSocket();
+      }, 2000);
+    };
+  }
+
+  function disconnectUpdatesSocket() {
+    if (updatesReconnectTimer) {
+      clearTimeout(updatesReconnectTimer);
+      updatesReconnectTimer = null;
+    }
+    if (updatesSocket) {
+      updatesSocket.close();
+      updatesSocket = null;
+    }
+  }
+
+  function loadPendingExternalImports() {
+    const ids = wsStore.pendingExternalImportIds.slice();
+    wsStore.clearPendingExternalImportIds();
+    if (!ids.length) {
+      fullGridReload();
+      return;
+    }
+    // Splice just the new ids in place; fall back to a full reload if the grid
+    // ref isn't available (e.g. unmounted) or is mid-fetch.
+    const grid = gridContainer.value;
+    if (grid?.insertGridImagesById && !grid.isImagesLoading?.()) {
+      grid.insertGridImagesById(ids);
+    } else {
+      fullGridReload();
+    }
+  }
+
+  function loadSortChangedExternal() {
+    // The user opted in to the reshuffle — reconcile by refetching + re-sorting.
+    wsStore.clearSortChangedExternalIds();
+    fullGridReload();
+  }
+
+  // ImageGrid asks to raise the "view changed externally" pill for an external
+  // tag change under an active tag filter (instead of reshuffling the filtered
+  // grid under the user). Skip ids already queued in the "new pictures" pill so a
+  // just-imported batch being tagged doesn't double-pill.
+  function onFlagSortChanged(ids) {
+    if (!Array.isArray(ids) || !ids.length) return;
+    const pending = new Set(wsStore.pendingExternalImportIds);
+    const fresh = ids.filter((id) => !pending.has(id));
+    if (fresh.length) wsStore.addSortChangedExternalIds(fresh);
+  }
+
+  onUnmounted(() => {
+    disconnectUpdatesSocket();
+    gridWsScheduler.cancel();
+  });
+
+  return {
+    connectUpdatesSocket,
+    disconnectUpdatesSocket,
+    sendUpdatesFilters,
+    fullGridReload,
+    loadPendingExternalImports,
+    loadSortChangedExternal,
+    onFlagSortChanged,
+  };
+}

--- a/frontend/src/composables/useUpdatesSocket.js
+++ b/frontend/src/composables/useUpdatesSocket.js
@@ -1,9 +1,5 @@
-import { onUnmounted } from "vue";
-import {
-  API_BASE_URL,
-  appendShareToken,
-  isReadOnly,
-} from "../utils/apiClient";
+import { onUnmounted, watch } from "vue";
+import { API_BASE_URL, appendShareToken, isReadOnly } from "../utils/apiClient";
 import { useGridRealtimeSync } from "./useGridRealtimeSync";
 import { useWsStore } from "../stores/useWsStore";
 import { useGridStore } from "../stores/useGridStore";
@@ -363,6 +359,30 @@ export function useUpdatesSocket({
     const fresh = ids.filter((id) => !pending.has(id));
     if (fresh.length) wsStore.addSortChangedExternalIds(fresh);
   }
+
+  // The backend only sends events this client's current view could care about,
+  // so any change to what the view is has to be re-announced.
+  watch(
+    [
+      () => selectionStore.selectedCharacter,
+      () => selectionStore.selectedSet,
+      () => selectionStore.selectedSetIds,
+      () => searchStore.searchQuery,
+    ],
+    () => {
+      sendUpdatesFilters();
+    },
+  );
+
+  // A grid rebuild has reconciled whatever the pills were offering, so the
+  // queued ids are stale.
+  watch(
+    () => gridStore.gridVersion,
+    () => {
+      wsStore.clearPendingExternalImportIds();
+      wsStore.clearSortChangedExternalIds();
+    },
+  );
 
   onUnmounted(() => {
     disconnectUpdatesSocket();

--- a/frontend/src/composables/useVersionCheck.js
+++ b/frontend/src/composables/useVersionCheck.js
@@ -15,7 +15,13 @@ function parseVersion(v) {
   if (!m) return null;
   const preTag = m[4]?.toLowerCase().replace(/^\./, "");
   const preWeight = { dev: -4, a: -3, b: -2, rc: -1 }[preTag] ?? 0;
-  return [Number(m[1]), Number(m[2]), Number(m[3]), preWeight, Number(m[5] || 0)];
+  return [
+    Number(m[1]),
+    Number(m[2]),
+    Number(m[3]),
+    preWeight,
+    Number(m[5] || 0),
+  ];
 }
 function isRemoteNewer(current, remote) {
   const a = parseVersion(current);
@@ -34,7 +40,12 @@ function isRemoteNewer(current, remote) {
 const LATEST_VERSION_BASE_URL = "https://pixlstash.dev/latest-version";
 // Install-type buckets allowed in the telemetry path; anything else (or
 // empty) collapses to "other". Detection must never block the check.
-const TELEMETRY_INSTALL_BUCKETS = new Set(["docker", "pip", "electron", "other"]);
+const TELEMETRY_INSTALL_BUCKETS = new Set([
+  "docker",
+  "pip",
+  "electron",
+  "other",
+]);
 const UPDATE_PAGE_URL = "https://pixlstash.dev/upgrade.html";
 
 const VERSION_CHECK_STORAGE_KEY = "pixlstash:lastVersionCheck";

--- a/frontend/src/composables/useViewportLayout.js
+++ b/frontend/src/composables/useViewportLayout.js
@@ -1,4 +1,4 @@
-import { onMounted, onUnmounted } from "vue";
+import { onMounted, onUnmounted, watch } from "vue";
 import { useGridStore } from "../stores/useGridStore";
 import { useSidebarStore } from "../stores/useSidebarStore";
 
@@ -67,6 +67,15 @@ export function useViewportLayout({ mainAreaRef }) {
       sidebarStore.hideAutoSidebar();
     }
   }
+
+  // Opening or closing the stats rail changes the width the grid has to work
+  // with, so the column ceiling is recomputed with it.
+  watch(
+    () => sidebarStore.statsOpen,
+    () => {
+      updateIsMobile();
+    },
+  );
 
   onMounted(() => window.addEventListener("resize", updateIsMobile));
   onUnmounted(() => window.removeEventListener("resize", updateIsMobile));

--- a/frontend/src/composables/useViewportLayout.js
+++ b/frontend/src/composables/useViewportLayout.js
@@ -1,0 +1,94 @@
+import { onMounted, onUnmounted, watch } from "vue";
+import { useRoute } from "vue-router";
+import { useViewStore } from "../stores/useViewStore";
+import { useGridStore } from "../stores/useGridStore";
+import { useSidebarStore } from "../stores/useSidebarStore";
+
+const MIN_THUMBNAIL_SIZE = 96;
+const MAX_THUMBNAIL_SIZE = 384;
+const MIN_COLUMNS = 2;
+const MAX_COLUMNS = 14;
+const SIDEBAR_HIDE_BREAKPOINT = 790;
+const STATS_HIDE_BREAKPOINT = 1280;
+
+/**
+ * Viewport-driven layout: which rails the window is wide enough to show, and
+ * how many grid columns fit in what is left.
+ *
+ * The column ceiling is a viewport fact, not a preference - it stops tiles
+ * shrinking below a usable width on a narrow window - so it is recomputed on
+ * every resize and whenever the space around the grid changes.
+ *
+ * @param {object} deps
+ * @param {import("vue").Ref} deps.mainAreaRef - the element the grid lives
+ *   in, measured for the column ceiling.
+ */
+export function useViewportLayout({ mainAreaRef }) {
+  const route = useRoute();
+  const viewStore = useViewStore();
+  const gridStore = useGridStore();
+  const sidebarStore = useSidebarStore();
+
+  function updateSidebarBreakpoints() {
+    if (typeof window !== "undefined") {
+      sidebarStore.sidebarForcedHidden =
+        window.innerWidth < SIDEBAR_HIDE_BREAKPOINT;
+      sidebarStore.statsForcedHidden =
+        window.innerWidth < STATS_HIDE_BREAKPOINT;
+    }
+  }
+
+  function updateIsMobile() {
+    updateSidebarBreakpoints();
+    updateMaxColumns();
+  }
+
+  function updateMaxColumns() {
+    // Maintain the responsive column bounds. gridStore.columns is derived from
+    // the size level and clamps itself to these bounds, so there is nothing to
+    // write back here — updating the bounds re-evaluates the derived count.
+    const width = mainAreaRef.value?.clientWidth ?? window.innerWidth ?? 0;
+    if (!width) {
+      gridStore.minColumns = MIN_COLUMNS;
+      gridStore.maxColumns = MAX_COLUMNS;
+      return;
+    }
+    const availableWidth = Math.max(0, width - 8);
+    const computedMin = Math.max(
+      1,
+      Math.ceil(availableWidth / MAX_THUMBNAIL_SIZE),
+    );
+    const computedMax = Math.max(
+      computedMin,
+      Math.floor(availableWidth / MIN_THUMBNAIL_SIZE),
+    );
+    gridStore.minColumns = Math.max(MIN_COLUMNS, computedMin);
+    gridStore.maxColumns = Math.min(MAX_COLUMNS, computedMax);
+  }
+
+  function closeSidebarIfMobile() {
+    if (sidebarStore.sidebarForcedHidden) {
+      sidebarStore.hideAutoSidebar();
+    }
+  }
+
+  // Route -> stores: install the app's single route watcher (immediately on
+  // mount for deep-linking, then on every navigation). The parsing and the
+  // writes live in useViewStore; App.vue keeps only the route PUSHING above.
+  viewStore.startRouteSync(route, { watch });
+
+  // A navigation retires the live undo receipt (owner decision, 2026-07-29):
+  // the pill narrates something that happened on the view being left, and a
+  // receipt carried into the next view reads as a fresh event there. Ctrl+Z
+  // keeps working everywhere regardless — the receipt is narration, not the
+
+  onMounted(() => window.addEventListener("resize", updateIsMobile));
+  onUnmounted(() => window.removeEventListener("resize", updateIsMobile));
+
+  return {
+    updateSidebarBreakpoints,
+    updateIsMobile,
+    updateMaxColumns,
+    closeSidebarIfMobile,
+  };
+}

--- a/frontend/src/composables/useViewportLayout.js
+++ b/frontend/src/composables/useViewportLayout.js
@@ -1,6 +1,4 @@
-import { onMounted, onUnmounted, watch } from "vue";
-import { useRoute } from "vue-router";
-import { useViewStore } from "../stores/useViewStore";
+import { onMounted, onUnmounted } from "vue";
 import { useGridStore } from "../stores/useGridStore";
 import { useSidebarStore } from "../stores/useSidebarStore";
 
@@ -24,8 +22,6 @@ const STATS_HIDE_BREAKPOINT = 1280;
  *   in, measured for the column ceiling.
  */
 export function useViewportLayout({ mainAreaRef }) {
-  const route = useRoute();
-  const viewStore = useViewStore();
   const gridStore = useGridStore();
   const sidebarStore = useSidebarStore();
 
@@ -71,16 +67,6 @@ export function useViewportLayout({ mainAreaRef }) {
       sidebarStore.hideAutoSidebar();
     }
   }
-
-  // Route -> stores: install the app's single route watcher (immediately on
-  // mount for deep-linking, then on every navigation). The parsing and the
-  // writes live in useViewStore; App.vue keeps only the route PUSHING above.
-  viewStore.startRouteSync(route, { watch });
-
-  // A navigation retires the live undo receipt (owner decision, 2026-07-29):
-  // the pill narrates something that happened on the view being left, and a
-  // receipt carried into the next view reads as a fresh event there. Ctrl+Z
-  // keeps working everywhere regardless — the receipt is narration, not the
 
   onMounted(() => window.addEventListener("resize", updateIsMobile));
   onUnmounted(() => window.removeEventListener("resize", updateIsMobile));

--- a/frontend/src/composables/useWheelZoom.js
+++ b/frontend/src/composables/useWheelZoom.js
@@ -73,9 +73,7 @@ export function useWheelZoom(options = {}) {
   let exitLastOutTs = 0;
   let settleTimer = null;
 
-  const effectiveMaxScale = computed(() =>
-    Math.max(maxScale, fitScale.value),
-  );
+  const effectiveMaxScale = computed(() => Math.max(maxScale, fitScale.value));
 
   /** Within the shared slack of a target scale. */
   function nearScale(target) {
@@ -118,8 +116,16 @@ export function useWheelZoom(options = {}) {
    * an axis where the image fits, the range is zero and the image re-centres. */
   function reclampOffset() {
     offset.value = {
-      x: clampOffsetAxis(offset.value.x, container.value.width, natural.value.width),
-      y: clampOffsetAxis(offset.value.y, container.value.height, natural.value.height),
+      x: clampOffsetAxis(
+        offset.value.x,
+        container.value.width,
+        natural.value.width,
+      ),
+      y: clampOffsetAxis(
+        offset.value.y,
+        container.value.height,
+        natural.value.height,
+      ),
     };
   }
 

--- a/frontend/src/composables/useWindowFileImport.js
+++ b/frontend/src/composables/useWindowFileImport.js
@@ -1,0 +1,105 @@
+import { onMounted, onUnmounted } from "vue";
+import { isInternalImageDrag } from "../utils/media.js";
+import { useReviewSessionsStore } from "../stores/useReviewSessionsStore";
+
+/**
+ * Import media dropped or pasted anywhere in the window.
+ *
+ * The grid has its own drop target, so drops that land inside it are left
+ * alone; this is the catch-all for everywhere else. Listeners are registered
+ * in the capture phase so a drop is claimed before the browser navigates to
+ * the file.
+ *
+ * @param {object} deps
+ * @param {import("vue").Ref} deps.sidebarRef - the sidebar, which owns the
+ *   import flow and knows the project a dropped file should land in.
+ */
+export function useWindowFileImport({ sidebarRef }) {
+  const reviewSessionsStore = useReviewSessionsStore();
+
+  function isInsideImageGrid(event) {
+    const target = event?.target;
+    if (!(target instanceof Element)) return false;
+    return Boolean(target.closest(".image-grid, .grid-scroll-wrapper"));
+  }
+
+  function isExternalFileDragEvent(event) {
+    const dataTransfer = event?.dataTransfer;
+    if (!dataTransfer) return false;
+    // An internal app drag (grid thumbnail → sidebar character/set/project) is
+    // never a file import — bail before the files check. On the desktop shell
+    // (Electron) such a drag ALSO populates dataTransfer.files with the dragged
+    // in-page image as a real File (the web does not), so without this guard the
+    // window-level import handler mistakes the assign-drag for an external file
+    // drop and imports the picture instead of assigning it.
+    if (isInternalImageDrag(dataTransfer)) return false;
+    const files = dataTransfer.files;
+    if (files && files.length > 0) return true;
+    const types = dataTransfer.types ? Array.from(dataTransfer.types) : [];
+    return types.includes("Files") || types.includes("application/x-moz-file");
+  }
+
+  function handleWindowDragOver(event) {
+    if (!isExternalFileDragEvent(event)) return;
+    // The review overlay is a modal review surface; dropping files into it
+    // must never start an import. Skip preventDefault so the drag is not shown as
+    // droppable here.
+    if (reviewSessionsStore.overlayOpen) return;
+    event.preventDefault();
+  }
+
+  function handleWindowDrop(event) {
+    if (!isExternalFileDragEvent(event)) return;
+    // While the review overlay is open, swallow the drop without importing
+    // (still preventDefault so the browser does not navigate to the dropped file).
+    if (reviewSessionsStore.overlayOpen) {
+      event.preventDefault();
+      return;
+    }
+    event.preventDefault();
+    if (isInsideImageGrid(event)) {
+      return;
+    }
+    const droppedFiles = Array.from(event.dataTransfer?.files || []);
+    if (!droppedFiles.length) return;
+    const projectId = sidebarRef.value?.currentProjectId ?? null;
+    sidebarRef.value?.startLocalImport?.(droppedFiles, projectId);
+  }
+
+  function handleWindowPaste(event) {
+    // Ignore paste events originating from editable elements (text inputs etc.)
+    const target = event.target;
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target?.isContentEditable
+    ) {
+      return;
+    }
+    const items = Array.from(event.clipboardData?.items || []);
+    const mediaFiles = items
+      .filter(
+        (item) =>
+          item.kind === "file" &&
+          (item.type.startsWith("image/") || item.type.startsWith("video/")),
+      )
+      .map((item) => item.getAsFile())
+      .filter(Boolean);
+    if (!mediaFiles.length) return;
+    event.preventDefault();
+    const projectId = sidebarRef.value?.currentProjectId ?? null;
+    sidebarRef.value?.startLocalImport?.(mediaFiles, projectId);
+  }
+
+  onMounted(() => {
+    window.addEventListener("dragover", handleWindowDragOver, true);
+    window.addEventListener("drop", handleWindowDrop, true);
+    window.addEventListener("paste", handleWindowPaste, true);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener("dragover", handleWindowDragOver, true);
+    window.removeEventListener("drop", handleWindowDrop, true);
+    window.removeEventListener("paste", handleWindowPaste, true);
+  });
+}

--- a/frontend/src/stores/useGridStore.js
+++ b/frontend/src/stores/useGridStore.js
@@ -55,11 +55,22 @@ export const useGridStore = defineStore("grid", () => {
     return Math.max(1, Math.min(maxColumns.value, desired));
   });
 
+  // Both modes render from the same stored bitmap - justified shows it whole,
+  // square crops it to the stored rectangle - so a valid change applies at once
+  // with no thumbnail regeneration. Rejecting the unchanged value keeps the
+  // persist watcher from firing for nothing.
+  function setThumbnailMode(value) {
+    if (value !== "square" && value !== "justified") return;
+    if (value === thumbnailMode.value) return;
+    thumbnailMode.value = value;
+  }
+
   function refreshGridVersion() {
     gridVersion.value++;
   }
 
   return {
+    setThumbnailMode,
     columns,
     sizeLevel,
     thumbnailSize,

--- a/frontend/src/stores/useSidebarStore.js
+++ b/frontend/src/stores/useSidebarStore.js
@@ -82,6 +82,11 @@ export const useSidebarStore = defineStore("sidebar", () => {
     sidebarForcedHidden.value ? false : sidebarPinned.value,
   );
   // Width used by the layout — forced to full on mobile.
+  // True while a reference/import folder is being scanned. The sidebar sets it
+  // (it owns the folder lists); the grid reads it, so its empty state can say
+  // "still scanning" instead of "nothing here".
+  const folderScanning = ref(false);
+
   const effectiveDocked = computed(() =>
     sidebarForcedHidden.value ? false : sidebarDocked.value,
   );
@@ -130,6 +135,7 @@ export const useSidebarStore = defineStore("sidebar", () => {
     sidebarPinned,
     autoRevealed,
     effectiveDocked,
+    folderScanning,
     sidebarVisible,
     sidebarOverlay,
     statsOpen,

--- a/frontend/src/stores/useSortStore.js
+++ b/frontend/src/stores/useSortStore.js
@@ -9,7 +9,17 @@ export const useSortStore = defineStore("sort", () => {
   const selectedSimilarityCharacter = ref(null);
   const similarityCharacterOptions = ref([]);
 
+  function setSortOptions(options) {
+    sortOptions.value = Array.isArray(options) ? options : [];
+  }
+
+  function setSimilarityCharacterOptions(options) {
+    similarityCharacterOptions.value = Array.isArray(options) ? options : [];
+  }
+
   return {
+    setSortOptions,
+    setSimilarityCharacterOptions,
     selectedSort,
     selectedDescending,
     sortOptions,

--- a/frontend/src/stores/useUserPrefsStore.js
+++ b/frontend/src/stores/useUserPrefsStore.js
@@ -35,7 +35,59 @@ export const useUserPrefsStore = defineStore("userPrefs", () => {
     }
   }
 
+  // Guarded setters. Each of these preferences drives a watcher (persisting to
+  // the server, and for a few of them repainting the grid), so writing an
+  // invalid value or rewriting the same one is not free - it costs a PATCH and
+  // sometimes a refetch. The guards used to sit in App.vue's handlers; they
+  // belong with the state so every writer gets them.
+  function setHiddenTags(tags) {
+    const next = Array.isArray(tags) ? tags : [];
+    if (
+      hiddenTags.value.length === next.length &&
+      hiddenTags.value.every((tag, i) => tag === next[i])
+    ) {
+      return;
+    }
+    hiddenTags.value = next;
+  }
+
+  function setApplyTagFilter(value) {
+    const next = Boolean(value);
+    if (applyTagFilter.value === next) return;
+    applyTagFilter.value = next;
+  }
+
+  function setDateFormat(value) {
+    if (value == null) return;
+    const next = String(value);
+    if (next === dateFormat.value) return;
+    dateFormat.value = next;
+  }
+
+  function setThemeMode(value) {
+    if (value == null) return;
+    themeMode.value = String(value);
+  }
+
+  function setSidebarThumbnailSize(value) {
+    const next = Number(value);
+    if (!Number.isFinite(next)) return;
+    sidebarThumbnailSize.value = next;
+  }
+
+  function setSidebarWidth(value) {
+    const next = Number(value);
+    if (!Number.isFinite(next)) return;
+    sidebarWidth.value = next;
+  }
+
   return {
+    setHiddenTags,
+    setApplyTagFilter,
+    setDateFormat,
+    setThemeMode,
+    setSidebarThumbnailSize,
+    setSidebarWidth,
     dateFormat,
     themeMode,
     showKeyboardHint,


### PR DESCRIPTION
Lane A, step 3. **Stacked on #660**; base retargets to `develop` when that merges.

App.vue goes from **2455 to 771 lines**, under the plan's ≤800. Seven commits, each one coherent cluster:

| composable / component | what moved |
|---|---|
| `useAppConfig` | config load, the config snapshot, and the fourteen watchers that persist a UI option |
| `useAppNavigation` | sidebar entry clicks and the route pushes that follow them |
| `useGlobalKeydown` | the app-wide shortcut handler and its listener |
| `useWindowFileImport` | window-level drag / drop / paste import |
| `useAppSettingsHandlers` | the settings-dialog and sidebar control handlers |
| `useUpdatesSocket` | the `/updates` socket, filter handshake, reconnect loop, realtime-sync wiring |
| `useSidebarRefresh` | the two debounced sidebar refreshes and their timers |
| `useViewportLayout` | breakpoints and the grid's column ceiling |
| `useAppEntityActions` | post-action reconciliation for assign / move / export / clear-search |
| `ShortcutsDialog.vue` | 130 lines of static key-hint table |

**One deviation from the plan's wording, flagged rather than buried.** Phase 3 step 6 says App.vue ends as "layout shell, router glue, WebSocket lifecycle, useGridRealtimeSync wiring". The socket internals moved into `useUpdatesSocket`; App.vue still owns the *lifecycle* (connects on mount, disconnects on unmount) but not the plumbing. ≤800 is not reachable with ~300 lines of socket code in the file, so I took the composable and am saying so.

**Exit criteria: two of four met.** Line count ✅ and e2e green ✅. Still outstanding: the template's per-child binding blocks (`SideBar` is 61 lines against a ≤15 target, `ImageGrid` 24) and the watcher count (11 against ≤8). `SideBar`'s prop drilling is Phase 3 step 4 and `ImageGrid`'s remaining 21 emits are Phase 5, so both are follow-ups rather than gaps in this PR — but the step is not fully closed and I would rather say that than claim it.

**New coverage:** `ShortcutsDialog` had no test of any kind, and extracting a 130-line template chunk is exactly the change that fails silently, so it gains an e2e spec pinning F1 and the table rendering.

Verified after every commit: unit suite 1656 passing, production build, and the full e2e suite — 86 passed, 4 skipped (87 now, with the new spec).