### PR TITLE
Fix picture-listing scope leak in the ComfyUI filter (1.8.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
           tests/test_batch_character_likeness_scope.py
           tests/test_ci_shards.py
           tests/test_clip_text_embedding_similarity.py
+          tests/test_comfyui_stack_filter.py
           tests/test_comfyui_workflow_extraction.py
           tests/test_detections_scope.py
           tests/test_facial_features_worker.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [1.8.3] [Security:Moderate]
+
+If you have given a share link to anyone, please update. Once you have, your existing links are safe again and keep working. Reissue a link only if you would rather the person you gave it to had never been able to see the information described below.
+
+- Fixed: a share link could be used to read details about pictures outside what was actually shared, including their file names and the folders they sit in on your computer. Nobody could see the pictures themselves, only information about them, and only while using one specific combination of filters. Affects every release from 1.3.0 onward. We will publish the details once people have had a chance to update.
+
 # [1.8.2]
 
 - Signed Windows installers and nothing else. If you already installed or you're not on Windows, this is not the release for you.

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixlstash-desktop",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixlstash-desktop",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "pixlstash-desktop",
   "productName": "PixlStash",
   "desktopName": "pixlstash.desktop",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "PixlStash desktop app: a native window around the local PixlStash server, with downloadable, hardware-matched compute backends.",
   "author": {
     "name": "Gaute Lindkvist",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixlstash-frontend",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixlstash-frontend",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "axios": "^1.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixlstash-frontend",
   "private": true,
-  "version": "1.8.2",
+  "version": "1.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pixlstash/db_models/picture.py
+++ b/pixlstash/db_models/picture.py
@@ -877,14 +877,24 @@ class Picture(SQLModel, table=True):
                 # *any* member of the stack satisfies the ComfyUI filter, not
                 # only when the leader row itself satisfies it.
                 member_where = " OR ".join(comfyui_member_parts)
+                # NOTE: the whole disjunction is wrapped in an extra outer pair of
+                # parentheses.  ``text()`` is opaque, so SQLAlchemy adds none of its
+                # own, and SQL ``AND`` binds tighter than ``OR``: without the wrapper
+                # this clause renders as ``... AND deleted = 0 AND <leader condition>
+                # AND self_match OR member_match``, which parses as ``(everything AND
+                # self) OR member``.  The stack-member branch then escapes every other
+                # predicate (the deleted filter, the stack-leader collapse, and any id
+                # or project scope narrowing) and returns each member of a matching
+                # stack as its own row.  Same trap, same fix, as the
+                # ``tags_confidence_above_filter`` branch in predicate_filter.py.
                 comfyui_sql = (
-                    f"({self_where})"
+                    f"(({self_where})"
                     f" OR (picture.stack_id IS NOT NULL"
                     f" AND EXISTS ("
                     f"SELECT 1 FROM picture AS _m"
                     f" WHERE _m.stack_id = picture.stack_id"
                     f" AND ({member_where})"
-                    f"))"
+                    f")))"
                 )
                 query = query.where(text(comfyui_sql).bindparams(**comfyui_bind_params))
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixlstash"
-version = "1.8.2"
+version = "1.8.3"
 description = "Self-hosted picture library with AI tagging, semantic search, and a clean web UI"
 readme = "README.md"
 license = "GPL-3.0-only AND MIT"

--- a/tests/test_ci_shards.py
+++ b/tests/test_ci_shards.py
@@ -95,6 +95,13 @@ MUST_BLOCK_ON_EVERY_PR = frozenset(
         # Streaming variant of the picture list — a separate code path from the
         # paged list, and historically its own BOLA vector.
         "test_pictures_stream.py",
+        # The ComfyUI membership filter is the one leaf `Picture.find()` does not
+        # delegate to `PredicateFilter`: it hand-rolls a raw `text()` WHERE
+        # fragment. An unparenthesised `OR` in it let the stack-member branch
+        # escape the id/project scope narrowing, so a scoped share token could
+        # read grid metadata library-wide. Same risk class as
+        # test_pictures_stream.py above.
+        "test_comfyui_stack_filter.py",
         # Deleted-picture retention: proves scrapheap rows stay scoped and are
         # actually reaped rather than lingering readable.
         "test_scrapheap_retention.py",

--- a/tests/test_ci_shards.py
+++ b/tests/test_ci_shards.py
@@ -95,6 +95,14 @@ MUST_BLOCK_ON_EVERY_PR = frozenset(
         # Streaming variant of the picture list — a separate code path from the
         # paged list, and historically its own BOLA vector.
         "test_pictures_stream.py",
+        # The token-level half of share-link scoping: the only suite that mints a
+        # real READ token and asserts on what comes back through the HTTP routes.
+        # `/pictures`, `/pictures/stream` and `/pictures/count` are SCOPED_LIST
+        # with `scope_aware=True`, so the AuthzGate does not object-check their
+        # rows and the handler's narrowing is the sole enforcement, so nothing
+        # else in the suite can catch a route that stops narrowing. It was
+        # already on the ci.yml gate; pinning it here makes deferral unavailable.
+        "test_read_token_security.py",
         # The ComfyUI membership filter is the one leaf `Picture.find()` does not
         # delegate to `PredicateFilter`: it hand-rolls a raw `text()` WHERE
         # fragment. An unparenthesised `OR` in it let the stack-member branch

--- a/tests/test_comfyui_stack_filter.py
+++ b/tests/test_comfyui_stack_filter.py
@@ -1,0 +1,309 @@
+"""Unit tests for the ComfyUI membership filter in :meth:`Picture.find`.
+
+ComfyUI membership is the one leaf ``find()`` does not delegate to
+:class:`PredicateFilter`: on a stack-collapsed grid a stack leader must be shown
+when *any* member of its stack was made with the filtered model or LoRA, not only
+when the leader row itself was.  That expansion is expressed as a raw ``text()``
+fragment of the shape ``(self match) OR (stack member match)``.
+
+``text()`` is opaque to SQLAlchemy, so nothing parenthesises that disjunction for
+us.  SQL ``AND`` binds tighter than ``OR``, so an unwrapped fragment ANDed into
+the rest of the WHERE clause renders as::
+
+    WHERE deleted = 0 AND <leader condition> AND self_match OR member_match
+
+which parses as ``(deleted = 0 AND leader AND self) OR member``.  The
+stack-member branch escapes the deleted filter, the stack-leader condition and
+any scope narrowing, returning every member of a matching stack instead of one
+tile for it.  These tests pin both directions: the leak is closed, and the
+legitimate stack expansion that the fragment exists for still works.
+
+The same precedence trap, and the same outer-parenthesis fix, is documented on
+``tags_confidence_above_filter`` in ``pixlstash/utils/query/predicate_filter.py``.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.pool import NullPool
+from sqlmodel import Session, SQLModel, create_engine
+
+# Importing the models registers them on SQLModel.metadata.
+from pixlstash.db_models import Picture, PictureProjectMember, PictureStack, Project
+
+_file_names = itertools.count()
+
+
+@pytest.fixture
+def session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'comfyui_stack.db'}",
+        echo=False,
+        poolclass=NullPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _enable_fk(dbapi_connection, _record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        yield s
+
+
+def _new_stack(session) -> int:
+    stack = PictureStack()
+    session.add(stack)
+    session.commit()
+    session.refresh(stack)
+    return stack.id
+
+
+def _add_picture(session, *, models=None, loras=None, **kwargs) -> Picture:
+    kwargs.setdefault("file_path", f"pic_{next(_file_names)}.jpg")
+    if models is not None:
+        kwargs["comfyui_models"] = json.dumps(models)
+    if loras is not None:
+        kwargs["comfyui_loras"] = json.dumps(loras)
+    pic = Picture(**kwargs)
+    session.add(pic)
+    session.commit()
+    session.refresh(pic)
+    return pic
+
+
+def _found_ids(session, **kwargs) -> set[int]:
+    return {pic.id for pic in Picture.find(session, **kwargs)}
+
+
+def _found_count(session, **kwargs) -> int:
+    return Picture.find(session, count_only=True, **kwargs)
+
+
+def _assert_found(session, expected: set[int], **kwargs):
+    """The id set and the COUNT(*) that the grid runs must agree."""
+    assert _found_ids(session, **kwargs) == expected
+    assert _found_count(session, **kwargs) == len(expected)
+
+
+# --- the leak: the member branch must not escape the other predicates ---------
+
+
+def test_stack_expansion_does_not_leak_non_leader_members(session):
+    """One tile per matching stack, not one per member.
+
+    The leader condition is ANDed alongside the ComfyUI fragment.  Without the
+    outer parentheses the member branch is OR'd against the whole conjunction,
+    so every sibling of a matching picture comes back as its own row.
+    """
+    stack = _new_stack(session)
+    cover = _add_picture(session, stack_id=stack, stack_position=0, models=["m1"])
+    second = _add_picture(session, stack_id=stack, stack_position=1, models=["other"])
+    third = _add_picture(session, stack_id=stack, stack_position=2)
+
+    _assert_found(
+        session,
+        {cover.id},
+        stack_leaders_only=True,
+        comfyui_models_filter=["m1"],
+    )
+    found = _found_ids(session, stack_leaders_only=True, comfyui_models_filter=["m1"])
+    assert second.id not in found
+    assert third.id not in found
+
+
+def test_stack_expansion_does_not_leak_deleted_pictures(session):
+    """A soft-deleted sibling of a match is still deleted.
+
+    ``deleted = 0`` is emitted by the PredicateFilter and ANDed in front of the
+    ComfyUI fragment, so it is one of the predicates an unwrapped ``OR`` escapes.
+    """
+    stack = _new_stack(session)
+    cover = _add_picture(session, stack_id=stack, stack_position=0, models=["m1"])
+    dead = _add_picture(
+        session, stack_id=stack, stack_position=1, models=["m1"], deleted=True
+    )
+
+    _assert_found(
+        session,
+        {cover.id},
+        stack_leaders_only=True,
+        comfyui_models_filter=["m1"],
+    )
+    assert dead.id not in _found_ids(
+        session, stack_leaders_only=True, comfyui_models_filter=["m1"]
+    )
+
+
+def test_stack_expansion_does_not_leak_outside_an_id_scope(session):
+    """A picture set / share-token scope is an ``id IN (...)`` narrowing.
+
+    It is applied as its own ANDed predicate, so an unwrapped ``OR`` hands the
+    caller rows it never asked for: a share token would return pictures outside
+    its scope purely because a stack sibling matched the model filter.
+    """
+    stack = _new_stack(session)
+    cover = _add_picture(session, stack_id=stack, stack_position=0, models=["m1"])
+    second = _add_picture(session, stack_id=stack, stack_position=1, models=["m1"])
+    third = _add_picture(session, stack_id=stack, stack_position=2, models=["m1"])
+
+    scope = [cover.id, second.id]
+    _assert_found(
+        session,
+        {cover.id},
+        stack_leaders_only=True,
+        comfyui_models_filter=["m1"],
+        id=scope,
+    )
+    assert third.id not in _found_ids(
+        session,
+        stack_leaders_only=True,
+        comfyui_models_filter=["m1"],
+        id=scope,
+    )
+
+
+def test_stack_expansion_does_not_leak_outside_a_project_scope(session):
+    """Project membership is an ANDed ``EXISTS``, and must survive the ``OR``."""
+    project = Project(name="scoped")
+    other_project = Project(name="elsewhere")
+    session.add(project)
+    session.add(other_project)
+    session.commit()
+    session.refresh(project)
+    session.refresh(other_project)
+
+    stack = _new_stack(session)
+    cover = _add_picture(session, stack_id=stack, stack_position=0, models=["m1"])
+    outsider = _add_picture(session, stack_id=stack, stack_position=1, models=["m1"])
+    session.add(PictureProjectMember(picture_id=cover.id, project_id=project.id))
+    session.add(
+        PictureProjectMember(picture_id=outsider.id, project_id=other_project.id)
+    )
+    session.commit()
+
+    _assert_found(
+        session,
+        {cover.id},
+        stack_leaders_only=True,
+        comfyui_models_filter=["m1"],
+        project_id=project.id,
+    )
+    assert outsider.id not in _found_ids(
+        session,
+        stack_leaders_only=True,
+        comfyui_models_filter=["m1"],
+        project_id=project.id,
+    )
+
+
+def test_lora_filter_does_not_leak_either(session):
+    """The LoRA fragments share the code path, so they share the trap."""
+    stack = _new_stack(session)
+    cover = _add_picture(session, stack_id=stack, stack_position=0, loras=["lora_x"])
+    second = _add_picture(session, stack_id=stack, stack_position=1)
+
+    _assert_found(
+        session,
+        {cover.id},
+        stack_leaders_only=True,
+        comfyui_loras_filter=["lora_x"],
+    )
+    assert second.id not in _found_ids(
+        session, stack_leaders_only=True, comfyui_loras_filter=["lora_x"]
+    )
+
+
+# --- the other direction: the filter must still return what it should --------
+
+
+def test_stack_is_shown_when_only_a_non_cover_member_matches(session):
+    """The behaviour the raw fragment exists for.
+
+    The cover was not made with the filtered model but a member was, so the
+    stack still earns exactly one tile: its leader.  Over-blocking here is its
+    own regression, and was the bug the stack-member branch was added to fix.
+    """
+    stack = _new_stack(session)
+    cover = _add_picture(session, stack_id=stack, stack_position=0, models=["other"])
+    member = _add_picture(session, stack_id=stack, stack_position=1, models=["m1"])
+
+    found = _found_ids(session, stack_leaders_only=True, comfyui_models_filter=["m1"])
+    assert found == {cover.id}
+    assert member.id not in found
+    assert (
+        _found_count(session, stack_leaders_only=True, comfyui_models_filter=["m1"])
+        == 1
+    )
+
+
+def test_unstacked_matches_are_returned_and_non_matches_are_not(session):
+    matching = _add_picture(session, models=["m1"])
+    _add_picture(session, models=["other"])
+    _add_picture(session)
+
+    _assert_found(
+        session,
+        {matching.id},
+        stack_leaders_only=True,
+        comfyui_models_filter=["m1"],
+    )
+
+
+def test_stack_with_no_matching_member_contributes_nothing(session):
+    stack = _new_stack(session)
+    _add_picture(session, stack_id=stack, stack_position=0, models=["other"])
+    _add_picture(session, stack_id=stack, stack_position=1, models=["another"])
+    loose = _add_picture(session, models=["m1"])
+
+    _assert_found(
+        session,
+        {loose.id},
+        stack_leaders_only=True,
+        comfyui_models_filter=["m1"],
+    )
+
+
+def test_expanded_stacks_and_loose_matches_combine(session):
+    """A whole-library shape: expansion, non-matching stacks and loose rows."""
+    matching_stack = _new_stack(session)
+    matching_cover = _add_picture(
+        session, stack_id=matching_stack, stack_position=0, models=["other"]
+    )
+    _add_picture(session, stack_id=matching_stack, stack_position=1, models=["m1"])
+    _add_picture(session, stack_id=matching_stack, stack_position=2)
+
+    quiet_stack = _new_stack(session)
+    _add_picture(session, stack_id=quiet_stack, stack_position=0, models=["other"])
+    _add_picture(session, stack_id=quiet_stack, stack_position=1)
+
+    loose_match = _add_picture(session, models=["m1", "extra"])
+    _add_picture(session, models=["extra"])
+
+    _assert_found(
+        session,
+        {matching_cover.id, loose_match.id},
+        stack_leaders_only=True,
+        comfyui_models_filter=["m1"],
+    )
+
+
+def test_without_stack_collapse_only_the_matching_rows_come_back(session):
+    """``stack_leaders_only=False`` takes the self-only branch: no expansion."""
+    stack = _new_stack(session)
+    _add_picture(session, stack_id=stack, stack_position=0, models=["other"])
+    member = _add_picture(session, stack_id=stack, stack_position=1, models=["m1"])
+    loose = _add_picture(session, models=["m1"])
+    _add_picture(session, models=["other"])
+
+    _assert_found(
+        session,
+        {member.id, loose.id},
+        comfyui_models_filter=["m1"],
+    )

--- a/tests/test_read_token_security.py
+++ b/tests/test_read_token_security.py
@@ -4,7 +4,9 @@ Coverage
 --------
 1. Read token cannot perform any write operation (POST/PUT/PATCH/DELETE).
 2. Read token cannot access owner-only data (config, token list, server config).
-3. Read token scoped to one resource cannot read a different resource.
+3. Read token scoped to one resource cannot read a different resource, including
+   via the ComfyUI stack-member filter on /pictures, /pictures/stream and
+   /pictures/count (see TestComfyuiFilterCannotEscapeTokenScope).
 4. Expired read token is rejected.
 5. ALL-scope bearer token scoped-token checks (READ token cannot create tokens).
 6. Unauthenticated login endpoint brute-force lockout (≥5 failures → 429).
@@ -17,6 +19,7 @@ the pictures from ``pictures/good/`` to give each scenario a realistic dataset.
 """
 
 import io
+import json
 import tempfile
 import time
 from pathlib import Path
@@ -28,7 +31,7 @@ from PIL import Image
 import pixlstash.routes.pictures._character_likeness as likeness_module
 import pixlstash.routes.pictures._listing as listing_module
 import pixlstash.utils.rate_limiter as rl_module
-from pixlstash.db_models import Picture
+from pixlstash.db_models import Picture, PictureStack
 from pixlstash.server import Server
 from tests.utils import upload_pictures_and_wait
 
@@ -1450,6 +1453,414 @@ class TestResourceScopedReadTokenIsolation:
                     assert r.status_code == 200, (
                         f"Set-A token wrongly scope-blocked from its own "
                         f"picture's workflow: {r.status_code} {r.text}"
+                    )
+            finally:
+                server.__exit__(None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# 3b. The ComfyUI stack filter must not widen a scoped token's grant
+# ---------------------------------------------------------------------------
+
+
+class TestComfyuiFilterCannotEscapeTokenScope:
+    """Token-level regression for the ComfyUI stack-member scope escape.
+
+    ``Picture.find`` expands a stack-collapsed grid so a stack leader shows when
+    *any* member of its stack was made with the filtered model or LoRA.  That
+    expansion is a raw ``text()`` fragment, and ``text()`` is opaque to
+    SQLAlchemy, so nothing parenthesises its ``OR`` for us.  ``AND`` binds
+    tighter than ``OR``, so an unwrapped fragment renders as ``<all other
+    predicates> AND self_match OR member_match`` and the member branch escapes
+    every ANDed predicate -- including the ``id IN (...)`` narrowing that a
+    share token's scope is expressed as.
+
+    ``/api/v1/pictures`` and its siblings are declared ``SCOPED_LIST`` with
+    ``scope_aware=True`` (``pixlstash/authz/registry.py``), which means the
+    AuthzGate deliberately does *not* object-check the rows that come back: the
+    handler's narrowing is the only enforcement there is.  So this is a property
+    of the route, not of the query builder, and it needs a test that actually
+    mints a token.  ``tests/test_comfyui_stack_filter.py`` calls
+    ``Picture.find`` directly and would still pass if the route stopped
+    narrowing altogether.
+
+    The fixture is a stack that **straddles** the token's scope boundary, which
+    is the only shape that reproduces the leak.  Picture-set membership is
+    stack-atomic on add, so a *picture*-scoped share token is the reliable way
+    to straddle; the set-scoped case only straddles when the pictures are
+    stacked after set membership is granted, which the last test does.
+    """
+
+    MODEL = "shared-model.safetensors"
+    LORA = "shared-lora.safetensors"
+    FILTER_PARAMS = ("comfyui_model", "comfyui_lora")
+
+    # Which seeded pictures carry the filtered model/LoRA, and how the two
+    # stacks are laid out once _form_stacks runs (``*`` = matches the filter)::
+    #
+    #     shared stack : cover*  sibling_a*  sibling_b*
+    #     other stack  : quiet_cover   quiet_member*
+    #     loose        : lone*
+    #
+    # Only ``cover`` is ever inside the token's grant. ``quiet_cover`` is the
+    # one that must come back for the *owner* purely through the member branch.
+    _MATCHING = {"cover", "sibling_a", "sibling_b", "quiet_member", "lone"}
+    _SHARED_STACK = ("cover", "sibling_a", "sibling_b")
+    _OTHER_STACK = ("quiet_cover", "quiet_member")
+
+    def _filter_value(self, filter_param: str) -> str:
+        return self.MODEL if filter_param == "comfyui_model" else self.LORA
+
+    def _seed_pictures(self, server) -> dict:
+        """Create the six unstacked pictures with their ComfyUI metadata.
+
+        ``comfyui_models`` / ``comfyui_loras`` are pipeline-populated JSON
+        columns with no owner-facing write API, so they are seeded directly via
+        the DB task runner (same pattern as ``_seed_comfyui_vocab`` above).
+        """
+
+        def _seed(session):
+            ids = {}
+            for name in (
+                *self._SHARED_STACK,
+                *self._OTHER_STACK,
+                "lone",
+            ):
+                matching = name in self._MATCHING
+                pic = Picture(
+                    file_path=f"/home/owner/private/{name}.png",
+                    comfyui_models=json.dumps(
+                        [self.MODEL if matching else "unrelated-model"]
+                    ),
+                    comfyui_loras=json.dumps(
+                        [self.LORA if matching else "unrelated-lora"]
+                    ),
+                )
+                session.add(pic)
+                session.commit()
+                session.refresh(pic)
+                ids[name] = pic.id
+            return ids
+
+        return server.vault.db.run_task(_seed)
+
+    def _form_stacks(self, server, ids: dict) -> None:
+        """Stack the seeded pictures, keeping ``lone`` unstacked.
+
+        Done in the DB rather than through the stack API so the stack can be
+        formed at an arbitrary point relative to picture-set membership -- the
+        set-scoped test below depends on forming it *after*.
+        """
+
+        def _stack(session):
+            for names in (self._SHARED_STACK, self._OTHER_STACK):
+                stack = PictureStack()
+                session.add(stack)
+                session.commit()
+                session.refresh(stack)
+                for position, name in enumerate(names):
+                    pic = session.get(Picture, ids[name])
+                    pic.stack_id = stack.id
+                    pic.stack_position = position
+                    session.add(pic)
+            session.commit()
+
+        server.vault.db.run_task(_stack)
+
+    def _setup(self, tmp: str):
+        """Start a server, seed the straddling stack, mint a picture token.
+
+        Returns ``(server, owner_client, ids, picture_token)`` where the token
+        grants READ on ``ids["cover"]`` and nothing else.
+        """
+        server = Server(f"{tmp}/server-config.json")
+        server.__enter__()
+        owner_client = TestClient(server.api, raise_server_exceptions=True)
+
+        r = owner_client.post(
+            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        )
+        assert r.status_code == 200, r.text
+
+        ids = self._seed_pictures(server)
+        self._form_stacks(server, ids)
+
+        r = owner_client.post(
+            f"{API}/users/me/token",
+            json={
+                "description": "single picture share",
+                "scope": "READ",
+                "resource_type": "picture",
+                "resource_id": ids["cover"],
+            },
+        )
+        assert r.status_code == 200, r.text
+        return server, owner_client, ids, r.json()["token"]
+
+    @staticmethod
+    def _ids_from(response) -> set[int]:
+        """Pull the id set out of a list response or a stream envelope."""
+        assert response.status_code == 200, response.text
+        body = response.json()
+        if isinstance(body, dict):
+            body = body["pictures"]
+        return {row["id"] for row in body}
+
+    def _scoped_get(self, server, token: str, path: str, params: dict):
+        return TestClient(server.api).get(
+            f"{API}{path}",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    def test_picture_token_cannot_widen_the_grid_via_comfyui_filter(self):
+        """``GET /pictures?fields=grid&comfyui_model=...`` stays inside scope.
+
+        ``fields=grid`` implies ``stack_leaders_only``, so this is the default
+        share-gallery view: the exact request a share-link visitor's browser
+        makes when they touch the ComfyUI filter chips.  Under the bug the
+        response carried grid rows -- ``file_path`` included -- for every member
+        of every stack that contained a match, library-wide.
+        """
+        for filter_param in self.FILTER_PARAMS:
+            with tempfile.TemporaryDirectory() as tmp:
+                server, _owner, ids, token = self._setup(tmp)
+                try:
+                    r = self._scoped_get(
+                        server,
+                        token,
+                        "/pictures",
+                        {
+                            "fields": "grid",
+                            "limit": 500,
+                            filter_param: self._filter_value(filter_param),
+                        },
+                    )
+                    returned = self._ids_from(r)
+                    out_of_scope = returned - {ids["cover"]}
+                    assert not out_of_scope, (
+                        f"Single-picture token leaked ids {sorted(out_of_scope)} "
+                        f"via /pictures?fields=grid&{filter_param}=..."
+                    )
+                    # Positive: the granted picture is still served. The whole
+                    # point of the narrowing is to return this row and no other.
+                    assert returned == {ids["cover"]}, (
+                        f"In-scope picture {ids['cover']} was dropped from "
+                        f"/pictures?fields=grid&{filter_param}=...: {returned}"
+                    )
+                    # The grid projection carries file_path, so the leak handed
+                    # out on-disk locations of pictures that were never shared.
+                    paths = {row.get("file_path") for row in r.json()}
+                    assert paths == {"/home/owner/private/cover.png"}, (
+                        f"Grid rows exposed out-of-scope file paths: {paths}"
+                    )
+                finally:
+                    server.__exit__(None, None, None)
+
+    def test_picture_token_cannot_widen_the_stream_via_comfyui_filter(self):
+        """``/pictures/stream`` is a separate handler and leaked identically.
+
+        Both the ``fields=grid`` form and the explicit ``stack_leaders_only``
+        form are exercised, because the stream endpoint reaches the collapsed
+        query by two different routes.
+        """
+        for filter_param in self.FILTER_PARAMS:
+            with tempfile.TemporaryDirectory() as tmp:
+                server, _owner, ids, token = self._setup(tmp)
+                try:
+                    value = self._filter_value(filter_param)
+                    for extra in (
+                        {"fields": "grid"},
+                        {"stack_leaders_only": "true"},
+                    ):
+                        r = self._scoped_get(
+                            server,
+                            token,
+                            "/pictures/stream",
+                            {"batch_limit": 500, filter_param: value, **extra},
+                        )
+                        returned = self._ids_from(r)
+                        out_of_scope = returned - {ids["cover"]}
+                        assert not out_of_scope, (
+                            f"Single-picture token leaked ids "
+                            f"{sorted(out_of_scope)} via /pictures/stream "
+                            f"({extra}, {filter_param})"
+                        )
+                        assert returned == {ids["cover"]}, (
+                            f"In-scope picture {ids['cover']} was dropped from "
+                            f"/pictures/stream ({extra}, {filter_param}): "
+                            f"{returned}"
+                        )
+                finally:
+                    server.__exit__(None, None, None)
+
+    def test_picture_token_cannot_widen_the_count_via_comfyui_filter(self):
+        """``/pictures/count`` leaked the size of the library, not just rows.
+
+        The count runs ``SELECT COUNT(*)`` over the same WHERE clause, so the
+        escaped ``OR`` inflated it to every member of every matching stack --
+        5 instead of 1 in this fixture.  Nothing in the suite asserted on that
+        number before.
+        """
+        for filter_param in self.FILTER_PARAMS:
+            with tempfile.TemporaryDirectory() as tmp:
+                server, _owner, ids, token = self._setup(tmp)
+                try:
+                    r = self._scoped_get(
+                        server,
+                        token,
+                        "/pictures/count",
+                        {
+                            "stack_leaders_only": "true",
+                            filter_param: self._filter_value(filter_param),
+                        },
+                    )
+                    assert r.status_code == 200, r.text
+                    count = r.json()["count"]
+                    # Exactly one: the granted picture matches the filter, so
+                    # this pins both directions at once -- an inflated count is
+                    # the leak, a zero count is over-blocking.
+                    assert count == 1, (
+                        f"Single-picture token saw count={count} for "
+                        f"{filter_param}; expected 1 (only picture "
+                        f"{ids['cover']} is in scope)"
+                    )
+                finally:
+                    server.__exit__(None, None, None)
+
+    def test_owner_still_gets_the_legitimate_stack_expansion(self):
+        """The over-blocking direction: the feature the fragment exists for.
+
+        For an unscoped owner the collapsed grid must return one tile per
+        matching stack: ``cover`` (the leader itself matches), ``quiet_cover``
+        (only a non-leader member matches -- the member branch) and ``lone``.
+        Tightening the parentheses must not cost the member branch its reach.
+        """
+        for filter_param in self.FILTER_PARAMS:
+            with tempfile.TemporaryDirectory() as tmp:
+                server, owner_client, ids, _token = self._setup(tmp)
+                try:
+                    value = self._filter_value(filter_param)
+                    r = owner_client.get(
+                        f"{API}/pictures",
+                        params={"fields": "grid", "limit": 500, filter_param: value},
+                    )
+                    returned = self._ids_from(r)
+                    expected = {ids["cover"], ids["quiet_cover"], ids["lone"]}
+                    assert returned == expected, (
+                        f"Owner's collapsed grid for {filter_param} returned "
+                        f"{sorted(returned)}, expected {sorted(expected)} "
+                        "(one leader per matching stack, plus the loose match)"
+                    )
+                    r = owner_client.get(
+                        f"{API}/pictures/count",
+                        params={"stack_leaders_only": "true", filter_param: value},
+                    )
+                    assert r.status_code == 200, r.text
+                    assert r.json()["count"] == len(expected), (
+                        f"Owner count for {filter_param} disagrees with the "
+                        f"row set: {r.json()['count']} vs {len(expected)}"
+                    )
+                finally:
+                    server.__exit__(None, None, None)
+
+    def test_set_token_cannot_widen_via_comfyui_filter_on_a_late_stack(self):
+        """The set-scoped straddle: pictures stacked *after* set membership.
+
+        Adding a picture to a set pulls its whole stack in (membership is
+        stack-atomic), so a set-scoped token normally cannot straddle a stack at
+        all.  It can when the stack is formed afterwards, which is exactly what
+        an auto-stack pass does to an already-shared set.  Same three routes,
+        same expectation: only the set's own picture comes back.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            server = Server(f"{tmp}/server-config.json")
+            server.__enter__()
+            try:
+                owner_client = TestClient(server.api, raise_server_exceptions=True)
+                r = owner_client.post(
+                    f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+                )
+                assert r.status_code == 200, r.text
+
+                # Order matters: seed loose pictures, put ONE of them in the set
+                # while nothing is stacked (so the stack-atomic add pulls in
+                # nothing), and only then form the stacks around it.
+                ids = self._seed_pictures(server)
+
+                r = owner_client.post(f"{API}/picture_sets", json={"name": "Shared"})
+                assert r.status_code == 200, r.text
+                set_id = r.json()["picture_set"]["id"]
+
+                r = owner_client.post(
+                    f"{API}/picture_sets/{set_id}/members/{ids['cover']}"
+                )
+                assert r.status_code in {200, 201, 204}, r.text
+
+                self._form_stacks(server, ids)
+
+                r = owner_client.post(
+                    f"{API}/users/me/token",
+                    json={
+                        "description": "set share",
+                        "scope": "READ",
+                        "resource_type": "picture_set",
+                        "resource_id": set_id,
+                    },
+                )
+                assert r.status_code == 200, r.text
+                token = r.json()["token"]
+
+                # Sanity: without the ComfyUI filter the token already sees only
+                # the cover, so any widening below is the filter's doing.
+                baseline = self._ids_from(
+                    self._scoped_get(
+                        server, token, "/pictures", {"fields": "grid", "limit": 500}
+                    )
+                )
+                assert baseline == {ids["cover"]}, (
+                    f"Set token's unfiltered grid is not the straddle shape this "
+                    f"test needs: {baseline}"
+                )
+
+                for filter_param in self.FILTER_PARAMS:
+                    value = self._filter_value(filter_param)
+                    returned = self._ids_from(
+                        self._scoped_get(
+                            server,
+                            token,
+                            "/pictures",
+                            {"fields": "grid", "limit": 500, filter_param: value},
+                        )
+                    )
+                    assert returned == {ids["cover"]}, (
+                        f"Set token widened via /pictures {filter_param}: "
+                        f"{sorted(returned)}"
+                    )
+
+                    returned = self._ids_from(
+                        self._scoped_get(
+                            server,
+                            token,
+                            "/pictures/stream",
+                            {"fields": "grid", "batch_limit": 500, filter_param: value},
+                        )
+                    )
+                    assert returned == {ids["cover"]}, (
+                        f"Set token widened via /pictures/stream {filter_param}: "
+                        f"{sorted(returned)}"
+                    )
+
+                    r = self._scoped_get(
+                        server,
+                        token,
+                        "/pictures/count",
+                        {"stack_leaders_only": "true", filter_param: value},
+                    )
+                    assert r.status_code == 200, r.text
+                    assert r.json()["count"] == 1, (
+                        f"Set token widened /pictures/count for {filter_param}: "
+                        f"{r.json()['count']}"
                     )
             finally:
                 server.__exit__(None, None, None)


### PR DESCRIPTION
Security fix, release 1.8.3.

The ComfyUI model/LoRA filter built its WHERE clause as a raw `text()` fragment with an unparenthesised `OR`. Because `AND` binds tighter than `OR`, the stack-member branch escaped the predicates it was meant to be combined with, including the scope narrowing that share tokens rely on. `/pictures`, `/pictures/stream` and `/pictures/count` could therefore return grid metadata for pictures outside a scoped token's grant. No image data was reachable; thumbnails and originals are separately scoped and were unaffected.

Affects releases from 1.3.0 onward. Details will follow once people have had a chance to update.

## Changes

- Wrap the disjunction so it cannot escape the ANDed predicates.
- `tests/test_comfyui_stack_filter.py` — 10 query-level tests, both directions.
- `tests/test_read_token_security.py` — 5 token-level tests over all three routes, asserting on ids and counts. Verified to fail with the fix reverted and pass with it restored.
- Both suites pinned in `MUST_BLOCK_ON_EVERY_PR`.
- CHANGELOG and version bump for 1.8.3.