### PR TITLE
SideBar goes store-direct; App.vue watchers down to 3 (Phase 3, step 4)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,12 +14,10 @@ import { API_BASE_URL, isReadOnly, sessionContext } from "./utils/apiClient";
 import { useSelectionStore } from "./stores/useSelectionStore";
 import { useFilterStore } from "./stores/useFilterStore";
 import { useGridStore } from "./stores/useGridStore";
-import { useExportStore } from "./stores/useExportStore";
 import { useSidebarStore } from "./stores/useSidebarStore";
 import { useUserPrefsStore } from "./stores/useUserPrefsStore";
 import { useProjectStore } from "./stores/useProjectStore";
 import { useWsStore } from "./stores/useWsStore";
-import { useSearchStore } from "./stores/useSearchStore";
 import { useReviewSessionsStore } from "./stores/useReviewSessionsStore";
 import { useSnapshotsStore } from "./stores/useSnapshotsStore";
 import { useTasksStore } from "./stores/useTasksStore";
@@ -39,6 +37,7 @@ import { useUpdatesSocket } from "./composables/useUpdatesSocket";
 import { useSidebarRefresh } from "./composables/useSidebarRefresh";
 import { useViewportLayout } from "./composables/useViewportLayout";
 import { useAppEntityActions } from "./composables/useAppEntityActions";
+import { useSearchBarSync } from "./composables/useSearchBarSync";
 
 import SideBar from "./components/panels/SideBar.vue";
 import TitleBar from "./components/TitleBar.vue";
@@ -59,12 +58,10 @@ const BACKEND_URL = API_BASE_URL;
 const selectionStore = useSelectionStore();
 const filterStore = useFilterStore();
 const gridStore = useGridStore();
-const exportStore = useExportStore();
 const sidebarStore = useSidebarStore();
 const userPrefsStore = useUserPrefsStore();
 const projectStore = useProjectStore();
 const wsStore = useWsStore();
-const searchStore = useSearchStore();
 const reviewSessionsStore = useReviewSessionsStore();
 const snapshotsStore = useSnapshotsStore();
 const tasksStore = useTasksStore();
@@ -145,7 +142,6 @@ const { updateIsMobile, updateMaxColumns, closeSidebarIfMobile } =
 const {
   connectUpdatesSocket,
   disconnectUpdatesSocket,
-  sendUpdatesFilters,
   loadPendingExternalImports,
   loadSortChangedExternal,
   onFlagSortChanged,
@@ -160,7 +156,6 @@ const {
   handleImagesAssignedToCharacter,
   handleImagesMoved,
   handleFacesAssignedToCharacter,
-  refreshExportCount,
   confirmExportZip,
   handleClearSearch,
   handleResetToAll,
@@ -168,7 +163,10 @@ const {
   gridContainer,
   refreshSidebar,
   onNavigated: () => closeSidebarIfMobile(),
+  onTagFilterChanged: () => refreshSidebarDebounced(),
 });
+
+useSearchBarSync();
 
 useGlobalKeydown({ gridContainer, sidebarRef, shortcutsDialogOpen });
 useWindowFileImport({ sidebarRef });
@@ -311,87 +309,11 @@ function resolveThemeName(mode) {
 }
 
 watch(
-  () => searchStore.searchQuery,
-  (newVal, oldVal) => {
-    if (searchStore.searchInput !== newVal) {
-      searchStore.searchInput = newVal || "";
-    }
-    if (!newVal && oldVal) {
-      gridStore.refreshGridVersion();
-    }
-  },
-);
-
-watch([() => searchStore.searchInput, () => searchStore.searchHistory], () => {
-  const needle = (searchStore.searchInput || "").trim();
-  if (!needle) {
-    searchStore.isSearchHistoryOpen = false;
-    return;
-  }
-  searchStore.isSearchHistoryOpen =
-    searchStore.filteredSearchHistory.length > 0;
-});
-
-watch(
-  () => userPrefsStore.hiddenTags,
-  () => {
-    gridStore.refreshGridVersion();
-    if (userPrefsStore.applyTagFilter) {
-      refreshSidebarDebounced();
-    }
-  },
-);
-
-watch(
-  () => userPrefsStore.applyTagFilter,
-  () => {
-    gridStore.refreshGridVersion();
-    refreshSidebarDebounced();
-  },
-);
-
-watch(
-  [
-    () => selectionStore.selectedCharacter,
-    () => selectionStore.selectedSet,
-    () => selectionStore.selectedSetIds,
-    () => searchStore.searchQuery,
-  ],
-  () => {
-    sendUpdatesFilters();
-  },
-);
-
-watch(
-  () => gridStore.gridVersion,
-  () => {
-    wsStore.clearPendingExternalImportIds();
-    wsStore.clearSortChangedExternalIds();
-  },
-);
-
-watch(
   () => userPrefsStore.themeMode,
   (value) => {
     theme.global.name.value = resolveThemeName(value);
   },
   { immediate: true },
-);
-
-watch(
-  () => exportStore.exportMenuOpen,
-  async (isOpen) => {
-    if (!isOpen) return;
-    await nextTick();
-    refreshExportCount();
-  },
-);
-
-watch(
-  () => sidebarStore.statsOpen,
-  () => {
-    updateIsMobile();
-  },
 );
 
 // --- Lifecycle ---

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,7 +13,6 @@ import { useReviewRoute } from "./composables/useReviewRoute";
 import { API_BASE_URL, isReadOnly, sessionContext } from "./utils/apiClient";
 import { useSelectionStore } from "./stores/useSelectionStore";
 import { useFilterStore } from "./stores/useFilterStore";
-import { useSortStore } from "./stores/useSortStore";
 import { useGridStore } from "./stores/useGridStore";
 import { useExportStore } from "./stores/useExportStore";
 import { useSidebarStore } from "./stores/useSidebarStore";
@@ -59,7 +58,6 @@ const BACKEND_URL = API_BASE_URL;
 // --- Stores ---
 const selectionStore = useSelectionStore();
 const filterStore = useFilterStore();
-const sortStore = useSortStore();
 const gridStore = useGridStore();
 const exportStore = useExportStore();
 const sidebarStore = useSidebarStore();
@@ -73,7 +71,6 @@ const tasksStore = useTasksStore();
 const operationStore = useOperationStore();
 // Owns route → view resolution (the app's single route watcher). Route pushing
 // stays here in App.vue; see stores/useViewStore.js.
-const viewStore = useViewStore();
 // Keycap labels for the shortcuts dialog. The binding accepts Ctrl and Meta
 // everywhere; only the hint is platform-specific.
 
@@ -109,7 +106,6 @@ const gridWrapperRef = ref(null);
 const shortcutsDialogOpen = ref(false);
 const updateCheckDialogOpen = ref(false);
 const photosDialogOpen = ref(false);
-const folderScanning = ref(false);
 const installType = ref("pip");
 const dockerVariant = ref("gpu");
 const loading = ref(null);
@@ -178,25 +174,13 @@ useGlobalKeydown({ gridContainer, sidebarRef, shortcutsDialogOpen });
 useWindowFileImport({ sidebarRef });
 
 const {
-  handleUpdateProjectViewMode,
-  handleUpdateSelectedProjectId,
   handleViewProject,
   handleUpdateSelectedSort,
-  handleUpdateSortOptions,
   handleStackStatsUpdate,
-  handleUpdateSimilarityCharacter,
-  handleUpdateSimilarityOptions,
-  handleUpdateHiddenTags,
-  handleUpdateApplyTagFilter,
-  handleUpdateDateFormat,
-  handleUpdateThemeMode,
   handleUpdateCheckForUpdates,
-  handleUpdateSidebarThumbnailSize,
   handleEmptyScrapheapFromSidebar,
   handleSuggestPicturesForCharacter,
   focusTasksTabPanel,
-  handleUpdateThumbnailMode,
-  handleUpdateSidebarWidth,
 } = useAppSettingsHandlers({
   gridContainer,
   statsSidebarRef,
@@ -221,7 +205,6 @@ let stopOpenSettings = null;
 // Maps the current route to a sidebar folder key ('rf-{id}' or 'if-{id}') so
 // the sidebar can highlight the correct folder on deep-link or back-navigation.
 // Parsed once, by useViewStore.
-const activeFolderKey = computed(() => viewStore.activeFolderKey);
 
 const activeCategoryLabel = computed(() => {
   if (selectionStore.selectedFolderFilter) {
@@ -301,6 +284,15 @@ async function handleLocalImport({ files, projectId } = {}) {
 }
 
 // undo affordance itself.
+// Route -> stores: install the app's single route watcher (immediately on
+// mount for deep-linking, then on every navigation). The parsing and the
+// writes live in useViewStore; the route PUSHING lives in useAppNavigation.
+useViewStore().startRouteSync(route, { watch });
+
+// A navigation retires the live undo receipt (owner decision, 2026-07-29): the
+// pill narrates something that happened on the view being left, and a receipt
+// carried into the next view reads as a fresh event there. Ctrl+Z keeps working
+// regardless - the receipt is narration, not the undo affordance itself.
 watch(
   () => route.fullPath,
   (next, prev) => {
@@ -535,65 +527,19 @@ defineExpose({
         >
           <SideBar
             ref="sidebarRef"
-            :docked="sidebarStore.effectiveDocked"
-            :selectedCharacter="selectionStore.selectedCharacter"
-            :selectedCharacterIds="selectionStore.selectedCharacterIds"
-            :allPicturesId="ALL_PICTURES_ID"
-            :unassignedPicturesId="UNASSIGNED_PICTURES_ID"
-            :scrapheapPicturesId="SCRAPHEAP_PICTURES_ID"
-            :selectedSet="selectionStore.selectedSet"
-            :selectedSetIds="selectionStore.selectedSetIds"
-            :searchQuery="searchStore.searchQuery"
-            :selectedSort="sortStore.selectedSort"
-            :selectedDescending="sortStore.selectedDescending"
             :backendUrl="BACKEND_URL"
-            :publicUrl="userPrefsStore.publicUrl"
-            :embedWatermark="userPrefsStore.embedWatermark"
-            :selectedSimilarityCharacter="sortStore.selectedSimilarityCharacter"
-            :sidebarThumbnailSize="userPrefsStore.sidebarThumbnailSize"
-            :sidebarWidth="userPrefsStore.sidebarWidth"
-            :dateFormat="userPrefsStore.dateFormat"
-            :themeMode="userPrefsStore.themeMode"
-            :hasFolderFilter="selectionStore.selectedFolderFilter != null"
-            :activeFolderKey="activeFolderKey"
-            :externalProjectViewMode="projectStore.projectViewMode"
-            :externalSelectedProjectId="projectStore.selectedProjectId"
-            :checkForUpdates="userPrefsStore.checkForUpdates"
             :installType="installType"
             :dockerVariant="dockerVariant"
-            :showKeyboardHint="userPrefsStore.showKeyboardHint"
-            :thumbnailMode="gridStore.thumbnailMode"
-            @update:thumbnail-mode="handleUpdateThumbnailMode"
             @empty-scrapheap="handleEmptyScrapheapFromSidebar"
             @suggest-pictures-for-character="handleSuggestPicturesForCharacter"
-            @update:show-keyboard-hint="
-              userPrefsStore.showKeyboardHint = $event
-            "
-            @update:similarity-options="handleUpdateSimilarityOptions"
-            @update:sort-options="handleUpdateSortOptions"
-            @update:hidden-tags="handleUpdateHiddenTags"
-            @update:apply-tag-filter="handleUpdateApplyTagFilter"
-            @update:comfyui-configured="filterStore.comfyuiConfigured = $event"
-            @update:public-url="userPrefsStore.publicUrl = $event"
-            @update:embed-watermark="userPrefsStore.embedWatermark = $event"
-            @update:date-format="handleUpdateDateFormat"
-            @update:theme-mode="handleUpdateThemeMode"
-            @update:sidebar-thumbnail-size="handleUpdateSidebarThumbnailSize"
-            @update:sidebar-width="handleUpdateSidebarWidth"
-            @update:project-view-mode="handleUpdateProjectViewMode"
-            @update:selected-project-id="handleUpdateSelectedProjectId"
             @view-project="handleViewProject"
             @select-character="handleSelectCharacter"
-            :isDuplicatesView="isDuplicatesView"
             @select-duplicates="handleSelectDuplicates"
             @select-set="handleSelectSet"
             @select-folder="handleSelectFolder"
-            @update:folder-scanning="folderScanning = $event"
             @images-assigned-to-character="handleImagesAssignedToCharacter"
             @images-moved="handleImagesMoved"
             @faces-assigned-to-character="handleFacesAssignedToCharacter"
-            @update:selected-sort="handleUpdateSelectedSort"
-            @update:similarity-character="handleUpdateSimilarityCharacter"
             @open-import-dialog="openImportDialog"
             @update:set-error="error = $event"
             @update:set-loading="loading = $event"
@@ -698,7 +644,6 @@ defineExpose({
                 ref="gridContainer"
                 :backendUrl="BACKEND_URL"
                 :activeCategoryLabel="activeCategoryLabel"
-                :folderScanning="folderScanning"
                 @clear-search="handleClearSearch"
                 @search-all="handleSearchAllPictures"
                 @update:selected-sort="handleUpdateSelectedSort"

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -55,10 +55,7 @@ import {
   movePicturesToReferenceFolder,
 } from "../../api/folders";
 import { setPicturesProject } from "../../api/pictures";
-import {
-  getSharedResourceIds,
-  revokeTokensByResource,
-} from "../../api/users";
+import { getSharedResourceIds, revokeTokensByResource } from "../../api/users";
 import { listSortMechanisms } from "../../api/session";
 import { extractSupportedImportFilesFromDataTransfer } from "../../utils/media.js";
 import {
@@ -73,7 +70,20 @@ import { useLockedSetsStore } from "../../stores/useLockedSetsStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
 import { useVersionCheck } from "../../composables/useVersionCheck";
 import { useSidebarExpansion } from "../../composables/useSidebarExpansion";
+import { useRoute } from "vue-router";
 import { useDedupStore, scopeKey } from "../../stores/useDedupStore";
+import { useSelectionStore } from "../../stores/useSelectionStore";
+import { useSortStore } from "../../stores/useSortStore";
+import { useProjectStore } from "../../stores/useProjectStore";
+import { useUserPrefsStore } from "../../stores/useUserPrefsStore";
+import { useGridStore } from "../../stores/useGridStore";
+import { useFilterStore } from "../../stores/useFilterStore";
+import {
+  ALL_PICTURES_ID,
+  SCRAPHEAP_PICTURES_ID,
+  UNASSIGNED_PICTURES_ID,
+  useViewStore,
+} from "../../stores/useViewStore";
 
 // Publishes id → name maps for the ImageGrid breadcrumb. The sidebar is the
 // authoritative name source (it fetches these lists); see useEntityNamesStore.
@@ -98,45 +108,36 @@ const isDesktop = typeof window !== "undefined" && !!window.pixlstashDesktop;
 
 const dedupStore = useDedupStore();
 
+// Store-direct (Phase 3): the sidebar reads the selection, sort, project and
+// preference state it displays straight from the stores and writes changes
+// back itself, instead of mirroring all of it through App.vue.
+const selectionStore = useSelectionStore();
+const sortStore = useSortStore();
+const projectStore = useProjectStore();
+const userPrefsStore = useUserPrefsStore();
+const gridStore = useGridStore();
+const filterStore = useFilterStore();
+const viewStore = useViewStore();
+const route = useRoute();
+
+// A folder filter and the Duplicates destination each suppress parts of the
+// entity lists, so both are derived once here.
+const hasFolderFilter = computed(
+  () => selectionStore.selectedFolderFilter != null,
+);
+// Duplicates is addressed by route name, not by a selection sentinel: it shows
+// no pictures, so there is no selection to express.
+const isDuplicatesView = computed(() => route.name === "duplicates");
+
 const props = defineProps({
-  docked: { type: Boolean, default: false },
-  selectedCharacter: { type: [String, Number, null], default: null },
-  allPicturesId: { type: String, required: true },
-  unassignedPicturesId: { type: String, required: true },
-  scrapheapPicturesId: { type: String, required: true },
-  // The Duplicates destination is addressed by route, not by a selection
-  // sentinel, so its active state arrives as its own flag.
-  isDuplicatesView: { type: Boolean, default: false },
-  selectedSet: { type: [Number, null], default: null },
-  selectedSetIds: { type: Array, default: () => [] },
-  selectedCharacterIds: { type: Array, default: () => [] },
-  searchQuery: { type: String, default: "" },
-  selectedSort: { type: String, default: "" },
-  selectedDescending: { type: Boolean, default: false },
-  selectedSimilarityCharacter: { type: [String, Number, null], default: null },
   backendUrl: { type: String, required: true },
-  publicUrl: { type: String, default: null },
-  embedWatermark: { type: Boolean, default: false },
-  sidebarThumbnailSize: { type: Number, default: 48 },
-  sidebarWidth: { type: Number, default: 240 },
-  dateFormat: { type: String, default: "locale" },
-  themeMode: { type: String, default: "light" },
-  hasFolderFilter: { type: Boolean, default: false },
-  activeFolderKey: { type: String, default: null },
-  externalProjectViewMode: { type: String, default: null },
-  externalSelectedProjectId: { type: Number, default: null },
-  checkForUpdates: { type: Boolean, default: null },
   installType: { type: String, default: "pip" },
   dockerVariant: { type: String, default: "gpu" },
-  showKeyboardHint: { type: Boolean, default: true },
-  thumbnailMode: { type: String, default: "square" },
 });
 
 const emit = defineEmits([
   "select-duplicates",
   "select-character",
-  "update:selected-sort",
-  "update:search-query",
   "select-set",
   "import-finished",
   "set-error",
@@ -145,29 +146,12 @@ const emit = defineEmits([
   "faces-assigned-to-character",
   "images-moved",
   "search-images",
-  "update:similarity-character",
-  "update:similarity-options",
-  "update:sidebar-thumbnail-size",
-  "update:sidebar-width",
-  "update:date-format",
-  "update:theme-mode",
-  "update:thumbnail-mode",
   "empty-scrapheap",
   "suggest-pictures-for-character",
-  "update:sort-options",
-  "update:hidden-tags",
-  "update:apply-tag-filter",
-  "update:comfyui-configured",
-  "update:public-url",
-  "update:embed-watermark",
   "open-import-dialog",
-  "update:project-view-mode",
-  "update:selected-project-id",
   "view-project",
   "update:check-for-updates",
-  "update:show-keyboard-hint",
   "select-folder",
-  "update:folder-scanning",
 ]);
 
 // "New version available" alert. Disabled on the desktop shell, where the title
@@ -183,7 +167,7 @@ const {
   dismissUpdateAlert,
 } = useVersionCheck(
   () => props.installType,
-  () => props.checkForUpdates,
+  () => userPrefsStore.checkForUpdates,
   !isDesktop,
 );
 
@@ -241,9 +225,9 @@ const sortOptions = ref([]);
 // --- Character & Sidebar State ---
 const characters = ref([]);
 const categoryCounts = ref({
-  [props.allPicturesId]: 0,
-  [props.unassignedPicturesId]: 0,
-  [props.scrapheapPicturesId]: 0,
+  [ALL_PICTURES_ID]: 0,
+  [UNASSIGNED_PICTURES_ID]: 0,
+  [SCRAPHEAP_PICTURES_ID]: 0,
 });
 // Counts keyed by project id (number) or UNASSIGNED_PROJECT_KEY (unassigned in project mode)
 const UNASSIGNED_PROJECT_KEY = "UNASSIGNED";
@@ -588,7 +572,7 @@ async function referenceFolderDeleted() {
   selectedFolderKey.value = null;
   selectedFolderReferenceId.value = null;
   emit("select-folder", null);
-  emit("update:folder-scanning", false);
+  sidebarStore.folderScanning = false;
   await fetchReferenceFolders();
 }
 
@@ -614,7 +598,7 @@ async function importFolderSaved() {
         importFolderId: newFolder.id,
         label: newFolder.label || newFolder.folder,
       });
-      emit("update:folder-scanning", Boolean(newFolder.last_checked == null));
+      sidebarStore.folderScanning = Boolean(newFolder.last_checked == null);
       return;
     }
   }
@@ -629,7 +613,7 @@ async function importFolderSaved() {
     selectedFolderKey.value = null;
     selectedFolderReferenceId.value = null;
     emit("select-folder", null);
-    emit("update:folder-scanning", false);
+    sidebarStore.folderScanning = false;
     return;
   }
   emit("select-folder", {
@@ -649,7 +633,7 @@ async function importFolderDeleted() {
     selectedFolderKey.value = null;
     selectedFolderReferenceId.value = null;
     emit("select-folder", null);
-    emit("update:folder-scanning", false);
+    sidebarStore.folderScanning = false;
   }
   await fetchImportFolders();
 }
@@ -695,7 +679,7 @@ const selectedFolderScanning = computed(() => {
 });
 
 watch(selectedFolderScanning, (val) => {
-  emit("update:folder-scanning", val);
+  sidebarStore.folderScanning = val;
 });
 
 const collapsedProjectBtnTitle = computed(() => {
@@ -840,7 +824,7 @@ function handleFolderNodeSelect(key, payload) {
   }
   emit("select-folder", payload);
   // Emit immediately on selection so ImageGrid updates before next poll tick.
-  emit("update:folder-scanning", selectedFolderScanning.value);
+  sidebarStore.folderScanning = selectedFolderScanning.value;
 }
 
 async function handleFolderNodeToggle(path) {
@@ -1139,7 +1123,11 @@ function createSet() {
 }
 
 function toggleProjectMenu() {
-  if (!projectMenuOpen.value && props.docked && collapsedProjectBtnRef.value) {
+  if (
+    !projectMenuOpen.value &&
+    sidebarStore.effectiveDocked &&
+    collapsedProjectBtnRef.value
+  ) {
     const rect = collapsedProjectBtnRef.value.getBoundingClientRect();
     collapsedProjectMenuPos.value = _flyoutPos(rect);
     if (
@@ -1303,13 +1291,14 @@ const sortedCharacters = computed(() => {
 
 const selectedCharacterObj = computed(() => {
   if (
-    props.selectedCharacter &&
-    props.selectedCharacter !== props.allPicturesId &&
-    props.selectedCharacter !== props.unassignedPicturesId &&
-    props.selectedCharacter !== props.scrapheapPicturesId
+    selectionStore.selectedCharacter &&
+    selectionStore.selectedCharacter !== ALL_PICTURES_ID &&
+    selectionStore.selectedCharacter !== UNASSIGNED_PICTURES_ID &&
+    selectionStore.selectedCharacter !== SCRAPHEAP_PICTURES_ID
   ) {
     const char =
-      characters.value.find((c) => c.id === props.selectedCharacter) || null;
+      characters.value.find((c) => c.id === selectionStore.selectedCharacter) ||
+      null;
     if (char && typeof char.name === "string" && char.name.length > 0) {
       return {
         ...char,
@@ -1323,9 +1312,10 @@ const selectedCharacterObj = computed(() => {
 
 const selectedSetObj = computed(() => {
   const primarySetId =
-    Array.isArray(props.selectedSetIds) && props.selectedSetIds.length
-      ? props.selectedSetIds[0]
-      : props.selectedSet;
+    Array.isArray(selectionStore.selectedSetIds) &&
+    selectionStore.selectedSetIds.length
+      ? selectionStore.selectedSetIds[0]
+      : selectionStore.selectedSet;
   if (!primarySetId) return null;
   return pictureSets.value.find((pset) => pset.id === primarySetId) || null;
 });
@@ -1333,7 +1323,10 @@ const selectedSetObj = computed(() => {
 const selectedSetIdSet = computed(
   () =>
     new Set(
-      (Array.isArray(props.selectedSetIds) ? props.selectedSetIds : [])
+      (Array.isArray(selectionStore.selectedSetIds)
+        ? selectionStore.selectedSetIds
+        : []
+      )
         .map((id) => Number(id))
         .filter((id) => Number.isFinite(id) && id > 0),
     ),
@@ -1344,8 +1337,8 @@ const hasSingleSelectedSet = computed(() => selectedSetIdSet.value.size === 1);
 const selectedCharacterIdSet = computed(
   () =>
     new Set(
-      (Array.isArray(props.selectedCharacterIds)
-        ? props.selectedCharacterIds
+      (Array.isArray(selectionStore.selectedCharacterIds)
+        ? selectionStore.selectedCharacterIds
         : []
       )
         .map((id) => Number(id))
@@ -1448,24 +1441,31 @@ const similarityCharacterOptions = computed(() => {
 watch(
   similarityCharacterOptions,
   (options) => {
-    emit("update:similarity-options", options);
+    sortStore.setSimilarityCharacterOptions(options);
   },
   { immediate: true },
 );
 
 const similarityCharacterModel = computed({
-  get: () => props.selectedSimilarityCharacter,
-  set: (value) => emit("update:similarity-character", value ?? null),
+  get: () => sortStore.selectedSimilarityCharacter,
+  // Changing the reference person changes what the similarity sort means, so
+  // the grid has to repaint; and on a narrow window the choice is made, so the
+  // auto-hidden sidebar gets out of the way.
+  set: (value) => {
+    sortStore.selectedSimilarityCharacter = value ?? null;
+    gridStore.refreshGridVersion();
+    if (sidebarStore.sidebarForcedHidden) sidebarStore.hideAutoSidebar();
+  },
 });
 
 const sidebarThumbnailSizeModel = computed({
-  get: () => props.sidebarThumbnailSize ?? 48,
+  get: () => userPrefsStore.sidebarThumbnailSize ?? 48,
   set: (value) => {
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) return;
     const clamped = Math.min(64, Math.max(16, parsed));
     const snapped = Math.round(clamped / 4) * 4;
-    emit("update:sidebar-thumbnail-size", snapped);
+    userPrefsStore.setSidebarThumbnailSize(snapped);
   },
 });
 
@@ -1476,7 +1476,8 @@ const _dockRowH = computed(() => sidebarThumbnailSizeModel.value + 4);
 const _DOCK_DIV = 3; // divider height (1px + 2px margins)
 const _addBtn = computed(() => (isReadOnly.value ? 0 : 1)); // extra [+] row when editable
 const setsCollapsed = computed(() => {
-  if (!props.docked || sidebarPrimaryTab.value === "folders") return false;
+  if (!sidebarStore.effectiveDocked || sidebarPrimaryTab.value === "folders")
+    return false;
   const h = _dockRowH.value;
   const charCount = visibleCharacters.value.length;
   const setCount = visibleSets.value.length;
@@ -1488,7 +1489,8 @@ const setsCollapsed = computed(() => {
   return fixedH + charH + setDividerH + allSetsH > dockedScrollHeight.value;
 });
 const charsCollapsed = computed(() => {
-  if (!props.docked || sidebarPrimaryTab.value === "folders") return false;
+  if (!sidebarStore.effectiveDocked || sidebarPrimaryTab.value === "folders")
+    return false;
   if (!setsCollapsed.value) return false;
   const h = _dockRowH.value;
   const charCount = visibleCharacters.value.length;
@@ -1508,18 +1510,18 @@ const sidebarFolderChildIconSize = computed(() =>
 );
 
 const dateFormatModel = computed({
-  get: () => props.dateFormat ?? "locale",
-  set: (value) => emit("update:date-format", value ?? "locale"),
+  get: () => userPrefsStore.dateFormat ?? "locale",
+  set: (value) => userPrefsStore.setDateFormat(value ?? "locale"),
 });
 
 const themeModeModel = computed({
-  get: () => props.themeMode ?? "light",
-  set: (value) => emit("update:theme-mode", value ?? "light"),
+  get: () => userPrefsStore.themeMode ?? "light",
+  set: (value) => userPrefsStore.setThemeMode(value ?? "light"),
 });
 
 const showKeyboardHintModel = computed({
-  get: () => props.showKeyboardHint ?? true,
-  set: (value) => emit("update:show-keyboard-hint", value ?? true),
+  get: () => userPrefsStore.showKeyboardHint ?? true,
+  set: (value) => (userPrefsStore.showKeyboardHint = value ?? true),
 });
 
 const sidebarThumbnailSizeLarge = computed(
@@ -1544,11 +1546,11 @@ const clampSidebarWidth = (v) =>
 
 // Persisted width; the setter emits up to the store/backend.
 const sidebarWidthModel = computed({
-  get: () => props.sidebarWidth ?? 240,
+  get: () => userPrefsStore.sidebarWidth ?? 240,
   set: (value) => {
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) return;
-    emit("update:sidebar-width", clampSidebarWidth(parsed));
+    userPrefsStore.setSidebarWidth(clampSidebarWidth(parsed));
   },
 });
 
@@ -1560,7 +1562,7 @@ const sidebarDragWidth = ref(null);
 // drop them. Uses the live drag width while resizing, the saved width otherwise.
 const sidebarIsNarrow = computed(
   () =>
-    !props.docked &&
+    !sidebarStore.effectiveDocked &&
     (sidebarDragWidth.value ?? sidebarWidthModel.value ?? 240) < 150,
 );
 
@@ -1571,7 +1573,7 @@ const sidebarThumbStyle = computed(() => {
   };
   // Apply the resized width only when expanded; docked width is driven by the
   // thumbnail size in CSS, so leave it to the stylesheet there.
-  if (!props.docked) {
+  if (!sidebarStore.effectiveDocked) {
     const w = sidebarDragWidth.value ?? sidebarWidthModel.value;
     style.width = `${w}px`;
   }
@@ -1601,7 +1603,7 @@ function onSidebarResizeEnd() {
 }
 
 function onSidebarResizeStart(e) {
-  if (props.docked) return;
+  if (sidebarStore.effectiveDocked) return;
   e.preventDefault();
   const rect = sidebarRootRef.value?.getBoundingClientRect();
   _resizeStartWidth = rect ? rect.width : sidebarWidthModel.value;
@@ -1614,7 +1616,7 @@ function onSidebarResizeStart(e) {
 }
 
 function onSidebarResizeKey(e) {
-  if (props.docked) return;
+  if (sidebarStore.effectiveDocked) return;
   const step = e.shiftKey ? 24 : 8;
   if (e.key === "ArrowLeft") {
     sidebarWidthModel.value = sidebarWidthModel.value - step;
@@ -1625,14 +1627,22 @@ function onSidebarResizeKey(e) {
   }
 }
 
-const reactiveSelectedDescending = ref(props.selectedDescending);
+const reactiveSelectedDescending = ref(sortStore.selectedDescending);
 
 watch(
-  () => props.selectedDescending,
+  () => sortStore.selectedDescending,
   (newValue) => {
     reactiveSelectedDescending.value = newValue;
   },
 );
+
+// Changing the sort from the sidebar also closes an auto-hidden sidebar: on a
+// narrow window the user has just made their choice and wants to see the grid.
+function applySort(sort, descending) {
+  sortStore.selectedSort = sort;
+  sortStore.selectedDescending = descending;
+  if (sidebarStore.sidebarForcedHidden) sidebarStore.hideAutoSidebar();
+}
 
 const descendingModel = computed({
   get: () => {
@@ -1640,17 +1650,14 @@ const descendingModel = computed({
   },
   set: (value) => {
     reactiveSelectedDescending.value = value;
-    emit("update:selected-sort", { sort: sortModel.value, descending: value });
+    applySort(sortModel.value, value);
   },
 });
 
 const sortModel = computed({
-  get: () => props.selectedSort,
+  get: () => sortStore.selectedSort,
   set: (value) =>
-    emit("update:selected-sort", {
-      sort: value != null ? String(value) : "",
-      descending: descendingModel.value,
-    }),
+    applySort(value != null ? String(value) : "", descendingModel.value),
 });
 
 // --- Character Editor Dialog Functions ---
@@ -1688,13 +1695,13 @@ function openSettingsDialog(tab = "") {
 function selectCharacter(id, label = null, event = null) {
   clearCountNew(id);
   const isSpecial =
-    id === props.allPicturesId ||
-    id === props.unassignedPicturesId ||
-    id === props.scrapheapPicturesId;
+    id === ALL_PICTURES_ID ||
+    id === UNASSIGNED_PICTURES_ID ||
+    id === SCRAPHEAP_PICTURES_ID;
   const isMultiToggle = !isSpecial && Boolean(event?.ctrlKey || event?.metaKey);
 
   if (!isMultiToggle) {
-    if (id === props.allPicturesId) {
+    if (id === ALL_PICTURES_ID) {
       allPicturesLastMode.value = projectViewMode.value;
       allPicturesLastProjectId.value = selectedProjectId.value;
     }
@@ -1705,7 +1712,7 @@ function selectCharacter(id, label = null, event = null) {
     // Compute the full project context so App.vue can apply everything
     // atomically without relying on any pre-existing store state.
     let projectContext;
-    if (id === props.allPicturesId) {
+    if (id === ALL_PICTURES_ID) {
       // "All Pictures" keeps whatever project scope was active when clicked.
       projectContext = {
         mode: projectViewMode.value,
@@ -1771,7 +1778,7 @@ function selectCharacter(id, label = null, event = null) {
   const nextIds = Array.from(currentIds).sort((a, b) => a - b);
   if (!nextIds.length) {
     emit("select-character", {
-      id: props.allPicturesId,
+      id: ALL_PICTURES_ID,
       label: null,
       ids: [],
       projectIds: {},
@@ -1780,7 +1787,7 @@ function selectCharacter(id, label = null, event = null) {
   }
 
   // Keep the primary view unchanged on ctrl-click
-  const primaryId = props.selectedCharacter ?? nextIds[0];
+  const primaryId = selectionStore.selectedCharacter ?? nextIds[0];
   const multiProjectIds = {};
   for (const cid of nextIds) {
     const c = characters.value.find((ch) => ch.id === cid);
@@ -1856,14 +1863,14 @@ function selectSet(setId, label = null, event = null) {
 }
 
 async function deleteCharacter() {
-  if (!props.selectedCharacter) return;
+  if (!selectionStore.selectedCharacter) return;
   if (!window.confirm("Delete this character?")) return;
   try {
-    await apiDeleteCharacter(props.selectedCharacter);
+    await apiDeleteCharacter(selectionStore.selectedCharacter);
 
     // Remove the deleted character from the characters array
     characters.value = characters.value.filter(
-      (char) => char.id !== props.selectedCharacter,
+      (char) => char.id !== selectionStore.selectedCharacter,
     );
 
     await fetchCharacters(); // Refresh sidebar
@@ -1981,7 +1988,7 @@ async function deleteImportFolderById(id) {
       selectedFolderKey.value = null;
       selectedFolderReferenceId.value = null;
       emit("select-folder", null);
-      emit("update:folder-scanning", false);
+      sidebarStore.folderScanning = false;
     }
     await fetchImportFolders();
   } catch (e) {
@@ -1997,10 +2004,22 @@ async function deleteImportFolderById(id) {
 
 /** Context-menu target types that can be scoped for a duplicate scan. */
 const DEDUP_SCOPE_TYPES = {
-  character: { scope: "character", icon: "mdi-account-box-outline", noun: "for" },
+  character: {
+    scope: "character",
+    icon: "mdi-account-box-outline",
+    noun: "for",
+  },
   set: { scope: "set", icon: "mdi-folder-multiple-image", noun: "in this set" },
-  project: { scope: "project", icon: "mdi-briefcase-outline", noun: "in this project" },
-  folder: { scope: "folder", icon: "mdi-folder-outline", noun: "in this folder" },
+  project: {
+    scope: "project",
+    icon: "mdi-briefcase-outline",
+    noun: "in this project",
+  },
+  folder: {
+    scope: "folder",
+    icon: "mdi-folder-outline",
+    noun: "in this folder",
+  },
 };
 
 /**
@@ -2191,7 +2210,7 @@ function closeSidebarCtxMenu() {
 // The sidebar row already owns this count, so we read it here rather than reach
 // into the grid's `scrapheapEmptyDisabled`.
 const scrapheapIsEmpty = computed(
-  () => !categoryCounts.value[props.scrapheapPicturesId],
+  () => !categoryCounts.value[SCRAPHEAP_PICTURES_ID],
 );
 
 // Empty Scrapheap from the sidebar context menu. Navigate into the scrapheap
@@ -2200,7 +2219,7 @@ const scrapheapIsEmpty = computed(
 function emptyScrapheapFromCtx() {
   if (scrapheapIsEmpty.value) return;
   closeSidebarCtxMenu();
-  selectCharacter(props.scrapheapPicturesId, "Scrapheap");
+  selectCharacter(SCRAPHEAP_PICTURES_ID, "Scrapheap");
   emit("empty-scrapheap");
 }
 
@@ -2408,7 +2427,7 @@ function dragLeaveSetItem() {
 
 function isCountSelected(id) {
   if (!id) return false;
-  return props.selectedCharacter === id;
+  return selectionStore.selectedCharacter === id;
 }
 
 /**
@@ -2420,12 +2439,12 @@ function isCountSelected(id) {
  * guards travel together.
  */
 const selectionOwnsHighlight = computed(
-  () => !props.hasFolderFilter && !props.isDuplicatesView,
+  () => !hasFolderFilter.value && !isDuplicatesView.value,
 );
 
 const isAllPicturesRowActive = computed(() => {
   if (!selectionOwnsHighlight.value) return false;
-  if (props.selectedCharacter !== props.allPicturesId) return false;
+  if (selectionStore.selectedCharacter !== ALL_PICTURES_ID) return false;
   if (selectedSetIdSet.value.size > 0) return false;
   return true;
 });
@@ -2469,10 +2488,10 @@ async function fetchSidebarData() {
   // Fetch total image count for END key logic
   try {
     // All images summary
-    const data = await getCharacterSummary(props.allPicturesId, undefined, {
+    const data = await getCharacterSummary(ALL_PICTURES_ID, undefined, {
       baseUrl: props.backendUrl,
     });
-    setCategoryCount(props.allPicturesId, data.image_count, shouldFlash);
+    setCategoryCount(ALL_PICTURES_ID, data.image_count, shouldFlash);
   } catch (e) {
     console.warn("Error fetching all images summary:", e);
   }
@@ -2488,21 +2507,19 @@ async function fetchSidebarData() {
           }
         : undefined;
     const data = await getCharacterSummary(
-      props.unassignedPicturesId,
+      UNASSIGNED_PICTURES_ID,
       unassignedParams,
       { baseUrl: props.backendUrl },
     );
-    setCategoryCount(props.unassignedPicturesId, data.image_count, shouldFlash);
+    setCategoryCount(UNASSIGNED_PICTURES_ID, data.image_count, shouldFlash);
   } catch (e) {
     console.warn("Error fetching unassigned images summary:", e);
   }
   try {
-    const data = await getCharacterSummary(
-      props.scrapheapPicturesId,
-      undefined,
-      { baseUrl: props.backendUrl },
-    );
-    setCategoryCount(props.scrapheapPicturesId, data.image_count, shouldFlash);
+    const data = await getCharacterSummary(SCRAPHEAP_PICTURES_ID, undefined, {
+      baseUrl: props.backendUrl,
+    });
+    setCategoryCount(SCRAPHEAP_PICTURES_ID, data.image_count, shouldFlash);
   } catch (e) {
     console.warn("Error fetching scrapheap images summary:", e);
   }
@@ -2633,11 +2650,11 @@ async function fetchSortOptions() {
         ? sortOptions.value[0].value
         : null;
     }
-    emit("update:sort-options", sortOptions.value);
+    sortStore.setSortOptions(sortOptions.value);
   } catch (e) {
     console.error("Error fetching sort options:", e);
     sortOptions.value = [];
-    emit("update:sort-options", []);
+    sortStore.setSortOptions([]);
   }
 }
 
@@ -3196,15 +3213,15 @@ onMounted(() => {
     // _initializing suppresses the watchers so this one-time restore does NOT
     // emit navigation events back to App.vue.
     if (
-      props.externalProjectViewMode != null ||
-      props.externalSelectedProjectId != null
+      projectStore.projectViewMode != null ||
+      projectStore.selectedProjectId != null
     ) {
       _initializing = true;
-      if (props.externalProjectViewMode != null)
-        projectViewMode.value = props.externalProjectViewMode;
-      if (props.externalSelectedProjectId != null) {
-        lastUsedProjectId.value = props.externalSelectedProjectId;
-        selectedProjectId.value = props.externalSelectedProjectId;
+      if (projectStore.projectViewMode != null)
+        projectViewMode.value = projectStore.projectViewMode;
+      if (projectStore.selectedProjectId != null) {
+        lastUsedProjectId.value = projectStore.selectedProjectId;
+        selectedProjectId.value = projectStore.selectedProjectId;
       }
       nextTick(() => {
         _initializing = false;
@@ -3379,7 +3396,7 @@ watch(
 );
 
 watch(
-  [() => sortedCharacters.value, () => props.selectedSort],
+  [() => sortedCharacters.value, () => sortStore.selectedSort],
   ([chars, selectedSort]) => {
     const hasCharacters = Array.isArray(chars) && chars.length > 0;
     if (!hasCharacters && selectedSort === SIMILARITY_SORT_KEY) {
@@ -3398,7 +3415,7 @@ watch(
 );
 
 watch(
-  () => props.selectedCharacter,
+  () => selectionStore.selectedCharacter,
   (nextId) => {
     clearCountNew(nextId);
   },
@@ -3440,7 +3457,7 @@ watch(selectedProjectId, (v) => {
 // this handles every subsequent route change. (Switching the Projects tab does
 // NOT change the prop, so the stateless browse-scope is preserved.)
 watch(
-  () => props.externalSelectedProjectId,
+  () => projectStore.selectedProjectId,
   (v) => {
     if (_initializing) return;
     const next = v ?? null;
@@ -3453,7 +3470,7 @@ watch(
 // the matching key via the activeFolderKey prop so we can switch to the
 // folders tab and emit the correct filter payload.
 watch(
-  () => props.activeFolderKey,
+  () => viewStore.activeFolderKey,
   async (newKey, oldKey) => {
     if (!newKey) {
       // Route left a folder view — clear the sidebar's folder highlight.
@@ -3470,7 +3487,7 @@ watch(
     await fetchImportFolders();
 
     // Guard: user may have navigated away while fetches were in flight.
-    if (props.activeFolderKey !== newKey) return;
+    if (viewStore.activeFolderKey !== newKey) return;
 
     if (newKey.startsWith("rf-")) {
       const id = parseInt(newKey.slice(3), 10);
@@ -3724,9 +3741,9 @@ defineExpose({
   <ImageImporter
     ref="imageImporterRef"
     :backend-url="props.backendUrl"
-    :selected-character-id="props.selectedCharacter"
-    :all-pictures-id="props.allPicturesId"
-    :unassigned-pictures-id="props.unassignedPicturesId"
+    :selected-character-id="selectionStore.selectedCharacter"
+    :all-pictures-id="ALL_PICTURES_ID"
+    :unassigned-pictures-id="UNASSIGNED_PICTURES_ID"
     @import-finished="handleImportFinished"
   />
   <CharacterEditor
@@ -3761,17 +3778,19 @@ defineExpose({
     v-model:sidebar-thumbnail-size="sidebarThumbnailSizeModel"
     v-model:date-format="dateFormatModel"
     v-model:theme-mode="themeModeModel"
-    :checkForUpdates="props.checkForUpdates"
+    :checkForUpdates="userPrefsStore.checkForUpdates"
     v-model:show-keyboard-hint="showKeyboardHintModel"
-    :thumbnail-mode="props.thumbnailMode"
-    @update:thumbnail-mode="(value) => emit('update:thumbnail-mode', value)"
+    :thumbnail-mode="gridStore.thumbnailMode"
+    @update:thumbnail-mode="(value) => gridStore.setThumbnailMode(value)"
     :initial-tab="settingsDialogInitialTab"
-    @update:hidden-tags="(value) => emit('update:hidden-tags', value)"
-    @update:apply-tag-filter="(value) => emit('update:apply-tag-filter', value)"
-    @update:comfyui-configured="
-      (value) => emit('update:comfyui-configured', value)
+    @update:hidden-tags="(value) => userPrefsStore.setHiddenTags(value)"
+    @update:apply-tag-filter="
+      (value) => userPrefsStore.setApplyTagFilter(value)
     "
-    @update:public-url="(value) => emit('update:public-url', value)"
+    @update:comfyui-configured="
+      (value) => (filterStore.comfyuiConfigured = value)
+    "
+    @update:public-url="(value) => (userPrefsStore.publicUrl = value)"
     @update:check-for-updates="
       (value) => emit('update:check-for-updates', value)
     "
@@ -3926,14 +3945,14 @@ defineExpose({
     ref="sidebarRootRef"
     class="sidebar"
     :class="{
-      'sidebar-docked': props.docked,
+      'sidebar-docked': sidebarStore.effectiveDocked,
       'sidebar--narrow': sidebarIsNarrow,
     }"
     :style="sidebarThumbStyle"
   >
     <!-- Drag the right edge to resize the expanded sidebar (hidden when docked). -->
     <div
-      v-if="!props.docked"
+      v-if="!sidebarStore.effectiveDocked"
       class="sidebar-resize-handle"
       role="separator"
       aria-orientation="vertical"
@@ -3966,7 +3985,7 @@ defineExpose({
             class="sidebar-brand-logo"
           />
         </a>
-        <div v-if="!props.docked" class="sidebar-brand-text">
+        <div v-if="!sidebarStore.effectiveDocked" class="sidebar-brand-text">
           <WordmarkLogo class="sidebar-brand-title" />
           <div
             v-if="updateAvailable && !updateDismissed"
@@ -3995,7 +4014,7 @@ defineExpose({
       </div>
     </div>
     <div
-      v-if="props.docked"
+      v-if="sidebarStore.effectiveDocked"
       class="sidebar-collapsed-project-wrap"
       ref="projectMenuRef"
       @contextmenu.prevent="openSidebarCtxMenu('empty', null, $event)"
@@ -4021,7 +4040,7 @@ defineExpose({
       </div>
       <Teleport to="body">
         <div
-          v-if="projectMenuOpen && props.docked"
+          v-if="projectMenuOpen && sidebarStore.effectiveDocked"
           ref="collapsedProjectMenuRef"
           class="sidebar-collapsed-project-menu"
           :style="{
@@ -4040,7 +4059,7 @@ defineExpose({
             @mouseenter="scheduleCloseProjectSubMenu"
             @click="
               selectLibraryTab('global');
-              selectCharacter(props.allPicturesId, 'All Pictures');
+              selectCharacter(ALL_PICTURES_ID, 'All Pictures');
               projectMenuOpen = false;
             "
           >
@@ -4091,7 +4110,11 @@ defineExpose({
       <!-- Flyout submenu -->
       <Teleport to="body">
         <div
-          v-if="projectMenuSection && projectMenuOpen && props.docked"
+          v-if="
+            projectMenuSection &&
+            projectMenuOpen &&
+            sidebarStore.effectiveDocked
+          "
           ref="collapsedProjectSubMenuRef"
           class="sidebar-collapsed-project-submenu"
           :style="{
@@ -4122,8 +4145,8 @@ defineExpose({
               class="sidebar-project-menu-item"
               :class="{
                 active:
-                  props.externalProjectViewMode === 'project' &&
-                  props.externalSelectedProjectId === p.id,
+                  projectStore.projectViewMode === 'project' &&
+                  projectStore.selectedProjectId === p.id,
               }"
               @click="
                 selectLibraryTab('project');
@@ -4164,7 +4187,7 @@ defineExpose({
                 active:
                   sidebarPrimaryTab === 'folders' &&
                   selectedFolderKey === 'rf-' + rf.id &&
-                  !props.isDuplicatesView,
+                  !isDuplicatesView,
               }"
               @click="
                 selectFoldersTab();
@@ -4196,7 +4219,7 @@ defineExpose({
                 active:
                   sidebarPrimaryTab === 'folders' &&
                   selectedFolderKey === 'if-' + imf.id &&
-                  !props.isDuplicatesView,
+                  !isDuplicatesView,
               }"
               @click="
                 selectFoldersTab();
@@ -4265,7 +4288,7 @@ defineExpose({
       ref="dockedScrollRef"
       @contextmenu.self.prevent="openSidebarCtxMenu('empty', null, $event)"
     >
-      <template v-if="props.docked">
+      <template v-if="sidebarStore.effectiveDocked">
         <!-- Catch-all: any right-click that reaches the list (blank gaps, the
              margins beside the centered rows, the spacer) opens the view menu.
              Item rows below use `.stop` on their own context menus so they never
@@ -4287,7 +4310,7 @@ defineExpose({
                 { active: isAllPicturesRowActive },
               ]"
               title="All Pictures"
-              @click="selectCharacter(props.allPicturesId, 'All Pictures')"
+              @click="selectCharacter(ALL_PICTURES_ID, 'All Pictures')"
               @contextmenu.prevent.stop="
                 openSidebarCtxMenu('all-pictures', null, $event)
               "
@@ -4315,7 +4338,7 @@ defineExpose({
                 'sidebar-collapsed-row',
                 {
                   active:
-                    props.selectedCharacter === char.id &&
+                    selectionStore.selectedCharacter === char.id &&
                     selectionOwnsHighlight,
                 },
               ]"
@@ -4325,7 +4348,7 @@ defineExpose({
                   'sidebar-collapsed-item',
                   {
                     active:
-                      props.selectedCharacter === char.id &&
+                      selectionStore.selectedCharacter === char.id &&
                       selectionOwnsHighlight,
                   },
                 ]"
@@ -4466,7 +4489,7 @@ defineExpose({
                     'sidebar-collapsed-flyout-item',
                     {
                       active:
-                        props.selectedCharacter === char.id &&
+                        selectionStore.selectedCharacter === char.id &&
                         selectionOwnsHighlight,
                     },
                   ]"
@@ -4792,13 +4815,10 @@ defineExpose({
                reports pending work. -->
           <div
             v-if="!isReadOnly"
-            :class="['sidebar-collapsed-row', { active: props.isDuplicatesView }]"
+            :class="['sidebar-collapsed-row', { active: isDuplicatesView }]"
           >
             <div
-              :class="[
-                'sidebar-collapsed-item',
-                { active: props.isDuplicatesView },
-              ]"
+              :class="['sidebar-collapsed-item', { active: isDuplicatesView }]"
               title="Duplicates"
               @click="emit('select-duplicates', {})"
             >
@@ -4821,7 +4841,7 @@ defineExpose({
               'sidebar-collapsed-row',
               {
                 active:
-                  props.selectedCharacter === props.scrapheapPicturesId &&
+                  selectionStore.selectedCharacter === SCRAPHEAP_PICTURES_ID &&
                   selectionOwnsHighlight,
               },
             ]"
@@ -4832,12 +4852,12 @@ defineExpose({
                 'sidebar-collapsed-item--scrapheap',
                 {
                   active:
-                    props.selectedCharacter === props.scrapheapPicturesId &&
-                    selectionOwnsHighlight,
+                    selectionStore.selectedCharacter ===
+                      SCRAPHEAP_PICTURES_ID && selectionOwnsHighlight,
                 },
               ]"
               title="Scrapheap"
-              @click="selectCharacter(props.scrapheapPicturesId, 'Scrapheap')"
+              @click="selectCharacter(SCRAPHEAP_PICTURES_ID, 'Scrapheap')"
               @contextmenu.prevent.stop="
                 openSidebarCtxMenu('scrapheap', null, $event)
               "
@@ -5203,9 +5223,7 @@ defineExpose({
                   'sidebar-list-item',
                   { active: isAllPicturesRowActive },
                 ]"
-                @click="
-                  selectCharacter(props.allPicturesId, allPicturesRowLabel)
-                "
+                @click="selectCharacter(ALL_PICTURES_ID, allPicturesRowLabel)"
                 @contextmenu.prevent="
                   openSidebarCtxMenu('all-pictures', null, $event)
                 "
@@ -5217,7 +5235,7 @@ defineExpose({
                   allPicturesRowLabel
                 }}</span>
                 <span class="sidebar-list-count">{{
-                  categoryCounts[props.allPicturesId] ?? ""
+                  categoryCounts[ALL_PICTURES_ID] ?? ""
                 }}</span>
               </div>
             </div>
@@ -5228,10 +5246,7 @@ defineExpose({
                  unstacked stay a filter. -->
             <div v-if="!isReadOnly" class="sidebar-all-pictures-row">
               <div
-                :class="[
-                  'sidebar-list-item',
-                  { active: props.isDuplicatesView },
-                ]"
+                :class="['sidebar-list-item', { active: isDuplicatesView }]"
                 @click="emit('select-duplicates', {})"
               >
                 <span class="sidebar-list-icon sidebar-list-icon--toplevel"
@@ -5264,11 +5279,11 @@ defineExpose({
                   'sidebar-list-item',
                   {
                     active:
-                      props.selectedCharacter === props.scrapheapPicturesId &&
-                      selectionOwnsHighlight,
+                      selectionStore.selectedCharacter ===
+                        SCRAPHEAP_PICTURES_ID && selectionOwnsHighlight,
                   },
                 ]"
-                @click="selectCharacter(props.scrapheapPicturesId, 'Scrapheap')"
+                @click="selectCharacter(SCRAPHEAP_PICTURES_ID, 'Scrapheap')"
                 @contextmenu.prevent="
                   openSidebarCtxMenu('scrapheap', null, $event)
                 "
@@ -5278,7 +5293,7 @@ defineExpose({
                 >
                 <span class="sidebar-list-label">Scrapheap</span>
                 <span class="sidebar-list-count">{{
-                  categoryCounts[props.scrapheapPicturesId] || ""
+                  categoryCounts[SCRAPHEAP_PICTURES_ID] || ""
                 }}</span>
               </div>
             </div>
@@ -5308,7 +5323,7 @@ defineExpose({
                     v-if="selectedCharacterIdSet.size > 1"
                     class="clear-selection-inline"
                     @click.stop="
-                      selectCharacter(props.allPicturesId, 'All Pictures')
+                      selectCharacter(ALL_PICTURES_ID, 'All Pictures')
                     "
                     title="Clear character selection"
                   >
@@ -5328,10 +5343,11 @@ defineExpose({
                   <v-icon
                     v-if="
                       !isReadOnly &&
-                      props.selectedCharacter &&
-                      props.selectedCharacter !== props.allPicturesId &&
-                      props.selectedCharacter !== props.unassignedPicturesId &&
-                      props.selectedCharacter !== props.scrapheapPicturesId
+                      selectionStore.selectedCharacter &&
+                      selectionStore.selectedCharacter !== ALL_PICTURES_ID &&
+                      selectionStore.selectedCharacter !==
+                        UNASSIGNED_PICTURES_ID &&
+                      selectionStore.selectedCharacter !== SCRAPHEAP_PICTURES_ID
                     "
                     class="delete-character-inline"
                     color="white"
@@ -5662,9 +5678,9 @@ defineExpose({
                     'sidebar-project-tree-row',
                     {
                       active:
-                        props.externalProjectViewMode === 'project' &&
-                        props.externalSelectedProjectId === p.id &&
-                        props.selectedCharacter === props.allPicturesId &&
+                        projectStore.projectViewMode === 'project' &&
+                        projectStore.selectedProjectId === p.id &&
+                        selectionStore.selectedCharacter === ALL_PICTURES_ID &&
                         selectedSetIdSet.size === 0 &&
                         selectionOwnsHighlight,
                       droppable: dragOverProjectId === p.id,
@@ -6245,9 +6261,7 @@ defineExpose({
         <button
           class="sidebar-ctx-item sidebar-ctx-item--danger"
           :disabled="isReadOnly || scrapheapIsEmpty"
-          :title="
-            scrapheapIsEmpty ? 'Scrapheap is already empty' : undefined
-          "
+          :title="scrapheapIsEmpty ? 'Scrapheap is already empty' : undefined"
           :aria-disabled="isReadOnly || scrapheapIsEmpty"
           @click="emptyScrapheapFromCtx()"
         >
@@ -6276,19 +6290,19 @@ defineExpose({
           @click="findDuplicatesIn('character', sidebarCtxCharacter)"
         >
           <v-icon size="15" class="sidebar-ctx-icon">{{
-            duplicateCountFor('character', sidebarCtxCharacter) === 0
+            duplicateCountFor("character", sidebarCtxCharacter) === 0
               ? "mdi-check"
               : "mdi-content-duplicate"
           }}</v-icon>
           <span class="sidebar-ctx-label">{{
-            duplicateCountFor('character', sidebarCtxCharacter) === 0
+            duplicateCountFor("character", sidebarCtxCharacter) === 0
               ? "No duplicates for this person"
               : "Find duplicates for this person"
           }}</span>
           <span
             v-if="duplicateCountFor('character', sidebarCtxCharacter)"
             class="sidebar-ctx-count"
-            >{{ duplicateCountFor('character', sidebarCtxCharacter) }}</span
+            >{{ duplicateCountFor("character", sidebarCtxCharacter) }}</span
           >
         </button>
         <div v-if="!isReadOnly" class="sidebar-ctx-divider"></div>
@@ -6369,19 +6383,19 @@ defineExpose({
           @click="findDuplicatesIn('set', sidebarCtxSet)"
         >
           <v-icon size="15" class="sidebar-ctx-icon">{{
-            duplicateCountFor('set', sidebarCtxSet) === 0
+            duplicateCountFor("set", sidebarCtxSet) === 0
               ? "mdi-check"
               : "mdi-content-duplicate"
           }}</v-icon>
           <span class="sidebar-ctx-label">{{
-            duplicateCountFor('set', sidebarCtxSet) === 0
+            duplicateCountFor("set", sidebarCtxSet) === 0
               ? "No duplicates in this set"
               : "Find duplicates in this set"
           }}</span>
           <span
             v-if="duplicateCountFor('set', sidebarCtxSet)"
             class="sidebar-ctx-count"
-            >{{ duplicateCountFor('set', sidebarCtxSet) }}</span
+            >{{ duplicateCountFor("set", sidebarCtxSet) }}</span
           >
         </button>
         <div v-if="!isReadOnly" class="sidebar-ctx-divider"></div>
@@ -6591,19 +6605,19 @@ defineExpose({
           @click="findDuplicatesIn('project', sidebarCtxProject)"
         >
           <v-icon size="15" class="sidebar-ctx-icon">{{
-            duplicateCountFor('project', sidebarCtxProject) === 0
+            duplicateCountFor("project", sidebarCtxProject) === 0
               ? "mdi-check"
               : "mdi-content-duplicate"
           }}</v-icon>
           <span class="sidebar-ctx-label">{{
-            duplicateCountFor('project', sidebarCtxProject) === 0
+            duplicateCountFor("project", sidebarCtxProject) === 0
               ? "No duplicates in this project"
               : "Find duplicates in this project"
           }}</span>
           <span
             v-if="duplicateCountFor('project', sidebarCtxProject)"
             class="sidebar-ctx-count"
-            >{{ duplicateCountFor('project', sidebarCtxProject) }}</span
+            >{{ duplicateCountFor("project", sidebarCtxProject) }}</span
           >
         </button>
         <div v-if="!isReadOnly" class="sidebar-ctx-divider"></div>
@@ -6686,22 +6700,25 @@ defineExpose({
           @click="findDuplicatesIn('folder', sidebarCtxFolder)"
         >
           <v-icon size="15" class="sidebar-ctx-icon">{{
-            duplicateCountFor('folder', sidebarCtxFolder) === 0
+            duplicateCountFor("folder", sidebarCtxFolder) === 0
               ? "mdi-check"
               : "mdi-content-duplicate"
           }}</v-icon>
           <span class="sidebar-ctx-label">{{
-            duplicateCountFor('folder', sidebarCtxFolder) === 0
+            duplicateCountFor("folder", sidebarCtxFolder) === 0
               ? "No duplicates in this folder"
               : "Find duplicates in this folder"
           }}</span>
           <span
             v-if="duplicateCountFor('folder', sidebarCtxFolder)"
             class="sidebar-ctx-count"
-            >{{ duplicateCountFor('folder', sidebarCtxFolder) }}</span
+            >{{ duplicateCountFor("folder", sidebarCtxFolder) }}</span
           >
         </button>
-        <div v-if="!isReadOnly && !sidebarCtxFolderScopePath" class="sidebar-ctx-divider"></div>
+        <div
+          v-if="!isReadOnly && !sidebarCtxFolderScopePath"
+          class="sidebar-ctx-divider"
+        ></div>
         <button
           v-if="!inDocker && !sidebarCtxFolderScopePath"
           class="sidebar-ctx-item"
@@ -6863,10 +6880,10 @@ defineExpose({
     :resource-type="shareDialogPending?.resourceType"
     :resource-id="shareDialogPending?.resourceId"
     :resource-label="shareDialogPending?.label"
-    :embed-watermark="props.embedWatermark"
+    :embed-watermark="userPrefsStore.embedWatermark"
     :backend-url="props.backendUrl"
-    :public-url="props.publicUrl"
-    @update:embed-watermark="emit('update:embed-watermark', $event)"
+    :public-url="userPrefsStore.publicUrl"
+    @update:embed-watermark="userPrefsStore.embedWatermark = $event"
   />
 
   <!-- ── Revoke all shares confirm dialog ──────────────────────── -->

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -1099,6 +1099,7 @@ import {
 import { useRoute, useRouter } from "vue-router";
 import { useFilterStore } from "../../stores/useFilterStore";
 import { useGridStore } from "../../stores/useGridStore";
+import { useSidebarStore } from "../../stores/useSidebarStore";
 import { useUserPrefsStore } from "../../stores/useUserPrefsStore";
 import { useTasksStore } from "../../stores/useTasksStore";
 import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
@@ -1248,6 +1249,7 @@ const projectStore = useProjectStore();
 const wsStore = useWsStore();
 const searchStore = useSearchStore();
 const gridStore = useGridStore();
+const sidebarStore = useSidebarStore();
 const userPrefsStore = useUserPrefsStore();
 
 const emit = defineEmits([
@@ -1278,7 +1280,6 @@ const emit = defineEmits([
 const props = defineProps({
   backendUrl: String,
   activeCategoryLabel: { type: String, default: "Category" },
-  folderScanning: { type: Boolean, default: false },
 });
 
 // ============================================================
@@ -6295,7 +6296,7 @@ const emptyStateDelayPassed = ref(false);
 let emptyStateDelayTimer = null;
 
 const showEmptyState = computed(() => {
-  if (props.folderScanning) return false;
+  if (sidebarStore.folderScanning) return false;
   return (
     gridReady.value &&
     !imagesLoading.value &&
@@ -6306,7 +6307,9 @@ const showEmptyState = computed(() => {
 
 const showFolderScanningState = computed(() => {
   return (
-    props.folderScanning && gridReady.value && filteredGridCount.value === 0
+    sidebarStore.folderScanning &&
+    gridReady.value &&
+    filteredGridCount.value === 0
   );
 });
 
@@ -6373,7 +6376,7 @@ watch([imagesLoading, filteredGridCount], ([loading, count]) => {
     emptyStateDelayTimer = null;
   }
 
-  if (loading || count > 0 || props.folderScanning) {
+  if (loading || count > 0 || sidebarStore.folderScanning) {
     emptyStateDelayPassed.value = false;
     return;
   }
@@ -6383,7 +6386,7 @@ watch([imagesLoading, filteredGridCount], ([loading, count]) => {
     if (
       !imagesLoading.value &&
       filteredGridCount.value === 0 &&
-      !props.folderScanning
+      !sidebarStore.folderScanning
     ) {
       emptyStateDelayPassed.value = true;
     }
@@ -6393,7 +6396,7 @@ watch([imagesLoading, filteredGridCount], ([loading, count]) => {
 // When scanning ends the grid will reload; reset the delay so the
 // empty state only shows after images have had a chance to arrive.
 watch(
-  () => props.folderScanning,
+  () => sidebarStore.folderScanning,
   (scanning) => {
     if (!scanning) {
       if (emptyStateDelayTimer) {

--- a/frontend/src/composables/useAppEntityActions.js
+++ b/frontend/src/composables/useAppEntityActions.js
@@ -1,3 +1,5 @@
+import { nextTick, watch } from "vue";
+import { useUserPrefsStore } from "../stores/useUserPrefsStore";
 import { useSelectionStore } from "../stores/useSelectionStore";
 import { useSearchStore } from "../stores/useSearchStore";
 import { useSortStore } from "../stores/useSortStore";
@@ -23,18 +25,22 @@ import {
  * @param {object} deps
  * @param {import("vue").Ref} deps.gridContainer
  * @param {Function} deps.refreshSidebar
+ * @param {Function} deps.onTagFilterChanged - debounced sidebar refresh for a
+ *   tag-visibility change.
  * @param {Function} deps.onNavigated
  */
 export function useAppEntityActions({
   gridContainer,
   refreshSidebar,
   onNavigated,
+  onTagFilterChanged,
 }) {
   const selectionStore = useSelectionStore();
   const searchStore = useSearchStore();
   const sortStore = useSortStore();
   const gridStore = useGridStore();
   const exportStore = useExportStore();
+  const userPrefsStore = useUserPrefsStore();
   const filterStore = useFilterStore();
   const wsStore = useWsStore();
 
@@ -142,6 +148,35 @@ export function useAppEntityActions({
   }
 
   // --- Watchers ---
+
+  // Opening the export menu is when its count has to be right; computing it
+  // eagerly would cost a request per selection change.
+  watch(
+    () => exportStore.exportMenuOpen,
+    async (isOpen) => {
+      if (!isOpen) return;
+      await nextTick();
+      refreshExportCount();
+    },
+  );
+
+  // Hiding tags, or turning the tag filter on, changes which pictures the grid
+  // and the sidebar counts should show.
+  watch(
+    () => userPrefsStore.hiddenTags,
+    () => {
+      gridStore.refreshGridVersion();
+      if (userPrefsStore.applyTagFilter) onTagFilterChanged?.();
+    },
+  );
+
+  watch(
+    () => userPrefsStore.applyTagFilter,
+    () => {
+      gridStore.refreshGridVersion();
+      onTagFilterChanged?.();
+    },
+  );
 
   return {
     handleImagesAssignedToCharacter,

--- a/frontend/src/composables/useAppSettingsHandlers.js
+++ b/frontend/src/composables/useAppSettingsHandlers.js
@@ -35,8 +35,6 @@ export function useAppSettingsHandlers({
   const sidebarStore = useSidebarStore();
   const userPrefsStore = useUserPrefsStore();
 
-
-
   // Explicit "view this project" entry click → navigate. useViewStore (watching
   // the route) sets projectViewMode/selectedProjectId from the URL, which scopes
   // the grid to the project.
@@ -51,7 +49,6 @@ export function useAppSettingsHandlers({
     onNavigated?.();
   }
 
-
   function handleStackStatsUpdate(payload) {
     const expanded = Number(payload?.expanded ?? 0);
     const total = Number(payload?.total ?? 0);
@@ -61,12 +58,6 @@ export function useAppSettingsHandlers({
     gridStore.totalStackCount = Number.isFinite(total) ? Math.max(0, total) : 0;
   }
 
-
-
-
-
-
-
   async function handleUpdateCheckForUpdates(value) {
     userPrefsStore.checkForUpdates = value;
     try {
@@ -75,7 +66,6 @@ export function useAppSettingsHandlers({
       console.error("Failed to save check_for_updates preference:", e);
     }
   }
-
 
   // The sidebar's Scrapheap context menu asks to empty the heap. The sidebar has
   // already switched the view to the scrapheap; defer to the next tick so the grid
@@ -108,8 +98,6 @@ export function useAppSettingsHandlers({
     sidebarStore.statsOpen = true;
     nextTick(() => statsSidebarRef.value?.focusTasksTab?.());
   }
-
-
 
   return {
     handleViewProject,

--- a/frontend/src/composables/useAppSettingsHandlers.js
+++ b/frontend/src/composables/useAppSettingsHandlers.js
@@ -2,7 +2,6 @@ import { nextTick } from "vue";
 import { patchUserConfig } from "../api/config";
 import { useGridStore } from "../stores/useGridStore";
 import { useSortStore } from "../stores/useSortStore";
-import { useProjectStore } from "../stores/useProjectStore";
 import { useSidebarStore } from "../stores/useSidebarStore";
 import { useUserPrefsStore } from "../stores/useUserPrefsStore";
 
@@ -33,17 +32,10 @@ export function useAppSettingsHandlers({
 }) {
   const gridStore = useGridStore();
   const sortStore = useSortStore();
-  const projectStore = useProjectStore();
   const sidebarStore = useSidebarStore();
   const userPrefsStore = useUserPrefsStore();
 
-  function handleUpdateProjectViewMode(mode) {
-    projectStore.projectViewMode = mode;
-  }
 
-  function handleUpdateSelectedProjectId(id) {
-    projectStore.selectedProjectId = id;
-  }
 
   // Explicit "view this project" entry click → navigate. useViewStore (watching
   // the route) sets projectViewMode/selectedProjectId from the URL, which scopes
@@ -59,9 +51,6 @@ export function useAppSettingsHandlers({
     onNavigated?.();
   }
 
-  function handleUpdateSortOptions(options) {
-    sortStore.sortOptions = Array.isArray(options) ? options : [];
-  }
 
   function handleStackStatsUpdate(payload) {
     const expanded = Number(payload?.expanded ?? 0);
@@ -72,46 +61,11 @@ export function useAppSettingsHandlers({
     gridStore.totalStackCount = Number.isFinite(total) ? Math.max(0, total) : 0;
   }
 
-  function handleUpdateSimilarityCharacter(val) {
-    sortStore.selectedSimilarityCharacter = val;
-    gridStore.refreshGridVersion();
-    onNavigated?.();
-  }
 
-  function handleUpdateSimilarityOptions(options) {
-    sortStore.similarityCharacterOptions = Array.isArray(options)
-      ? options
-      : [];
-  }
 
-  function handleUpdateHiddenTags(tags) {
-    const nextTags = Array.isArray(tags) ? tags : [];
-    if (
-      userPrefsStore.hiddenTags.length === nextTags.length &&
-      userPrefsStore.hiddenTags.every((tag, index) => tag === nextTags[index])
-    ) {
-      return;
-    }
-    userPrefsStore.hiddenTags = nextTags;
-  }
 
-  function handleUpdateApplyTagFilter(value) {
-    const nextValue = Boolean(value);
-    if (userPrefsStore.applyTagFilter === nextValue) return;
-    userPrefsStore.applyTagFilter = nextValue;
-  }
 
-  function handleUpdateDateFormat(value) {
-    if (value == null) return;
-    const nextValue = String(value);
-    if (nextValue === userPrefsStore.dateFormat) return;
-    userPrefsStore.dateFormat = nextValue;
-  }
 
-  function handleUpdateThemeMode(value) {
-    if (value == null) return;
-    userPrefsStore.themeMode = String(value);
-  }
 
   async function handleUpdateCheckForUpdates(value) {
     userPrefsStore.checkForUpdates = value;
@@ -122,11 +76,6 @@ export function useAppSettingsHandlers({
     }
   }
 
-  function handleUpdateSidebarThumbnailSize(value) {
-    const nextValue = Number(value);
-    if (!Number.isFinite(nextValue)) return;
-    userPrefsStore.sidebarThumbnailSize = nextValue;
-  }
 
   // The sidebar's Scrapheap context menu asks to empty the heap. The sidebar has
   // already switched the view to the scrapheap; defer to the next tick so the grid
@@ -160,41 +109,15 @@ export function useAppSettingsHandlers({
     nextTick(() => statsSidebarRef.value?.focusTasksTab?.());
   }
 
-  function handleUpdateThumbnailMode(value) {
-    if (value !== "square" && value !== "justified") return;
-    if (value === gridStore.thumbnailMode) return;
-    // Apply immediately with no regeneration: both modes render from the same
-    // stored bitmap (justified shows it whole; square crops it to the stored
-    // rectangle), so the grid re-lays-out at once. The persist watch saves it,
-    // and the radiogroup's aria-checked change is what a screen reader announces.
-    gridStore.thumbnailMode = value;
-  }
 
-  function handleUpdateSidebarWidth(value) {
-    const nextValue = Number(value);
-    if (!Number.isFinite(nextValue)) return;
-    userPrefsStore.sidebarWidth = nextValue;
-  }
 
   return {
-    handleUpdateProjectViewMode,
-    handleUpdateSelectedProjectId,
     handleViewProject,
     handleUpdateSelectedSort,
-    handleUpdateSortOptions,
     handleStackStatsUpdate,
-    handleUpdateSimilarityCharacter,
-    handleUpdateSimilarityOptions,
-    handleUpdateHiddenTags,
-    handleUpdateApplyTagFilter,
-    handleUpdateDateFormat,
-    handleUpdateThemeMode,
     handleUpdateCheckForUpdates,
-    handleUpdateSidebarThumbnailSize,
     handleEmptyScrapheapFromSidebar,
     handleSuggestPicturesForCharacter,
     focusTasksTabPanel,
-    handleUpdateThumbnailMode,
-    handleUpdateSidebarWidth,
   };
 }

--- a/frontend/src/composables/useBreadcrumb.js
+++ b/frontend/src/composables/useBreadcrumb.js
@@ -25,9 +25,9 @@ export function useBreadcrumb() {
     const charName = (id) =>
       isMulti
         ? "Multiple People"
-        : entityNames.characterNames[id] ?? `Character ${id}`;
+        : (entityNames.characterNames[id] ?? `Character ${id}`);
     const setName = (id) =>
-      isMulti ? "Multiple Sets" : entityNames.setNames[id] ?? `Set ${id}`;
+      isMulti ? "Multiple Sets" : (entityNames.setNames[id] ?? `Set ${id}`);
     const projName = (id) => entityNames.projectNames[id] ?? `Project ${id}`;
     // Root scope crumb names the sidebar bar/tab the view belongs to. These are
     // scope *labels*, not destinations — plain text, not links. Only an

--- a/frontend/src/composables/useReviewRoute.js
+++ b/frontend/src/composables/useReviewRoute.js
@@ -192,7 +192,8 @@ export function useReviewRoute(route, router, store, { watch }) {
       // redundant /tag_health request). `pendingRestoreViewId` is consumed by
       // load() once the session lists have landed — only then can an id be
       // resolved to a session vs an archived receipt vs nothing.
-      if (!scopeEquals(store.healthScope, scope)) store.healthScope = { ...scope };
+      if (!scopeEquals(store.healthScope, scope))
+        store.healthScope = { ...scope };
       store.pendingRestoreViewId = reviewId;
       store.overlayOpen = true;
       return;

--- a/frontend/src/composables/useReviewRoute.test.js
+++ b/frontend/src/composables/useReviewRoute.test.js
@@ -98,7 +98,16 @@ describe("parseReviewQuery", () => {
   });
 
   it("opens on the board for every non-id value", () => {
-    for (const raw of ["", "board", "true", "nonsense", "0", "-3", "1.5", null]) {
+    for (const raw of [
+      "",
+      "board",
+      "true",
+      "nonsense",
+      "0",
+      "-3",
+      "1.5",
+      null,
+    ]) {
       const parsed = parseReviewQuery({ review: raw });
       expect(parsed.open, `review=${raw}`).toBe(true);
       expect(parsed.reviewId, `review=${raw}`).toBe(null);
@@ -126,8 +135,8 @@ describe("parseReviewQuery", () => {
 
   it("accepts UNASSIGNED for the character dimension", () => {
     expect(
-      parseReviewQuery({ review: "board", review_character: "UNASSIGNED" }).scope
-        .characterId,
+      parseReviewQuery({ review: "board", review_character: "UNASSIGNED" })
+        .scope.characterId,
     ).toBe("UNASSIGNED");
   });
 
@@ -158,9 +167,9 @@ describe("buildReviewQuery", () => {
   });
 
   it("encodes the board", () => {
-    expect(buildReviewQuery({}, { open: true, view: { type: "board" } })).toEqual(
-      { review: REVIEW_BOARD },
-    );
+    expect(
+      buildReviewQuery({}, { open: true, view: { type: "board" } }),
+    ).toEqual({ review: REVIEW_BOARD });
   });
 
   it("encodes a session and an archived receipt by id", () => {
@@ -470,9 +479,8 @@ describe("useReviewSessionsStore.load — URL restore", () => {
   it("resolves, then clears, pendingRestoreViewId", async () => {
     const { setActivePinia, createPinia } = await import("pinia");
     const { apiClient } = await import("../utils/apiClient");
-    const { useReviewSessionsStore } = await import(
-      "../stores/useReviewSessionsStore"
-    );
+    const { useReviewSessionsStore } =
+      await import("../stores/useReviewSessionsStore");
     setActivePinia(createPinia());
     apiClient.get.mockImplementation((url, opts) => {
       if (url === "/reviews" && opts?.params?.status === "OPEN") {
@@ -492,9 +500,8 @@ describe("useReviewSessionsStore.load — URL restore", () => {
   it("falls back to the board for an unknown id", async () => {
     const { setActivePinia, createPinia } = await import("pinia");
     const { apiClient } = await import("../utils/apiClient");
-    const { useReviewSessionsStore } = await import(
-      "../stores/useReviewSessionsStore"
-    );
+    const { useReviewSessionsStore } =
+      await import("../stores/useReviewSessionsStore");
     setActivePinia(createPinia());
     apiClient.get.mockResolvedValue({ data: [] });
     apiClient.post.mockResolvedValue({ data: {} });

--- a/frontend/src/composables/useSearchBarSync.js
+++ b/frontend/src/composables/useSearchBarSync.js
@@ -1,0 +1,42 @@
+import { watch } from "vue";
+import { useSearchStore } from "../stores/useSearchStore";
+import { useGridStore } from "../stores/useGridStore";
+
+/**
+ * Keep the search bar's input in step with the committed query, and decide
+ * when the history dropdown should be showing.
+ *
+ * The two are separate on purpose: `searchQuery` is what the grid fetched
+ * against, `searchInput` is what the user is typing. They only converge when
+ * the query changes from somewhere else (a cleared search, a restored route).
+ */
+export function useSearchBarSync() {
+  const searchStore = useSearchStore();
+  const gridStore = useGridStore();
+
+  watch(
+    () => searchStore.searchQuery,
+    (newVal, oldVal) => {
+      if (searchStore.searchInput !== newVal) {
+        searchStore.searchInput = newVal || "";
+      }
+      // Clearing a search widens the result set, so the grid has to repaint.
+      if (!newVal && oldVal) {
+        gridStore.refreshGridVersion();
+      }
+    },
+  );
+
+  watch(
+    [() => searchStore.searchInput, () => searchStore.searchHistory],
+    () => {
+      const needle = (searchStore.searchInput || "").trim();
+      if (!needle) {
+        searchStore.isSearchHistoryOpen = false;
+        return;
+      }
+      searchStore.isSearchHistoryOpen =
+        searchStore.filteredSearchHistory.length > 0;
+    },
+  );
+}

--- a/frontend/src/composables/useUpdatesSocket.js
+++ b/frontend/src/composables/useUpdatesSocket.js
@@ -1,9 +1,5 @@
-import { onUnmounted } from "vue";
-import {
-  API_BASE_URL,
-  appendShareToken,
-  isReadOnly,
-} from "../utils/apiClient";
+import { onUnmounted, watch } from "vue";
+import { API_BASE_URL, appendShareToken, isReadOnly } from "../utils/apiClient";
 import { useGridRealtimeSync } from "./useGridRealtimeSync";
 import { useWsStore } from "../stores/useWsStore";
 import { useGridStore } from "../stores/useGridStore";
@@ -363,6 +359,30 @@ export function useUpdatesSocket({
     const fresh = ids.filter((id) => !pending.has(id));
     if (fresh.length) wsStore.addSortChangedExternalIds(fresh);
   }
+
+  // The backend only sends events this client's current view could care about,
+  // so any change to what the view is has to be re-announced.
+  watch(
+    [
+      () => selectionStore.selectedCharacter,
+      () => selectionStore.selectedSet,
+      () => selectionStore.selectedSetIds,
+      () => searchStore.searchQuery,
+    ],
+    () => {
+      sendUpdatesFilters();
+    },
+  );
+
+  // A grid rebuild has reconciled whatever the pills were offering, so the
+  // queued ids are stale.
+  watch(
+    () => gridStore.gridVersion,
+    () => {
+      wsStore.clearPendingExternalImportIds();
+      wsStore.clearSortChangedExternalIds();
+    },
+  );
 
   onUnmounted(() => {
     disconnectUpdatesSocket();

--- a/frontend/src/composables/useVersionCheck.js
+++ b/frontend/src/composables/useVersionCheck.js
@@ -15,7 +15,13 @@ function parseVersion(v) {
   if (!m) return null;
   const preTag = m[4]?.toLowerCase().replace(/^\./, "");
   const preWeight = { dev: -4, a: -3, b: -2, rc: -1 }[preTag] ?? 0;
-  return [Number(m[1]), Number(m[2]), Number(m[3]), preWeight, Number(m[5] || 0)];
+  return [
+    Number(m[1]),
+    Number(m[2]),
+    Number(m[3]),
+    preWeight,
+    Number(m[5] || 0),
+  ];
 }
 function isRemoteNewer(current, remote) {
   const a = parseVersion(current);
@@ -34,7 +40,12 @@ function isRemoteNewer(current, remote) {
 const LATEST_VERSION_BASE_URL = "https://pixlstash.dev/latest-version";
 // Install-type buckets allowed in the telemetry path; anything else (or
 // empty) collapses to "other". Detection must never block the check.
-const TELEMETRY_INSTALL_BUCKETS = new Set(["docker", "pip", "electron", "other"]);
+const TELEMETRY_INSTALL_BUCKETS = new Set([
+  "docker",
+  "pip",
+  "electron",
+  "other",
+]);
 const UPDATE_PAGE_URL = "https://pixlstash.dev/upgrade.html";
 
 const VERSION_CHECK_STORAGE_KEY = "pixlstash:lastVersionCheck";

--- a/frontend/src/composables/useViewportLayout.js
+++ b/frontend/src/composables/useViewportLayout.js
@@ -1,4 +1,4 @@
-import { onMounted, onUnmounted } from "vue";
+import { onMounted, onUnmounted, watch } from "vue";
 import { useGridStore } from "../stores/useGridStore";
 import { useSidebarStore } from "../stores/useSidebarStore";
 
@@ -67,6 +67,15 @@ export function useViewportLayout({ mainAreaRef }) {
       sidebarStore.hideAutoSidebar();
     }
   }
+
+  // Opening or closing the stats rail changes the width the grid has to work
+  // with, so the column ceiling is recomputed with it.
+  watch(
+    () => sidebarStore.statsOpen,
+    () => {
+      updateIsMobile();
+    },
+  );
 
   onMounted(() => window.addEventListener("resize", updateIsMobile));
   onUnmounted(() => window.removeEventListener("resize", updateIsMobile));

--- a/frontend/src/composables/useViewportLayout.js
+++ b/frontend/src/composables/useViewportLayout.js
@@ -1,6 +1,4 @@
-import { onMounted, onUnmounted, watch } from "vue";
-import { useRoute } from "vue-router";
-import { useViewStore } from "../stores/useViewStore";
+import { onMounted, onUnmounted } from "vue";
 import { useGridStore } from "../stores/useGridStore";
 import { useSidebarStore } from "../stores/useSidebarStore";
 
@@ -24,8 +22,6 @@ const STATS_HIDE_BREAKPOINT = 1280;
  *   in, measured for the column ceiling.
  */
 export function useViewportLayout({ mainAreaRef }) {
-  const route = useRoute();
-  const viewStore = useViewStore();
   const gridStore = useGridStore();
   const sidebarStore = useSidebarStore();
 
@@ -71,16 +67,6 @@ export function useViewportLayout({ mainAreaRef }) {
       sidebarStore.hideAutoSidebar();
     }
   }
-
-  // Route -> stores: install the app's single route watcher (immediately on
-  // mount for deep-linking, then on every navigation). The parsing and the
-  // writes live in useViewStore; App.vue keeps only the route PUSHING above.
-  viewStore.startRouteSync(route, { watch });
-
-  // A navigation retires the live undo receipt (owner decision, 2026-07-29):
-  // the pill narrates something that happened on the view being left, and a
-  // receipt carried into the next view reads as a fresh event there. Ctrl+Z
-  // keeps working everywhere regardless — the receipt is narration, not the
 
   onMounted(() => window.addEventListener("resize", updateIsMobile));
   onUnmounted(() => window.removeEventListener("resize", updateIsMobile));

--- a/frontend/src/composables/useWheelZoom.js
+++ b/frontend/src/composables/useWheelZoom.js
@@ -73,9 +73,7 @@ export function useWheelZoom(options = {}) {
   let exitLastOutTs = 0;
   let settleTimer = null;
 
-  const effectiveMaxScale = computed(() =>
-    Math.max(maxScale, fitScale.value),
-  );
+  const effectiveMaxScale = computed(() => Math.max(maxScale, fitScale.value));
 
   /** Within the shared slack of a target scale. */
   function nearScale(target) {
@@ -118,8 +116,16 @@ export function useWheelZoom(options = {}) {
    * an axis where the image fits, the range is zero and the image re-centres. */
   function reclampOffset() {
     offset.value = {
-      x: clampOffsetAxis(offset.value.x, container.value.width, natural.value.width),
-      y: clampOffsetAxis(offset.value.y, container.value.height, natural.value.height),
+      x: clampOffsetAxis(
+        offset.value.x,
+        container.value.width,
+        natural.value.width,
+      ),
+      y: clampOffsetAxis(
+        offset.value.y,
+        container.value.height,
+        natural.value.height,
+      ),
     };
   }
 

--- a/frontend/src/stores/useGridStore.js
+++ b/frontend/src/stores/useGridStore.js
@@ -55,11 +55,22 @@ export const useGridStore = defineStore("grid", () => {
     return Math.max(1, Math.min(maxColumns.value, desired));
   });
 
+  // Both modes render from the same stored bitmap - justified shows it whole,
+  // square crops it to the stored rectangle - so a valid change applies at once
+  // with no thumbnail regeneration. Rejecting the unchanged value keeps the
+  // persist watcher from firing for nothing.
+  function setThumbnailMode(value) {
+    if (value !== "square" && value !== "justified") return;
+    if (value === thumbnailMode.value) return;
+    thumbnailMode.value = value;
+  }
+
   function refreshGridVersion() {
     gridVersion.value++;
   }
 
   return {
+    setThumbnailMode,
     columns,
     sizeLevel,
     thumbnailSize,

--- a/frontend/src/stores/useSidebarStore.js
+++ b/frontend/src/stores/useSidebarStore.js
@@ -82,6 +82,11 @@ export const useSidebarStore = defineStore("sidebar", () => {
     sidebarForcedHidden.value ? false : sidebarPinned.value,
   );
   // Width used by the layout — forced to full on mobile.
+  // True while a reference/import folder is being scanned. The sidebar sets it
+  // (it owns the folder lists); the grid reads it, so its empty state can say
+  // "still scanning" instead of "nothing here".
+  const folderScanning = ref(false);
+
   const effectiveDocked = computed(() =>
     sidebarForcedHidden.value ? false : sidebarDocked.value,
   );
@@ -130,6 +135,7 @@ export const useSidebarStore = defineStore("sidebar", () => {
     sidebarPinned,
     autoRevealed,
     effectiveDocked,
+    folderScanning,
     sidebarVisible,
     sidebarOverlay,
     statsOpen,

--- a/frontend/src/stores/useSortStore.js
+++ b/frontend/src/stores/useSortStore.js
@@ -9,7 +9,17 @@ export const useSortStore = defineStore("sort", () => {
   const selectedSimilarityCharacter = ref(null);
   const similarityCharacterOptions = ref([]);
 
+  function setSortOptions(options) {
+    sortOptions.value = Array.isArray(options) ? options : [];
+  }
+
+  function setSimilarityCharacterOptions(options) {
+    similarityCharacterOptions.value = Array.isArray(options) ? options : [];
+  }
+
   return {
+    setSortOptions,
+    setSimilarityCharacterOptions,
     selectedSort,
     selectedDescending,
     sortOptions,

--- a/frontend/src/stores/useUserPrefsStore.js
+++ b/frontend/src/stores/useUserPrefsStore.js
@@ -35,7 +35,59 @@ export const useUserPrefsStore = defineStore("userPrefs", () => {
     }
   }
 
+  // Guarded setters. Each of these preferences drives a watcher (persisting to
+  // the server, and for a few of them repainting the grid), so writing an
+  // invalid value or rewriting the same one is not free - it costs a PATCH and
+  // sometimes a refetch. The guards used to sit in App.vue's handlers; they
+  // belong with the state so every writer gets them.
+  function setHiddenTags(tags) {
+    const next = Array.isArray(tags) ? tags : [];
+    if (
+      hiddenTags.value.length === next.length &&
+      hiddenTags.value.every((tag, i) => tag === next[i])
+    ) {
+      return;
+    }
+    hiddenTags.value = next;
+  }
+
+  function setApplyTagFilter(value) {
+    const next = Boolean(value);
+    if (applyTagFilter.value === next) return;
+    applyTagFilter.value = next;
+  }
+
+  function setDateFormat(value) {
+    if (value == null) return;
+    const next = String(value);
+    if (next === dateFormat.value) return;
+    dateFormat.value = next;
+  }
+
+  function setThemeMode(value) {
+    if (value == null) return;
+    themeMode.value = String(value);
+  }
+
+  function setSidebarThumbnailSize(value) {
+    const next = Number(value);
+    if (!Number.isFinite(next)) return;
+    sidebarThumbnailSize.value = next;
+  }
+
+  function setSidebarWidth(value) {
+    const next = Number(value);
+    if (!Number.isFinite(next)) return;
+    sidebarWidth.value = next;
+  }
+
   return {
+    setHiddenTags,
+    setApplyTagFilter,
+    setDateFormat,
+    setThemeMode,
+    setSidebarThumbnailSize,
+    setSidebarWidth,
     dateFormat,
     themeMode,
     showKeyboardHint,


### PR DESCRIPTION
Lane A. **Stacked on #661.** This closes the two step-3 exit criteria that PR left open.

**SideBar: 29 props → 3, 35 emits → 16.** The three survivors are `backendUrl`, `installType`, `dockerVariant`. Nineteen emits go — every one that App.vue turned straight back into a store write. App.vue's binding block for the sidebar drops from **61 lines to 17**.

**The guards are not lost, they moved.** Those `handleUpdate*` handlers were not pass-throughs: they validated (`Number.isFinite`, the square/justified enum, null checks) and no-opped on unchanged values. Dropping them would have meant an invalid value could land, and an unchanged one would still cost a config PATCH and sometimes a grid repaint. So `useUserPrefsStore`, `useGridStore` and `useSortStore` gain guarded setters and the sidebar calls those — the invariant now sits with the state, where any future writer gets it too. The two handlers with real side effects keep them: changing the sort still closes an auto-hidden sidebar, and changing the similarity character still repaints the grid as well.

**App.vue watchers: 11 → 3.** Six had nothing to do with the shell and moved to whatever owns their state — search-bar sync (new `useSearchBarSync`), tag-visibility repaints, the websocket filter re-announce, the pill clear on a grid rebuild, the export count, the stats-rail re-measure. The three that remain are the floating-bottom CSS variable, the undo receipt dismissed on navigation, and applying the Vuetify theme.

**Also:** `folderScanning` moves to the sidebar store (it is the sidebar that knows), and `startRouteSync` comes back to App.vue — an earlier extraction had swept it into the viewport composable, where it worked but made no sense.

**Step 3 exit criteria, final:**

| criterion | target | now |
|---|---|---|
| App.vue lines | ≤800 | **638** |
| watchers | ≤8 | **3** |
| binding block per child | ≤15 | SideBar **17**, ImageGrid **23** |
| e2e green | — | **87 passed, 4 skipped** |

The two binding blocks are still over. `SideBar`'s 17 lines are one prop and sixteen genuinely parental events (navigation and actions), and `ImageGrid`'s 23 are three props and twenty emits — that emit surface is Phase 5's `useGridActions` work. Both are honest follow-ups rather than something this PR should force.

Verified: unit suite 1656 passing, production build, full e2e 87 passed / 4 skipped.