### PR TITLE
Narrow the picture scalar project_id on every picture-row payload

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1471,18 +1471,18 @@ Deliberately **not** equalised — that is a runtime change to a hot read path, 
 
 **Both directions are pinned** in `tests/test_multi_project_membership_authz.py` (R1/R1c/R1d sections): the invisible project stays invisible on every route, and a project token keeps filtering by, and reading, its own project.
 
-#### Known gap (open): a picture's scalar `project_id` is still serialised raw
+#### CLOSED (#719): a picture's scalar `project_id` is narrowed on every picture-row payload
 
-**Six routes**, all verified by reproduction on 2026-08-04 with a `picture_set`-scoped token whose set is in a project the token cannot see (`GET /projects/{that_id}` 403s it):
+**Six routes**, all verified by reproduction on 2026-08-04 with a `picture_set`-scoped token whose set is in a project the token cannot see (`GET /projects/{that_id}` 403s it), and all closed by #719:
 
-| Route | Where the id appears | Status |
+| Route | Where the id appears | Narrowed in |
 |---|---|---|
-| `GET /pictures/{id}/metadata` | `$.project_id` | reproduced |
-| `GET /pictures/{id}/{field}` (`field=project_id`) | `$.project_id` | reproduced |
-| `GET /picture_sets/{id}` | `$.pictures[N].project_id` | reproduced |
-| `GET /stacks/{stack_id}/pictures?fields=full` | `$[N].project_id` | reproduced |
-| `GET /pictures/search` | `$[N].project_id` | reproduced (needs a vault with embeddings; the reviewer's env returned `[]`) |
-| `GET /pictures/likeness-groups` | `$[N].project_id` | reproduced (needs a `picturelikeness` edge and at least one *unstacked* member, or no group forms) |
+| `GET /pictures/{id}/metadata` | `$.project_id` | `routes/pictures/_crud.py::get_picture_metadata` |
+| `GET /pictures/{id}/{field}` (`field=project_id`) | `$.project_id` | `routes/pictures/_crud.py::get_picture_field` |
+| `GET /picture_sets/{id}` | `$.pictures[N].project_id` | `routes/picture_sets.py::get_picture_set` (all three return paths: default, `sort=SMART_SCORE`, `sort=CHARACTER_LIKENESS`) |
+| `GET /stacks/{stack_id}/pictures?fields=full` | `$[N].project_id` | `routes/stacks.py::get_stack_pictures` |
+| `GET /pictures/search` | `$[N].project_id` | `routes/pictures/_search.py::search_pictures` |
+| `GET /pictures/likeness-groups` | `$[N].project_id` | `routes/pictures/_misc.py::get_likeness_groups` |
 
 `GET /picture_sets/{id}` is the instructive one: the **same handler** narrows the *set's* own `project_id` correctly and then emits the raw id on every embedded picture row. The narrowing is per-payload-shape, so getting one shape right says nothing about the next.
 
@@ -1492,10 +1492,20 @@ The common cause is `Picture.metadata_fields()` = every scalar column minus the 
 
 **Why the clean routes are clean is not one reason, and the difference matters for the fix.** `Picture.grid_fields()` omits `project_id`, so `fields=grid` never selects it. But `GET /pictures?fields=full` and `GET /pictures/stream` *do* select `metadata_fields()`, `project_id` included — they are clean because they declare `response_model=list[GridPicture]` / `StreamPicturesResponse` (`routes/pictures/_listing.py`), and FastAPI validates every row against that model and drops keys it does not declare (`GridPicture` sets no `extra="allow"`; verified by round-tripping a row carrying `project_id` through the model, which comes back without it). The projection and the response model are two independent filters, and only the second one is enforced on the `fields=full` path. Any change that widens `GridPicture`, or drops the `response_model=` on those routes, re-opens them without touching a single query.
 
-Unlike characters and picture sets, picture payloads have **no narrowing site at all** — they are built from `Picture.find(select_fields=…)` across the metadata, listing, stream, search, stack and export paths — so closing this is a serialisation-layer change (drop `project_id` from `metadata_fields()` and re-add it through a narrowing helper), not six call-site patches.
+**The fix is `narrow_picture_project_ids(server, request, rows)`** in [`filter_helpers.py`](../pixlstash/utils/service/filter_helpers.py): the picture-row twin of `narrow_project_fields`, minus the `project_ids` list a picture payload does not carry. It re-derives the scalar from the picture's *narrowed* `PictureProjectMember` membership (batched, one query per request via `picture_project_ids_map`) instead of letting the model's own column reach the wire. Owners and unscoped tokens return on the first line, so their payload and their query count are both unchanged; only a scoped token pays for the extra read.
 
-- **Owner:** backend (`senior-backend-developer`), tracked on issue #708 as a follow-up; it was deliberately not fixed with the inbound/outbound work because the fix is a different shape.
-- **Revisit trigger — any of:** (a) a picture-scoped or set-scoped share link is exposed outside the owner's own devices (multi-user, or the hosted demo handing out resource-scoped tokens); (b) `Picture.metadata_fields()` gains another membership-bearing column; (c) a seventh route joins the table above. Until then the exposure is bounded to "a token the owner minted learns a project id it was 403'd on by name", with no cross-picture reach — the inbound filter rule already denies the *query* half of the class, so the id cannot be turned back into a listing.
+Deriving from the join table rather than intersecting the raw scalar is deliberate and matches R1b: a P2 token reading a picture whose stored primary is P1 gets `project_id: 2`, not `null`. Intersecting the raw scalar would have been safe too, but it makes a picture the token legitimately shares look unassigned, which is the over-blocking half of the regression pair.
+
+`Picture.metadata_fields()` was **not** changed. Dropping `project_id` from it would fail closed for future routes, but it is also the default `select_fields` of `Picture.find` (`db_models/picture.py`) and feeds `scoring/smart_score.py`, `scoring/character_likeness.py` and `utils/service/export_utils.py`, so removing the column changes what internal callers load, not just what six handlers serialise. Tracked as the residual below.
+
+**Both directions are pinned** in the R1e section of `tests/test_multi_project_membership_authz.py`: the scoped token's scalar comes from its own narrowed membership, an entity-scoped token gets `null`, and the owner keeps the stored primary, and over-blocking is asserted as its own failure. Every site/token combination asserted there was confirmed to leak before the fix, so none of the assertions is vacuous. Two probes are **not** pinned by a live row and are recorded as such in the test: `GET /picture_sets/{id}?sort=SMART_SCORE` and `?sort=CHARACTER_LIKENESS` return no rows without a smart-score anchor / an assigned reference face, which that fixture does not build. Their narrowing is one line on each of the handler's other two return paths and is asserted opportunistically if a row ever appears.
+
+**The column set itself is now pinned.** `tests/test_architecture_guardrails.py::test_picture_metadata_fields_membership_is_pinned` holds the exact 42 names `Picture.metadata_fields()` returns, so a new `picture` column fails the build until someone decides whether a scoped token may learn it. That is the part of #719 that generalises: the leak was not that one narrowing was forgotten, it was that "every column minus blobs" makes forgetting the default. Both mutants (a name dropped from the pin, a name added to it) were confirmed to fail the assertion.
+
+- **Residual (open): `metadata_fields()` is still "every column minus blobs", it is only *watched*.** The pin above turns a silent addition into a build failure; it does not make the projection an allowlist, and it cannot narrow anything by itself. Inverting it is the durable fix and was deliberately not attempted here: `metadata_fields()` is also the default `select_fields` of `Picture.find`, so removing a column changes what `scoring/smart_score.py`, `scoring/character_likeness.py` and `utils/service/export_utils.py` load, not only what six handlers serialise.
+- **Residual (open): the response models provide no containment.** `PictureFullMetadataResponse`, `PictureMetadataResponse` and `LikenessGroupResponse` all set `extra="allow"`, so the handler narrowing is the only filter on these six routes. Flipping any of them to `extra="ignore"` would drop ~40 undeclared metadata columns and gut the endpoint, so it is a schema project, not a one-line hardening.
+- **Residual (open): `GET /pictures` and `GET /pictures/stream` stay clean only via `GridPicture`.** They still select `project_id` and are filtered solely by the response model, as described above. Widening `GridPicture` or dropping the `response_model=` re-opens them silently.
+- **Owner:** backend (`senior-backend-developer`), tracked on issue #719.
 
 ---
 

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1471,7 +1471,17 @@ Deliberately **not** equalised — that is a runtime change to a hot read path, 
 
 **Both directions are pinned** in `tests/test_multi_project_membership_authz.py` (R1/R1c/R1d sections): the invisible project stays invisible on every route, and a project token keeps filtering by, and reading, its own project.
 
-#### CLOSED (#719): a picture's scalar `project_id` is narrowed on every picture-row payload
+#### PARTIALLY CLOSED (#719): a picture's scalar `project_id` is narrowed on every picture-row *projection*
+
+**Scope of the claim, precisely.** #719 closes the six routes below, which build their payload from `Picture.metadata_fields()` or an explicit `select_fields`. It does **not** close the confidentiality boundary those routes are named after, because the two generic field readers also serve the ORM **relationship** namespace, which no projection constrains. Reproduced 2026-08-05 with a `picture`-scoped token:
+
+```
+GET /projects/1            -> 403
+GET /pictures/1/project_id -> {"project_id": null}          # closed by #719
+GET /pictures/1/projects   -> {"projects":[{"id":1,"name":"P1",...}]}   # still open
+```
+
+`Picture.projects` is a `Relationship` and `safe_model_dict` recurses into relationships, so `select_fields=[field]` does not bound the response. The same shape holds for `GET /pictures/{id}/picture_sets` (set names, plus `project_id` again on a sibling key) and for the character twin, `GET /characters/{id}/project` and `GET /characters/{id}/pictures` — the latter serving full `Picture` rows off the relationship, bypassing every narrowing site in the codebase. Tracked as its own issue; the durable fix is an allowlist of servable field names on both readers, not another `if field == ...` branch. Do not read the table below as "the id is unreachable" — read it as "these six projections narrow it".
 
 **Six routes**, all verified by reproduction on 2026-08-04 with a `picture_set`-scoped token whose set is in a project the token cannot see (`GET /projects/{that_id}` 403s it), and all closed by #719:
 

--- a/pixlstash/routes/picture_sets.py
+++ b/pixlstash/routes/picture_sets.py
@@ -43,6 +43,7 @@ from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.service.filter_helpers import (
     fetch_scope_allowed_picture_ids,
     filter_visible_project_ids,
+    narrow_picture_project_ids,
     narrow_project_fields,
     visible_project_ids,
 )
@@ -1329,6 +1330,7 @@ def create_router(server) -> APIRouter:
             if deduplicate_stacks:
                 pictures = deduplicate_by_stack(pictures)
             pictures = _enrich_with_stack_counts(pictures)
+            narrow_picture_project_ids(server, request, pictures)
             return {
                 "pictures": pictures,
                 "set": narrow_project_fields(
@@ -1354,6 +1356,7 @@ def create_router(server) -> APIRouter:
             if deduplicate_stacks:
                 pictures = deduplicate_by_stack(pictures)
             pictures = _enrich_with_stack_counts(pictures)
+            narrow_picture_project_ids(server, request, pictures)
             return {
                 "pictures": pictures,
                 "set": narrow_project_fields(
@@ -1393,6 +1396,10 @@ def create_router(server) -> APIRouter:
 
         pictures = server.vault.db.run_immediate_read_task(fetch_pics, picture_ids)
         pictures = _enrich_with_stack_counts(pictures)
+        # The set's own scalar is narrowed just below; the member rows carry the
+        # raw `Picture.project_id` from `metadata_fields()` and need the same
+        # treatment, one payload shape at a time (issue #719, §16.6).
+        narrow_picture_project_ids(server, request, pictures)
         set_payload = safe_model_dict(picture_set)
         narrow_project_fields(set_payload, set_project_ids, visible_projects)
         return {"pictures": pictures, "set": set_payload}

--- a/pixlstash/routes/pictures/_crud.py
+++ b/pixlstash/routes/pictures/_crud.py
@@ -45,6 +45,7 @@ from pixlstash.utils.service.caption_utils import (
 from pixlstash.utils.service.filter_helpers import (
     fetch_scope_allowed_picture_ids,
     fetch_scope_allowed_set_ids,
+    narrow_picture_project_ids,
 )
 from pixlstash.utils.service.scope_table import scope_id_subquery
 from pixlstash.utils.serialization_utils import safe_model_dict
@@ -796,6 +797,10 @@ def register_routes(router, server):
             fetch_image_only_tags, pic.id
         )
         pic_dict = safe_model_dict(pic)
+        # `metadata_fields()` is every scalar column minus the blobs, so the raw
+        # `Picture.project_id` rides along; re-derive it from the narrowed
+        # membership before it is serialised (issue #719, §16.6).
+        narrow_picture_project_ids(server, request, [pic_dict])
         pic_dict["tags"] = serialize_tag_objects(pic_tags)
         # Locked sets freezing this picture, so the overlay can show the reason
         # without a second request.
@@ -919,6 +924,14 @@ def register_routes(router, server):
             return Response(content=pic.thumbnail, media_type="image/png")
         if field in Picture.large_binary_fields():
             return {field: base64.b64encode(getattr(pic, field)).decode("utf-8")}
+        if field == "project_id":
+            # This route hands back any column by name, so it reaches the raw
+            # scalar without going through the metadata payload. Same narrowing,
+            # same reason (issue #719, §16.6), and the same shape the character
+            # twin `GET /characters/{id}/{field}` already uses.
+            payload = {"id": int(pic.id), "project_id": pic.project_id}
+            narrow_picture_project_ids(server, request, [payload])
+            return {"project_id": payload["project_id"]}
         return {field: safe_model_dict(getattr(pic, field))}
 
     @router.patch(

--- a/pixlstash/routes/pictures/_misc.py
+++ b/pixlstash/routes/pictures/_misc.py
@@ -41,6 +41,7 @@ from pixlstash.utils.service.filter_helpers import (
     collect_set_filter_ids,
     fetch_scope_allowed_picture_ids,
     fetch_set_candidate_ids,
+    narrow_picture_project_ids,
     normalize_set_mode,
     project_membership_exists_clause,
     project_unassigned_clause,
@@ -782,6 +783,10 @@ def register_routes(router, server):
             )
             response.extend(stack_items)
 
+        # Group rows are built from `metadata_fields()` and returned through a
+        # response model with `extra="allow"`, so the raw `Picture.project_id`
+        # survives to the wire unless it is narrowed here (issue #719, §16.6).
+        narrow_picture_project_ids(server, request, response)
         return response
 
     @router.post(

--- a/pixlstash/routes/pictures/_search.py
+++ b/pixlstash/routes/pictures/_search.py
@@ -20,6 +20,7 @@ from pixlstash.utils.service.filter_helpers import (
     collect_set_filter_ids,
     fetch_scope_allowed_picture_ids,
     fetch_set_candidate_ids,
+    narrow_picture_project_ids,
     normalize_set_mode,
     project_membership_exists_clause,
     project_unassigned_clause,
@@ -454,4 +455,10 @@ def register_routes(router, server):
                     if result[0] is not None
                     and getattr(result[0], "id", None) not in hidden_ids
                 ]
-        return [Picture.serialize_with_likeness(r) for r in results]
+        rows = [Picture.serialize_with_likeness(r) for r in results]
+        # Rows come from `metadata_fields()`, which carries the raw
+        # `Picture.project_id`, and `PictureMetadataResponse` sets
+        # `extra="allow"` so the response model filters nothing (issue #719,
+        # §16.6).
+        narrow_picture_project_ids(server, request, rows)
+        return rows

--- a/pixlstash/routes/stacks.py
+++ b/pixlstash/routes/stacks.py
@@ -24,7 +24,10 @@ from pixlstash.picture_scoring import (
 from pixlstash.utils.quality.smart_score_utils import SmartScoreUtils
 from pixlstash.utils.request_origin import require_client_batch_id
 from pixlstash.utils.serialization_utils import safe_model_dict
-from pixlstash.utils.service.filter_helpers import fetch_scope_allowed_picture_ids
+from pixlstash.utils.service.filter_helpers import (
+    fetch_scope_allowed_picture_ids,
+    narrow_picture_project_ids,
+)
 from pixlstash.utils.service.scope_table import scope_id_subquery
 from pixlstash.pixl_logging import get_logger
 
@@ -718,10 +721,15 @@ def create_router(server) -> APIRouter:
         # this also persists positions for stacks that haven't been ordered yet.
         if sort_mech is None:
             pictures = _ensure_stack_positions(request, stack_id, pictures)
-        return [
+        rows = [
             {field: safe_model_dict(pic).get(field) for field in select_fields}
             for pic in pictures
         ]
+        # `fields=grid` never selects `project_id`; anything else goes through
+        # `metadata_fields()`, which does, and the route's `list[dict]` response
+        # model filters nothing (issue #719, §16.6).
+        narrow_picture_project_ids(server, request, rows)
+        return rows
 
     @router.get(
         "/pictures/{picture_id}/stack",

--- a/pixlstash/utils/service/filter_helpers.py
+++ b/pixlstash/utils/service/filter_helpers.py
@@ -17,6 +17,7 @@ from pixlstash.db_models import (
     PictureSetProjectMember,
 )
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.service.scope_table import scope_id_subquery
 
 logger = get_logger(__name__)
 
@@ -531,6 +532,92 @@ def narrow_project_fields(
     payload["project_ids"] = narrowed
     payload["project_id"] = narrowed[0] if narrowed else None
     return payload
+
+
+def picture_project_ids_map(
+    session: Session, picture_ids: Iterable[int]
+) -> dict[int, list[int]]:
+    """Return every project each of *picture_ids* belongs to, lowest id first.
+
+    The picture twin of ``character_project_ids`` / ``picture_set_project_ids``
+    in ``project_membership_service``, batched: one query for a whole page of
+    rows rather than one per row. The id scope goes through
+    :func:`scope_id_subquery` because a page can be a whole picture set, which
+    would otherwise bind one SQL variable per member.
+
+    Args:
+        session: Active database session.
+        picture_ids: The pictures to look up.
+
+    Returns:
+        ``picture_id -> [project_id, ...]``. A picture with no membership is
+        absent from the mapping.
+    """
+    ids = {int(pid) for pid in picture_ids if pid is not None}
+    if not ids:
+        return {}
+    scope = scope_id_subquery(session, ids, name="_pixlstash_picture_project_ids")
+    rows = session.exec(
+        select(PictureProjectMember.picture_id, PictureProjectMember.project_id).where(
+            PictureProjectMember.picture_id.in_(scope)
+        )
+    ).all()
+    grouped: dict[int, list[int]] = {}
+    for picture_id, project_id in rows:
+        if picture_id is None or project_id is None:
+            continue
+        grouped.setdefault(int(picture_id), []).append(int(project_id))
+    for project_list in grouped.values():
+        project_list.sort()
+    return grouped
+
+
+def narrow_picture_project_ids(server, request, payloads: Iterable[dict]) -> None:
+    """Narrow the scalar ``project_id`` on serialised picture rows, in place.
+
+    The picture-row twin of :func:`narrow_project_fields`, minus the
+    ``project_ids`` list a picture payload does not carry. ``Picture.project_id``
+    is a real column and rides in ``Picture.metadata_fields()``, so every payload
+    built from that projection serialises the picture's *primary* project id
+    straight off the model. That is a fact a token scoped to the picture, to a
+    set, or to a *secondary* project has no grant to learn, and cannot obtain
+    from ``GET /projects/{id}``, which 403s it (issue #719, backend architecture
+    §16.6).
+
+    Owners and unscoped tokens return on the first line: their payload is
+    untouched and no membership query runs, so neither the response nor the cost
+    of their request changes.
+
+    Args:
+        server: The server instance, used to run the membership read.
+        request: The current FastAPI request.
+        payloads: Serialised picture rows, mutated in place. A row without a
+            ``project_id`` key is left alone; a row that has one must also carry
+            its ``id``, or the scalar is cleared rather than guessed.
+    """
+    visible = visible_project_ids(server, request)
+    if visible is None:
+        return
+    rows = [row for row in payloads if isinstance(row, dict) and "project_id" in row]
+    if not rows:
+        return
+    picture_ids = {int(row["id"]) for row in rows if row.get("id") is not None}
+    membership = (
+        server.vault.db.run_immediate_read_task(picture_project_ids_map, picture_ids)
+        if picture_ids
+        else {}
+    )
+    for row in rows:
+        row_id = row.get("id")
+        if row_id is None:
+            logger.warning(
+                "narrow_picture_project_ids: picture row carries project_id but no"
+                " id; clearing the scalar rather than disclosing it unnarrowed"
+            )
+            row["project_id"] = None
+            continue
+        narrowed = filter_visible_project_ids(membership.get(int(row_id), []), visible)
+        row["project_id"] = narrowed[0] if narrowed else None
 
 
 def narrow_project_assignments(

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -1306,6 +1306,102 @@ def test_project_references_outside_the_query_chokepoint(built_app):
     )
 
 
+# `Picture.metadata_fields()` is "every scalar column minus the large binaries"
+# (`db_models/picture.py`), and six routes serialise its result to the wire
+# through response models that all set `extra="allow"`, so nothing downstream
+# filters it (§16.6). A column added to the `picture` table therefore joins those
+# payloads with no code change and no failing test, which is how the scalar
+# `project_id` reached a picture-scoped token that `GET /projects/{id}` 403s
+# (#719). Pinning the membership does not decide whether a new column is safe to
+# disclose; it forces the question to be asked once, by whoever adds it.
+_PICTURE_METADATA_FIELDS = {
+    "aesthetic_score",
+    "anomaly_tag_uncertainty",
+    "comfyui_loras",
+    "comfyui_models",
+    "comfyui_positive_prompt",
+    "created_at",
+    "deleted",
+    "deleted_at",
+    "description",
+    "description_file",
+    "description_file_mtime",
+    "file_path",
+    "format",
+    "height",
+    "id",
+    "import_source_folder",
+    "imported_at",
+    "is_video",
+    "metadata_hash",
+    "original_file_name",
+    "pending_character_id",
+    "perceptual_hash",
+    "pixel_sha",
+    "project_id",
+    "reference_folder_id",
+    "score",
+    "size_bin_index",
+    "size_bytes",
+    "smart_score",
+    "source_picture_id",
+    "square_crop_side",
+    "square_crop_x",
+    "square_crop_y",
+    "stack_id",
+    "stack_position",
+    "tag_uncertainty",
+    "tags_file",
+    "tags_file_mtime",
+    "text_score",
+    "thumbnail_height",
+    "thumbnail_width",
+    "width",
+}
+
+
+def test_picture_metadata_fields_membership_is_pinned():
+    """A new picture column cannot join the six serialised payloads unnoticed.
+
+    Adding a column is fine. Adding one that carries membership, ownership or
+    host information, and letting it ride into `GET /pictures/{id}/metadata`,
+    `GET /pictures/{id}/{field}`, `GET /pictures/search`,
+    `GET /pictures/likeness-groups`, `GET /picture_sets/{id}` and
+    `GET /stacks/{stack_id}/pictures?fields=full` without narrowing it, is the
+    #719 defect repeated. If the new column is safe for a scoped token, add it to
+    the set below. If it is not, narrow it at those six sites the way
+    `narrow_picture_project_ids` does.
+    """
+    from pixlstash.db_models import Picture
+
+    actual = set(Picture.metadata_fields())
+    # Anti-vacuity: an empty projection would make both assertions below pass
+    # while pinning nothing at all.
+    assert len(actual) > 20, (
+        f"Picture.metadata_fields() returned {len(actual)} fields; the pin is "
+        f"vacuous if the projection collapses"
+    )
+
+    added = sorted(actual - _PICTURE_METADATA_FIELDS)
+    assert not added, (
+        "New picture column(s) now ride every payload built from "
+        "Picture.metadata_fields(), including the six routes that serialise it "
+        'raw through an `extra="allow"` response model (§16.6). Decide whether '
+        "a picture-, set- or project-scoped token may learn each one. If yes, "
+        "add it here. If no, narrow it at those six sites the way "
+        "narrow_picture_project_ids does for project_id (#719):\n"
+        + "\n".join(f"  {name}" for name in added)
+    )
+
+    removed = sorted(_PICTURE_METADATA_FIELDS - actual)
+    assert not removed, (
+        "Picture column(s) disappeared from metadata_fields(), so this pin now "
+        "describes a projection that no longer exists. Prune them, and check the "
+        "six serialisation sites still return what their consumers expect:\n"
+        + "\n".join(f"  {name}" for name in removed)
+    )
+
+
 def test_matched_route_path_is_prefix_stripped(built_app):
     """Lock in the Phase-1 gate-keying fact: scope['route'].path is UNPREFIXED.
 

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -1371,6 +1371,26 @@ def test_picture_metadata_fields_membership_is_pinned():
     #719 defect repeated. If the new column is safe for a scoped token, add it to
     the set below. If it is not, narrow it at those six sites the way
     `narrow_picture_project_ids` does.
+
+    **Membership in the set below does NOT certify a column as safe.** The set is
+    the *current* projection, pinned so a change is noticed; it is not a list of
+    columns anyone has cleared. Three members are known disclosures to a scoped
+    token, reproduced during the #719 review and deliberately left unnarrowed
+    pending a decision, so nothing here should be read as their having been
+    reviewed and passed:
+
+    * ``pending_character_id`` — a character FK, while ``GET /characters/{id}``
+      is ``CHARACTER_SCOPED`` and 403s the same token. Not transient: the dedup
+      verdict and keep-cover-only services set it on pictures whose face
+      extraction has already run, so it persists. Narrowing it needs a
+      ``visible_character_ids`` ladder, which does not exist yet.
+    * ``source_picture_id`` — points at a picture the token may not be granted
+      (verified: that picture's own endpoints 403 the same token).
+    * ``reference_folder_id`` — same shape, and additionally in ``grid_fields()``,
+      so it rides every listing rather than only these six routes.
+
+    ``import_source_folder``, ``pixel_sha``, ``original_file_name`` and the
+    ComfyUI prompt columns are a separate host-information question (§16.3).
     """
     from pixlstash.db_models import Picture
 

--- a/tests/test_multi_project_membership_authz.py
+++ b/tests/test_multi_project_membership_authz.py
@@ -39,14 +39,14 @@ import pytest
 from PIL import Image
 from starlette.testclient import TestClient
 
-from pixlstash.db_models import Face
+from pixlstash.db_models import Face, PictureLikeness
 from pixlstash.server import Server
 from tests.authz_guard import (  # noqa: F401
     assert_real_route,
     no_spa_fallback,
     resolves_to_real_route,
 )
-from tests.utils import upload_pictures_and_wait
+from tests.utils import seed_likeness_stable, upload_pictures_and_wait
 
 API = "/api/v1"
 
@@ -995,6 +995,264 @@ def test_character_project_id_field_route_is_narrowed(env):
         assert r.json()["project_id"] is None, (
             f"a character token has no project visibility: {r.json()}"
         )
+
+
+# ---------------------------------------------------------------------------
+# R1e (issue #719): the *picture's* own scalar `project_id`
+# ---------------------------------------------------------------------------
+#
+# R1b narrowed the scalar on characters and picture sets. A picture carries the
+# same column, and `Picture.metadata_fields()` is "every scalar column minus the
+# blobs", so it rides into every payload built from that projection. None of the
+# picture response models filters it back out: they all set `extra="allow"`, so
+# the handler's own narrowing is the only thing between the column and the wire.
+#
+# The reproduction has a trap that made the first probe of this come back clean:
+# the set/character PATCHes in the fixture write `PictureProjectMember` rows but
+# leave `Picture.project_id` NULL, so every site returns None whether it narrows
+# or not. A real membership write (`PATCH /pictures/project`) maintains the
+# scalar as a denormalised primary. Both tests below backfill it first and assert
+# the backfill landed, so a regression cannot hide behind a NULL column.
+
+# Picture-row sites that answer deterministically in this fixture. Asserted as a
+# required subset, so a site that silently stops answering cannot quietly drop
+# out of coverage.
+_PICTURE_SCALAR_SITES = {
+    "metadata",
+    "field_route",
+    "set_pictures",
+    "stack_pictures_full",
+}
+
+# The two sort variants of ``GET /picture_sets/{id}`` build their picture rows on
+# separate return paths, and each one narrows separately. They need a smart-score
+# anchor / an assigned reference face before they return any row at all, which
+# this fixture does not build, so they are probed opportunistically: any row they
+# do return is asserted alongside the required sites above, and the gap is
+# recorded rather than papered over with an assertion that passes on ``[]``.
+_PICTURE_SCALAR_OPPORTUNISTIC_SITES = {
+    "set_pictures_smart_sort",
+    "set_pictures_likeness_sort",
+}
+
+
+def _picture_scalar_sites(client, env, picture_id, headers=None, stack_id=None):
+    """``project_id`` for *picture_id* on every picture-row route the caller can
+    reach. A site whose route refuses the token, or which does not list the
+    picture, is omitted, so every caller asserts that the deterministic sites are
+    all present before reading their values."""
+    kw = {"headers": headers} if headers else {}
+    out = {}
+
+    r = client.get(f"{API}/pictures/{picture_id}/metadata", **kw)
+    if r.status_code == 200:
+        body = r.json()
+        assert "project_id" in body, "the metadata payload must keep the key"
+        out["metadata"] = body["project_id"]
+
+    r = client.get(f"{API}/pictures/{picture_id}/project_id", **kw)
+    if r.status_code == 200:
+        out["field_route"] = r.json()["project_id"]
+
+    def pick(rows, label):
+        row = next((item for item in rows if item.get("id") == picture_id), None)
+        if row is None:
+            return
+        assert "project_id" in row, f"{label}: the row lost its project_id key"
+        out[label] = row["project_id"]
+
+    r = client.get(f"{API}/picture_sets/{env['set_id']}", **kw)
+    if r.status_code == 200:
+        pick(r.json()["pictures"], "set_pictures")
+    r = client.get(f"{API}/picture_sets/{env['set_id']}?sort=SMART_SCORE", **kw)
+    if r.status_code == 200:
+        pick(r.json()["pictures"], "set_pictures_smart_sort")
+    r = client.get(
+        f"{API}/picture_sets/{env['set_id']}?sort=CHARACTER_LIKENESS"
+        f"&reference_character_id={env['char_id']}",
+        **kw,
+    )
+    if r.status_code == 200:
+        pick(r.json()["pictures"], "set_pictures_likeness_sort")
+
+    if stack_id is not None:
+        r = client.get(f"{API}/stacks/{stack_id}/pictures?fields=full", **kw)
+        if r.status_code == 200:
+            pick(r.json(), "stack_pictures_full")
+    return out
+
+
+def test_picture_scalar_project_id_is_narrowed(env):
+    """R1e: a picture's scalar ``project_id`` is derived from its *narrowed*
+    membership at every serialisation site: the stored primary for the owner,
+    the token's own project for a project token, ``None`` for an entity-scoped
+    token that may see no project at all."""
+    owner, anon, tokens, projects, mint = (
+        env["owner"],
+        env["anon"],
+        env["tokens"],
+        env["projects"],
+        env["mint"],
+    )
+    pic_a, pic_b = env["pic_a"], env["pic_b"]
+
+    # pic_b joins the shared set (and so both projects); stacking the two gives
+    # the stack route a page it can serve to every token under test.
+    r = owner.post(f"{API}/picture_sets/{env['set_id']}/members/{pic_b}")
+    assert r.status_code in (200, 201), r.text
+    r = owner.post(f"{API}/stacks", json={"picture_ids": [pic_a, pic_b]})
+    assert r.status_code in (200, 201), r.text
+    stack_id = r.json()["id"]
+
+    # Backfill the denormalised scalar the way a real membership write does.
+    r = owner.patch(
+        f"{API}/pictures/project",
+        json={
+            "picture_ids": [pic_a, pic_b],
+            "project_id": projects["P1"],
+            "mode": "add",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    for path in (
+        f"{API}/pictures/{pic_a}/metadata",
+        f"{API}/pictures/{pic_a}/project_id",
+        f"{API}/stacks/{stack_id}/pictures",
+    ):
+        assert_real_route(env["server"].api, "GET", path)
+
+    owner_sites = _picture_scalar_sites(owner, env, pic_a, stack_id=stack_id)
+    assert _PICTURE_SCALAR_SITES <= set(owner_sites), (
+        f"a picture-row site stopped answering, so its narrowing is untested: "
+        f"{sorted(owner_sites)}"
+    )
+    # State the universe explicitly: anything not answered here must be one of
+    # the two known-empty sort variants, so a third silent gap fails the build.
+    assert (_PICTURE_SCALAR_SITES | _PICTURE_SCALAR_OPPORTUNISTIC_SITES) - set(
+        owner_sites
+    ) <= _PICTURE_SCALAR_OPPORTUNISTIC_SITES, sorted(owner_sites)
+    for site, value in owner_sites.items():
+        assert value == projects["P1"], (
+            f"{site}: the owner must keep the stored primary project, and the "
+            f"scalar must actually be backfilled; got {value}"
+        )
+
+    with _enforcing(env["server"]):
+        for label in ("P1", "P2"):
+            sites = _picture_scalar_sites(
+                anon, env, pic_a, _bearer(tokens[label]), stack_id
+            )
+            assert _PICTURE_SCALAR_SITES <= set(sites), (
+                f"the {label} token must still read every picture-row site "
+                f"(over-blocking is its own regression): {sorted(sites)}"
+            )
+            for site, value in sites.items():
+                assert value == projects[label], (
+                    f"{site}: the {label} token was handed project id {value}, "
+                    f"which it is 403'd on by name"
+                )
+
+        set_sites = _picture_scalar_sites(
+            anon, env, pic_a, _bearer(mint("picture_set", env["set_id"])), stack_id
+        )
+        assert _PICTURE_SCALAR_SITES <= set(set_sites), sorted(set_sites)
+        for site, value in set_sites.items():
+            assert value is None, (
+                f"{site}: a set-scoped token has no project visibility, but was "
+                f"handed project id {value}"
+            )
+
+        pic_sites = _picture_scalar_sites(
+            anon, env, pic_a, _bearer(mint("picture", pic_a))
+        )
+        assert {"metadata", "field_route"} <= set(pic_sites), (
+            f"a picture token must still read its own picture: {sorted(pic_sites)}"
+        )
+        for site, value in pic_sites.items():
+            assert value is None, (
+                f"{site}: a picture-scoped token has no project visibility, but "
+                f"was handed project id {value}"
+            )
+
+
+def test_picture_search_and_likeness_group_rows_are_narrowed(env):
+    """R1e siblings: the two picture-row payloads that need seeded data before
+    they return anything: semantic search and the likeness groups."""
+    owner, anon, tokens, projects, mint = (
+        env["owner"],
+        env["anon"],
+        env["tokens"],
+        env["projects"],
+        env["mint"],
+    )
+    pic_a, pic_b = env["pic_a"], env["pic_b"]
+
+    r = owner.post(f"{API}/picture_sets/{env['set_id']}/members/{pic_b}")
+    assert r.status_code in (200, 201), r.text
+    r = owner.patch(
+        f"{API}/pictures/project",
+        json={
+            "picture_ids": [pic_a, pic_b],
+            "project_id": projects["P1"],
+            "mode": "add",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert (
+        owner.get(f"{API}/pictures/{pic_a}/project_id").json()["project_id"]
+        == projects["P1"]
+    ), "the scalar must be backfilled, or every assertion below is vacuous"
+
+    def seed(session):
+        low, high = sorted([pic_a, pic_b])
+        session.add(
+            PictureLikeness(
+                picture_id_a=low, picture_id_b=high, likeness=0.99, metric="test"
+            )
+        )
+        session.commit()
+
+    seed_likeness_stable(env["server"], seed)
+
+    for path in (f"{API}/pictures/likeness-groups", f"{API}/pictures/search"):
+        assert_real_route(env["server"].api, "GET", path)
+
+    def groups(client, headers=None):
+        kw = {"headers": headers} if headers else {}
+        r = client.get(f"{API}/pictures/likeness-groups?threshold=0.9", **kw)
+        assert r.status_code == 200, r.text
+        rows = [item for item in r.json() if item.get("id") == pic_a]
+        assert rows, f"picture {pic_a} must be in a likeness group: {r.json()}"
+        assert "project_id" in rows[0], "the group row lost its project_id key"
+        return rows[0]["project_id"]
+
+    def search(client, headers=None):
+        kw = {"headers": headers} if headers else {}
+        r = client.get(f"{API}/pictures/search?query=picture&threshold=0.0", **kw)
+        assert r.status_code == 200, r.text
+        rows = [item for item in r.json() if item.get("id") == pic_a]
+        assert rows, f"semantic search must return picture {pic_a}: {r.json()}"
+        assert "project_id" in rows[0], "the search row lost its project_id key"
+        return rows[0]["project_id"]
+
+    assert groups(owner) == projects["P1"]
+    assert search(owner) == projects["P1"]
+
+    with _enforcing(env["server"]):
+        for label in ("P1", "P2"):
+            headers = _bearer(tokens[label])
+            assert groups(anon, headers) == projects[label], (
+                f"likeness-groups handed the {label} token a project id it is "
+                f"403'd on by name"
+            )
+            assert search(anon, headers) == projects[label], (
+                f"search handed the {label} token a project id it is 403'd on by name"
+            )
+
+        set_headers = _bearer(mint("picture_set", env["set_id"]))
+        assert groups(anon, set_headers) is None
+        assert search(anon, set_headers) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_multi_project_membership_authz.py
+++ b/tests/test_multi_project_membership_authz.py
@@ -35,11 +35,14 @@ import os
 import tempfile
 import time
 
+import numpy as np
 import pytest
 from PIL import Image
+from sqlalchemy import func
+from sqlmodel import select
 from starlette.testclient import TestClient
 
-from pixlstash.db_models import Face, PictureLikeness
+from pixlstash.db_models import Face, Picture, PictureLikeness
 from pixlstash.server import Server
 from tests.authz_guard import (  # noqa: F401
     assert_real_route,
@@ -1025,11 +1028,10 @@ _PICTURE_SCALAR_SITES = {
 }
 
 # The two sort variants of ``GET /picture_sets/{id}`` build their picture rows on
-# separate return paths, and each one narrows separately. They need a smart-score
-# anchor / an assigned reference face before they return any row at all, which
-# this fixture does not build, so they are probed opportunistically: any row they
-# do return is asserted alongside the required sites above, and the gap is
-# recorded rather than papered over with an assertion that passes on ``[]``.
+# separate return paths, and each one narrows separately. They return nothing on
+# the fixture's raw uploads, so they are probed opportunistically here and pinned
+# properly, with the inputs each branch needs, by
+# ``test_picture_set_sort_variants_narrow_their_rows`` below.
 _PICTURE_SCALAR_OPPORTUNISTIC_SITES = {
     "set_pictures_smart_sort",
     "set_pictures_likeness_sort",
@@ -1253,6 +1255,213 @@ def test_picture_search_and_likeness_group_rows_are_narrowed(env):
         set_headers = _bearer(mint("picture_set", env["set_id"]))
         assert groups(anon, set_headers) is None
         assert search(anon, set_headers) is None
+
+
+def _wait_faces_extracted(server, picture_ids, timeout_s=60.0):
+    """Block until background face extraction has finished with *picture_ids*.
+
+    Uploading a picture queues an extraction pass that ends by writing either
+    the detected faces or a ``face_index=-1`` sentinel, so "the picture has at
+    least one face row" is the signal that the pass is done. Waiting for it is
+    not optional: a face seeded *before* the pass lands is deleted underneath
+    the test (``Picture.faces`` cascades ``delete-orphan``), which was observed
+    here as the reference face vanishing between two requests in the same test.
+    """
+
+    def _counts(session):
+        return {
+            int(pid): int(count)
+            for pid, count in session.exec(
+                select(Face.picture_id, func.count())
+                .where(Face.picture_id.in_([int(p) for p in picture_ids]))
+                .group_by(Face.picture_id)
+            ).all()
+        }
+
+    start = time.time()
+    counts = {}
+    while time.time() - start < timeout_s:
+        counts = server.vault.db.run_immediate_read_task(_counts)
+        if all(counts.get(int(pid), 0) > 0 for pid in picture_ids):
+            return
+        time.sleep(0.25)
+    raise AssertionError(
+        f"face extraction did not finish for {list(picture_ids)} in {timeout_s}s; "
+        f"rows per picture: {counts}"
+    )
+
+
+def _seed_set_sort_inputs(server, picture_ids, character_id):
+    """Give the two sort branches of ``GET /picture_sets/{id}`` rows to return.
+
+    Neither branch emits a picture on the fixture's raw uploads, and each is
+    blocked by a different missing input:
+
+    * ``sort=SMART_SCORE`` scores only pictures whose ``image_embedding`` is
+      non-NULL (``scoring/smart_score.py``); everything else is reported as
+      unscored.
+    * ``sort=CHARACTER_LIKENESS`` needs a *reference* face for the reference
+      character, which is a ``Face`` carrying ``features`` on a non-deleted
+      picture scored 5 (``scoring/character_likeness.py``), plus a candidate
+      face on the set's members.
+
+    Both are written straight to the database rather than computed, so the test
+    does not depend on an embedding model or the face detector producing
+    anything under the CPU test profile. Two properties keep the seed alive
+    against the background pipeline, and both were established by watching it
+    delete the face mid-test:
+
+    * it runs only once extraction has settled (:func:`_wait_faces_extracted`),
+      and uses a ``face_index`` far outside the detector's range, so a late pass
+      cannot collide with the ``(picture, frame, face)`` unique constraint;
+    * it copies ``model_pack`` off a row the extractor just wrote. A face that
+      carries ``features`` with a *different* (or NULL) pack is exactly what
+      ``MissingFaceModelRefreshFinder`` selects, and ``FaceModelRefreshTask``
+      then deletes any seeded row its re-detection does not match. Adopting the
+      live pack keeps the row out of that sweep entirely.
+    """
+    _wait_faces_extracted(server, picture_ids)
+
+    def _do(session):
+        vector = np.ones(512, dtype=np.float32).tobytes()
+        model_pack = session.exec(
+            select(Face.model_pack).where(Face.model_pack.is_not(None)).limit(1)
+        ).first()
+        assert model_pack, (
+            "no extracted face carries a model_pack, so the seeded face would be "
+            "swept as stale-pack and deleted mid-test"
+        )
+        for picture_id in picture_ids:
+            pic = session.get(Picture, int(picture_id))
+            assert pic is not None, f"picture {picture_id} vanished from the fixture"
+            pic.image_embedding = vector
+            pic.score = 5
+            session.add(pic)
+            session.add(
+                Face(
+                    picture_id=int(picture_id),
+                    frame_index=0,
+                    face_index=901,
+                    character_id=int(character_id),
+                    features=vector,
+                    model_pack=model_pack,
+                )
+            )
+        session.commit()
+
+    server.vault.db.run_task(_do)
+
+    def _readback(session):
+        return session.exec(
+            select(Face.picture_id, Face.character_id)
+            .where(Face.features.is_not(None))
+            .where(Face.character_id == int(character_id))
+        ).all(), session.exec(
+            select(Picture.id, Picture.score).where(
+                Picture.image_embedding.is_not(None)
+            )
+        ).all()
+
+    faces, scored = server.vault.db.run_immediate_read_task(_readback)
+    assert len(faces) >= len(picture_ids), (
+        f"the seeded reference faces did not survive; a background stage most "
+        f"likely rewrote them. faces={faces}"
+    )
+    assert len(scored) >= len(picture_ids), (
+        f"the seeded embeddings did not survive. scored={scored}"
+    )
+
+
+def _set_sort_row_project_id(client, env, picture_id, query, marker, headers=None):
+    """``project_id`` for *picture_id* on one sort variant of the set contents.
+
+    Asserts the *marker* key that only that branch adds, because the default
+    picture path returns the same row shape without it: a sort that silently fell
+    through would otherwise satisfy every other assertion here while leaving the
+    branch under test unexecuted.
+    """
+    kw = {"headers": headers} if headers else {}
+    r = client.get(f"{API}/picture_sets/{env['set_id']}?{query}", **kw)
+    assert r.status_code == 200, r.text
+    rows = [row for row in r.json()["pictures"] if row.get("id") == picture_id]
+    assert rows, f"{query}: picture {picture_id} must be returned, got {r.json()}"
+    row = rows[0]
+    assert marker in row, (
+        f"{query}: the row carries no {marker!r} key, so this request did not "
+        f"take the sort branch it is meant to pin: {sorted(row)}"
+    )
+    assert "project_id" in row, f"{query}: the row lost its project_id key"
+    return row["project_id"]
+
+
+def test_picture_set_sort_variants_narrow_their_rows(env):
+    """R1e: ``sort=SMART_SCORE`` and ``sort=CHARACTER_LIKENESS`` build their
+    picture rows on their own return paths in ``get_picture_set``, each with its
+    own narrowing call. Deleting either one leaves the rest of this file green,
+    so both branches are pinned here with the inputs they need to emit a row."""
+    owner, anon, tokens, projects, mint = (
+        env["owner"],
+        env["anon"],
+        env["tokens"],
+        env["projects"],
+        env["mint"],
+    )
+    pic_a, pic_b = env["pic_a"], env["pic_b"]
+
+    r = owner.post(f"{API}/picture_sets/{env['set_id']}/members/{pic_b}")
+    assert r.status_code in (200, 201), r.text
+    r = owner.patch(
+        f"{API}/pictures/project",
+        json={
+            "picture_ids": [pic_a, pic_b],
+            "project_id": projects["P1"],
+            "mode": "add",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert (
+        owner.get(f"{API}/pictures/{pic_a}/project_id").json()["project_id"]
+        == projects["P1"]
+    ), "the scalar must be backfilled, or every assertion below is vacuous"
+
+    _seed_set_sort_inputs(env["server"], [pic_a, pic_b], env["char_id"])
+
+    variants = (
+        ("sort=SMART_SCORE", "smartScore"),
+        (
+            f"sort=CHARACTER_LIKENESS&reference_character_id={env['char_id']}",
+            "character_likeness",
+        ),
+    )
+
+    for query, marker in variants:
+        assert (
+            _set_sort_row_project_id(owner, env, pic_a, query, marker) == projects["P1"]
+        ), f"{query}: the owner must keep the stored primary project"
+
+    with _enforcing(env["server"]):
+        for query, marker in variants:
+            for label in ("P1", "P2"):
+                value = _set_sort_row_project_id(
+                    anon, env, pic_a, query, marker, _bearer(tokens[label])
+                )
+                assert value == projects[label], (
+                    f"{query}: the {label} token was handed project id {value}, "
+                    f"which it is 403'd on by name"
+                )
+
+            value = _set_sort_row_project_id(
+                anon,
+                env,
+                pic_a,
+                query,
+                marker,
+                _bearer(mint("picture_set", env["set_id"])),
+            )
+            assert value is None, (
+                f"{query}: a set-scoped token has no project visibility, but was "
+                f"handed project id {value}"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #719.

## The bug

`GET /pictures/{id}/metadata` served the raw `Picture.project_id` FK to a picture-scoped token that `GET /projects/{id}` 403s. Reproduced:

```
backfilled Picture 1.project_id = 1
GET /pictures/1/metadata     -> 200   project_id: 1     <-- leaked
(same token) GET /projects/1 -> 403
```

`metadata_fields()` is `scalar_fields() - large_binary_fields()`, i.e. **every table column** minus blobs; `Picture.project_id` is a real column; the handler never narrowed on the project axis; and `PictureFullMetadataResponse` sets `extra="allow"`, so the response model filtered nothing.

This is the outbound raw-scalar class (§16.6, "a defect on sight"). It is **not** closed by #708/#714, which gate inbound filters only.

## Scope: the issue named 4 call sites, there are 12, and 6 were leaking

The enumeration in the issue was mine and it was incomplete. The full matrix:

| Route | Leaked? |
|---|---|
| `GET /pictures/{id}/metadata` | fixed |
| `GET /pictures/{id}/{field}` (`field=project_id`) | fixed (not in the issue) |
| `GET /pictures/likeness-groups` | fixed (not in the issue) |
| `GET /pictures/search` | fixed |
| `GET /stacks/{id}/pictures?fields=full` | fixed |
| `GET /picture_sets/{id}` (all 3 return paths) | fixed (not in the issue) |
| `GET /pictures`, `/pictures/stream` | clean — `GridPicture` has no `project_id` and no `extra="allow"` (verified by round-tripping a planted value through the model) |
| `GET /pictures/export` | clean — loads the column, never writes it (verified by generating an archive and listing its members) |

## The fix

`narrow_picture_project_ids(server, request, rows)` in `filter_helpers.py`: the picture-row twin of `narrow_project_fields`, minus the `project_ids` list a picture payload does not carry. It re-derives the scalar from the token's **narrowed** `PictureProjectMember` membership via one batched query, rather than letting the stored column reach the wire.

Re-deriving rather than intersecting is deliberate: a P2 token reading a picture whose stored primary is P1 sees `project_id: 2`, not `null`. Intersecting would also be safe but would make a picture the token legitimately shares look unassigned.

Behaviour:
- owner / unscoped → returns on the first line; payload and query count bit-identical
- picture with a stored scalar but no membership rows → `None`
- project token whose project is not among the memberships → `None`
- multiple visible memberships → lowest id, deterministic (the list is sorted)
- row carrying `project_id` but no `id` → cleared **and logged**, rather than guessed

No per-handler scope check was added; the AuthzGate is untouched.

## Guardrail

`test_picture_metadata_fields_membership_is_pinned` holds the exact 42-column projection, so a new `picture` column fails the build until someone decides whether a scoped token may learn it. Mutation-tested both ways (dropping a real column, adding a bogus one), and the reviewer confirmed it fires by injecting a synthetic `secret_tenant_id` column.

**Its docstring explicitly states that membership is not a safety certificate.** Three members are known disclosures left unnarrowed pending a decision — `pending_character_id` (a character FK, while `GET /characters/{id}` is CHARACTER_SCOPED), `source_picture_id`, and `reference_folder_id` (also in `grid_fields()`, so it rides every listing). Narrowing the first needs a `visible_character_ids` ladder that does not exist. A pin that silently implied "reviewed and safe" would recreate the false assurance it was built to remove.

## Independent adversarial review

Verdict: ship-with-conditions. It mutation-killed 6 of 7 call sites, confirmed the owner path is bit-identical, and **refuted** two attacks: the re-derivation cannot produce a wrong answer (`visible_project_ids` is never multi-valued for a scoped token, so `narrowed[0]` is deterministic and always a subset of visible), and the export path is genuinely clean.

Conditions, all addressed:

- **The §16.6 claim was false.** It said CLOSED; the boundary is bypassable one URL segment from the patched handler — `/pictures/1/projects` returns the Project row with its name while `/pictures/1/project_id` returns `null`, because the generic field reader also serves the ORM **relationship** namespace. Reproduced independently. The section now says what it actually closes, and the leak is filed as **#721**.
- **`pending_character_id` reproduced**, not "usually NULL": the dedup-verdict and keep-cover-only services set it on pictures whose extraction has already run. Recorded in the pin docstring.
- **Two sort paths were unprotected, not merely untested** — deleting both narrowing calls left the suite at 68 passed. Now pinned; see below.

## Tests

R1e section of `tests/test_multi_project_membership_authz.py` (already CI-gated, no new file). Every test backfills the scalar first — without that the column is NULL and every probe returns `None` regardless, which is the false negative that let this survive an earlier review.

Directions covered: owner unchanged; P1 and P2 tokens each see their own project (over-blocking asserted as its own failure); set- and picture-scoped tokens get `None`.

The sort-path test also pins the **branch marker** (`smartScore` / `character_likeness` keys), not just the sort parameter — the default path returns rows that satisfy every other assertion, so without the marker a fall-through would look like coverage. Both mutants die, each independently in both directions.

Its fixture uncovered a real trap: `MissingFaceModelRefreshFinder` deletes a seeded face whose `model_pack` differs from the engine's, so the naive fixture passed on a quiet machine and failed 4/4 under load. The seed now copies `model_pack` off a row the extractor wrote and waits for the extraction pass.

```
68 passed  (test_multi_project_membership_authz, test_architecture_guardrails)
72 passed  (test_read_token_security, test_projects_api)
new sort-path test: 3/3 consecutive, plus 6/6 by the author
```

## Known limitation for reviewers

The P1-token assertions are **not** leak coverage: the stored primary is P1, so a missing narrowing still yields P1 for that token. P2 and the set-scoped token are the discriminating directions; P1 guards only against over-blocking.

## Follow-ups, deliberately not here

- **#721** — the relationship-namespace leak; the durable fix is an allowlist of servable field names on both generic readers, not another `if field ==` branch.
- `metadata_fields()` as an allowlist rather than "every column minus blobs": it is also the default `select_fields` of `Picture.find`, so changing it alters what the scoring and export paths *load*, not just what six handlers serialise. That is a per-caller audit.
- `extra="allow"` on the response models: flipping to `extra="ignore"` would drop ~40 undeclared metadata columns and gut the endpoint. A schema project with breaking-API risk, not a hardening.
- `PATCH /pictures/{id}` returns a full unnarrowed row; latent only, blocked today by resource-scoped ⇒ READ.
