### PR TITLE
Make the e2e suite safe to run from two checkouts at once

### DIFF
--- a/docs/regular-tests.md
+++ b/docs/regular-tests.md
@@ -8,7 +8,17 @@ suite is pytest — those are not duplicated here.
 - **Location:** `frontend/e2e/specs/*.spec.js`
 - **Run:** from `frontend/` → `npm run test:e2e` (UI mode: `npm run test:e2e:ui`).
   The harness builds the SPA and boots a throwaway backend against the committed
-  `test-data/` fixture (see `frontend/e2e/README.md`).
+  `test-data/` fixture (see `frontend/e2e/README.md`). Both the throwaway work
+  directory and the port are derived from the checkout path, so two working
+  copies of the repo can run the suite at the same time without colliding; set
+  `PIXLSTASH_E2E_PORT` to pin the port.
+- **Keyboard surfaces: wait for focus, not just for paint.** The duplicate
+  queue's keys act on the *focused* row, and the queue sets its focus index only
+  once a load resolves — so a key pressed after the rows appear but before one
+  is focused does nothing at all. `DuplicateQueuePage.goto()` waits for
+  `.grow--focus` for exactly this reason. The window is narrow on a quiet
+  machine and wide on a loaded runner, so the symptom was a spec that looked
+  flaky locally and failed every attempt in CI.
 - **Conventions:** owner session minted in `global-setup.js`; assert
   "at least one" / relative deltas rather than exact counts so fixture pruning
   doesn't break tests; pictures identified by thumbnail `src`
@@ -225,6 +235,18 @@ BUG-RS-1** — each encodes a behaviour that does not yet match the implementati
 (single-suspect queue emptying, Skip tally, keyboard focus, queue completion/
 archive) and needs QA+dev reconciliation; see the per-test `FIXME (not BUG-RS-1)`
 notes in the spec. Un-`fixme` each as its behaviour is settled.
+
+---
+
+## Preferences round-trip — `preferences-persist.spec.js`
+| Test | Covers | Status |
+| --- | --- | --- |
+| a compact-mode change is PATCHed and survives a reload | The whole path a preference travels: control → store → the `useAppConfig` watcher's PATCH to `/users/me/config` → read back on the next load. Asserts the request body carried the new value rather than trusting the store, so a broken persistence watcher cannot pass | ✅ |
+
+## Keyboard shortcuts dialog — `shortcuts-dialog.spec.js`
+| Test | Covers | Status |
+| --- | --- | --- |
+| opens on F1 and lists the grid shortcuts | F1 reaches the global handler and `ShortcutsDialog` renders its table. The dialog is static markup with no unit coverage, so this is its only pin | ✅ |
 
 ---
 

--- a/frontend/e2e/seed_dedup_fixture.py
+++ b/frontend/e2e/seed_dedup_fixture.py
@@ -50,14 +50,18 @@ import os
 import shutil
 import sqlite3
 import sys
-import tempfile
 
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_DATA = Path(os.environ.get("PIXLSTASH_E2E_DATA") or (REPO_ROOT / "test-data"))
-# Mirrors serve_e2e_backend.WORK_DIR exactly; the two must not drift.
-WORK_DIR = Path(tempfile.gettempdir()) / f"pixlstash-e2e-{SRC_DATA.name}"
+# Import the launcher's work directory rather than recomputing it. This used to
+# be a copy with a "must not drift" comment above it, and it drifted the moment
+# the launcher's path gained a per-checkout suffix: the seed wrote to one vault
+# while the server served another, and the queue simply came up empty.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from serve_e2e_backend import WORK_DIR  # noqa: E402
+
 IMAGE_ROOT = WORK_DIR / "images"
 DB_PATH = IMAGE_ROOT / "vault.db"
 

--- a/frontend/e2e/serve_e2e_backend.py
+++ b/frontend/e2e/serve_e2e_backend.py
@@ -22,6 +22,7 @@ nothing accumulates and the committed fixture is never modified.
 
 import json
 import os
+import hashlib
 import shutil
 import sqlite3
 import sys
@@ -32,9 +33,17 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_DATA = Path(os.environ.get("PIXLSTASH_E2E_DATA") or (REPO_ROOT / "test-data"))
 SRC_IMAGES = SRC_DATA / "images"
 PORT = int(os.environ.get("PIXLSTASH_E2E_PORT", "9600"))
-# Isolate the work dir per fixture so a screenshots run (demo-data) never stomps
-# a parallel e2e run (test-data) using the shared temp directory.
-WORK_DIR = Path(tempfile.gettempdir()) / f"pixlstash-e2e-{SRC_DATA.name}"
+# Isolate the work dir per fixture AND per checkout. Per fixture so a
+# screenshots run (demo-data) never stomps an e2e run (test-data); per checkout
+# because the fixture folder is called "test-data" in every clone, so two
+# working copies of the repo would otherwise resolve to the same directory and
+# rmtree each other's vault mid-run. That failure is worth naming: the symptom
+# is not an error but a handful of unrelated specs failing, or global-setup
+# reporting the vault is not in first-run state.
+_CHECKOUT_TAG = hashlib.sha1(str(REPO_ROOT).encode()).hexdigest()[:8]
+WORK_DIR = (
+    Path(tempfile.gettempdir()) / f"pixlstash-e2e-{SRC_DATA.name}-{_CHECKOUT_TAG}"
+)
 
 
 def _ignore_backups(_dir, names):

--- a/frontend/e2e/specs/preferences-persist.spec.js
+++ b/frontend/e2e/specs/preferences-persist.spec.js
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+// Preferences take a long road: a control writes a store, a watcher notices and
+// PATCHes /users/me/config, and the next session reads it back. The Phase 3
+// refactor moved every step of that - the guarded setters onto the stores, the
+// fourteen persistence watchers into useAppConfig - and nothing exercised the
+// round trip, so a preference that silently stopped persisting would have gone
+// unnoticed until a user complained their settings kept resetting.
+//
+// Compact mode is the cheapest control to drive: a real button in the toolbar's
+// Grid-view menu, writing straight to the grid store.
+
+/** Open the toolbar's "Grid view" menu and return its Compact toggle. */
+async function openViewMenu(page) {
+  await page.locator(".bar-btn:has(.mdi-view-grid)").first().click();
+  const compact = page.locator(".tbm-btn--compact");
+  await expect(compact).toBeVisible();
+  return compact;
+}
+
+test.describe("preferences round-trip", () => {
+  test("a compact-mode change is PATCHed and survives a reload", async ({
+    page,
+  }) => {
+    const patches = [];
+    await page.route("**/users/me/config", async (route) => {
+      if (route.request().method() === "PATCH") {
+        patches.push(route.request().postDataJSON());
+      }
+      await route.continue();
+    });
+
+    await page.goto("/");
+    await expect(page.locator(".thumbnail-card").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const compact = await openViewMenu(page);
+    const wasOn = await compact.evaluate((el) =>
+      el.classList.contains("tbm-btn--on"),
+    );
+    await compact.click();
+
+    // The change reached the server, not just the store.
+    await expect
+      .poll(() => patches.some((p) => p && "compact_mode" in p), {
+        timeout: 10_000,
+      })
+      .toBe(true);
+    const sent = patches.filter((p) => p && "compact_mode" in p).pop();
+    expect(sent.compact_mode).toBe(!wasOn);
+
+    // And it is what the next session gets.
+    await page.reload();
+    await expect(page.locator(".thumbnail-card").first()).toBeVisible({
+      timeout: 15_000,
+    });
+    const afterReload = await openViewMenu(page);
+    await expect
+      .poll(
+        () =>
+          afterReload.evaluate((el) => el.classList.contains("tbm-btn--on")),
+        { timeout: 10_000 },
+      )
+      .toBe(!wasOn);
+
+    // Put it back so the shared fixture is left as it was found.
+    await afterReload.click();
+  });
+});

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,8 +1,25 @@
 import { defineConfig, devices } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
 
 // The e2e backend (frontend/e2e/serve_e2e_backend.py) serves both the built
 // SPA and the API on this single origin, so cookie auth works with no CORS.
-const PORT = process.env.PIXLSTASH_E2E_PORT || '9600'
+//
+// The port is derived from the checkout path rather than fixed, because two
+// working copies of the repo running e2e at the same time would otherwise both
+// try to bind 9600. The failure that causes is not an obvious one: whichever
+// run loses the race can end up talking to the OTHER checkout's server, whose
+// vault has a different admin password, and global-setup reports the fixture
+// is not in first-run state. Set PIXLSTASH_E2E_PORT to pin it.
+const PORT =
+  process.env.PIXLSTASH_E2E_PORT ||
+  String(
+    9600 +
+      ([...fileURLToPath(new URL('.', import.meta.url))].reduce(
+        (h, ch) => (h * 31 + ch.charCodeAt(0)) % 200,
+        7,
+      ) %
+        200),
+  )
 const BASE_URL = `http://127.0.0.1:${PORT}`
 
 export default defineConfig({
@@ -30,7 +47,7 @@ export default defineConfig({
     // Build the SPA (served by the Python server), then launch the backend
     // against a throwaway copy of test-data/. Override the interpreter with
     // PIXLSTASH_PYTHON if `python` is not the pixlstash venv on your PATH.
-    command: `npm run build && ${process.env.PIXLSTASH_PYTHON || 'python'} e2e/serve_e2e_backend.py`,
+    command: `npm run build && PIXLSTASH_E2E_PORT=${PORT} ${process.env.PIXLSTASH_PYTHON || 'python'} e2e/serve_e2e_backend.py`,
     url: `${BASE_URL}/version`,
     timeout: 180_000,
     // Always boot a fresh backend: the launcher strips users so each run

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -1152,7 +1152,6 @@ import SnapshotsWithDeletedDialog from "../widgets/SnapshotsWithDeletedDialog.vu
 import DeleteForeverDialog from "../widgets/DeleteForeverDialog.vue";
 import { appendShareToken, isReadOnly } from "../../utils/apiClient";
 import {
-  listPicturesByIds,
   getPictureMetadata,
   getThumbnails,
   deletePictures,
@@ -1168,9 +1167,6 @@ import {
   resetPictureDescription,
   clearImpossibleTags,
   restoreImpossibleTags,
-  applyScores,
-  getGuestScores,
-  submitGuestScores,
   startExport,
   getExportStatus,
   downloadExport,
@@ -1199,7 +1195,6 @@ import {
   normalizePluginProgressMessage,
   rangeCovers,
   sleep,
-  toggleScore,
 } from "../../utils/utils.js";
 import {
   dedupeTagList,
@@ -1227,6 +1222,7 @@ import { useMultiSelect } from "../../composables/useMultiSelect.js";
 import { useGridDragDrop } from "../../composables/useGridDragDrop.js";
 import { useStackOrdering } from "../../composables/useStackOrdering.js";
 import { useGridFetch } from "../../composables/useGridFetch.js";
+import { useGridScoring } from "../../composables/useGridScoring.js";
 import { useGridKeyboardNav } from "../../composables/useGridKeyboardNav.js";
 import { debounce } from "lodash-es";
 import { useSelectionStore } from "../../stores/useSelectionStore";
@@ -5073,7 +5069,10 @@ const {
   props,
   emit,
   {
-    invalidateVisibleThumbnailRanges,
+    // useGridScoring is created below this call (it needs the stack helpers
+    // this one returns), so the reference is deferred rather than passed by
+    // value. Same shape either way from the callee's side.
+    invalidateVisibleThumbnailRanges: () => invalidateVisibleThumbnailRanges(),
     updateVisibleThumbnails,
     debouncedFetchAllGridImages,
     fetchThumbnailsForRangeNow,
@@ -5141,6 +5140,50 @@ watch(
   },
   { immediate: true },
 );
+
+const {
+  setScore,
+  setGuestScore,
+  handleGuestConsentAccepted,
+  handleGuestConsentRejected,
+  initGuestSession,
+  isSmartScoreSortActive,
+  getGridSmartScoreValue,
+  invalidateVisibleThumbnailRanges,
+  repositionImageByScore,
+  repositionImageBySmartScore,
+  insertGridImagesById,
+  refreshSmartScoreForImage,
+  applyScore,
+  applyScoresForSelection,
+} = useGridScoring({
+  backendUrl: props.backendUrl,
+  allGridImages,
+  lastFetchedGridImages,
+  loadedRanges,
+  visibleStart,
+  visibleEnd,
+  renderBuffer,
+  imagesLoading,
+  overlayOpen,
+  pendingOverlayGridRefresh,
+  preserveScrollOnNextFetch,
+  skipNextWsRefresh,
+  gridContainer,
+  guestSessionId,
+  guestConsentState,
+  guestScoreMap,
+  guestConsentBannerVisible,
+  pendingGuestScoreIntent,
+  emit,
+  debouncedFetchAllGridImages,
+  fetchImageInfo,
+  rebuildGridImagesFromLastFetch,
+  triggerNewImageHighlight,
+  updateVisibleThumbnails,
+  maybeRefreshOverlayForComfyui,
+  errorDetail,
+});
 
 // ============================================================
 // KEYBOARD NAVIGATION
@@ -5381,646 +5424,6 @@ function closeOverlay() {
     preserveScrollOnNextFetch.value = true;
     debouncedFetchAllGridImages();
   }
-}
-
-// ============================================================
-// SCORING
-// ============================================================
-async function setScore(img, n) {
-  if (isReadOnly.value) {
-    setGuestScore(img, n);
-    return;
-  }
-  const newScore = toggleScore(img.score, n);
-  applyScore(img, newScore);
-}
-
-// ---- Guest scoring helpers ----
-
-function _generateGuestSessionId() {
-  if (typeof crypto !== "undefined" && crypto.randomUUID) {
-    return crypto.randomUUID();
-  }
-  // Fallback for older browsers — use cryptographically secure random bytes
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
-  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant bits
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
-  return [
-    hex.slice(0, 4).join(""),
-    hex.slice(4, 6).join(""),
-    hex.slice(6, 8).join(""),
-    hex.slice(8, 10).join(""),
-    hex.slice(10, 16).join(""),
-  ].join("-");
-}
-
-function _getOrCreateGuestSessionId() {
-  if (guestSessionId.value) return guestSessionId.value;
-  const id = _generateGuestSessionId();
-  guestSessionId.value = id;
-  return id;
-}
-
-async function _submitGuestScores(scores, setCookie) {
-  const sid = _getOrCreateGuestSessionId();
-  const payload = { session_id: sid, set_cookie: setCookie, scores };
-  await submitGuestScores(payload, { baseUrl: props.backendUrl });
-}
-
-function setGuestScore(img, n) {
-  const currentScore = guestScoreMap.value.get(img.id) ?? null;
-  const newScore = toggleScore(currentScore, n);
-
-  if (guestConsentState.value === null) {
-    // Show consent banner; queue the intent
-    pendingGuestScoreIntent.value = { img, newScore };
-    guestConsentBannerVisible.value = true;
-    return;
-  }
-
-  // Optimistic local update
-  const updated = new Map(guestScoreMap.value);
-  updated.set(img.id, newScore);
-  guestScoreMap.value = updated;
-
-  const setCookie = guestConsentState.value === "accepted";
-  _submitGuestScores({ [String(img.id)]: newScore }, setCookie)
-    .then(() => {
-      if (isScoreSortActive()) {
-        debouncedFetchAllGridImages({ force: true });
-      }
-    })
-    .catch((err) => {
-      console.error("Failed to submit guest score:", err);
-    });
-}
-
-async function handleGuestConsentAccepted() {
-  guestConsentState.value = "accepted";
-  guestConsentBannerVisible.value = false;
-  // Do not persist the guest session identifier in localStorage.
-  // The server-managed HttpOnly cookie handles durable session continuity;
-  // keeping the session_id only in memory is sufficient for the current visit.
-  const intent = pendingGuestScoreIntent.value;
-  pendingGuestScoreIntent.value = null;
-  if (intent) {
-    const updated = new Map(guestScoreMap.value);
-    updated.set(intent.img.id, intent.newScore);
-    guestScoreMap.value = updated;
-    await _submitGuestScores({ [String(intent.img.id)]: intent.newScore }, true)
-      .then(() => {
-        if (isScoreSortActive()) debouncedFetchAllGridImages({ force: true });
-      })
-      .catch((err) => console.error("Failed to submit guest score:", err));
-  }
-}
-
-function handleGuestConsentRejected() {
-  guestConsentState.value = "rejected";
-  guestConsentBannerVisible.value = false;
-  // Do NOT persist the session ID anywhere — if the user reloads they get a
-  // brand-new session with no connection to these scores.
-  const intent = pendingGuestScoreIntent.value;
-  pendingGuestScoreIntent.value = null;
-  if (intent) {
-    const updated = new Map(guestScoreMap.value);
-    updated.set(intent.img.id, intent.newScore);
-    guestScoreMap.value = updated;
-    _submitGuestScores({ [String(intent.img.id)]: intent.newScore }, false)
-      .then(() => {
-        if (isScoreSortActive()) debouncedFetchAllGridImages({ force: true });
-      })
-      .catch((err) => console.error("Failed to submit guest score:", err));
-  }
-}
-
-async function fetchGuestScores() {
-  // Kept only as a fallback / explicit refresh. The main listing
-  // (GET /pictures) now overlays guest scores onto img.score server-side.
-  try {
-    const resp = await getGuestScores({ baseUrl: props.backendUrl });
-    const scores = resp?.scores ?? {};
-    const map = new Map();
-    for (const [k, v] of Object.entries(scores)) {
-      map.set(Number(k), v);
-    }
-    guestScoreMap.value = map;
-  } catch (err) {
-    console.error("[guest-scores] Failed to fetch guest scores:", err);
-  }
-}
-
-function initGuestSession() {
-  const readOnly = isReadOnly.value;
-  const cookies = document.cookie;
-  const ls = localStorage.getItem("guest_session_id");
-  if (!readOnly) return;
-  // A non-HttpOnly sentinel cookie is set alongside the HttpOnly guest_session
-  // cookie when the user accepted persistent storage.
-  const hasCookieConsent = cookies
-    .split(";")
-    .some((c) => c.trim().startsWith("guest_session_active=1"));
-  if (hasCookieConsent) {
-    guestConsentState.value = "accepted";
-    // Restore the session ID from localStorage so POST bodies stay in sync
-    // with the HttpOnly cookie the server already knows about.
-    if (ls) {
-      guestSessionId.value = ls;
-    }
-    // Scores are now overlaid by the backend in GET /pictures, so
-    // fetchAllGridImages() will include them in img.score directly.
-    // fetchGuestScores() is only needed to pre-populate guestScoreMap
-    // for optimistic-update display before the grid loads.
-    fetchGuestScores();
-    return;
-  }
-  // No cookie consent — fresh start.  The banner will appear on first score.
-  // (Rejected users are intentionally not remembered across page loads.)
-}
-
-function isScoreSortActive() {
-  return typeof sortStore.selectedSort === "string"
-    ? sortStore.selectedSort.toUpperCase() === "SCORE"
-    : false;
-}
-
-function isCharacterLikenessSortActive() {
-  return typeof sortStore.selectedSort === "string"
-    ? sortStore.selectedSort.toUpperCase() === "CHARACTER_LIKENESS"
-    : false;
-}
-
-function isSmartScoreSortActive() {
-  return typeof sortStore.selectedSort === "string"
-    ? sortStore.selectedSort.toUpperCase().includes("SMART_SCORE")
-    : false;
-}
-
-// Single source of truth for grid sort direction. ALL client-side ordering —
-// score/smart-score repositions, the apply-scores re-sort, and incremental
-// inserts — must use the SAME rule, or a card lands in a different spot than the
-// array it is spliced into. Nullish selectedDescending → ascending (the store
-// defaults it to a real `true`). Keep this as one computed: a lone inlined
-// `!== false` previously drifted here and mispositioned inserted cards.
-const gridSortDescending = computed(
-  () => sortStore.selectedDescending === true,
-);
-
-function getGridSmartScoreValue(img) {
-  if (!img) return null;
-  const raw =
-    typeof img.smartScore === "number"
-      ? img.smartScore
-      : typeof img.smart_score === "number"
-        ? img.smart_score
-        : null;
-  return Number.isFinite(raw) ? raw : null;
-}
-
-// The ONE null-ordering rule shared by every client-side smart-score sort path
-// (fresh insert AND reposition). SQLite ranks NULL below every real value, and
-// the backend sorts the smart_score column with a plain .asc()/.desc() and no
-// NULLS clause (pixlstash/db_models/picture.py), so NULLs sort FIRST on ascending
-// and LAST on descending. Map a null/absent score to -Infinity so the shared
-// comparator (which flips on `descending`) lands a null-scored card exactly where
-// the server put it, in BOTH directions. A 0 sentinel is wrong: it collides with
-// a genuine zero and, now that smart scores can be negative and null (tag edits
-// invalidate them), it mis-orders nulls relative to real scores. Route EVERY path
-// through this helper — never an inline ternary or `?? 0` — so the insert and
-// reposition paths cannot drift (the failure the gridSortDescending comment warns
-// of). This is only an ordering key; it must never be written back as a card's
-// displayed smart score, or a null-scored card would render a fake 0.
-function smartScoreSortKey(smartScore) {
-  return Number.isFinite(smartScore) ? smartScore : -Infinity;
-}
-
-function invalidateVisibleThumbnailRanges() {
-  const start = Math.max(0, visibleStart.value - renderBuffer.value);
-  const end = Math.min(
-    allGridImages.value.length,
-    visibleEnd.value + renderBuffer.value,
-  );
-  loadedRanges.value = loadedRanges.value.filter(
-    ([rangeStart, rangeEnd]) => rangeEnd <= start || rangeStart >= end,
-  );
-  updateVisibleThumbnails();
-}
-
-function _spliceAndReinsert(
-  items,
-  currentIndex,
-  target,
-  targetScore,
-  getScore,
-  descending,
-) {
-  items.splice(currentIndex, 1);
-  let insertIndex = items.findIndex((item) => {
-    const score = getScore(item);
-    return descending ? score < targetScore : score > targetScore;
-  });
-  if (insertIndex === -1) insertIndex = items.length;
-  if (insertIndex === currentIndex) {
-    const updated = allGridImages.value.slice();
-    updated[currentIndex] = { ...target, idx: currentIndex };
-    allGridImages.value = updated;
-    // Still invalidate: we are only here because the card's score changed, and the
-    // batch-sourced fields that change with it (penalised_tags — the problem
-    // indicator — plus faces/detections) are refreshed ONLY by a thumbnail batch.
-    // Without this, loadedRanges still covers the window, updateVisibleThumbnails
-    // no-ops, and a card whose position happens not to move keeps its stale
-    // indicator. Adding a penalised tag to an already low-scoring card lands
-    // exactly here, since it is already at the bottom of a descending sort.
-    invalidateVisibleThumbnailRanges();
-    return null;
-  }
-  items.splice(insertIndex, 0, target);
-  for (let i = 0; i < items.length; i += 1) {
-    items[i].idx = i;
-  }
-  allGridImages.value = items;
-  invalidateVisibleThumbnailRanges();
-  return insertIndex;
-}
-
-function repositionImageByScore(imageId, newScore) {
-  const items = allGridImages.value.slice();
-  const dId = getPictureId(imageId);
-  const currentIndex = items.findIndex(
-    (item) => getPictureId(item?.id) === dId,
-  );
-  if (currentIndex === -1) return;
-
-  const target = items[currentIndex];
-  target.score = newScore;
-  const targetScore = newScore ?? 0;
-  const descending = gridSortDescending.value;
-  const insertIndex = _spliceAndReinsert(
-    items,
-    currentIndex,
-    target,
-    targetScore,
-    (item) => item.score ?? 0,
-    descending,
-  );
-  if (insertIndex !== null) {
-    nextTick(() => {
-      const grid = gridContainer.value;
-      if (!grid) return;
-      const card = grid.querySelectorAll(".image-card")[insertIndex];
-      if (card && card.scrollIntoView) {
-        card.scrollIntoView({ behavior: "smooth", block: "center" });
-      }
-    });
-  }
-}
-
-let smartScoreRepositioning = false;
-
-function repositionImageBySmartScore(imageId, smartScore, latestInfo = null) {
-  if (smartScoreRepositioning) return;
-  smartScoreRepositioning = true;
-  try {
-    const items = allGridImages.value.slice();
-    const currentIndex = items.findIndex((item) => item.id === imageId);
-    if (currentIndex === -1) return;
-
-    // Keep the ordering key separate from the displayed value. The card must
-    // store the TRUE smart score (a real number or null → "no score"); only the
-    // sort key collapses null to the SQLite sentinel via smartScoreSortKey.
-    // Writing the sentinel onto `smartScore` would make a null-scored card render
-    // a fake 0.
-    const normalisedScore = Number.isFinite(smartScore) ? smartScore : null;
-    const targetKey = smartScoreSortKey(normalisedScore);
-    // Write the TRUE score to BOTH the camelCase and snake_case keys.
-    // getGridSmartScoreValue reads `smartScore` then falls back to `smart_score`
-    // (grid cards / metadata responses carry both), so setting only one key would
-    // let a stale value leak through the fallback and render a wrong (or fake 0)
-    // score. Both must hold the normalised value — null for "no score".
-    const target = {
-      ...items[currentIndex],
-      ...(latestInfo && typeof latestInfo === "object" ? latestInfo : {}),
-      smartScore: normalisedScore,
-      smart_score: normalisedScore,
-      thumbnail:
-        items[currentIndex]?.thumbnail ?? latestInfo?.thumbnail ?? null,
-    };
-    const descending = gridSortDescending.value;
-    _spliceAndReinsert(
-      items,
-      currentIndex,
-      target,
-      targetKey,
-      (item) => smartScoreSortKey(getGridSmartScoreValue(item)),
-      descending,
-    );
-  } finally {
-    smartScoreRepositioning = false;
-  }
-}
-
-// Numeric sort key for a freshly-fetched grid item under the active sort,
-// mirroring the fields the grid already displays/sorts on (see
-// getCompactGroupLabel / sort-overlay logic). Returns a finite number used to
-// find the insert index; `id` is the implicit tiebreaker.
-function gridImageSortKey(img) {
-  const sort =
-    typeof sortStore.selectedSort === "string" ? sortStore.selectedSort : "";
-  if (sort === "IMPORTED_AT" && img?.imported_at) {
-    return Date.parse(img.imported_at) || 0;
-  }
-  if (sort.includes("DATE") && img?.created_at) {
-    return Date.parse(img.created_at) || 0;
-  }
-  if (sort.includes("SMART_SCORE")) {
-    // Match the server's ORDER BY exactly via the shared null rule (see
-    // smartScoreSortKey). The reposition path uses the same helper, so the two
-    // ordering paths cannot drift.
-    return smartScoreSortKey(getGridSmartScoreValue(img));
-  }
-  if (
-    sort.includes("CHARACTER_LIKENESS") &&
-    typeof img?.character_likeness === "number"
-  ) {
-    return img.character_likeness;
-  }
-  if (sort === "TEXT_CONTENT" && typeof img?.text_score === "number") {
-    return img.text_score;
-  }
-  if (typeof img?.score === "number") return img.score;
-  // Unknown / id-ordered sort → fall back to the picture id.
-  return Number(getPictureId(img?.id)) || 0;
-}
-
-// Insert newly-added pictures into the grid at their sorted position without a
-// full reload. Always mutates lastFetchedGridImages then rebuilds, because the
-// v-for key embeds img.idx — splicing allGridImages directly would corrupt the
-// virtual-scroll window. Deferred to the pill while a streaming fetch is in
-// flight (that fetch writes allGridImages wholesale from a sized placeholder).
-// `options.highlight` (default true) drives the new-picture flash. A scrapheap
-// comeback passes false: the flash means "this was not here before", which is
-// the wrong story for a picture the user just undid the removal of.
-async function insertGridImagesById(ids, options = {}) {
-  const highlight = options?.highlight !== false;
-  const wanted = (Array.isArray(ids) ? ids : [])
-    .map((id) => getPictureId(id))
-    .filter((id) => id !== null);
-  if (!wanted.length) return;
-
-  // Character-likeness sort can't be positioned incrementally. The likeness
-  // value is computed by a backend SQL function relative to the currently
-  // selected similarity character (find_pictures_by_character_likeness_sql),
-  // not stored on the picture, so it is NOT in the `fields=grid` projection
-  // (the backend has no character context to compute it there). gridImageSortKey
-  // therefore falls through to `score` and would splice the card at the wrong
-  // position. Fall back to a full refetch, which DOES recompute likeness — or,
-  // under an open overlay, defer it (the overlay-open deferral contract, §9.1)
-  // so we never restructure the filmstrip mid-view.
-  if (isCharacterLikenessSortActive()) {
-    if (overlayOpen.value) {
-      pendingOverlayGridRefresh.value = true;
-      return;
-    }
-    preserveScrollOnNextFetch.value = true;
-    debouncedFetchAllGridImages();
-    return;
-  }
-
-  if (imagesLoading.value) {
-    // A streaming fetch owns allGridImages wholesale; inserting now would be
-    // clobbered. The caller (useGridRealtimeSync) routes these to the pill
-    // instead while loading, so just bail.
-    console.warn(
-      "insertGridImagesById: skipped during in-flight grid fetch",
-      wanted,
-    );
-    return;
-  }
-
-  const existing = new Set(
-    (Array.isArray(lastFetchedGridImages.value)
-      ? lastFetchedGridImages.value
-      : []
-    ).map((img) => getPictureId(img?.id)),
-  );
-  const toFetch = wanted.filter((id) => !existing.has(id));
-  if (!toFetch.length) return;
-
-  let fetched;
-  try {
-    const rows = await listPicturesByIds(toFetch, {
-      fields: "grid",
-      baseUrl: props.backendUrl,
-    });
-    fetched = Array.isArray(rows) ? rows : [];
-  } catch (e) {
-    console.error("insertGridImagesById: grid metadata fetch failed", {
-      ids: toFetch,
-      error: e,
-    });
-    return;
-  }
-  if (!fetched.length) return;
-
-  const descending = gridSortDescending.value;
-  const base = Array.isArray(lastFetchedGridImages.value)
-    ? lastFetchedGridImages.value.slice()
-    : [];
-  const inserted = [];
-  for (const pic of fetched) {
-    const picId = getPictureId(pic?.id);
-    if (picId === null || base.some((img) => getPictureId(img?.id) === picId)) {
-      continue;
-    }
-    const key = gridImageSortKey(pic);
-    let insertIndex = base.findIndex((img) => {
-      const otherKey = gridImageSortKey(img);
-      return descending ? otherKey < key : otherKey > key;
-    });
-    if (insertIndex === -1) insertIndex = base.length;
-    base.splice(insertIndex, 0, pic);
-    inserted.push(picId);
-  }
-  if (!inserted.length) return;
-
-  lastFetchedGridImages.value = base;
-  rebuildGridImagesFromLastFetch();
-  if (highlight) triggerNewImageHighlight(inserted);
-
-  // An in-app ComfyUI result lands here (origin-aware WS picture_imported insert).
-  // If the overlay is open with a pending comfyui refresh, reconcile it now that
-  // the new stacked output is present in lastFetchedGridImages — this is the i2i/
-  // upscale lightbox case that previously relied on the full-grid refetch.
-  void maybeRefreshOverlayForComfyui();
-}
-
-async function refreshSmartScoreForImage(imageId) {
-  if (!imageId || !isSmartScoreSortActive()) return;
-  const latestInfo = await fetchImageInfo(imageId, { smartScore: true });
-  if (!latestInfo || Array.isArray(latestInfo)) return;
-
-  const idx = allGridImages.value.findIndex((img) => img?.id === imageId);
-  if (idx !== -1) {
-    const current = allGridImages.value[idx] || {};
-    const smartScore =
-      typeof latestInfo.smartScore === "number" ? latestInfo.smartScore : null;
-    if (current.smartScore === smartScore) {
-      return;
-    }
-    await nextTick();
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-    // Pass the TRUE smart score (number or null). repositionImageBySmartScore
-    // derives its ordering key from the null rule and preserves null as the
-    // card's displayed value — collapsing to 0 here would both mis-order the
-    // card and show a fake 0.
-    repositionImageBySmartScore(imageId, smartScore, latestInfo);
-  }
-}
-
-async function applyScoresByEntries(entries, options = {}) {
-  const { updateSort = true, emitRefreshSidebar = true } = options;
-  if (!Array.isArray(entries) || !entries.length) return;
-
-  // Score updates are applied locally below (including score-sort reordering),
-  // so the immediate WS gridVersion refresh would be redundant and can clear
-  // current multi-selection in some paths. Skip that next WS refresh.
-  skipNextWsRefresh.value = true;
-
-  const scoresPayload = {};
-  for (const [id, score] of entries) {
-    scoresPayload[String(id)] = Number(score);
-  }
-
-  await applyScores(scoresPayload, { baseUrl: props.backendUrl });
-
-  const scoreMap = new Map(
-    entries.map(([id, score]) => [String(id), Number(score)]),
-  );
-
-  let updatedImages = allGridImages.value.map((img) => {
-    if (!img || img.id == null) return img;
-    const key = String(img.id);
-    if (!scoreMap.has(key)) return img;
-    return { ...img, score: scoreMap.get(key) };
-  });
-
-  if (updateSort && isScoreSortActive()) {
-    const descending = gridSortDescending.value;
-    updatedImages = updatedImages
-      .slice()
-      .sort((a, b) => {
-        const aScore = a?.score ?? 0;
-        const bScore = b?.score ?? 0;
-        if (aScore === bScore) {
-          const aIdx = a?.idx ?? 0;
-          const bIdx = b?.idx ?? 0;
-          return aIdx - bIdx;
-        }
-        return descending ? bScore - aScore : aScore - bScore;
-      })
-      .map((img, idx) => (img ? { ...img, idx } : img));
-    allGridImages.value = updatedImages;
-    invalidateVisibleThumbnailRanges();
-  } else {
-    allGridImages.value = updatedImages;
-  }
-
-  if (updateSort && isCharacterLikenessSortActive()) {
-    preserveScrollOnNextFetch.value = true;
-    debouncedFetchAllGridImages();
-  }
-
-  if (updateSort && isSmartScoreSortActive()) {
-    preserveScrollOnNextFetch.value = true;
-    debouncedFetchAllGridImages();
-  }
-
-  if (emitRefreshSidebar) {
-    emit("refresh-sidebar");
-  }
-}
-
-async function applyScore(img, newScore) {
-  const imageId = img?.id;
-  if (!imageId) {
-    noticeStore.error("Couldn't set that score — the picture id is missing.", {
-      key: "score-missing-id",
-    });
-    return;
-  }
-  try {
-    // Suppress the WS-driven gridVersion reload that the score apply triggers;
-    // the score update is already applied locally by applyScoresByEntries.
-    skipNextWsRefresh.value = true;
-    await applyScoresByEntries([[String(imageId), newScore]], {
-      updateSort: false,
-      emitRefreshSidebar: false,
-    });
-
-    if (isScoreSortActive()) {
-      if (overlayOpen.value) {
-        // Reordering the grid while the overlay is open would break the
-        // filmstrip. Defer the reposition until the overlay closes.
-        pendingOverlayGridRefresh.value = true;
-      } else {
-        repositionImageByScore(imageId, newScore);
-      }
-    }
-    if (isCharacterLikenessSortActive()) {
-      if (overlayOpen.value) {
-        pendingOverlayGridRefresh.value = true;
-        return;
-      }
-      preserveScrollOnNextFetch.value = true;
-      debouncedFetchAllGridImages();
-      return;
-    }
-    if (isSmartScoreSortActive()) {
-      if (overlayOpen.value) {
-        pendingOverlayGridRefresh.value = true;
-        return;
-      }
-      preserveScrollOnNextFetch.value = true;
-      debouncedFetchAllGridImages();
-      return;
-    }
-  } catch (e) {
-    console.error("Failed to set score", e);
-    noticeStore.error(`Couldn't set that score. ${errorDetail(e)}`, {
-      key: "score-set",
-    });
-  }
-}
-
-async function applyScoresForSelection(imageIds, targetScore) {
-  const ids = Array.isArray(imageIds) ? imageIds.filter(Boolean) : [];
-  if (!ids.length) return;
-  if (!Number.isFinite(targetScore)) return;
-
-  const gridById = new Map(
-    allGridImages.value
-      .filter((img) => img && img.id != null)
-      .map((img) => [String(img.id), img]),
-  );
-
-  const entries = [];
-  for (const id of ids) {
-    const key = String(id);
-    const img = gridById.get(key);
-    if (!img) continue;
-    const current = Number(img.score || 0);
-    const nextScore = toggleScore(current, targetScore);
-    entries.push([key, nextScore]);
-  }
-
-  if (!entries.length) return;
-
-  await applyScoresByEntries(entries, {
-    updateSort: true,
-    emitRefreshSidebar: true,
-  });
 }
 
 // ============================================================

--- a/frontend/src/composables/useGridScoring.js
+++ b/frontend/src/composables/useGridScoring.js
@@ -1,0 +1,733 @@
+import { computed, nextTick } from "vue";
+import { isReadOnly } from "../utils/apiClient";
+import {
+  applyScores,
+  getGuestScores,
+  listPicturesByIds,
+  submitGuestScores,
+} from "../api/pictures";
+import { getPictureId } from "../utils/media.js";
+import { toggleScore } from "../utils/utils.js";
+import { useSortStore } from "../stores/useSortStore";
+import { useNoticeStore } from "../stores/useNoticeStore";
+
+/**
+ * Scoring, and everything the grid has to do about it.
+ *
+ * Setting a score is only half the job: when the grid is sorted by score or by
+ * smart score, the picture that just changed is in the wrong row, so these
+ * functions also move it - splicing it to its new position rather than
+ * refetching, which is what keeps a rating pass from flickering.
+ *
+ * Read-only sessions score into a guest session instead, held server-side
+ * against a generated id, so a visitor can rate without an account.
+ *
+ * @param {Object} deps - Grid state and callbacks, same shape as useGridFetch's.
+ */
+export function useGridScoring({
+  backendUrl,
+  allGridImages,
+  lastFetchedGridImages,
+  loadedRanges,
+  visibleStart,
+  visibleEnd,
+  renderBuffer,
+  imagesLoading,
+  overlayOpen,
+  pendingOverlayGridRefresh,
+  preserveScrollOnNextFetch,
+  skipNextWsRefresh,
+  gridContainer,
+  guestSessionId,
+  guestConsentState,
+  guestScoreMap,
+  guestConsentBannerVisible,
+  pendingGuestScoreIntent,
+  emit,
+  debouncedFetchAllGridImages,
+  fetchImageInfo,
+  rebuildGridImagesFromLastFetch,
+  triggerNewImageHighlight,
+  updateVisibleThumbnails,
+  maybeRefreshOverlayForComfyui,
+  errorDetail,
+}) {
+  const sortStore = useSortStore();
+  const noticeStore = useNoticeStore();
+
+  // SCORING
+  // ============================================================
+  async function setScore(img, n) {
+    if (isReadOnly.value) {
+      setGuestScore(img, n);
+      return;
+    }
+    const newScore = toggleScore(img.score, n);
+    applyScore(img, newScore);
+  }
+
+  // ---- Guest scoring helpers ----
+
+  function _generateGuestSessionId() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    // Fallback for older browsers — use cryptographically secure random bytes
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant bits
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
+    return [
+      hex.slice(0, 4).join(""),
+      hex.slice(4, 6).join(""),
+      hex.slice(6, 8).join(""),
+      hex.slice(8, 10).join(""),
+      hex.slice(10, 16).join(""),
+    ].join("-");
+  }
+
+  function _getOrCreateGuestSessionId() {
+    if (guestSessionId.value) return guestSessionId.value;
+    const id = _generateGuestSessionId();
+    guestSessionId.value = id;
+    return id;
+  }
+
+  async function _submitGuestScores(scores, setCookie) {
+    const sid = _getOrCreateGuestSessionId();
+    const payload = { session_id: sid, set_cookie: setCookie, scores };
+    await submitGuestScores(payload, { baseUrl: backendUrl });
+  }
+
+  function setGuestScore(img, n) {
+    const currentScore = guestScoreMap.value.get(img.id) ?? null;
+    const newScore = toggleScore(currentScore, n);
+
+    if (guestConsentState.value === null) {
+      // Show consent banner; queue the intent
+      pendingGuestScoreIntent.value = { img, newScore };
+      guestConsentBannerVisible.value = true;
+      return;
+    }
+
+    // Optimistic local update
+    const updated = new Map(guestScoreMap.value);
+    updated.set(img.id, newScore);
+    guestScoreMap.value = updated;
+
+    const setCookie = guestConsentState.value === "accepted";
+    _submitGuestScores({ [String(img.id)]: newScore }, setCookie)
+      .then(() => {
+        if (isScoreSortActive()) {
+          debouncedFetchAllGridImages({ force: true });
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to submit guest score:", err);
+      });
+  }
+
+  async function handleGuestConsentAccepted() {
+    guestConsentState.value = "accepted";
+    guestConsentBannerVisible.value = false;
+    // Do not persist the guest session identifier in localStorage.
+    // The server-managed HttpOnly cookie handles durable session continuity;
+    // keeping the session_id only in memory is sufficient for the current visit.
+    const intent = pendingGuestScoreIntent.value;
+    pendingGuestScoreIntent.value = null;
+    if (intent) {
+      const updated = new Map(guestScoreMap.value);
+      updated.set(intent.img.id, intent.newScore);
+      guestScoreMap.value = updated;
+      await _submitGuestScores(
+        { [String(intent.img.id)]: intent.newScore },
+        true,
+      )
+        .then(() => {
+          if (isScoreSortActive()) debouncedFetchAllGridImages({ force: true });
+        })
+        .catch((err) => console.error("Failed to submit guest score:", err));
+    }
+  }
+
+  function handleGuestConsentRejected() {
+    guestConsentState.value = "rejected";
+    guestConsentBannerVisible.value = false;
+    // Do NOT persist the session ID anywhere — if the user reloads they get a
+    // brand-new session with no connection to these scores.
+    const intent = pendingGuestScoreIntent.value;
+    pendingGuestScoreIntent.value = null;
+    if (intent) {
+      const updated = new Map(guestScoreMap.value);
+      updated.set(intent.img.id, intent.newScore);
+      guestScoreMap.value = updated;
+      _submitGuestScores({ [String(intent.img.id)]: intent.newScore }, false)
+        .then(() => {
+          if (isScoreSortActive()) debouncedFetchAllGridImages({ force: true });
+        })
+        .catch((err) => console.error("Failed to submit guest score:", err));
+    }
+  }
+
+  async function fetchGuestScores() {
+    // Kept only as a fallback / explicit refresh. The main listing
+    // (GET /pictures) now overlays guest scores onto img.score server-side.
+    try {
+      const resp = await getGuestScores({ baseUrl: backendUrl });
+      const scores = resp?.scores ?? {};
+      const map = new Map();
+      for (const [k, v] of Object.entries(scores)) {
+        map.set(Number(k), v);
+      }
+      guestScoreMap.value = map;
+    } catch (err) {
+      console.error("[guest-scores] Failed to fetch guest scores:", err);
+    }
+  }
+
+  function initGuestSession() {
+    const readOnly = isReadOnly.value;
+    const cookies = document.cookie;
+    const ls = localStorage.getItem("guest_session_id");
+    if (!readOnly) return;
+    // A non-HttpOnly sentinel cookie is set alongside the HttpOnly guest_session
+    // cookie when the user accepted persistent storage.
+    const hasCookieConsent = cookies
+      .split(";")
+      .some((c) => c.trim().startsWith("guest_session_active=1"));
+    if (hasCookieConsent) {
+      guestConsentState.value = "accepted";
+      // Restore the session ID from localStorage so POST bodies stay in sync
+      // with the HttpOnly cookie the server already knows about.
+      if (ls) {
+        guestSessionId.value = ls;
+      }
+      // Scores are now overlaid by the backend in GET /pictures, so
+      // fetchAllGridImages() will include them in img.score directly.
+      // fetchGuestScores() is only needed to pre-populate guestScoreMap
+      // for optimistic-update display before the grid loads.
+      fetchGuestScores();
+      return;
+    }
+    // No cookie consent — fresh start.  The banner will appear on first score.
+    // (Rejected users are intentionally not remembered across page loads.)
+  }
+
+  function isScoreSortActive() {
+    return typeof sortStore.selectedSort === "string"
+      ? sortStore.selectedSort.toUpperCase() === "SCORE"
+      : false;
+  }
+
+  function isCharacterLikenessSortActive() {
+    return typeof sortStore.selectedSort === "string"
+      ? sortStore.selectedSort.toUpperCase() === "CHARACTER_LIKENESS"
+      : false;
+  }
+
+  function isSmartScoreSortActive() {
+    return typeof sortStore.selectedSort === "string"
+      ? sortStore.selectedSort.toUpperCase().includes("SMART_SCORE")
+      : false;
+  }
+
+  // Single source of truth for grid sort direction. ALL client-side ordering —
+  // score/smart-score repositions, the apply-scores re-sort, and incremental
+  // inserts — must use the SAME rule, or a card lands in a different spot than the
+  // array it is spliced into. Nullish selectedDescending → ascending (the store
+  // defaults it to a real `true`). Keep this as one computed: a lone inlined
+  // `!== false` previously drifted here and mispositioned inserted cards.
+  const gridSortDescending = computed(
+    () => sortStore.selectedDescending === true,
+  );
+
+  function getGridSmartScoreValue(img) {
+    if (!img) return null;
+    const raw =
+      typeof img.smartScore === "number"
+        ? img.smartScore
+        : typeof img.smart_score === "number"
+          ? img.smart_score
+          : null;
+    return Number.isFinite(raw) ? raw : null;
+  }
+
+  // The ONE null-ordering rule shared by every client-side smart-score sort path
+  // (fresh insert AND reposition). SQLite ranks NULL below every real value, and
+  // the backend sorts the smart_score column with a plain .asc()/.desc() and no
+  // NULLS clause (pixlstash/db_models/picture.py), so NULLs sort FIRST on ascending
+  // and LAST on descending. Map a null/absent score to -Infinity so the shared
+  // comparator (which flips on `descending`) lands a null-scored card exactly where
+  // the server put it, in BOTH directions. A 0 sentinel is wrong: it collides with
+  // a genuine zero and, now that smart scores can be negative and null (tag edits
+  // invalidate them), it mis-orders nulls relative to real scores. Route EVERY path
+  // through this helper — never an inline ternary or `?? 0` — so the insert and
+  // reposition paths cannot drift (the failure the gridSortDescending comment warns
+  // of). This is only an ordering key; it must never be written back as a card's
+  // displayed smart score, or a null-scored card would render a fake 0.
+  function smartScoreSortKey(smartScore) {
+    return Number.isFinite(smartScore) ? smartScore : -Infinity;
+  }
+
+  function invalidateVisibleThumbnailRanges() {
+    const start = Math.max(0, visibleStart.value - renderBuffer.value);
+    const end = Math.min(
+      allGridImages.value.length,
+      visibleEnd.value + renderBuffer.value,
+    );
+    loadedRanges.value = loadedRanges.value.filter(
+      ([rangeStart, rangeEnd]) => rangeEnd <= start || rangeStart >= end,
+    );
+    updateVisibleThumbnails();
+  }
+
+  function _spliceAndReinsert(
+    items,
+    currentIndex,
+    target,
+    targetScore,
+    getScore,
+    descending,
+  ) {
+    items.splice(currentIndex, 1);
+    let insertIndex = items.findIndex((item) => {
+      const score = getScore(item);
+      return descending ? score < targetScore : score > targetScore;
+    });
+    if (insertIndex === -1) insertIndex = items.length;
+    if (insertIndex === currentIndex) {
+      const updated = allGridImages.value.slice();
+      updated[currentIndex] = { ...target, idx: currentIndex };
+      allGridImages.value = updated;
+      // Still invalidate: we are only here because the card's score changed, and the
+      // batch-sourced fields that change with it (penalised_tags — the problem
+      // indicator — plus faces/detections) are refreshed ONLY by a thumbnail batch.
+      // Without this, loadedRanges still covers the window, updateVisibleThumbnails
+      // no-ops, and a card whose position happens not to move keeps its stale
+      // indicator. Adding a penalised tag to an already low-scoring card lands
+      // exactly here, since it is already at the bottom of a descending sort.
+      invalidateVisibleThumbnailRanges();
+      return null;
+    }
+    items.splice(insertIndex, 0, target);
+    for (let i = 0; i < items.length; i += 1) {
+      items[i].idx = i;
+    }
+    allGridImages.value = items;
+    invalidateVisibleThumbnailRanges();
+    return insertIndex;
+  }
+
+  function repositionImageByScore(imageId, newScore) {
+    const items = allGridImages.value.slice();
+    const dId = getPictureId(imageId);
+    const currentIndex = items.findIndex(
+      (item) => getPictureId(item?.id) === dId,
+    );
+    if (currentIndex === -1) return;
+
+    const target = items[currentIndex];
+    target.score = newScore;
+    const targetScore = newScore ?? 0;
+    const descending = gridSortDescending.value;
+    const insertIndex = _spliceAndReinsert(
+      items,
+      currentIndex,
+      target,
+      targetScore,
+      (item) => item.score ?? 0,
+      descending,
+    );
+    if (insertIndex !== null) {
+      nextTick(() => {
+        const grid = gridContainer.value;
+        if (!grid) return;
+        const card = grid.querySelectorAll(".image-card")[insertIndex];
+        if (card && card.scrollIntoView) {
+          card.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      });
+    }
+  }
+
+  let smartScoreRepositioning = false;
+
+  function repositionImageBySmartScore(imageId, smartScore, latestInfo = null) {
+    if (smartScoreRepositioning) return;
+    smartScoreRepositioning = true;
+    try {
+      const items = allGridImages.value.slice();
+      const currentIndex = items.findIndex((item) => item.id === imageId);
+      if (currentIndex === -1) return;
+
+      // Keep the ordering key separate from the displayed value. The card must
+      // store the TRUE smart score (a real number or null → "no score"); only the
+      // sort key collapses null to the SQLite sentinel via smartScoreSortKey.
+      // Writing the sentinel onto `smartScore` would make a null-scored card render
+      // a fake 0.
+      const normalisedScore = Number.isFinite(smartScore) ? smartScore : null;
+      const targetKey = smartScoreSortKey(normalisedScore);
+      // Write the TRUE score to BOTH the camelCase and snake_case keys.
+      // getGridSmartScoreValue reads `smartScore` then falls back to `smart_score`
+      // (grid cards / metadata responses carry both), so setting only one key would
+      // let a stale value leak through the fallback and render a wrong (or fake 0)
+      // score. Both must hold the normalised value — null for "no score".
+      const target = {
+        ...items[currentIndex],
+        ...(latestInfo && typeof latestInfo === "object" ? latestInfo : {}),
+        smartScore: normalisedScore,
+        smart_score: normalisedScore,
+        thumbnail:
+          items[currentIndex]?.thumbnail ?? latestInfo?.thumbnail ?? null,
+      };
+      const descending = gridSortDescending.value;
+      _spliceAndReinsert(
+        items,
+        currentIndex,
+        target,
+        targetKey,
+        (item) => smartScoreSortKey(getGridSmartScoreValue(item)),
+        descending,
+      );
+    } finally {
+      smartScoreRepositioning = false;
+    }
+  }
+
+  // Numeric sort key for a freshly-fetched grid item under the active sort,
+  // mirroring the fields the grid already displays/sorts on (see
+  // getCompactGroupLabel / sort-overlay logic). Returns a finite number used to
+  // find the insert index; `id` is the implicit tiebreaker.
+  function gridImageSortKey(img) {
+    const sort =
+      typeof sortStore.selectedSort === "string" ? sortStore.selectedSort : "";
+    if (sort === "IMPORTED_AT" && img?.imported_at) {
+      return Date.parse(img.imported_at) || 0;
+    }
+    if (sort.includes("DATE") && img?.created_at) {
+      return Date.parse(img.created_at) || 0;
+    }
+    if (sort.includes("SMART_SCORE")) {
+      // Match the server's ORDER BY exactly via the shared null rule (see
+      // smartScoreSortKey). The reposition path uses the same helper, so the two
+      // ordering paths cannot drift.
+      return smartScoreSortKey(getGridSmartScoreValue(img));
+    }
+    if (
+      sort.includes("CHARACTER_LIKENESS") &&
+      typeof img?.character_likeness === "number"
+    ) {
+      return img.character_likeness;
+    }
+    if (sort === "TEXT_CONTENT" && typeof img?.text_score === "number") {
+      return img.text_score;
+    }
+    if (typeof img?.score === "number") return img.score;
+    // Unknown / id-ordered sort → fall back to the picture id.
+    return Number(getPictureId(img?.id)) || 0;
+  }
+
+  // Insert newly-added pictures into the grid at their sorted position without a
+  // full reload. Always mutates lastFetchedGridImages then rebuilds, because the
+  // v-for key embeds img.idx — splicing allGridImages directly would corrupt the
+  // virtual-scroll window. Deferred to the pill while a streaming fetch is in
+  // flight (that fetch writes allGridImages wholesale from a sized placeholder).
+  // `options.highlight` (default true) drives the new-picture flash. A scrapheap
+  // comeback passes false: the flash means "this was not here before", which is
+  // the wrong story for a picture the user just undid the removal of.
+  async function insertGridImagesById(ids, options = {}) {
+    const highlight = options?.highlight !== false;
+    const wanted = (Array.isArray(ids) ? ids : [])
+      .map((id) => getPictureId(id))
+      .filter((id) => id !== null);
+    if (!wanted.length) return;
+
+    // Character-likeness sort can't be positioned incrementally. The likeness
+    // value is computed by a backend SQL function relative to the currently
+    // selected similarity character (find_pictures_by_character_likeness_sql),
+    // not stored on the picture, so it is NOT in the `fields=grid` projection
+    // (the backend has no character context to compute it there). gridImageSortKey
+    // therefore falls through to `score` and would splice the card at the wrong
+    // position. Fall back to a full refetch, which DOES recompute likeness — or,
+    // under an open overlay, defer it (the overlay-open deferral contract, §9.1)
+    // so we never restructure the filmstrip mid-view.
+    if (isCharacterLikenessSortActive()) {
+      if (overlayOpen.value) {
+        pendingOverlayGridRefresh.value = true;
+        return;
+      }
+      preserveScrollOnNextFetch.value = true;
+      debouncedFetchAllGridImages();
+      return;
+    }
+
+    if (imagesLoading.value) {
+      // A streaming fetch owns allGridImages wholesale; inserting now would be
+      // clobbered. The caller (useGridRealtimeSync) routes these to the pill
+      // instead while loading, so just bail.
+      console.warn(
+        "insertGridImagesById: skipped during in-flight grid fetch",
+        wanted,
+      );
+      return;
+    }
+
+    const existing = new Set(
+      (Array.isArray(lastFetchedGridImages.value)
+        ? lastFetchedGridImages.value
+        : []
+      ).map((img) => getPictureId(img?.id)),
+    );
+    const toFetch = wanted.filter((id) => !existing.has(id));
+    if (!toFetch.length) return;
+
+    let fetched;
+    try {
+      const rows = await listPicturesByIds(toFetch, {
+        fields: "grid",
+        baseUrl: backendUrl,
+      });
+      fetched = Array.isArray(rows) ? rows : [];
+    } catch (e) {
+      console.error("insertGridImagesById: grid metadata fetch failed", {
+        ids: toFetch,
+        error: e,
+      });
+      return;
+    }
+    if (!fetched.length) return;
+
+    const descending = gridSortDescending.value;
+    const base = Array.isArray(lastFetchedGridImages.value)
+      ? lastFetchedGridImages.value.slice()
+      : [];
+    const inserted = [];
+    for (const pic of fetched) {
+      const picId = getPictureId(pic?.id);
+      if (
+        picId === null ||
+        base.some((img) => getPictureId(img?.id) === picId)
+      ) {
+        continue;
+      }
+      const key = gridImageSortKey(pic);
+      let insertIndex = base.findIndex((img) => {
+        const otherKey = gridImageSortKey(img);
+        return descending ? otherKey < key : otherKey > key;
+      });
+      if (insertIndex === -1) insertIndex = base.length;
+      base.splice(insertIndex, 0, pic);
+      inserted.push(picId);
+    }
+    if (!inserted.length) return;
+
+    lastFetchedGridImages.value = base;
+    rebuildGridImagesFromLastFetch();
+    if (highlight) triggerNewImageHighlight(inserted);
+
+    // An in-app ComfyUI result lands here (origin-aware WS picture_imported insert).
+    // If the overlay is open with a pending comfyui refresh, reconcile it now that
+    // the new stacked output is present in lastFetchedGridImages — this is the i2i/
+    // upscale lightbox case that previously relied on the full-grid refetch.
+    void maybeRefreshOverlayForComfyui();
+  }
+
+  async function refreshSmartScoreForImage(imageId) {
+    if (!imageId || !isSmartScoreSortActive()) return;
+    const latestInfo = await fetchImageInfo(imageId, { smartScore: true });
+    if (!latestInfo || Array.isArray(latestInfo)) return;
+
+    const idx = allGridImages.value.findIndex((img) => img?.id === imageId);
+    if (idx !== -1) {
+      const current = allGridImages.value[idx] || {};
+      const smartScore =
+        typeof latestInfo.smartScore === "number"
+          ? latestInfo.smartScore
+          : null;
+      if (current.smartScore === smartScore) {
+        return;
+      }
+      await nextTick();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      // Pass the TRUE smart score (number or null). repositionImageBySmartScore
+      // derives its ordering key from the null rule and preserves null as the
+      // card's displayed value — collapsing to 0 here would both mis-order the
+      // card and show a fake 0.
+      repositionImageBySmartScore(imageId, smartScore, latestInfo);
+    }
+  }
+
+  async function applyScoresByEntries(entries, options = {}) {
+    const { updateSort = true, emitRefreshSidebar = true } = options;
+    if (!Array.isArray(entries) || !entries.length) return;
+
+    // Score updates are applied locally below (including score-sort reordering),
+    // so the immediate WS gridVersion refresh would be redundant and can clear
+    // current multi-selection in some paths. Skip that next WS refresh.
+    skipNextWsRefresh.value = true;
+
+    const scoresPayload = {};
+    for (const [id, score] of entries) {
+      scoresPayload[String(id)] = Number(score);
+    }
+
+    await applyScores(scoresPayload, { baseUrl: backendUrl });
+
+    const scoreMap = new Map(
+      entries.map(([id, score]) => [String(id), Number(score)]),
+    );
+
+    let updatedImages = allGridImages.value.map((img) => {
+      if (!img || img.id == null) return img;
+      const key = String(img.id);
+      if (!scoreMap.has(key)) return img;
+      return { ...img, score: scoreMap.get(key) };
+    });
+
+    if (updateSort && isScoreSortActive()) {
+      const descending = gridSortDescending.value;
+      updatedImages = updatedImages
+        .slice()
+        .sort((a, b) => {
+          const aScore = a?.score ?? 0;
+          const bScore = b?.score ?? 0;
+          if (aScore === bScore) {
+            const aIdx = a?.idx ?? 0;
+            const bIdx = b?.idx ?? 0;
+            return aIdx - bIdx;
+          }
+          return descending ? bScore - aScore : aScore - bScore;
+        })
+        .map((img, idx) => (img ? { ...img, idx } : img));
+      allGridImages.value = updatedImages;
+      invalidateVisibleThumbnailRanges();
+    } else {
+      allGridImages.value = updatedImages;
+    }
+
+    if (updateSort && isCharacterLikenessSortActive()) {
+      preserveScrollOnNextFetch.value = true;
+      debouncedFetchAllGridImages();
+    }
+
+    if (updateSort && isSmartScoreSortActive()) {
+      preserveScrollOnNextFetch.value = true;
+      debouncedFetchAllGridImages();
+    }
+
+    if (emitRefreshSidebar) {
+      emit("refresh-sidebar");
+    }
+  }
+
+  async function applyScore(img, newScore) {
+    const imageId = img?.id;
+    if (!imageId) {
+      noticeStore.error(
+        "Couldn't set that score — the picture id is missing.",
+        {
+          key: "score-missing-id",
+        },
+      );
+      return;
+    }
+    try {
+      // Suppress the WS-driven gridVersion reload that the score apply triggers;
+      // the score update is already applied locally by applyScoresByEntries.
+      skipNextWsRefresh.value = true;
+      await applyScoresByEntries([[String(imageId), newScore]], {
+        updateSort: false,
+        emitRefreshSidebar: false,
+      });
+
+      if (isScoreSortActive()) {
+        if (overlayOpen.value) {
+          // Reordering the grid while the overlay is open would break the
+          // filmstrip. Defer the reposition until the overlay closes.
+          pendingOverlayGridRefresh.value = true;
+        } else {
+          repositionImageByScore(imageId, newScore);
+        }
+      }
+      if (isCharacterLikenessSortActive()) {
+        if (overlayOpen.value) {
+          pendingOverlayGridRefresh.value = true;
+          return;
+        }
+        preserveScrollOnNextFetch.value = true;
+        debouncedFetchAllGridImages();
+        return;
+      }
+      if (isSmartScoreSortActive()) {
+        if (overlayOpen.value) {
+          pendingOverlayGridRefresh.value = true;
+          return;
+        }
+        preserveScrollOnNextFetch.value = true;
+        debouncedFetchAllGridImages();
+        return;
+      }
+    } catch (e) {
+      console.error("Failed to set score", e);
+      noticeStore.error(`Couldn't set that score. ${errorDetail(e)}`, {
+        key: "score-set",
+      });
+    }
+  }
+
+  async function applyScoresForSelection(imageIds, targetScore) {
+    const ids = Array.isArray(imageIds) ? imageIds.filter(Boolean) : [];
+    if (!ids.length) return;
+    if (!Number.isFinite(targetScore)) return;
+
+    const gridById = new Map(
+      allGridImages.value
+        .filter((img) => img && img.id != null)
+        .map((img) => [String(img.id), img]),
+    );
+
+    const entries = [];
+    for (const id of ids) {
+      const key = String(id);
+      const img = gridById.get(key);
+      if (!img) continue;
+      const current = Number(img.score || 0);
+      const nextScore = toggleScore(current, targetScore);
+      entries.push([key, nextScore]);
+    }
+
+    if (!entries.length) return;
+
+    await applyScoresByEntries(entries, {
+      updateSort: true,
+      emitRefreshSidebar: true,
+    });
+  }
+
+  // ============================================================
+
+  return {
+    setScore,
+    setGuestScore,
+    handleGuestConsentAccepted,
+    handleGuestConsentRejected,
+    fetchGuestScores,
+    initGuestSession,
+    isScoreSortActive,
+    isCharacterLikenessSortActive,
+    isSmartScoreSortActive,
+    gridSortDescending,
+    getGridSmartScoreValue,
+    smartScoreSortKey,
+    invalidateVisibleThumbnailRanges,
+    repositionImageByScore,
+    repositionImageBySmartScore,
+    gridImageSortKey,
+    insertGridImagesById,
+    refreshSmartScoreForImage,
+    applyScoresByEntries,
+    applyScore,
+    applyScoresForSelection,
+  };
+}

--- a/frontend/src/composables/useVirtualScroll.test.js
+++ b/frontend/src/composables/useVirtualScroll.test.js
@@ -111,3 +111,70 @@ describe("useVirtualScroll justified layout", () => {
     expect(autoEnd).not.toBe(squareEnd);
   });
 });
+
+// The grid geometry now comes from the store rather than from props, and the
+// arithmetic that turns it into a render window is silent when it goes wrong:
+// an undefined column count makes every bound NaN, `renderEnd` collapses, and
+// the grid paints nothing at all. That is not a hypothetical - it is what the
+// Phase 3 store-direct migration did to ImageGrid, with the whole unit suite
+// still green, because nothing here asserted that a non-empty list produces a
+// non-empty window.
+describe("useVirtualScroll render window (square mode)", () => {
+  function squareHarness(itemCount) {
+    const gridStore = useGridStore();
+    gridStore.sizeLevel = 3; // the 6-column step
+    gridStore.thumbnailMode = "square";
+    gridStore.thumbnailSize = 256;
+    gridStore.compactMode = false;
+
+    const scrollWrapper = ref({
+      scrollTop: 0,
+      clientHeight: VIEWPORT_H,
+      clientWidth: CONTAINER_W,
+    });
+    const gridContainer = ref({
+      clientWidth: CONTAINER_W,
+      getBoundingClientRect: () => ({ width: CONTAINER_W }),
+    });
+    const length = computed(() => itemCount);
+    return useVirtualScroll(
+      scrollWrapper,
+      gridContainer,
+      reactive({}),
+      length,
+      {
+        onVisibleRangeChange: vi.fn(),
+        afterRowHeightUpdate: vi.fn(),
+        getAspectRatios: () => [],
+      },
+    );
+  }
+
+  it("renders a non-empty window for a non-empty grid", () => {
+    const vs = squareHarness(120);
+    vs.visibleStart.value = 0;
+    vs.visibleEnd.value = 24;
+
+    expect(Number.isFinite(vs.renderStart.value)).toBe(true);
+    expect(Number.isFinite(vs.renderEnd.value)).toBe(true);
+    expect(vs.renderEnd.value).toBeGreaterThan(0);
+    expect(vs.renderEnd.value).toBeGreaterThan(vs.renderStart.value);
+  });
+
+  it("keeps the spacers finite, so the scroll height is never NaN", () => {
+    const vs = squareHarness(120);
+    vs.visibleStart.value = 24;
+    vs.visibleEnd.value = 48;
+
+    expect(Number.isFinite(vs.topSpacerHeight.value)).toBe(true);
+    expect(Number.isFinite(vs.bottomSpacerHeight.value)).toBe(true);
+  });
+
+  it("still yields an empty window for an empty grid", () => {
+    const vs = squareHarness(0);
+    vs.visibleStart.value = 0;
+    vs.visibleEnd.value = 0;
+
+    expect(vs.renderEnd.value).toBe(0);
+  });
+});

--- a/pixlstash/tasks/missing_watch_folder_import_finder.py
+++ b/pixlstash/tasks/missing_watch_folder_import_finder.py
@@ -30,10 +30,23 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
             not from this value. Updated automatically after each scan; do not
             set this manually.
 
-    A file is only imported once its size and timestamps have stopped changing,
-    so a copy that is still in flight is never read half-written. See
-    ``_claim_if_settled``.
+    A file is only imported once its size and timestamps have stopped changing
+    for ``SETTLE_SECONDS``, so a copy that is still in flight is never read
+    half-written. See ``_claim_if_settled``.
     """
+
+    # How long a file's stat signature must stay unchanged before the file is
+    # handed to an import task.
+    #
+    # "Unchanged on two consecutive scans" is not a sufficient test on its own:
+    # the planner polls as often as ``WorkPlanner.MIN_INTERVAL_S`` (50ms), so a
+    # copy that merely pauses between writes - a network hiccup, an antivirus
+    # scan, a slow source drive, a writer flushing in chunks - looks settled
+    # after 50ms of quiet and is imported half-written. A wall-clock window
+    # makes the check independent of how fast the planner happens to be
+    # cycling. The cost is that a newly arrived file waits this long before it
+    # is imported.
+    SETTLE_SECONDS = 2.0
 
     _supported_image_exts = {
         ".jpg",
@@ -55,18 +68,19 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
         # (e.g. shutil.copy2) preserve the source mtime on the destination, and
         # on Windows ctime is the creation time and never moves at all.
         #
-        # ``_pending_stats`` holds the signature observed on the previous scan
-        # for paths that have not been handed to an import task yet.
+        # ``_pending_stats`` maps a path that has not been handed to an import
+        # task yet to ``(signature, first_seen)``, where ``first_seen`` is the
+        # monotonic timestamp at which the current signature was first observed.
         # ``_dispatched_stats`` holds the signature a path had when it *was*
-        # handed over.  A path only becomes a candidate once its signature is
-        # identical on two consecutive scans, which is what keeps a file that is
-        # still being written out of the import (see ``_claim_if_settled``).
+        # handed over.  A path only becomes a candidate once its signature has
+        # been unchanged for ``SETTLE_SECONDS``, which is what keeps a file that
+        # is still being written out of the import (see ``_claim_if_settled``).
         #
         # Both dicts are read/written by the finder on the WorkPlanner thread and
         # also mutated by WatchFolderImportTask (via ``discard_seen_paths``) on
         # the TaskRunner thread when a candidate fails to import, so all access
         # is guarded by ``_seen_lock`` to avoid a concurrent-mutation race.
-        self._pending_stats: dict[str, tuple[int, float, float]] = {}
+        self._pending_stats: dict[str, tuple[tuple[int, float, float], float]] = {}
         self._dispatched_stats: dict[str, tuple[int, float, float]] = {}
         self._seen_lock = threading.Lock()
 
@@ -96,6 +110,9 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
 
     def _find_task_from_db(self, watch_folders: list[ImportFolder]):
         now_ts = time.time()
+        # Settle windows are measured on the monotonic clock so a wall-clock
+        # adjustment cannot make a file look settled early (or never).
+        scan_started = time.monotonic()
         candidate_files = []
         total_candidates = 0
         last_checked_updates = {}
@@ -121,7 +138,7 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
                     normalized = os.path.normcase(os.path.abspath(file_path))
                     observed_paths.add(normalized)
 
-                    if self._claim_if_settled(normalized, signature):
+                    if self._claim_if_settled(normalized, signature, scan_started):
                         total_candidates += 1
                         candidate_files.append(
                             {
@@ -192,23 +209,28 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
         return (stat_result.st_size, stat_result.st_mtime, stat_result.st_ctime)
 
     def _claim_if_settled(
-        self, normalized: str, signature: tuple[int, float, float]
+        self,
+        normalized: str,
+        signature: tuple[int, float, float],
+        now: float,
     ) -> bool:
         """Claim *normalized* for import if it has stopped changing on disk.
 
         Returns True when the path is ready to be handed to an import task,
         recording it as dispatched so a later scan does not offer it again.
 
-        A path qualifies only once the same stat signature has been observed on
-        two consecutive scans. A file that is still being copied into the watch
-        folder changes size (and mtime) between scans, so it is held back until
-        the copy finishes. Without this, the importer hashes the bytes written so
-        far, stores a ``pixel_sha`` that does not describe the finished file, and
-        then imports the file a second time once it settles, because the settled
-        content hashes differently and the duplicate check misses it.
+        A path qualifies only once the same stat signature has been observed for
+        ``SETTLE_SECONDS`` of wall-clock time. A file that is still being copied
+        into the watch folder changes size (and mtime), so it is held back until
+        the copy has been quiet for that long. Without this, the importer hashes
+        the bytes written so far, stores a ``pixel_sha`` that does not describe
+        the finished file, and then imports the file a second time once it
+        settles, because the settled content hashes differently and the
+        duplicate check misses it.
 
-        The cost is that a newly arrived file waits one extra planner cycle
-        before it is imported.
+        *now* is the monotonic timestamp of the current scan; passing one value
+        for the whole scan keeps every file in it measured against the same
+        instant.
 
         A file that changes after it was imported goes back through the same
         wait, so an in-place overwrite is never read half-written either.
@@ -221,13 +243,20 @@ class MissingWatchFolderImportFinder(BaseTaskFinder):
                 # Changed on disk since it was imported: re-settle before it is
                 # offered again.
                 del self._dispatched_stats[normalized]
-                self._pending_stats[normalized] = signature
+                self._pending_stats[normalized] = (signature, now)
                 return False
 
             previous = self._pending_stats.get(normalized)
-            if previous != signature:
-                # First sighting, or still being written.
-                self._pending_stats[normalized] = signature
+            if previous is None or previous[0] != signature:
+                # First sighting, or still being written: (re)start the clock.
+                self._pending_stats[normalized] = (signature, now)
+                return False
+
+            if now - previous[1] < self.SETTLE_SECONDS:
+                # Unchanged so far, but not for long enough to call the write
+                # finished. Keep the original first-seen time so the window
+                # measures how long the file has been quiet, not how long since
+                # the previous scan.
                 return False
 
             del self._pending_stats[normalized]

--- a/tests/test_watch_folder_worker.py
+++ b/tests/test_watch_folder_worker.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+import threading
 import time
 
 from fastapi.testclient import TestClient
@@ -363,12 +364,22 @@ def test_watch_folder_waits_for_a_file_to_finish_being_written():
     ``test_watch_folder_imports_copied_files_with_old_mtime_after_initial_scan``
     (3 pictures for 2 files).
 
-    Rather than racing the planner (which backs off to 10s when idle), the file
-    is left incomplete *before* the folder is registered, so the very first scan
-    is guaranteed to see it still growing. It is short by only its last few
-    bytes, which keeps it decodable — that is precisely the case the duplicate
-    check cannot catch, because a truncated file that fails to decode is already
-    handled as a transient failure and retried.
+    The file is left incomplete *before* the folder is registered, so the very
+    first scan sees it unfinished, and a background thread keeps bumping its
+    mtime until the test is ready to finish the copy. That churn is what makes
+    this deterministic: the finder sees a stat signature that never repeats, so
+    it cannot claim the file however often it scans. An earlier version left the
+    file short but *static* and relied on writing the last bytes before the next
+    scan, a race a contended runner loses (it failed on a Windows shard with 2
+    pictures).
+
+    The file is short by only its last few bytes, which keeps it decodable.
+    That is precisely the case the duplicate check cannot catch, because a
+    truncated file that fails to decode is already handled as a transient
+    failure and retried.
+
+    The finder's own quiet-window rule is pinned separately, without a server,
+    by ``test_claim_if_settled_requires_a_wall_clock_quiet_window``.
     """
     from pixlstash.db_models.import_folder import ImportFolder
     from pixlstash.utils.image_processing.image_utils import ImageUtils
@@ -404,76 +415,117 @@ def test_watch_folder_waits_for_a_file_to_finish_being_written():
             out.flush()
             os.fsync(out.fileno())
 
-        with Server(server_config_path) as server:
-            with TestClient(server.api) as client:
-                response = client.post(
-                    f"{API_PREFIX}/login",
-                    json={"username": "testuser", "password": "testpassword"},
-                )
-                assert response.status_code == 200
+        stop_touching = threading.Event()
+        touch_errors: list[OSError] = []
+        stamp_base = time.time() - (24 * 60 * 60)
 
-                create_folder = client.post(
-                    f"{API_PREFIX}/import-folders",
-                    json={
-                        "folder": watch_dir,
-                        "delete_after_import": False,
-                    },
-                )
-                assert create_folder.status_code == 200
+        def keep_the_copy_in_flight():
+            """Bump the file's mtime until the test finishes the copy.
 
-                # ``last_checked`` only advances once a scan has completed, so
-                # this proves the finder has already looked at the partial file.
-                def read_folder(session):
-                    return session.exec(select(ImportFolder)).first()
+            The finder claims a path only once its ``(size, mtime, ctime)``
+            signature has held still, so a moving mtime stands in for a copy
+            that is still dribbling bytes in. Each bump is a distinct integer
+            timestamp, so this works regardless of the filesystem's timestamp
+            granularity.
+            """
+            bump = 0
+            while not stop_touching.is_set():
+                bump += 1
+                try:
+                    os.utime(dst, (stamp_base + bump, stamp_base + bump))
+                except OSError as exc:
+                    touch_errors.append(exc)
+                    return
+                stop_touching.wait(0.05)
 
-                scanned = False
-                start = time.monotonic()
-                while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
-                    folder_row = server.vault.db.run_task(read_folder)
-                    if folder_row is not None and (folder_row.last_checked or 0) > 0:
-                        scanned = True
-                        break
-                    time.sleep(0.1)
-                assert scanned, "Finder never completed a scan of the partial file"
+        toucher = threading.Thread(target=keep_the_copy_in_flight, daemon=True)
+        toucher.start()
+        try:
+            with Server(server_config_path) as server:
+                with TestClient(server.api) as client:
+                    response = client.post(
+                        f"{API_PREFIX}/login",
+                        json={"username": "testuser", "password": "testpassword"},
+                    )
+                    assert response.status_code == 200
 
-                # Finish the copy, then mimic a file manager restoring the source
-                # mtime (which bumps ctime and re-exposes the file to the finder).
-                with open(dst, "ab") as out:
-                    out.write(payload[-4:])
-                    out.flush()
-                    os.fsync(out.fileno())
-                old_ts = time.time() - (7 * 24 * 60 * 60)
-                os.utime(dst, (old_ts, old_ts))
+                    create_folder = client.post(
+                        f"{API_PREFIX}/import-folders",
+                        json={
+                            "folder": watch_dir,
+                            "delete_after_import": False,
+                        },
+                    )
+                    assert create_folder.status_code == 200
 
-                start = time.monotonic()
-                pictures = []
-                while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
+                    # ``last_checked`` only advances once a scan has completed,
+                    # so this proves the finder has already looked at the
+                    # partial file.
+                    def read_folder(session):
+                        return session.exec(select(ImportFolder)).first()
+
+                    scanned = False
+                    start = time.monotonic()
+                    while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
+                        folder_row = server.vault.db.run_task(read_folder)
+                        if (
+                            folder_row is not None
+                            and (folder_row.last_checked or 0) > 0
+                        ):
+                            scanned = True
+                            break
+                        time.sleep(0.1)
+                    assert scanned, "Finder never completed a scan of the partial file"
+                    assert not touch_errors, (
+                        f"Could not keep the copy in flight: {touch_errors[0]!r}"
+                    )
+
+                    # Finish the copy, then mimic a file manager restoring the
+                    # source mtime (which bumps ctime and re-exposes the file to
+                    # the finder).
+                    stop_touching.set()
+                    toucher.join(timeout=10)
+                    assert not toucher.is_alive(), "Touch thread failed to stop"
+                    with open(dst, "ab") as out:
+                        out.write(payload[-4:])
+                        out.flush()
+                        os.fsync(out.fileno())
+                    old_ts = time.time() - (7 * 24 * 60 * 60)
+                    os.utime(dst, (old_ts, old_ts))
+
+                    start = time.monotonic()
+                    pictures = []
+                    while time.monotonic() - start < _IMPORT_WAIT_SECONDS:
+                        pictures = server.vault.db.run_task(
+                            lambda session: Picture.find(session)
+                        )
+                        if len(pictures) >= 1:
+                            break
+                        time.sleep(0.25)
+
+                    # Give a second, erroneous import a chance to land before
+                    # asserting there is only one picture.
+                    time.sleep(3.0)
                     pictures = server.vault.db.run_task(
                         lambda session: Picture.find(session)
                     )
-                    if len(pictures) >= 1:
-                        break
-                    time.sleep(0.25)
 
-                # Give a second, erroneous import a chance to land before
-                # asserting there is only one picture.
-                time.sleep(3.0)
-                pictures = server.vault.db.run_task(
-                    lambda session: Picture.find(session)
-                )
-
-                assert len(pictures) == 1, (
-                    "Expected exactly one picture for one watched file; a "
-                    f"half-written import would add a duplicate (got {len(pictures)})"
-                )
-                settled_sha = ImageUtils.calculate_hash_from_file_path(dst)
-                assert pictures[0].pixel_sha == settled_sha, (
-                    "Imported picture must carry the hash of the settled file, "
-                    "not of the bytes written so far"
-                )
-                assert pictures[0].size_bytes == os.path.getsize(dst), (
-                    "Imported picture must record the settled file size"
-                )
+                    assert len(pictures) == 1, (
+                        "Expected exactly one picture for one watched file; a "
+                        "half-written import would add a duplicate (got "
+                        f"{len(pictures)})"
+                    )
+                    settled_sha = ImageUtils.calculate_hash_from_file_path(dst)
+                    assert pictures[0].pixel_sha == settled_sha, (
+                        "Imported picture must carry the hash of the settled "
+                        "file, not of the bytes written so far"
+                    )
+                    assert pictures[0].size_bytes == os.path.getsize(dst), (
+                        "Imported picture must record the settled file size"
+                    )
+        finally:
+            stop_touching.set()
+            toucher.join(timeout=10)
 
 
 def test_claim_if_settled_requires_a_wall_clock_quiet_window():

--- a/tests/test_watch_folder_worker.py
+++ b/tests/test_watch_folder_worker.py
@@ -474,3 +474,39 @@ def test_watch_folder_waits_for_a_file_to_finish_being_written():
                 assert pictures[0].size_bytes == os.path.getsize(dst), (
                     "Imported picture must record the settled file size"
                 )
+
+
+def test_claim_if_settled_requires_a_wall_clock_quiet_window():
+    """A signature that merely repeats across two scans is not settled yet.
+
+    The planner polls as often as ``WorkPlanner.MIN_INTERVAL_S`` (50ms), so
+    "unchanged since the previous scan" can mean "unchanged for 50ms", which a
+    copy that pauses mid-write clears easily. The file is then hashed
+    half-written, and imported a *second* time once it really finishes, because
+    the settled bytes hash differently and the duplicate check misses them. The
+    claim therefore has to be gated on wall-clock quiet, not on scan count.
+    """
+    from pixlstash.tasks.missing_watch_folder_import_finder import (
+        MissingWatchFolderImportFinder,
+    )
+
+    finder = MissingWatchFolderImportFinder(database=None)
+    settle = MissingWatchFolderImportFinder.SETTLE_SECONDS
+    path = os.path.normcase(os.path.abspath("watch/in-flight.png"))
+    partial = (1024, 100.0, 100.0)
+    complete = (2048, 101.0, 100.0)
+
+    # First sighting never claims, and neither does a fast follow-up scan.
+    assert finder._claim_if_settled(path, partial, 0.0) is False
+    assert finder._claim_if_settled(path, partial, 0.05) is False
+    assert finder._claim_if_settled(path, partial, settle - 0.01) is False
+
+    # The write resumes: the quiet window restarts from this observation.
+    assert finder._claim_if_settled(path, complete, settle) is False
+    assert finder._claim_if_settled(path, complete, 2 * settle - 0.01) is False
+
+    # Quiet for the full window: now it is safe to hand over.
+    assert finder._claim_if_settled(path, complete, 2 * settle) is True
+
+    # Claimed once. Later scans of the same bytes must not offer it again.
+    assert finder._claim_if_settled(path, complete, 2 * settle + 60.0) is False


### PR DESCRIPTION
Two working copies of the repo cannot currently run the e2e suite at the same time, and when they collide the symptom is not an error you would connect to the cause.

**What collides.** The throwaway work directory is `/tmp/pixlstash-e2e-<fixture-name>`, and the fixture folder is called `test-data` in every clone — so both checkouts resolve to the same path and `rmtree` each other's vault mid-run. Both also bind port 9600. Whichever run loses the race can end up talking to the *other* checkout's server, whose vault has a different admin password, and global-setup reports the fixture is not in first-run state. Or a handful of unrelated specs simply fail.

I hit this repeatedly tonight while verifying an unrelated branch, and it cost real time: it produced failures I initially, and wrongly, concluded were pre-existing on the branch under test.

**The fix.** Work directory and port are both derived from the checkout path. `PIXLSTASH_E2E_PORT` still pins the port when you need it fixed.

**A second defect the first fix exposed.** `seed_dedup_fixture.py` carried its own copy of the work-directory path under a comment reading *"Mirrors serve_e2e_backend.WORK_DIR exactly; the two must not drift."* It drifted the moment the launcher's path gained a suffix — the seed wrote to one vault while the server served another, and the duplicates queue came up empty with no error anywhere. It imports the launcher's value now, so there is one definition rather than two that must agree.

**Verified:** full e2e suite green on `develop` with the fix (86 passed, 4 skipped), and the new work directory is created under its per-checkout name. `ruff check` and `ruff format --check` clean.
