### PR TITLE
Fix two stale test suites that the CI gate never runs

### DIFF
--- a/tests/test_guest_scoring.py
+++ b/tests/test_guest_scoring.py
@@ -45,8 +45,17 @@ _SID = "test-session-id-0001"
 # ---------------------------------------------------------------------------
 
 
-def _make_png_bytes(width: int = 16, height: int = 16) -> bytes:
-    img = Image.new("RGB", (width, height), color=(200, 100, 50))
+def _make_png_bytes(
+    width: int = 16, height: int = 16, color: tuple[int, int, int] = (200, 100, 50)
+) -> bytes:
+    """Build a solid-colour PNG.
+
+    A test that uploads more than one picture MUST vary ``color`` (or the
+    dimensions) between them: import rejects byte-identical files as duplicates
+    (``status: "duplicate"``), so uploading the same bytes twice yields a single
+    Picture row, not two.
+    """
+    img = Image.new("RGB", (width, height), color=color)
     buf = io.BytesIO()
     img.save(buf, format="PNG")
     return buf.getvalue()
@@ -573,13 +582,15 @@ def test_score_sort_uses_guest_scores():
     with tempfile.TemporaryDirectory() as tmp:
         server, owner_client, read_token = _setup(tmp)
         try:
-            # Upload two pictures
-            png = _make_png_bytes()
+            # Upload two pictures. They must differ in content — identical bytes
+            # are rejected by import as duplicates and would leave only one row.
+            png_a = _make_png_bytes(color=(200, 100, 50))
+            png_b = _make_png_bytes(color=(50, 100, 200))
             resp = owner_client.post(
                 f"{API}/pictures/import",
                 files=[
-                    ("file", ("a.png", png, "image/png")),
-                    ("file", ("b.png", png, "image/png")),
+                    ("file", ("a.png", png_a, "image/png")),
+                    ("file", ("b.png", png_b, "image/png")),
                 ],
             )
             assert resp.status_code == 200, resp.text
@@ -642,12 +653,14 @@ def test_score_sort_fallback_to_picture_score():
     with tempfile.TemporaryDirectory() as tmp:
         server, owner_client, read_token = _setup(tmp)
         try:
-            png = _make_png_bytes()
+            # Distinct content per file — see the note on _make_png_bytes.
+            png_x = _make_png_bytes(color=(200, 100, 50))
+            png_y = _make_png_bytes(color=(50, 100, 200))
             resp = owner_client.post(
                 f"{API}/pictures/import",
                 files=[
-                    ("file", ("x.png", png, "image/png")),
-                    ("file", ("y.png", png, "image/png")),
+                    ("file", ("x.png", png_x, "image/png")),
+                    ("file", ("y.png", png_y, "image/png")),
                 ],
             )
             assert resp.status_code == 200, resp.text

--- a/tests/test_server_external_listener.py
+++ b/tests/test_server_external_listener.py
@@ -159,6 +159,10 @@ def _fake_lifespan_server(config, password_set=True):
         _ws_loop=None,
         _shutdown_on_lifespan=False,
         vault=SimpleNamespace(start=lambda: None, close=lambda: None),
+        # lifespan pings telemetry right after vault.start() (cf4da2bf). These
+        # tests only exercise the ready/remote-access logging, so the ping is a
+        # no-op here — consent and payload are covered by the telemetry suite.
+        _maybe_send_telemetry_ping=lambda: None,
     )
 
 


### PR DESCRIPTION
Two suites have been failing locally for a while. Both are stale tests, not product bugs.

### `test_server_external_listener` (2 failures)

`cf4da2bf` added `self._maybe_send_telemetry_ping()` to `Server.lifespan` but did not update `_fake_lifespan_server`, whose docstring says it carries "the few attributes `Server.lifespan` reads". Both lifespan tests died on `AttributeError`.

`lifespan` touches six attributes off `self`; the fake provided four. Only the one actually breaking is added here. The other (`_cleanup_missing_pictures`) sits behind `DEFAULT_CLEANUP_MISSING_PICTURES`, which is off — stubbing it would blunt the loud `AttributeError` that is exactly what caught this.

### `test_guest_scoring` (2 failures)

Both score-sort tests uploaded **the same bytes twice** (`png = _make_png_bytes()` reused for `a.png`/`b.png`) and then asserted `len(pics) >= 2`. Import correctly rejects byte-identical files. Reproduced directly:

```
import result payload: {"status": "duplicate", "imported_count": 1, "duplicate_count": 1}
GET /pictures count: 1
RAW Picture rows in DB: 1
```

Fixed by giving each upload a distinct colour, with the constraint documented on `_make_png_bytes` so it does not recur.

### Why CI stayed green

Both files are in `DEFERRED_FROM_GATE` (`tests/test_ci_shards.py`), so the blocking `backend` job never runs them. The only job that does is `backend_release_sweep`, which is non-blocking twice over:

1. Its `if:` restricts it to `rc-prep*`/`release*` branches, `v*` tags, or manual `workflow_dispatch` — it does not run on ordinary PRs or pushes at all.
2. Its pytest step carries `continue-on-error: true`, so even during release prep a failure cannot fail the job.

The comment above `DEFERRED_FROM_GATE` says these files "still run in the informational `backend_release_sweep`, so the coverage is visible". That is optimistic: on a normal PR they do not run, and when they do they cannot go red.

### Verification

Both files pass on this branch (**38 passed**), verified on top of `develop` with no other changes.

Not included: promoting these two files off `DEFERRED_FROM_GATE` into the `ci.yml` gate. That is the documented direction of travel and would stop this recurring, but it is a workflow change and per `CLAUDE.md` needs `chief-security-officer` clearance before it is pushed. Happy to do it as a follow-up.
