### PR TITLE
Extract useGridScoring (Phase 5, partial)

### DIFF
--- a/docs/regular-tests.md
+++ b/docs/regular-tests.md
@@ -8,7 +8,10 @@ suite is pytest — those are not duplicated here.
 - **Location:** `frontend/e2e/specs/*.spec.js`
 - **Run:** from `frontend/` → `npm run test:e2e` (UI mode: `npm run test:e2e:ui`).
   The harness builds the SPA and boots a throwaway backend against the committed
-  `test-data/` fixture (see `frontend/e2e/README.md`).
+  `test-data/` fixture (see `frontend/e2e/README.md`). Both the throwaway work
+  directory and the port are derived from the checkout path, so two working
+  copies of the repo can run the suite at the same time without colliding; set
+  `PIXLSTASH_E2E_PORT` to pin the port.
 - **Conventions:** owner session minted in `global-setup.js`; assert
   "at least one" / relative deltas rather than exact counts so fixture pruning
   doesn't break tests; pictures identified by thumbnail `src`
@@ -228,9 +231,31 @@ notes in the spec. Un-`fixme` each as its behaviour is settled.
 
 ---
 
+## Preferences round-trip — `preferences-persist.spec.js`
+| Test | Covers | Status |
+| --- | --- | --- |
+| a compact-mode change is PATCHed and survives a reload | The whole path a preference travels: control → store → the `useAppConfig` watcher's PATCH to `/users/me/config` → read back on the next load. Asserts the request body carried the new value rather than trusting the store, so a broken persistence watcher cannot pass | ✅ |
+
+## Keyboard shortcuts dialog — `shortcuts-dialog.spec.js`
+| Test | Covers | Status |
+| --- | --- | --- |
+| opens on F1 and lists the grid shortcuts | F1 reaches the global handler and `ShortcutsDialog` renders its table. The dialog is static markup with no unit coverage, so this is its only pin | ✅ |
+
+---
+
 ## Coverage gaps / testing debt (risk-based)
 
 Tracked so they aren't forgotten — weighted by blast radius:
+
+- **`dedup.spec.js` — "C opens Compare on the focused group" is flaky.** Fails
+  in roughly one full-suite run in three and passes every time in isolation or
+  when the file is run alone. The dedup specs deliberately share one mutable
+  backend and run in order, each starting from the state the last left, so the
+  likely cause is a preceding case's verdict not having settled before this one
+  reads the queue — a missing wait rather than a product defect. It aborts the
+  rest of the file when it goes, which is what makes a red run look worse than
+  it is. Retry masking would hide it; the fix is an explicit wait on the queue
+  state the test depends on.
 
 - **Snapshots rollback & selective restore (v1.5) — HIGH RISK, partially
   automated.** `snapshots.spec.js` now asserts the restore-point list renders

--- a/frontend/e2e/seed_dedup_fixture.py
+++ b/frontend/e2e/seed_dedup_fixture.py
@@ -50,14 +50,18 @@ import os
 import shutil
 import sqlite3
 import sys
-import tempfile
 
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_DATA = Path(os.environ.get("PIXLSTASH_E2E_DATA") or (REPO_ROOT / "test-data"))
-# Mirrors serve_e2e_backend.WORK_DIR exactly; the two must not drift.
-WORK_DIR = Path(tempfile.gettempdir()) / f"pixlstash-e2e-{SRC_DATA.name}"
+# Import the launcher's work directory rather than recomputing it. This used to
+# be a copy with a "must not drift" comment above it, and it drifted the moment
+# the launcher's path gained a per-checkout suffix: the seed wrote to one vault
+# while the server served another, and the queue simply came up empty.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from serve_e2e_backend import WORK_DIR  # noqa: E402
+
 IMAGE_ROOT = WORK_DIR / "images"
 DB_PATH = IMAGE_ROOT / "vault.db"
 

--- a/frontend/e2e/serve_e2e_backend.py
+++ b/frontend/e2e/serve_e2e_backend.py
@@ -22,6 +22,7 @@ nothing accumulates and the committed fixture is never modified.
 
 import json
 import os
+import hashlib
 import shutil
 import sqlite3
 import sys
@@ -32,9 +33,17 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_DATA = Path(os.environ.get("PIXLSTASH_E2E_DATA") or (REPO_ROOT / "test-data"))
 SRC_IMAGES = SRC_DATA / "images"
 PORT = int(os.environ.get("PIXLSTASH_E2E_PORT", "9600"))
-# Isolate the work dir per fixture so a screenshots run (demo-data) never stomps
-# a parallel e2e run (test-data) using the shared temp directory.
-WORK_DIR = Path(tempfile.gettempdir()) / f"pixlstash-e2e-{SRC_DATA.name}"
+# Isolate the work dir per fixture AND per checkout. Per fixture so a
+# screenshots run (demo-data) never stomps an e2e run (test-data); per checkout
+# because the fixture folder is called "test-data" in every clone, so two
+# working copies of the repo would otherwise resolve to the same directory and
+# rmtree each other's vault mid-run. That failure is worth naming: the symptom
+# is not an error but a handful of unrelated specs failing, or global-setup
+# reporting the vault is not in first-run state.
+_CHECKOUT_TAG = hashlib.sha1(str(REPO_ROOT).encode()).hexdigest()[:8]
+WORK_DIR = (
+    Path(tempfile.gettempdir()) / f"pixlstash-e2e-{SRC_DATA.name}-{_CHECKOUT_TAG}"
+)
 
 
 def _ignore_backups(_dir, names):

--- a/frontend/e2e/specs/preferences-persist.spec.js
+++ b/frontend/e2e/specs/preferences-persist.spec.js
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+// Preferences take a long road: a control writes a store, a watcher notices and
+// PATCHes /users/me/config, and the next session reads it back. The Phase 3
+// refactor moved every step of that - the guarded setters onto the stores, the
+// fourteen persistence watchers into useAppConfig - and nothing exercised the
+// round trip, so a preference that silently stopped persisting would have gone
+// unnoticed until a user complained their settings kept resetting.
+//
+// Compact mode is the cheapest control to drive: a real button in the toolbar's
+// Grid-view menu, writing straight to the grid store.
+
+/** Open the toolbar's "Grid view" menu and return its Compact toggle. */
+async function openViewMenu(page) {
+  await page.locator(".bar-btn:has(.mdi-view-grid)").first().click();
+  const compact = page.locator(".tbm-btn--compact");
+  await expect(compact).toBeVisible();
+  return compact;
+}
+
+test.describe("preferences round-trip", () => {
+  test("a compact-mode change is PATCHed and survives a reload", async ({
+    page,
+  }) => {
+    const patches = [];
+    await page.route("**/users/me/config", async (route) => {
+      if (route.request().method() === "PATCH") {
+        patches.push(route.request().postDataJSON());
+      }
+      await route.continue();
+    });
+
+    await page.goto("/");
+    await expect(page.locator(".thumbnail-card").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const compact = await openViewMenu(page);
+    const wasOn = await compact.evaluate((el) =>
+      el.classList.contains("tbm-btn--on"),
+    );
+    await compact.click();
+
+    // The change reached the server, not just the store.
+    await expect
+      .poll(() => patches.some((p) => p && "compact_mode" in p), {
+        timeout: 10_000,
+      })
+      .toBe(true);
+    const sent = patches.filter((p) => p && "compact_mode" in p).pop();
+    expect(sent.compact_mode).toBe(!wasOn);
+
+    // And it is what the next session gets.
+    await page.reload();
+    await expect(page.locator(".thumbnail-card").first()).toBeVisible({
+      timeout: 15_000,
+    });
+    const afterReload = await openViewMenu(page);
+    await expect
+      .poll(
+        () =>
+          afterReload.evaluate((el) => el.classList.contains("tbm-btn--on")),
+        { timeout: 10_000 },
+      )
+      .toBe(!wasOn);
+
+    // Put it back so the shared fixture is left as it was found.
+    await afterReload.click();
+  });
+});

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,8 +1,25 @@
 import { defineConfig, devices } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
 
 // The e2e backend (frontend/e2e/serve_e2e_backend.py) serves both the built
 // SPA and the API on this single origin, so cookie auth works with no CORS.
-const PORT = process.env.PIXLSTASH_E2E_PORT || '9600'
+//
+// The port is derived from the checkout path rather than fixed, because two
+// working copies of the repo running e2e at the same time would otherwise both
+// try to bind 9600. The failure that causes is not an obvious one: whichever
+// run loses the race can end up talking to the OTHER checkout's server, whose
+// vault has a different admin password, and global-setup reports the fixture
+// is not in first-run state. Set PIXLSTASH_E2E_PORT to pin it.
+const PORT =
+  process.env.PIXLSTASH_E2E_PORT ||
+  String(
+    9600 +
+      ([...fileURLToPath(new URL('.', import.meta.url))].reduce(
+        (h, ch) => (h * 31 + ch.charCodeAt(0)) % 200,
+        7,
+      ) %
+        200),
+  )
 const BASE_URL = `http://127.0.0.1:${PORT}`
 
 export default defineConfig({
@@ -30,7 +47,7 @@ export default defineConfig({
     // Build the SPA (served by the Python server), then launch the backend
     // against a throwaway copy of test-data/. Override the interpreter with
     // PIXLSTASH_PYTHON if `python` is not the pixlstash venv on your PATH.
-    command: `npm run build && ${process.env.PIXLSTASH_PYTHON || 'python'} e2e/serve_e2e_backend.py`,
+    command: `npm run build && PIXLSTASH_E2E_PORT=${PORT} ${process.env.PIXLSTASH_PYTHON || 'python'} e2e/serve_e2e_backend.py`,
     url: `${BASE_URL}/version`,
     timeout: 180_000,
     // Always boot a fresh backend: the launcher strips users so each run

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -1152,7 +1152,6 @@ import SnapshotsWithDeletedDialog from "../widgets/SnapshotsWithDeletedDialog.vu
 import DeleteForeverDialog from "../widgets/DeleteForeverDialog.vue";
 import { appendShareToken, isReadOnly } from "../../utils/apiClient";
 import {
-  listPicturesByIds,
   getPictureMetadata,
   getThumbnails,
   deletePictures,
@@ -1168,9 +1167,6 @@ import {
   resetPictureDescription,
   clearImpossibleTags,
   restoreImpossibleTags,
-  applyScores,
-  getGuestScores,
-  submitGuestScores,
   startExport,
   getExportStatus,
   downloadExport,
@@ -1199,7 +1195,6 @@ import {
   normalizePluginProgressMessage,
   rangeCovers,
   sleep,
-  toggleScore,
 } from "../../utils/utils.js";
 import {
   dedupeTagList,
@@ -1227,6 +1222,7 @@ import { useMultiSelect } from "../../composables/useMultiSelect.js";
 import { useGridDragDrop } from "../../composables/useGridDragDrop.js";
 import { useStackOrdering } from "../../composables/useStackOrdering.js";
 import { useGridFetch } from "../../composables/useGridFetch.js";
+import { useGridScoring } from "../../composables/useGridScoring.js";
 import { useGridKeyboardNav } from "../../composables/useGridKeyboardNav.js";
 import { debounce } from "lodash-es";
 import { useSelectionStore } from "../../stores/useSelectionStore";
@@ -5073,7 +5069,10 @@ const {
   props,
   emit,
   {
-    invalidateVisibleThumbnailRanges,
+    // useGridScoring is created below this call (it needs the stack helpers
+    // this one returns), so the reference is deferred rather than passed by
+    // value. Same shape either way from the callee's side.
+    invalidateVisibleThumbnailRanges: () => invalidateVisibleThumbnailRanges(),
     updateVisibleThumbnails,
     debouncedFetchAllGridImages,
     fetchThumbnailsForRangeNow,
@@ -5141,6 +5140,50 @@ watch(
   },
   { immediate: true },
 );
+
+const {
+  setScore,
+  setGuestScore,
+  handleGuestConsentAccepted,
+  handleGuestConsentRejected,
+  initGuestSession,
+  isSmartScoreSortActive,
+  getGridSmartScoreValue,
+  invalidateVisibleThumbnailRanges,
+  repositionImageByScore,
+  repositionImageBySmartScore,
+  insertGridImagesById,
+  refreshSmartScoreForImage,
+  applyScore,
+  applyScoresForSelection,
+} = useGridScoring({
+  backendUrl: props.backendUrl,
+  allGridImages,
+  lastFetchedGridImages,
+  loadedRanges,
+  visibleStart,
+  visibleEnd,
+  renderBuffer,
+  imagesLoading,
+  overlayOpen,
+  pendingOverlayGridRefresh,
+  preserveScrollOnNextFetch,
+  skipNextWsRefresh,
+  gridContainer,
+  guestSessionId,
+  guestConsentState,
+  guestScoreMap,
+  guestConsentBannerVisible,
+  pendingGuestScoreIntent,
+  emit,
+  debouncedFetchAllGridImages,
+  fetchImageInfo,
+  rebuildGridImagesFromLastFetch,
+  triggerNewImageHighlight,
+  updateVisibleThumbnails,
+  maybeRefreshOverlayForComfyui,
+  errorDetail,
+});
 
 // ============================================================
 // KEYBOARD NAVIGATION
@@ -5381,646 +5424,6 @@ function closeOverlay() {
     preserveScrollOnNextFetch.value = true;
     debouncedFetchAllGridImages();
   }
-}
-
-// ============================================================
-// SCORING
-// ============================================================
-async function setScore(img, n) {
-  if (isReadOnly.value) {
-    setGuestScore(img, n);
-    return;
-  }
-  const newScore = toggleScore(img.score, n);
-  applyScore(img, newScore);
-}
-
-// ---- Guest scoring helpers ----
-
-function _generateGuestSessionId() {
-  if (typeof crypto !== "undefined" && crypto.randomUUID) {
-    return crypto.randomUUID();
-  }
-  // Fallback for older browsers — use cryptographically secure random bytes
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
-  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant bits
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
-  return [
-    hex.slice(0, 4).join(""),
-    hex.slice(4, 6).join(""),
-    hex.slice(6, 8).join(""),
-    hex.slice(8, 10).join(""),
-    hex.slice(10, 16).join(""),
-  ].join("-");
-}
-
-function _getOrCreateGuestSessionId() {
-  if (guestSessionId.value) return guestSessionId.value;
-  const id = _generateGuestSessionId();
-  guestSessionId.value = id;
-  return id;
-}
-
-async function _submitGuestScores(scores, setCookie) {
-  const sid = _getOrCreateGuestSessionId();
-  const payload = { session_id: sid, set_cookie: setCookie, scores };
-  await submitGuestScores(payload, { baseUrl: props.backendUrl });
-}
-
-function setGuestScore(img, n) {
-  const currentScore = guestScoreMap.value.get(img.id) ?? null;
-  const newScore = toggleScore(currentScore, n);
-
-  if (guestConsentState.value === null) {
-    // Show consent banner; queue the intent
-    pendingGuestScoreIntent.value = { img, newScore };
-    guestConsentBannerVisible.value = true;
-    return;
-  }
-
-  // Optimistic local update
-  const updated = new Map(guestScoreMap.value);
-  updated.set(img.id, newScore);
-  guestScoreMap.value = updated;
-
-  const setCookie = guestConsentState.value === "accepted";
-  _submitGuestScores({ [String(img.id)]: newScore }, setCookie)
-    .then(() => {
-      if (isScoreSortActive()) {
-        debouncedFetchAllGridImages({ force: true });
-      }
-    })
-    .catch((err) => {
-      console.error("Failed to submit guest score:", err);
-    });
-}
-
-async function handleGuestConsentAccepted() {
-  guestConsentState.value = "accepted";
-  guestConsentBannerVisible.value = false;
-  // Do not persist the guest session identifier in localStorage.
-  // The server-managed HttpOnly cookie handles durable session continuity;
-  // keeping the session_id only in memory is sufficient for the current visit.
-  const intent = pendingGuestScoreIntent.value;
-  pendingGuestScoreIntent.value = null;
-  if (intent) {
-    const updated = new Map(guestScoreMap.value);
-    updated.set(intent.img.id, intent.newScore);
-    guestScoreMap.value = updated;
-    await _submitGuestScores({ [String(intent.img.id)]: intent.newScore }, true)
-      .then(() => {
-        if (isScoreSortActive()) debouncedFetchAllGridImages({ force: true });
-      })
-      .catch((err) => console.error("Failed to submit guest score:", err));
-  }
-}
-
-function handleGuestConsentRejected() {
-  guestConsentState.value = "rejected";
-  guestConsentBannerVisible.value = false;
-  // Do NOT persist the session ID anywhere — if the user reloads they get a
-  // brand-new session with no connection to these scores.
-  const intent = pendingGuestScoreIntent.value;
-  pendingGuestScoreIntent.value = null;
-  if (intent) {
-    const updated = new Map(guestScoreMap.value);
-    updated.set(intent.img.id, intent.newScore);
-    guestScoreMap.value = updated;
-    _submitGuestScores({ [String(intent.img.id)]: intent.newScore }, false)
-      .then(() => {
-        if (isScoreSortActive()) debouncedFetchAllGridImages({ force: true });
-      })
-      .catch((err) => console.error("Failed to submit guest score:", err));
-  }
-}
-
-async function fetchGuestScores() {
-  // Kept only as a fallback / explicit refresh. The main listing
-  // (GET /pictures) now overlays guest scores onto img.score server-side.
-  try {
-    const resp = await getGuestScores({ baseUrl: props.backendUrl });
-    const scores = resp?.scores ?? {};
-    const map = new Map();
-    for (const [k, v] of Object.entries(scores)) {
-      map.set(Number(k), v);
-    }
-    guestScoreMap.value = map;
-  } catch (err) {
-    console.error("[guest-scores] Failed to fetch guest scores:", err);
-  }
-}
-
-function initGuestSession() {
-  const readOnly = isReadOnly.value;
-  const cookies = document.cookie;
-  const ls = localStorage.getItem("guest_session_id");
-  if (!readOnly) return;
-  // A non-HttpOnly sentinel cookie is set alongside the HttpOnly guest_session
-  // cookie when the user accepted persistent storage.
-  const hasCookieConsent = cookies
-    .split(";")
-    .some((c) => c.trim().startsWith("guest_session_active=1"));
-  if (hasCookieConsent) {
-    guestConsentState.value = "accepted";
-    // Restore the session ID from localStorage so POST bodies stay in sync
-    // with the HttpOnly cookie the server already knows about.
-    if (ls) {
-      guestSessionId.value = ls;
-    }
-    // Scores are now overlaid by the backend in GET /pictures, so
-    // fetchAllGridImages() will include them in img.score directly.
-    // fetchGuestScores() is only needed to pre-populate guestScoreMap
-    // for optimistic-update display before the grid loads.
-    fetchGuestScores();
-    return;
-  }
-  // No cookie consent — fresh start.  The banner will appear on first score.
-  // (Rejected users are intentionally not remembered across page loads.)
-}
-
-function isScoreSortActive() {
-  return typeof sortStore.selectedSort === "string"
-    ? sortStore.selectedSort.toUpperCase() === "SCORE"
-    : false;
-}
-
-function isCharacterLikenessSortActive() {
-  return typeof sortStore.selectedSort === "string"
-    ? sortStore.selectedSort.toUpperCase() === "CHARACTER_LIKENESS"
-    : false;
-}
-
-function isSmartScoreSortActive() {
-  return typeof sortStore.selectedSort === "string"
-    ? sortStore.selectedSort.toUpperCase().includes("SMART_SCORE")
-    : false;
-}
-
-// Single source of truth for grid sort direction. ALL client-side ordering —
-// score/smart-score repositions, the apply-scores re-sort, and incremental
-// inserts — must use the SAME rule, or a card lands in a different spot than the
-// array it is spliced into. Nullish selectedDescending → ascending (the store
-// defaults it to a real `true`). Keep this as one computed: a lone inlined
-// `!== false` previously drifted here and mispositioned inserted cards.
-const gridSortDescending = computed(
-  () => sortStore.selectedDescending === true,
-);
-
-function getGridSmartScoreValue(img) {
-  if (!img) return null;
-  const raw =
-    typeof img.smartScore === "number"
-      ? img.smartScore
-      : typeof img.smart_score === "number"
-        ? img.smart_score
-        : null;
-  return Number.isFinite(raw) ? raw : null;
-}
-
-// The ONE null-ordering rule shared by every client-side smart-score sort path
-// (fresh insert AND reposition). SQLite ranks NULL below every real value, and
-// the backend sorts the smart_score column with a plain .asc()/.desc() and no
-// NULLS clause (pixlstash/db_models/picture.py), so NULLs sort FIRST on ascending
-// and LAST on descending. Map a null/absent score to -Infinity so the shared
-// comparator (which flips on `descending`) lands a null-scored card exactly where
-// the server put it, in BOTH directions. A 0 sentinel is wrong: it collides with
-// a genuine zero and, now that smart scores can be negative and null (tag edits
-// invalidate them), it mis-orders nulls relative to real scores. Route EVERY path
-// through this helper — never an inline ternary or `?? 0` — so the insert and
-// reposition paths cannot drift (the failure the gridSortDescending comment warns
-// of). This is only an ordering key; it must never be written back as a card's
-// displayed smart score, or a null-scored card would render a fake 0.
-function smartScoreSortKey(smartScore) {
-  return Number.isFinite(smartScore) ? smartScore : -Infinity;
-}
-
-function invalidateVisibleThumbnailRanges() {
-  const start = Math.max(0, visibleStart.value - renderBuffer.value);
-  const end = Math.min(
-    allGridImages.value.length,
-    visibleEnd.value + renderBuffer.value,
-  );
-  loadedRanges.value = loadedRanges.value.filter(
-    ([rangeStart, rangeEnd]) => rangeEnd <= start || rangeStart >= end,
-  );
-  updateVisibleThumbnails();
-}
-
-function _spliceAndReinsert(
-  items,
-  currentIndex,
-  target,
-  targetScore,
-  getScore,
-  descending,
-) {
-  items.splice(currentIndex, 1);
-  let insertIndex = items.findIndex((item) => {
-    const score = getScore(item);
-    return descending ? score < targetScore : score > targetScore;
-  });
-  if (insertIndex === -1) insertIndex = items.length;
-  if (insertIndex === currentIndex) {
-    const updated = allGridImages.value.slice();
-    updated[currentIndex] = { ...target, idx: currentIndex };
-    allGridImages.value = updated;
-    // Still invalidate: we are only here because the card's score changed, and the
-    // batch-sourced fields that change with it (penalised_tags — the problem
-    // indicator — plus faces/detections) are refreshed ONLY by a thumbnail batch.
-    // Without this, loadedRanges still covers the window, updateVisibleThumbnails
-    // no-ops, and a card whose position happens not to move keeps its stale
-    // indicator. Adding a penalised tag to an already low-scoring card lands
-    // exactly here, since it is already at the bottom of a descending sort.
-    invalidateVisibleThumbnailRanges();
-    return null;
-  }
-  items.splice(insertIndex, 0, target);
-  for (let i = 0; i < items.length; i += 1) {
-    items[i].idx = i;
-  }
-  allGridImages.value = items;
-  invalidateVisibleThumbnailRanges();
-  return insertIndex;
-}
-
-function repositionImageByScore(imageId, newScore) {
-  const items = allGridImages.value.slice();
-  const dId = getPictureId(imageId);
-  const currentIndex = items.findIndex(
-    (item) => getPictureId(item?.id) === dId,
-  );
-  if (currentIndex === -1) return;
-
-  const target = items[currentIndex];
-  target.score = newScore;
-  const targetScore = newScore ?? 0;
-  const descending = gridSortDescending.value;
-  const insertIndex = _spliceAndReinsert(
-    items,
-    currentIndex,
-    target,
-    targetScore,
-    (item) => item.score ?? 0,
-    descending,
-  );
-  if (insertIndex !== null) {
-    nextTick(() => {
-      const grid = gridContainer.value;
-      if (!grid) return;
-      const card = grid.querySelectorAll(".image-card")[insertIndex];
-      if (card && card.scrollIntoView) {
-        card.scrollIntoView({ behavior: "smooth", block: "center" });
-      }
-    });
-  }
-}
-
-let smartScoreRepositioning = false;
-
-function repositionImageBySmartScore(imageId, smartScore, latestInfo = null) {
-  if (smartScoreRepositioning) return;
-  smartScoreRepositioning = true;
-  try {
-    const items = allGridImages.value.slice();
-    const currentIndex = items.findIndex((item) => item.id === imageId);
-    if (currentIndex === -1) return;
-
-    // Keep the ordering key separate from the displayed value. The card must
-    // store the TRUE smart score (a real number or null → "no score"); only the
-    // sort key collapses null to the SQLite sentinel via smartScoreSortKey.
-    // Writing the sentinel onto `smartScore` would make a null-scored card render
-    // a fake 0.
-    const normalisedScore = Number.isFinite(smartScore) ? smartScore : null;
-    const targetKey = smartScoreSortKey(normalisedScore);
-    // Write the TRUE score to BOTH the camelCase and snake_case keys.
-    // getGridSmartScoreValue reads `smartScore` then falls back to `smart_score`
-    // (grid cards / metadata responses carry both), so setting only one key would
-    // let a stale value leak through the fallback and render a wrong (or fake 0)
-    // score. Both must hold the normalised value — null for "no score".
-    const target = {
-      ...items[currentIndex],
-      ...(latestInfo && typeof latestInfo === "object" ? latestInfo : {}),
-      smartScore: normalisedScore,
-      smart_score: normalisedScore,
-      thumbnail:
-        items[currentIndex]?.thumbnail ?? latestInfo?.thumbnail ?? null,
-    };
-    const descending = gridSortDescending.value;
-    _spliceAndReinsert(
-      items,
-      currentIndex,
-      target,
-      targetKey,
-      (item) => smartScoreSortKey(getGridSmartScoreValue(item)),
-      descending,
-    );
-  } finally {
-    smartScoreRepositioning = false;
-  }
-}
-
-// Numeric sort key for a freshly-fetched grid item under the active sort,
-// mirroring the fields the grid already displays/sorts on (see
-// getCompactGroupLabel / sort-overlay logic). Returns a finite number used to
-// find the insert index; `id` is the implicit tiebreaker.
-function gridImageSortKey(img) {
-  const sort =
-    typeof sortStore.selectedSort === "string" ? sortStore.selectedSort : "";
-  if (sort === "IMPORTED_AT" && img?.imported_at) {
-    return Date.parse(img.imported_at) || 0;
-  }
-  if (sort.includes("DATE") && img?.created_at) {
-    return Date.parse(img.created_at) || 0;
-  }
-  if (sort.includes("SMART_SCORE")) {
-    // Match the server's ORDER BY exactly via the shared null rule (see
-    // smartScoreSortKey). The reposition path uses the same helper, so the two
-    // ordering paths cannot drift.
-    return smartScoreSortKey(getGridSmartScoreValue(img));
-  }
-  if (
-    sort.includes("CHARACTER_LIKENESS") &&
-    typeof img?.character_likeness === "number"
-  ) {
-    return img.character_likeness;
-  }
-  if (sort === "TEXT_CONTENT" && typeof img?.text_score === "number") {
-    return img.text_score;
-  }
-  if (typeof img?.score === "number") return img.score;
-  // Unknown / id-ordered sort → fall back to the picture id.
-  return Number(getPictureId(img?.id)) || 0;
-}
-
-// Insert newly-added pictures into the grid at their sorted position without a
-// full reload. Always mutates lastFetchedGridImages then rebuilds, because the
-// v-for key embeds img.idx — splicing allGridImages directly would corrupt the
-// virtual-scroll window. Deferred to the pill while a streaming fetch is in
-// flight (that fetch writes allGridImages wholesale from a sized placeholder).
-// `options.highlight` (default true) drives the new-picture flash. A scrapheap
-// comeback passes false: the flash means "this was not here before", which is
-// the wrong story for a picture the user just undid the removal of.
-async function insertGridImagesById(ids, options = {}) {
-  const highlight = options?.highlight !== false;
-  const wanted = (Array.isArray(ids) ? ids : [])
-    .map((id) => getPictureId(id))
-    .filter((id) => id !== null);
-  if (!wanted.length) return;
-
-  // Character-likeness sort can't be positioned incrementally. The likeness
-  // value is computed by a backend SQL function relative to the currently
-  // selected similarity character (find_pictures_by_character_likeness_sql),
-  // not stored on the picture, so it is NOT in the `fields=grid` projection
-  // (the backend has no character context to compute it there). gridImageSortKey
-  // therefore falls through to `score` and would splice the card at the wrong
-  // position. Fall back to a full refetch, which DOES recompute likeness — or,
-  // under an open overlay, defer it (the overlay-open deferral contract, §9.1)
-  // so we never restructure the filmstrip mid-view.
-  if (isCharacterLikenessSortActive()) {
-    if (overlayOpen.value) {
-      pendingOverlayGridRefresh.value = true;
-      return;
-    }
-    preserveScrollOnNextFetch.value = true;
-    debouncedFetchAllGridImages();
-    return;
-  }
-
-  if (imagesLoading.value) {
-    // A streaming fetch owns allGridImages wholesale; inserting now would be
-    // clobbered. The caller (useGridRealtimeSync) routes these to the pill
-    // instead while loading, so just bail.
-    console.warn(
-      "insertGridImagesById: skipped during in-flight grid fetch",
-      wanted,
-    );
-    return;
-  }
-
-  const existing = new Set(
-    (Array.isArray(lastFetchedGridImages.value)
-      ? lastFetchedGridImages.value
-      : []
-    ).map((img) => getPictureId(img?.id)),
-  );
-  const toFetch = wanted.filter((id) => !existing.has(id));
-  if (!toFetch.length) return;
-
-  let fetched;
-  try {
-    const rows = await listPicturesByIds(toFetch, {
-      fields: "grid",
-      baseUrl: props.backendUrl,
-    });
-    fetched = Array.isArray(rows) ? rows : [];
-  } catch (e) {
-    console.error("insertGridImagesById: grid metadata fetch failed", {
-      ids: toFetch,
-      error: e,
-    });
-    return;
-  }
-  if (!fetched.length) return;
-
-  const descending = gridSortDescending.value;
-  const base = Array.isArray(lastFetchedGridImages.value)
-    ? lastFetchedGridImages.value.slice()
-    : [];
-  const inserted = [];
-  for (const pic of fetched) {
-    const picId = getPictureId(pic?.id);
-    if (picId === null || base.some((img) => getPictureId(img?.id) === picId)) {
-      continue;
-    }
-    const key = gridImageSortKey(pic);
-    let insertIndex = base.findIndex((img) => {
-      const otherKey = gridImageSortKey(img);
-      return descending ? otherKey < key : otherKey > key;
-    });
-    if (insertIndex === -1) insertIndex = base.length;
-    base.splice(insertIndex, 0, pic);
-    inserted.push(picId);
-  }
-  if (!inserted.length) return;
-
-  lastFetchedGridImages.value = base;
-  rebuildGridImagesFromLastFetch();
-  if (highlight) triggerNewImageHighlight(inserted);
-
-  // An in-app ComfyUI result lands here (origin-aware WS picture_imported insert).
-  // If the overlay is open with a pending comfyui refresh, reconcile it now that
-  // the new stacked output is present in lastFetchedGridImages — this is the i2i/
-  // upscale lightbox case that previously relied on the full-grid refetch.
-  void maybeRefreshOverlayForComfyui();
-}
-
-async function refreshSmartScoreForImage(imageId) {
-  if (!imageId || !isSmartScoreSortActive()) return;
-  const latestInfo = await fetchImageInfo(imageId, { smartScore: true });
-  if (!latestInfo || Array.isArray(latestInfo)) return;
-
-  const idx = allGridImages.value.findIndex((img) => img?.id === imageId);
-  if (idx !== -1) {
-    const current = allGridImages.value[idx] || {};
-    const smartScore =
-      typeof latestInfo.smartScore === "number" ? latestInfo.smartScore : null;
-    if (current.smartScore === smartScore) {
-      return;
-    }
-    await nextTick();
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-    // Pass the TRUE smart score (number or null). repositionImageBySmartScore
-    // derives its ordering key from the null rule and preserves null as the
-    // card's displayed value — collapsing to 0 here would both mis-order the
-    // card and show a fake 0.
-    repositionImageBySmartScore(imageId, smartScore, latestInfo);
-  }
-}
-
-async function applyScoresByEntries(entries, options = {}) {
-  const { updateSort = true, emitRefreshSidebar = true } = options;
-  if (!Array.isArray(entries) || !entries.length) return;
-
-  // Score updates are applied locally below (including score-sort reordering),
-  // so the immediate WS gridVersion refresh would be redundant and can clear
-  // current multi-selection in some paths. Skip that next WS refresh.
-  skipNextWsRefresh.value = true;
-
-  const scoresPayload = {};
-  for (const [id, score] of entries) {
-    scoresPayload[String(id)] = Number(score);
-  }
-
-  await applyScores(scoresPayload, { baseUrl: props.backendUrl });
-
-  const scoreMap = new Map(
-    entries.map(([id, score]) => [String(id), Number(score)]),
-  );
-
-  let updatedImages = allGridImages.value.map((img) => {
-    if (!img || img.id == null) return img;
-    const key = String(img.id);
-    if (!scoreMap.has(key)) return img;
-    return { ...img, score: scoreMap.get(key) };
-  });
-
-  if (updateSort && isScoreSortActive()) {
-    const descending = gridSortDescending.value;
-    updatedImages = updatedImages
-      .slice()
-      .sort((a, b) => {
-        const aScore = a?.score ?? 0;
-        const bScore = b?.score ?? 0;
-        if (aScore === bScore) {
-          const aIdx = a?.idx ?? 0;
-          const bIdx = b?.idx ?? 0;
-          return aIdx - bIdx;
-        }
-        return descending ? bScore - aScore : aScore - bScore;
-      })
-      .map((img, idx) => (img ? { ...img, idx } : img));
-    allGridImages.value = updatedImages;
-    invalidateVisibleThumbnailRanges();
-  } else {
-    allGridImages.value = updatedImages;
-  }
-
-  if (updateSort && isCharacterLikenessSortActive()) {
-    preserveScrollOnNextFetch.value = true;
-    debouncedFetchAllGridImages();
-  }
-
-  if (updateSort && isSmartScoreSortActive()) {
-    preserveScrollOnNextFetch.value = true;
-    debouncedFetchAllGridImages();
-  }
-
-  if (emitRefreshSidebar) {
-    emit("refresh-sidebar");
-  }
-}
-
-async function applyScore(img, newScore) {
-  const imageId = img?.id;
-  if (!imageId) {
-    noticeStore.error("Couldn't set that score — the picture id is missing.", {
-      key: "score-missing-id",
-    });
-    return;
-  }
-  try {
-    // Suppress the WS-driven gridVersion reload that the score apply triggers;
-    // the score update is already applied locally by applyScoresByEntries.
-    skipNextWsRefresh.value = true;
-    await applyScoresByEntries([[String(imageId), newScore]], {
-      updateSort: false,
-      emitRefreshSidebar: false,
-    });
-
-    if (isScoreSortActive()) {
-      if (overlayOpen.value) {
-        // Reordering the grid while the overlay is open would break the
-        // filmstrip. Defer the reposition until the overlay closes.
-        pendingOverlayGridRefresh.value = true;
-      } else {
-        repositionImageByScore(imageId, newScore);
-      }
-    }
-    if (isCharacterLikenessSortActive()) {
-      if (overlayOpen.value) {
-        pendingOverlayGridRefresh.value = true;
-        return;
-      }
-      preserveScrollOnNextFetch.value = true;
-      debouncedFetchAllGridImages();
-      return;
-    }
-    if (isSmartScoreSortActive()) {
-      if (overlayOpen.value) {
-        pendingOverlayGridRefresh.value = true;
-        return;
-      }
-      preserveScrollOnNextFetch.value = true;
-      debouncedFetchAllGridImages();
-      return;
-    }
-  } catch (e) {
-    console.error("Failed to set score", e);
-    noticeStore.error(`Couldn't set that score. ${errorDetail(e)}`, {
-      key: "score-set",
-    });
-  }
-}
-
-async function applyScoresForSelection(imageIds, targetScore) {
-  const ids = Array.isArray(imageIds) ? imageIds.filter(Boolean) : [];
-  if (!ids.length) return;
-  if (!Number.isFinite(targetScore)) return;
-
-  const gridById = new Map(
-    allGridImages.value
-      .filter((img) => img && img.id != null)
-      .map((img) => [String(img.id), img]),
-  );
-
-  const entries = [];
-  for (const id of ids) {
-    const key = String(id);
-    const img = gridById.get(key);
-    if (!img) continue;
-    const current = Number(img.score || 0);
-    const nextScore = toggleScore(current, targetScore);
-    entries.push([key, nextScore]);
-  }
-
-  if (!entries.length) return;
-
-  await applyScoresByEntries(entries, {
-    updateSort: true,
-    emitRefreshSidebar: true,
-  });
 }
 
 // ============================================================

--- a/frontend/src/composables/useGridScoring.js
+++ b/frontend/src/composables/useGridScoring.js
@@ -1,0 +1,733 @@
+import { computed, nextTick } from "vue";
+import { isReadOnly } from "../utils/apiClient";
+import {
+  applyScores,
+  getGuestScores,
+  listPicturesByIds,
+  submitGuestScores,
+} from "../api/pictures";
+import { getPictureId } from "../utils/media.js";
+import { toggleScore } from "../utils/utils.js";
+import { useSortStore } from "../stores/useSortStore";
+import { useNoticeStore } from "../stores/useNoticeStore";
+
+/**
+ * Scoring, and everything the grid has to do about it.
+ *
+ * Setting a score is only half the job: when the grid is sorted by score or by
+ * smart score, the picture that just changed is in the wrong row, so these
+ * functions also move it - splicing it to its new position rather than
+ * refetching, which is what keeps a rating pass from flickering.
+ *
+ * Read-only sessions score into a guest session instead, held server-side
+ * against a generated id, so a visitor can rate without an account.
+ *
+ * @param {Object} deps - Grid state and callbacks, same shape as useGridFetch's.
+ */
+export function useGridScoring({
+  backendUrl,
+  allGridImages,
+  lastFetchedGridImages,
+  loadedRanges,
+  visibleStart,
+  visibleEnd,
+  renderBuffer,
+  imagesLoading,
+  overlayOpen,
+  pendingOverlayGridRefresh,
+  preserveScrollOnNextFetch,
+  skipNextWsRefresh,
+  gridContainer,
+  guestSessionId,
+  guestConsentState,
+  guestScoreMap,
+  guestConsentBannerVisible,
+  pendingGuestScoreIntent,
+  emit,
+  debouncedFetchAllGridImages,
+  fetchImageInfo,
+  rebuildGridImagesFromLastFetch,
+  triggerNewImageHighlight,
+  updateVisibleThumbnails,
+  maybeRefreshOverlayForComfyui,
+  errorDetail,
+}) {
+  const sortStore = useSortStore();
+  const noticeStore = useNoticeStore();
+
+  // SCORING
+  // ============================================================
+  async function setScore(img, n) {
+    if (isReadOnly.value) {
+      setGuestScore(img, n);
+      return;
+    }
+    const newScore = toggleScore(img.score, n);
+    applyScore(img, newScore);
+  }
+
+  // ---- Guest scoring helpers ----
+
+  function _generateGuestSessionId() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    // Fallback for older browsers — use cryptographically secure random bytes
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant bits
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
+    return [
+      hex.slice(0, 4).join(""),
+      hex.slice(4, 6).join(""),
+      hex.slice(6, 8).join(""),
+      hex.slice(8, 10).join(""),
+      hex.slice(10, 16).join(""),
+    ].join("-");
+  }
+
+  function _getOrCreateGuestSessionId() {
+    if (guestSessionId.value) return guestSessionId.value;
+    const id = _generateGuestSessionId();
+    guestSessionId.value = id;
+    return id;
+  }
+
+  async function _submitGuestScores(scores, setCookie) {
+    const sid = _getOrCreateGuestSessionId();
+    const payload = { session_id: sid, set_cookie: setCookie, scores };
+    await submitGuestScores(payload, { baseUrl: backendUrl });
+  }
+
+  function setGuestScore(img, n) {
+    const currentScore = guestScoreMap.value.get(img.id) ?? null;
+    const newScore = toggleScore(currentScore, n);
+
+    if (guestConsentState.value === null) {
+      // Show consent banner; queue the intent
+      pendingGuestScoreIntent.value = { img, newScore };
+      guestConsentBannerVisible.value = true;
+      return;
+    }
+
+    // Optimistic local update
+    const updated = new Map(guestScoreMap.value);
+    updated.set(img.id, newScore);
+    guestScoreMap.value = updated;
+
+    const setCookie = guestConsentState.value === "accepted";
+    _submitGuestScores({ [String(img.id)]: newScore }, setCookie)
+      .then(() => {
+        if (isScoreSortActive()) {
+          debouncedFetchAllGridImages({ force: true });
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to submit guest score:", err);
+      });
+  }
+
+  async function handleGuestConsentAccepted() {
+    guestConsentState.value = "accepted";
+    guestConsentBannerVisible.value = false;
+    // Do not persist the guest session identifier in localStorage.
+    // The server-managed HttpOnly cookie handles durable session continuity;
+    // keeping the session_id only in memory is sufficient for the current visit.
+    const intent = pendingGuestScoreIntent.value;
+    pendingGuestScoreIntent.value = null;
+    if (intent) {
+      const updated = new Map(guestScoreMap.value);
+      updated.set(intent.img.id, intent.newScore);
+      guestScoreMap.value = updated;
+      await _submitGuestScores(
+        { [String(intent.img.id)]: intent.newScore },
+        true,
+      )
+        .then(() => {
+          if (isScoreSortActive()) debouncedFetchAllGridImages({ force: true });
+        })
+        .catch((err) => console.error("Failed to submit guest score:", err));
+    }
+  }
+
+  function handleGuestConsentRejected() {
+    guestConsentState.value = "rejected";
+    guestConsentBannerVisible.value = false;
+    // Do NOT persist the session ID anywhere — if the user reloads they get a
+    // brand-new session with no connection to these scores.
+    const intent = pendingGuestScoreIntent.value;
+    pendingGuestScoreIntent.value = null;
+    if (intent) {
+      const updated = new Map(guestScoreMap.value);
+      updated.set(intent.img.id, intent.newScore);
+      guestScoreMap.value = updated;
+      _submitGuestScores({ [String(intent.img.id)]: intent.newScore }, false)
+        .then(() => {
+          if (isScoreSortActive()) debouncedFetchAllGridImages({ force: true });
+        })
+        .catch((err) => console.error("Failed to submit guest score:", err));
+    }
+  }
+
+  async function fetchGuestScores() {
+    // Kept only as a fallback / explicit refresh. The main listing
+    // (GET /pictures) now overlays guest scores onto img.score server-side.
+    try {
+      const resp = await getGuestScores({ baseUrl: backendUrl });
+      const scores = resp?.scores ?? {};
+      const map = new Map();
+      for (const [k, v] of Object.entries(scores)) {
+        map.set(Number(k), v);
+      }
+      guestScoreMap.value = map;
+    } catch (err) {
+      console.error("[guest-scores] Failed to fetch guest scores:", err);
+    }
+  }
+
+  function initGuestSession() {
+    const readOnly = isReadOnly.value;
+    const cookies = document.cookie;
+    const ls = localStorage.getItem("guest_session_id");
+    if (!readOnly) return;
+    // A non-HttpOnly sentinel cookie is set alongside the HttpOnly guest_session
+    // cookie when the user accepted persistent storage.
+    const hasCookieConsent = cookies
+      .split(";")
+      .some((c) => c.trim().startsWith("guest_session_active=1"));
+    if (hasCookieConsent) {
+      guestConsentState.value = "accepted";
+      // Restore the session ID from localStorage so POST bodies stay in sync
+      // with the HttpOnly cookie the server already knows about.
+      if (ls) {
+        guestSessionId.value = ls;
+      }
+      // Scores are now overlaid by the backend in GET /pictures, so
+      // fetchAllGridImages() will include them in img.score directly.
+      // fetchGuestScores() is only needed to pre-populate guestScoreMap
+      // for optimistic-update display before the grid loads.
+      fetchGuestScores();
+      return;
+    }
+    // No cookie consent — fresh start.  The banner will appear on first score.
+    // (Rejected users are intentionally not remembered across page loads.)
+  }
+
+  function isScoreSortActive() {
+    return typeof sortStore.selectedSort === "string"
+      ? sortStore.selectedSort.toUpperCase() === "SCORE"
+      : false;
+  }
+
+  function isCharacterLikenessSortActive() {
+    return typeof sortStore.selectedSort === "string"
+      ? sortStore.selectedSort.toUpperCase() === "CHARACTER_LIKENESS"
+      : false;
+  }
+
+  function isSmartScoreSortActive() {
+    return typeof sortStore.selectedSort === "string"
+      ? sortStore.selectedSort.toUpperCase().includes("SMART_SCORE")
+      : false;
+  }
+
+  // Single source of truth for grid sort direction. ALL client-side ordering —
+  // score/smart-score repositions, the apply-scores re-sort, and incremental
+  // inserts — must use the SAME rule, or a card lands in a different spot than the
+  // array it is spliced into. Nullish selectedDescending → ascending (the store
+  // defaults it to a real `true`). Keep this as one computed: a lone inlined
+  // `!== false` previously drifted here and mispositioned inserted cards.
+  const gridSortDescending = computed(
+    () => sortStore.selectedDescending === true,
+  );
+
+  function getGridSmartScoreValue(img) {
+    if (!img) return null;
+    const raw =
+      typeof img.smartScore === "number"
+        ? img.smartScore
+        : typeof img.smart_score === "number"
+          ? img.smart_score
+          : null;
+    return Number.isFinite(raw) ? raw : null;
+  }
+
+  // The ONE null-ordering rule shared by every client-side smart-score sort path
+  // (fresh insert AND reposition). SQLite ranks NULL below every real value, and
+  // the backend sorts the smart_score column with a plain .asc()/.desc() and no
+  // NULLS clause (pixlstash/db_models/picture.py), so NULLs sort FIRST on ascending
+  // and LAST on descending. Map a null/absent score to -Infinity so the shared
+  // comparator (which flips on `descending`) lands a null-scored card exactly where
+  // the server put it, in BOTH directions. A 0 sentinel is wrong: it collides with
+  // a genuine zero and, now that smart scores can be negative and null (tag edits
+  // invalidate them), it mis-orders nulls relative to real scores. Route EVERY path
+  // through this helper — never an inline ternary or `?? 0` — so the insert and
+  // reposition paths cannot drift (the failure the gridSortDescending comment warns
+  // of). This is only an ordering key; it must never be written back as a card's
+  // displayed smart score, or a null-scored card would render a fake 0.
+  function smartScoreSortKey(smartScore) {
+    return Number.isFinite(smartScore) ? smartScore : -Infinity;
+  }
+
+  function invalidateVisibleThumbnailRanges() {
+    const start = Math.max(0, visibleStart.value - renderBuffer.value);
+    const end = Math.min(
+      allGridImages.value.length,
+      visibleEnd.value + renderBuffer.value,
+    );
+    loadedRanges.value = loadedRanges.value.filter(
+      ([rangeStart, rangeEnd]) => rangeEnd <= start || rangeStart >= end,
+    );
+    updateVisibleThumbnails();
+  }
+
+  function _spliceAndReinsert(
+    items,
+    currentIndex,
+    target,
+    targetScore,
+    getScore,
+    descending,
+  ) {
+    items.splice(currentIndex, 1);
+    let insertIndex = items.findIndex((item) => {
+      const score = getScore(item);
+      return descending ? score < targetScore : score > targetScore;
+    });
+    if (insertIndex === -1) insertIndex = items.length;
+    if (insertIndex === currentIndex) {
+      const updated = allGridImages.value.slice();
+      updated[currentIndex] = { ...target, idx: currentIndex };
+      allGridImages.value = updated;
+      // Still invalidate: we are only here because the card's score changed, and the
+      // batch-sourced fields that change with it (penalised_tags — the problem
+      // indicator — plus faces/detections) are refreshed ONLY by a thumbnail batch.
+      // Without this, loadedRanges still covers the window, updateVisibleThumbnails
+      // no-ops, and a card whose position happens not to move keeps its stale
+      // indicator. Adding a penalised tag to an already low-scoring card lands
+      // exactly here, since it is already at the bottom of a descending sort.
+      invalidateVisibleThumbnailRanges();
+      return null;
+    }
+    items.splice(insertIndex, 0, target);
+    for (let i = 0; i < items.length; i += 1) {
+      items[i].idx = i;
+    }
+    allGridImages.value = items;
+    invalidateVisibleThumbnailRanges();
+    return insertIndex;
+  }
+
+  function repositionImageByScore(imageId, newScore) {
+    const items = allGridImages.value.slice();
+    const dId = getPictureId(imageId);
+    const currentIndex = items.findIndex(
+      (item) => getPictureId(item?.id) === dId,
+    );
+    if (currentIndex === -1) return;
+
+    const target = items[currentIndex];
+    target.score = newScore;
+    const targetScore = newScore ?? 0;
+    const descending = gridSortDescending.value;
+    const insertIndex = _spliceAndReinsert(
+      items,
+      currentIndex,
+      target,
+      targetScore,
+      (item) => item.score ?? 0,
+      descending,
+    );
+    if (insertIndex !== null) {
+      nextTick(() => {
+        const grid = gridContainer.value;
+        if (!grid) return;
+        const card = grid.querySelectorAll(".image-card")[insertIndex];
+        if (card && card.scrollIntoView) {
+          card.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      });
+    }
+  }
+
+  let smartScoreRepositioning = false;
+
+  function repositionImageBySmartScore(imageId, smartScore, latestInfo = null) {
+    if (smartScoreRepositioning) return;
+    smartScoreRepositioning = true;
+    try {
+      const items = allGridImages.value.slice();
+      const currentIndex = items.findIndex((item) => item.id === imageId);
+      if (currentIndex === -1) return;
+
+      // Keep the ordering key separate from the displayed value. The card must
+      // store the TRUE smart score (a real number or null → "no score"); only the
+      // sort key collapses null to the SQLite sentinel via smartScoreSortKey.
+      // Writing the sentinel onto `smartScore` would make a null-scored card render
+      // a fake 0.
+      const normalisedScore = Number.isFinite(smartScore) ? smartScore : null;
+      const targetKey = smartScoreSortKey(normalisedScore);
+      // Write the TRUE score to BOTH the camelCase and snake_case keys.
+      // getGridSmartScoreValue reads `smartScore` then falls back to `smart_score`
+      // (grid cards / metadata responses carry both), so setting only one key would
+      // let a stale value leak through the fallback and render a wrong (or fake 0)
+      // score. Both must hold the normalised value — null for "no score".
+      const target = {
+        ...items[currentIndex],
+        ...(latestInfo && typeof latestInfo === "object" ? latestInfo : {}),
+        smartScore: normalisedScore,
+        smart_score: normalisedScore,
+        thumbnail:
+          items[currentIndex]?.thumbnail ?? latestInfo?.thumbnail ?? null,
+      };
+      const descending = gridSortDescending.value;
+      _spliceAndReinsert(
+        items,
+        currentIndex,
+        target,
+        targetKey,
+        (item) => smartScoreSortKey(getGridSmartScoreValue(item)),
+        descending,
+      );
+    } finally {
+      smartScoreRepositioning = false;
+    }
+  }
+
+  // Numeric sort key for a freshly-fetched grid item under the active sort,
+  // mirroring the fields the grid already displays/sorts on (see
+  // getCompactGroupLabel / sort-overlay logic). Returns a finite number used to
+  // find the insert index; `id` is the implicit tiebreaker.
+  function gridImageSortKey(img) {
+    const sort =
+      typeof sortStore.selectedSort === "string" ? sortStore.selectedSort : "";
+    if (sort === "IMPORTED_AT" && img?.imported_at) {
+      return Date.parse(img.imported_at) || 0;
+    }
+    if (sort.includes("DATE") && img?.created_at) {
+      return Date.parse(img.created_at) || 0;
+    }
+    if (sort.includes("SMART_SCORE")) {
+      // Match the server's ORDER BY exactly via the shared null rule (see
+      // smartScoreSortKey). The reposition path uses the same helper, so the two
+      // ordering paths cannot drift.
+      return smartScoreSortKey(getGridSmartScoreValue(img));
+    }
+    if (
+      sort.includes("CHARACTER_LIKENESS") &&
+      typeof img?.character_likeness === "number"
+    ) {
+      return img.character_likeness;
+    }
+    if (sort === "TEXT_CONTENT" && typeof img?.text_score === "number") {
+      return img.text_score;
+    }
+    if (typeof img?.score === "number") return img.score;
+    // Unknown / id-ordered sort → fall back to the picture id.
+    return Number(getPictureId(img?.id)) || 0;
+  }
+
+  // Insert newly-added pictures into the grid at their sorted position without a
+  // full reload. Always mutates lastFetchedGridImages then rebuilds, because the
+  // v-for key embeds img.idx — splicing allGridImages directly would corrupt the
+  // virtual-scroll window. Deferred to the pill while a streaming fetch is in
+  // flight (that fetch writes allGridImages wholesale from a sized placeholder).
+  // `options.highlight` (default true) drives the new-picture flash. A scrapheap
+  // comeback passes false: the flash means "this was not here before", which is
+  // the wrong story for a picture the user just undid the removal of.
+  async function insertGridImagesById(ids, options = {}) {
+    const highlight = options?.highlight !== false;
+    const wanted = (Array.isArray(ids) ? ids : [])
+      .map((id) => getPictureId(id))
+      .filter((id) => id !== null);
+    if (!wanted.length) return;
+
+    // Character-likeness sort can't be positioned incrementally. The likeness
+    // value is computed by a backend SQL function relative to the currently
+    // selected similarity character (find_pictures_by_character_likeness_sql),
+    // not stored on the picture, so it is NOT in the `fields=grid` projection
+    // (the backend has no character context to compute it there). gridImageSortKey
+    // therefore falls through to `score` and would splice the card at the wrong
+    // position. Fall back to a full refetch, which DOES recompute likeness — or,
+    // under an open overlay, defer it (the overlay-open deferral contract, §9.1)
+    // so we never restructure the filmstrip mid-view.
+    if (isCharacterLikenessSortActive()) {
+      if (overlayOpen.value) {
+        pendingOverlayGridRefresh.value = true;
+        return;
+      }
+      preserveScrollOnNextFetch.value = true;
+      debouncedFetchAllGridImages();
+      return;
+    }
+
+    if (imagesLoading.value) {
+      // A streaming fetch owns allGridImages wholesale; inserting now would be
+      // clobbered. The caller (useGridRealtimeSync) routes these to the pill
+      // instead while loading, so just bail.
+      console.warn(
+        "insertGridImagesById: skipped during in-flight grid fetch",
+        wanted,
+      );
+      return;
+    }
+
+    const existing = new Set(
+      (Array.isArray(lastFetchedGridImages.value)
+        ? lastFetchedGridImages.value
+        : []
+      ).map((img) => getPictureId(img?.id)),
+    );
+    const toFetch = wanted.filter((id) => !existing.has(id));
+    if (!toFetch.length) return;
+
+    let fetched;
+    try {
+      const rows = await listPicturesByIds(toFetch, {
+        fields: "grid",
+        baseUrl: backendUrl,
+      });
+      fetched = Array.isArray(rows) ? rows : [];
+    } catch (e) {
+      console.error("insertGridImagesById: grid metadata fetch failed", {
+        ids: toFetch,
+        error: e,
+      });
+      return;
+    }
+    if (!fetched.length) return;
+
+    const descending = gridSortDescending.value;
+    const base = Array.isArray(lastFetchedGridImages.value)
+      ? lastFetchedGridImages.value.slice()
+      : [];
+    const inserted = [];
+    for (const pic of fetched) {
+      const picId = getPictureId(pic?.id);
+      if (
+        picId === null ||
+        base.some((img) => getPictureId(img?.id) === picId)
+      ) {
+        continue;
+      }
+      const key = gridImageSortKey(pic);
+      let insertIndex = base.findIndex((img) => {
+        const otherKey = gridImageSortKey(img);
+        return descending ? otherKey < key : otherKey > key;
+      });
+      if (insertIndex === -1) insertIndex = base.length;
+      base.splice(insertIndex, 0, pic);
+      inserted.push(picId);
+    }
+    if (!inserted.length) return;
+
+    lastFetchedGridImages.value = base;
+    rebuildGridImagesFromLastFetch();
+    if (highlight) triggerNewImageHighlight(inserted);
+
+    // An in-app ComfyUI result lands here (origin-aware WS picture_imported insert).
+    // If the overlay is open with a pending comfyui refresh, reconcile it now that
+    // the new stacked output is present in lastFetchedGridImages — this is the i2i/
+    // upscale lightbox case that previously relied on the full-grid refetch.
+    void maybeRefreshOverlayForComfyui();
+  }
+
+  async function refreshSmartScoreForImage(imageId) {
+    if (!imageId || !isSmartScoreSortActive()) return;
+    const latestInfo = await fetchImageInfo(imageId, { smartScore: true });
+    if (!latestInfo || Array.isArray(latestInfo)) return;
+
+    const idx = allGridImages.value.findIndex((img) => img?.id === imageId);
+    if (idx !== -1) {
+      const current = allGridImages.value[idx] || {};
+      const smartScore =
+        typeof latestInfo.smartScore === "number"
+          ? latestInfo.smartScore
+          : null;
+      if (current.smartScore === smartScore) {
+        return;
+      }
+      await nextTick();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      // Pass the TRUE smart score (number or null). repositionImageBySmartScore
+      // derives its ordering key from the null rule and preserves null as the
+      // card's displayed value — collapsing to 0 here would both mis-order the
+      // card and show a fake 0.
+      repositionImageBySmartScore(imageId, smartScore, latestInfo);
+    }
+  }
+
+  async function applyScoresByEntries(entries, options = {}) {
+    const { updateSort = true, emitRefreshSidebar = true } = options;
+    if (!Array.isArray(entries) || !entries.length) return;
+
+    // Score updates are applied locally below (including score-sort reordering),
+    // so the immediate WS gridVersion refresh would be redundant and can clear
+    // current multi-selection in some paths. Skip that next WS refresh.
+    skipNextWsRefresh.value = true;
+
+    const scoresPayload = {};
+    for (const [id, score] of entries) {
+      scoresPayload[String(id)] = Number(score);
+    }
+
+    await applyScores(scoresPayload, { baseUrl: backendUrl });
+
+    const scoreMap = new Map(
+      entries.map(([id, score]) => [String(id), Number(score)]),
+    );
+
+    let updatedImages = allGridImages.value.map((img) => {
+      if (!img || img.id == null) return img;
+      const key = String(img.id);
+      if (!scoreMap.has(key)) return img;
+      return { ...img, score: scoreMap.get(key) };
+    });
+
+    if (updateSort && isScoreSortActive()) {
+      const descending = gridSortDescending.value;
+      updatedImages = updatedImages
+        .slice()
+        .sort((a, b) => {
+          const aScore = a?.score ?? 0;
+          const bScore = b?.score ?? 0;
+          if (aScore === bScore) {
+            const aIdx = a?.idx ?? 0;
+            const bIdx = b?.idx ?? 0;
+            return aIdx - bIdx;
+          }
+          return descending ? bScore - aScore : aScore - bScore;
+        })
+        .map((img, idx) => (img ? { ...img, idx } : img));
+      allGridImages.value = updatedImages;
+      invalidateVisibleThumbnailRanges();
+    } else {
+      allGridImages.value = updatedImages;
+    }
+
+    if (updateSort && isCharacterLikenessSortActive()) {
+      preserveScrollOnNextFetch.value = true;
+      debouncedFetchAllGridImages();
+    }
+
+    if (updateSort && isSmartScoreSortActive()) {
+      preserveScrollOnNextFetch.value = true;
+      debouncedFetchAllGridImages();
+    }
+
+    if (emitRefreshSidebar) {
+      emit("refresh-sidebar");
+    }
+  }
+
+  async function applyScore(img, newScore) {
+    const imageId = img?.id;
+    if (!imageId) {
+      noticeStore.error(
+        "Couldn't set that score — the picture id is missing.",
+        {
+          key: "score-missing-id",
+        },
+      );
+      return;
+    }
+    try {
+      // Suppress the WS-driven gridVersion reload that the score apply triggers;
+      // the score update is already applied locally by applyScoresByEntries.
+      skipNextWsRefresh.value = true;
+      await applyScoresByEntries([[String(imageId), newScore]], {
+        updateSort: false,
+        emitRefreshSidebar: false,
+      });
+
+      if (isScoreSortActive()) {
+        if (overlayOpen.value) {
+          // Reordering the grid while the overlay is open would break the
+          // filmstrip. Defer the reposition until the overlay closes.
+          pendingOverlayGridRefresh.value = true;
+        } else {
+          repositionImageByScore(imageId, newScore);
+        }
+      }
+      if (isCharacterLikenessSortActive()) {
+        if (overlayOpen.value) {
+          pendingOverlayGridRefresh.value = true;
+          return;
+        }
+        preserveScrollOnNextFetch.value = true;
+        debouncedFetchAllGridImages();
+        return;
+      }
+      if (isSmartScoreSortActive()) {
+        if (overlayOpen.value) {
+          pendingOverlayGridRefresh.value = true;
+          return;
+        }
+        preserveScrollOnNextFetch.value = true;
+        debouncedFetchAllGridImages();
+        return;
+      }
+    } catch (e) {
+      console.error("Failed to set score", e);
+      noticeStore.error(`Couldn't set that score. ${errorDetail(e)}`, {
+        key: "score-set",
+      });
+    }
+  }
+
+  async function applyScoresForSelection(imageIds, targetScore) {
+    const ids = Array.isArray(imageIds) ? imageIds.filter(Boolean) : [];
+    if (!ids.length) return;
+    if (!Number.isFinite(targetScore)) return;
+
+    const gridById = new Map(
+      allGridImages.value
+        .filter((img) => img && img.id != null)
+        .map((img) => [String(img.id), img]),
+    );
+
+    const entries = [];
+    for (const id of ids) {
+      const key = String(id);
+      const img = gridById.get(key);
+      if (!img) continue;
+      const current = Number(img.score || 0);
+      const nextScore = toggleScore(current, targetScore);
+      entries.push([key, nextScore]);
+    }
+
+    if (!entries.length) return;
+
+    await applyScoresByEntries(entries, {
+      updateSort: true,
+      emitRefreshSidebar: true,
+    });
+  }
+
+  // ============================================================
+
+  return {
+    setScore,
+    setGuestScore,
+    handleGuestConsentAccepted,
+    handleGuestConsentRejected,
+    fetchGuestScores,
+    initGuestSession,
+    isScoreSortActive,
+    isCharacterLikenessSortActive,
+    isSmartScoreSortActive,
+    gridSortDescending,
+    getGridSmartScoreValue,
+    smartScoreSortKey,
+    invalidateVisibleThumbnailRanges,
+    repositionImageByScore,
+    repositionImageBySmartScore,
+    gridImageSortKey,
+    insertGridImagesById,
+    refreshSmartScoreForImage,
+    applyScoresByEntries,
+    applyScore,
+    applyScoresForSelection,
+  };
+}

--- a/frontend/src/composables/useVirtualScroll.test.js
+++ b/frontend/src/composables/useVirtualScroll.test.js
@@ -111,3 +111,70 @@ describe("useVirtualScroll justified layout", () => {
     expect(autoEnd).not.toBe(squareEnd);
   });
 });
+
+// The grid geometry now comes from the store rather than from props, and the
+// arithmetic that turns it into a render window is silent when it goes wrong:
+// an undefined column count makes every bound NaN, `renderEnd` collapses, and
+// the grid paints nothing at all. That is not a hypothetical - it is what the
+// Phase 3 store-direct migration did to ImageGrid, with the whole unit suite
+// still green, because nothing here asserted that a non-empty list produces a
+// non-empty window.
+describe("useVirtualScroll render window (square mode)", () => {
+  function squareHarness(itemCount) {
+    const gridStore = useGridStore();
+    gridStore.sizeLevel = 3; // the 6-column step
+    gridStore.thumbnailMode = "square";
+    gridStore.thumbnailSize = 256;
+    gridStore.compactMode = false;
+
+    const scrollWrapper = ref({
+      scrollTop: 0,
+      clientHeight: VIEWPORT_H,
+      clientWidth: CONTAINER_W,
+    });
+    const gridContainer = ref({
+      clientWidth: CONTAINER_W,
+      getBoundingClientRect: () => ({ width: CONTAINER_W }),
+    });
+    const length = computed(() => itemCount);
+    return useVirtualScroll(
+      scrollWrapper,
+      gridContainer,
+      reactive({}),
+      length,
+      {
+        onVisibleRangeChange: vi.fn(),
+        afterRowHeightUpdate: vi.fn(),
+        getAspectRatios: () => [],
+      },
+    );
+  }
+
+  it("renders a non-empty window for a non-empty grid", () => {
+    const vs = squareHarness(120);
+    vs.visibleStart.value = 0;
+    vs.visibleEnd.value = 24;
+
+    expect(Number.isFinite(vs.renderStart.value)).toBe(true);
+    expect(Number.isFinite(vs.renderEnd.value)).toBe(true);
+    expect(vs.renderEnd.value).toBeGreaterThan(0);
+    expect(vs.renderEnd.value).toBeGreaterThan(vs.renderStart.value);
+  });
+
+  it("keeps the spacers finite, so the scroll height is never NaN", () => {
+    const vs = squareHarness(120);
+    vs.visibleStart.value = 24;
+    vs.visibleEnd.value = 48;
+
+    expect(Number.isFinite(vs.topSpacerHeight.value)).toBe(true);
+    expect(Number.isFinite(vs.bottomSpacerHeight.value)).toBe(true);
+  });
+
+  it("still yields an empty window for an empty grid", () => {
+    const vs = squareHarness(0);
+    vs.visibleStart.value = 0;
+    vs.visibleEnd.value = 0;
+
+    expect(vs.renderEnd.value).toBe(0);
+  });
+});


### PR DESCRIPTION
Lane A, step 4. **Stacked on #662.**

Scoring, guest scoring, and the repositioning that follows a score change move into `useGridScoring` — 640 lines out of ImageGrid, taking a deps object in the same shape `useGridFetch` and `useStackOrdering` already use.

Keeping the repositioning with the scoring is the point: under a score or smart-score sort, a rated picture is immediately in the wrong row, so these functions splice it to its new position rather than refetching. That is what stops a rating pass from flickering, and it only makes sense next to the code that changed the score.

`useStackOrdering` is constructed before this composable and consumes its range invalidation, so that one reference is deferred rather than passed by value — flagged in a comment at the call site.

## Phase 5 is not finished, and the line target is not close

| | before | target | after |
|---|---|---|---|
| ImageGrid.vue | 8,884 | ≤2,500 | **8,287** |

Being straight about what that means: reaching 2,500 needs roughly 5,800 more lines out, and the remaining work is not shaped like this PR.

- **~1,125 lines are the style block** — that is Phase 7 (CSS consolidation into shared stylesheets), a different phase.
- **~1,087 lines are template** — reducing it means extracting child components, closer to Phase 6's shape than Phase 5's.
- The script sections that remain (face bboxes, thumbnail text-fitting, membership, import, ghosts, search) **do not align with the file's comment banners** — I checked, and the banner ranges interleave with lifecycle and websocket code. Each needs boundaries worked out function by function, which is real work rather than a mechanical cut, and doing it unattended against an 8,000-line file is how a silent breakage gets in. Part 2 of the ImageGrid migration already demonstrated that this file can render zero cards with the entire unit suite green.
- The other named Phase 5 deliverable, the **`useGridActions` action vocabulary**, touches ImageGrid plus SelectionBar plus ImageGridContextMenu (22 emits) plus the overlay menu. It is worth doing and it is the piece that would bring ImageGrid's emit surface down from 21, but it is a four-component change that deserves its own PR and review.

So this PR is honest partial progress on Phase 5, not its completion.

## Verification

Unit suite 1656 passing, production build clean, and the rating and dedup specs green (rating is the path this PR touches).

**One e2e caveat, checked rather than assumed.** The full suite currently fails on `dedup.spec.js:154` ("C opens Compare"). It passes in isolation and alongside its neighbours. I ran the full suite on the parent commit with this change stashed and **it fails there identically**, so it is not caused by this PR — it is pre-existing on the branch as of tonight. The e2e backend does copy a fresh vault per launch, so it is either within-run interference or a collision with another process using the same work directory. Worth a look, but not something to fix inside this PR.
