### PR TITLE
Run the artifacts CI already builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,7 @@ jobs:
   build:
     name: build
     if: always()
-    needs: [checks, backend, backend_release_sweep, e2e]
+    needs: [checks, backend, backend_release_sweep, e2e, electron]
     runs-on: ubuntu-latest
     steps:
       # Each dependency is checked against what IT is allowed to report, not
@@ -466,16 +466,18 @@ jobs:
           BACKEND_RESULT: ${{ needs.backend.result }}
           SWEEP_RESULT: ${{ needs.backend_release_sweep.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
+          ELECTRON_RESULT: ${{ needs.electron.result }}
         run: |
           set -euo pipefail
-          echo "checks=$CHECKS_RESULT backend=$BACKEND_RESULT sweep=$SWEEP_RESULT e2e=$E2E_RESULT"
+          echo "checks=$CHECKS_RESULT backend=$BACKEND_RESULT sweep=$SWEEP_RESULT e2e=$E2E_RESULT electron=$ELECTRON_RESULT"
 
           failed=0
-          for job in checks backend e2e; do
+          for job in checks backend e2e electron; do
             case "$job" in
               checks) result="$CHECKS_RESULT" ;;
               backend) result="$BACKEND_RESULT" ;;
               e2e) result="$E2E_RESULT" ;;
+              electron) result="$ELECTRON_RESULT" ;;
             esac
             if [ "$result" != "success" ]; then
               echo "::error::Blocking job '$job' reported '$result' (must be 'success')."
@@ -570,6 +572,58 @@ jobs:
           name: playwright-report
           path: frontend/playwright-report
           retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # Electron main-process unit tests (electron/test/, `node --test` over the
+  # compiled TypeScript). They cover the logic behind real desktop incidents:
+  # overlay install args, the CPU fallback state machine, backends location,
+  # forced-backend parsing, hardware-detector injection, and the media IPC
+  # boundary. Until now they ran only when someone remembered to type
+  # `cd electron && npm test`, so a regression in any of it reached a release
+  # candidate unchallenged — docs/release-test-plan.md called this out as "not
+  # wired into any workflow yet".
+  #
+  # The Electron BINARY is never needed here. These are plain Node tests, and
+  # `require('electron')` outside an Electron runtime returns the path to the
+  # executable, not the Electron API — so `app`/`ipcRenderer` are already
+  # undefined when these tests run locally, and nothing touches them at import
+  # time. That makes the ~100 MB download pure cost:
+  #   - ELECTRON_SKIP_BINARY_DOWNLOAD stops `npm ci` fetching it, but it leaves
+  #     node_modules/electron/path.txt absent, and that package's index.js
+  #     re-attempts the download AT REQUIRE TIME when the file is missing.
+  #   - ELECTRON_OVERRIDE_DIST_PATH is checked BEFORE that existence test, so
+  #     the require resolves to a string and returns without any filesystem or
+  #     network access. The path is never opened; it does not need to exist.
+  # Both are required — either one alone still downloads.
+  # ---------------------------------------------------------------------------
+  electron:
+    name: electron
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: electron/package-lock.json
+
+      - name: Install electron deps
+        working-directory: electron
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: electron
+        run: npm run lint
+
+      - name: Run electron unit tests
+        working-directory: electron
+        env:
+          ELECTRON_OVERRIDE_DIST_PATH: /nonexistent/electron-dist
+        run: npm test
 
   # ---------------------------------------------------------------------------
   # Windows only validates OS-sensitive behaviour (file/path/process handling,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,7 +600,12 @@ jobs:
     name: electron
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false — the `npm ci` below executes dependency
+      # lifecycle scripts, and checkout otherwise leaves the job token in
+      # .git/config where they can read it. No git operation follows.
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,10 +607,17 @@ jobs:
         with:
           persist-credentials: false
 
+      # Node 22, not the 20 used by the e2e job. `npm test` runs
+      # `node --test "dist-test/test/*.test.js"` with the glob QUOTED, so the
+      # shell does not expand it and the test runner has to — and runner-side
+      # glob support only arrived in Node 22. On 20 this fails with
+      # "Could not find .../dist-test/test/*.test.js" and zero tests run.
+      # 22 also matches electron.yml's build job, @types/node, and the
+      # Dockerfile's frontend builder.
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: electron/package-lock.json
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,12 +35,14 @@ jobs:
         uses: actions/checkout@v4
 
       # `load: true` exports the built image into the docker daemon, so the
-      # layers land on disk a second time on top of the buildx cache. The CPU
-      # image is multi-GB (torch, transformers, insightface, spacy), and a
-      # stock ubuntu-latest runner has ~14 GB free — not enough for both
-      # copies. This frees ~30 GB before the build rather than after, because
-      # once buildx has filled the disk the failure is a confusing mid-layer
-      # write error rather than an honest "no space left".
+      # layers land on disk a second time on top of the buildx cache. The
+      # published CPU image is ~1 GB compressed / ~3 GB unpacked, which fits a
+      # stock runner comfortably — but the buildx cache for a torch-sized image
+      # does not leave much room beside it, and once buildx has filled the disk
+      # the failure is a confusing mid-layer write error rather than an honest
+      # "no space left". `large-packages` is left off deliberately: it costs a
+      # couple of minutes for space this job does not need (the `e2e` job makes
+      # the same trade).
       - name: Free disk space
         if: matrix.smoke
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -49,7 +51,7 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,12 @@ name: Build Docker Images (no push)
 # without pushing to any registry and without logging in, so you can confirm both
 # Dockerfiles build (e.g. before tagging a release) without consuming anything.
 # The publish path lives in docker-publish.yml and stays tag-driven.
+#
+# The CPU leg additionally BOOTS what it just built (see the smoke steps below).
+# A Dockerfile that builds is not a Dockerfile that runs: the entrypoint writes
+# the first-run config, the non-root pixlstash user has to own its volume, and
+# uvicorn has to bind — none of which a build exercises. That gap is why
+# docs/release-test-plan.md §1.2 was a hand-run `docker run` on release day.
 on:
   workflow_dispatch:
 
@@ -18,11 +24,32 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: CPU, file: Dockerfile, scope: cpu }
-          - { name: GPU, file: Dockerfile.gpu, scope: gpu }
+          # `smoke: true` also loads the image into the local daemon and runs it.
+          # Only the CPU leg can: hosted runners have no NVIDIA device, so the
+          # GPU image would fall back to CPU and prove nothing about the thing
+          # that makes it the GPU image.
+          - { name: CPU, file: Dockerfile, scope: cpu, smoke: true }
+          - { name: GPU, file: Dockerfile.gpu, scope: gpu, smoke: false }
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      # `load: true` exports the built image into the docker daemon, so the
+      # layers land on disk a second time on top of the buildx cache. The CPU
+      # image is multi-GB (torch, transformers, insightface, spacy), and a
+      # stock ubuntu-latest runner has ~14 GB free — not enough for both
+      # copies. This frees ~30 GB before the build rather than after, because
+      # once buildx has filled the disk the failure is a confusing mid-layer
+      # write error rather than an honest "no space left".
+      - name: Free disk space
+        if: matrix.smoke
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -33,5 +60,122 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           push: false
+          load: ${{ matrix.smoke }}
+          tags: ${{ matrix.smoke && 'pixlstash:ci-smoke' || '' }}
           cache-from: type=gha,scope=${{ matrix.scope }}
           cache-to: type=gha,scope=${{ matrix.scope }},mode=max
+
+      # ── Smoke: boot the image we just built ──────────────────────────────
+      #
+      # Deliberately runs the DEFAULT entrypoint path with no config mounted,
+      # because that first-run path is what a new user hits and what the
+      # entrypoint's config-writing branch exists for. Nothing here needs an ML
+      # model: the server binds and serves before any background work starts.
+      - name: Start the container
+        if: matrix.smoke
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/pixlstash-home"
+          # The image runs as uid 10001; the bind mount inherits the host owner,
+          # so it must be world-writable or the entrypoint cannot create its
+          # config dir. This mirrors the documented `-v ~/Pictures/pixlstash`
+          # usage rather than avoiding the volume entirely.
+          chmod 777 "${RUNNER_TEMP}/pixlstash-home"
+          docker run -d --name pixlstash-smoke \
+            -e PIXLSTASH_HOST=0.0.0.0 \
+            -p 19537:9537 \
+            -v "${RUNNER_TEMP}/pixlstash-home:/home/pixlstash" \
+            pixlstash:ci-smoke
+
+      - name: Wait for the API to serve /version
+        if: matrix.smoke
+        run: |
+          set -euo pipefail
+          # Boots in ~25 s on a warm laptop; 180 s is headroom for a cold
+          # runner, not an expectation.
+          for i in $(seq 1 180); do
+            if curl -fsS -o /tmp/version.json http://127.0.0.1:19537/version; then
+              echo "API ready after ${i}s"
+              cat /tmp/version.json
+              exit 0
+            fi
+            # A container that has already died will never become ready, so
+            # stop waiting out the full timeout and surface why.
+            if [ -z "$(docker ps -q -f name=pixlstash-smoke)" ]; then
+              echo "::error::Container exited before serving /version."
+              docker logs pixlstash-smoke
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "::error::/version did not respond within 180s."
+          docker logs pixlstash-smoke
+          exit 1
+
+      - name: Assert the built image reports the CPU variant
+        if: matrix.smoke
+        run: |
+          set -euo pipefail
+          variant=$(python3 -c "import json;print(json.load(open('/tmp/version.json')).get('docker_variant'))")
+          echo "docker_variant=${variant}"
+          # Guards the tag/Dockerfile pairing in docker-publish.yml. The
+          # published :latest is currently a GPU-variant image, so this
+          # assertion is not hypothetical.
+          if [ "$variant" != "cpu" ]; then
+            echo "::error::Dockerfile produced docker_variant='${variant}', expected 'cpu'."
+            exit 1
+          fi
+
+      - name: Assert the SPA is served
+        if: matrix.smoke
+        run: |
+          set -euo pipefail
+          # The frontend is baked in by the builder stage; if that COPY path
+          # ever drifts the API still answers and only the UI 404s, which is
+          # exactly the failure a build-only check cannot see.
+          code=$(curl -s -o /tmp/index.html -w '%{http_code}' http://127.0.0.1:19537/)
+          echo "GET / -> ${code}"
+          test "$code" = "200"
+          grep -qi '<div id="app"' /tmp/index.html || {
+            echo "::error::/ did not return the built SPA shell."
+            head -c 500 /tmp/index.html
+            exit 1
+          }
+
+      - name: Assert uvicorn logged a clean start
+        if: matrix.smoke
+        run: |
+          set -euo pipefail
+          docker logs pixlstash-smoke > /tmp/boot.log 2>&1
+          grep -q "Uvicorn running" /tmp/boot.log || {
+            echo "::error::No 'Uvicorn running' line in container logs."
+            cat /tmp/boot.log
+            exit 1
+          }
+          if grep -qi "Traceback (most recent call last)" /tmp/boot.log; then
+            echo "::error::Container logged a traceback during startup."
+            cat /tmp/boot.log
+            exit 1
+          fi
+
+      - name: Assert the container stops cleanly
+        if: matrix.smoke
+        run: |
+          set -euo pipefail
+          docker stop -t 30 pixlstash-smoke
+          exit_code=$(docker inspect pixlstash-smoke --format '{{.State.ExitCode}}')
+          oom=$(docker inspect pixlstash-smoke --format '{{.State.OOMKilled}}')
+          echo "exit=${exit_code} oom=${oom}"
+          # SIGTERM handled = 0. 137 means it ignored SIGTERM and was killed,
+          # which is the "orphaned process on quit" class the release plan
+          # checks for by hand.
+          test "$oom" = "false"
+          test "$exit_code" = "0"
+
+      - name: Container logs (on failure)
+        if: ${{ failure() && matrix.smoke }}
+        run: docker logs pixlstash-smoke || true
+
+      - name: Clean up
+        if: ${{ always() && matrix.smoke }}
+        run: docker rm -f pixlstash-smoke || true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,16 +77,19 @@ jobs:
         if: matrix.smoke
         run: |
           set -euo pipefail
-          mkdir -p "${RUNNER_TEMP}/pixlstash-home"
-          # The image runs as uid 10001; the bind mount inherits the host owner,
-          # so it must be world-writable or the entrypoint cannot create its
-          # config dir. This mirrors the documented `-v ~/Pictures/pixlstash`
-          # usage rather than avoiding the volume entirely.
-          chmod 777 "${RUNNER_TEMP}/pixlstash-home"
+          # No bind mount: the image already declares VOLUME /home/pixlstash
+          # owned by its uid 10001, so the entrypoint's first-run config write
+          # is exercised against an anonymous volume. Bind-mounting a runner
+          # directory instead would need it world-writable (the host owner is
+          # not uid 10001), and a chmod 777 to make a test pass is how that
+          # habit reaches production compose files.
+          #
+          # Published to 127.0.0.1 only. `-p 19537:9537` binds 0.0.0.0, which
+          # would expose an unauthenticated first-run server on every runner
+          # interface for the life of the job.
           docker run -d --name pixlstash-smoke \
             -e PIXLSTASH_HOST=0.0.0.0 \
-            -p 19537:9537 \
-            -v "${RUNNER_TEMP}/pixlstash-home:/home/pixlstash" \
+            -p 127.0.0.1:19537:9537 \
             pixlstash:ci-smoke
 
       - name: Wait for the API to serve /version
@@ -180,4 +183,6 @@ jobs:
 
       - name: Clean up
         if: ${{ always() && matrix.smoke }}
-        run: docker rm -f pixlstash-smoke || true
+        # -v also drops the anonymous volume, so a vault created by the smoke
+        # never outlives the job.
+        run: docker rm -fv pixlstash-smoke || true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -94,6 +94,12 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             docker.io/lindkvis/pixlstash
+          # `latest` is issued ONLY by the explicit type=raw line below, which is
+          # gated on a stable release. metadata-action's default (latest=auto)
+          # would additionally synthesise a bare `latest` from any semver tag,
+          # which is how the GPU job below came to own it.
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -212,6 +218,15 @@ jobs:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             docker.io/lindkvis/pixlstash
+          # Every tag this job publishes is -gpu suffixed. Without this,
+          # metadata-action's default latest=auto ALSO emits a bare `latest`,
+          # and since build-cpu and build-gpu run concurrently with no ordering
+          # between them, whichever finished last owned `latest`. At v1.8.5 that
+          # was the GPU image: `latest` and `latest-gpu` are currently the same
+          # 7.7 GB CUDA manifest, so the documented CPU quickstart hands users
+          # the GPU image.
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}}-gpu
             type=semver,pattern={{major}}.{{minor}}-gpu

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,110 @@
+name: Install smoke (pip, 3 OSes)
+
+# Builds the wheel exactly as the release does, installs it into a clean venv on
+# each supported OS, and boots it. This is the automated half of
+# docs/release-test-plan.md §1.1 and §1.4 — the "does it install and come up"
+# rows, which were previously hand-run on three machines on release day.
+#
+# NOT on every PR. Installing torch three times is minutes of runner per run,
+# and the fast PR gate is deliberately kept fast; this fires on release prep and
+# on demand, which is when packaging can actually have broken.
+#
+# What stays manual (and why): importing a picture and looking at the grid needs
+# a human or a browser harness, GPU/overlay behaviour needs real hardware, and
+# the Windows installer's Authenticode signature and SmartScreen prompt cannot
+# be asserted from a runner. Those rows remain in the release plan.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'release-**'
+      - 'rc-prep-**'
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: ubuntu / py3.12, os: ubuntu-latest, python: '3.12' }
+          - { name: macos / py3.12, os: macos-latest, python: '3.12' }
+          - { name: windows / py3.12, os: windows-latest, python: '3.12' }
+          # The floor the README and the release plan both promise. A dependency
+          # that quietly requires 3.11+ is invisible on the version everyone
+          # develops against, and only surfaces as a user's failed install.
+          - { name: ubuntu / py3.10 (floor), os: ubuntu-latest, python: '3.10' }
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # The wheel carries the built SPA via [tool.setuptools.package-data]
+      # (pixlstash/frontend/dist/**). Without this step the wheel still builds
+      # and still installs — it just serves a 404 where the UI should be, which
+      # is precisely the packaging regression the smoke asserts against.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build the frontend
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Build the wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+
+      - name: Install the wheel into a clean venv
+        shell: bash
+        run: |
+          set -euo pipefail
+          # A fresh venv, not the runner's Python: this has to exercise real
+          # dependency resolution from the wheel's own metadata, the same thing
+          # `pip install pixlstash` does for a user.
+          python -m venv .smokevenv
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            VENV_PY=".smokevenv/Scripts/python.exe"
+          else
+            VENV_PY=".smokevenv/bin/python"
+          fi
+          "$VENV_PY" -m pip install --upgrade pip
+          wheel=$(ls dist/*.whl)
+          echo "Installing ${wheel}"
+          "$VENV_PY" -m pip install "$wheel"
+
+      - name: Boot the installed server and assert it serves
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Derive the expected version from the artifact that was actually
+          # built, so a wheel reporting a stale version fails here rather than
+          # shipping.
+          version=$(python -c "
+          import glob, os
+          wheel = os.path.basename(glob.glob('dist/*.whl')[0])
+          print(wheel.split('-')[1])
+          ")
+          echo "Expecting /version to report ${version}"
+          python scripts/smoke_install.py \
+            --venv .smokevenv \
+            --port 19538 \
+            --expected-version "$version"

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -42,14 +42,24 @@ jobs:
           - { name: ubuntu / py3.10 (floor), os: ubuntu-latest, python: '3.10' }
 
     steps:
-      - uses: actions/checkout@v6
+      # Actions are pinned by commit SHA, not tag: a tag is mutable, so a
+      # compromised upstream can repoint it at new code that runs with this
+      # workflow's token. These are the same SHAs already vetted elsewhere in
+      # .github/workflows/.
+      # persist-credentials: false — this job runs `npm ci`, which executes
+      # dependency lifecycle scripts. Left on, checkout writes the job token
+      # into .git/config where any such script can read it. Nothing here talks
+      # to git after checkout, so the credential has no reason to stay.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       # The wheel carries the built SPA via [tool.setuptools.package-data]
       # (pixlstash/frontend/dist/**). Without this step the wheel still builds
       # and still installs — it just serves a 404 where the UI should be, which
       # is precisely the packaging regression the smoke asserts against.
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: npm
@@ -62,7 +72,7 @@ jobs:
           npm run build
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python }}
 

--- a/scripts/smoke_install.py
+++ b/scripts/smoke_install.py
@@ -1,0 +1,396 @@
+"""Boot a freshly installed PixlStash and assert it actually serves.
+
+This is the automated half of ``docs/release-test-plan.md`` §1.1/§1.4: the part
+that only checks that an install *works*, as opposed to the parts that need a
+human looking at a screen. It is deliberately a Python script rather than shell
+steps in the workflow, because the same checks have to run identically on
+Ubuntu, macOS, and Windows, and the Windows differences (venv ``Scripts``
+instead of ``bin``, no POSIX job control, ``CTRL_BREAK`` instead of ``SIGTERM``)
+are exactly where a bash translation would rot.
+
+What it proves:
+
+* the wheel installs and the ``pixlstash-server`` console script exists,
+* the packaged frontend really shipped inside the wheel (``package-data`` drift
+  is invisible until someone opens the page and gets a 404),
+* Alembic brings a brand-new vault to head and uvicorn binds,
+* the process shuts down on request without being killed.
+
+What it deliberately does NOT prove: anything needing ML models. The server is
+booted with ``disable_background_workers``, the same lever
+``frontend/e2e/serve_e2e_backend.py`` uses, so no model is downloaded. Worker
+startup and real inference stay in the manual plan and in the GPU jobs — a
+smoke test that pulled multi-GB weights on three operating systems would be
+slow enough that it stopped being run, which is the failure mode this whole
+exercise is trying to remove.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger("smoke_install")
+
+# The server binds before it is ready to answer, so every check polls rather
+# than sleeping a fixed amount. A warm local venv answers in ~6 s; the ceiling
+# is headroom for a cold runner (first-import of torch dominates), not an
+# expectation of how long boot should take.
+READY_TIMEOUT_S = 240
+SHUTDOWN_TIMEOUT_S = 60
+
+
+class SmokeFailure(RuntimeError):
+    """Raised when a smoke assertion fails, with the diagnostic already logged."""
+
+
+def venv_python(venv_dir: Path) -> Path:
+    """Return the interpreter path inside ``venv_dir`` for the current OS.
+
+    Args:
+        venv_dir (Path): Root of a virtual environment created by ``venv``.
+
+    Returns:
+        Path: Path to the ``python`` executable inside that environment.
+    """
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def venv_script(venv_dir: Path, name: str) -> Path:
+    """Return the path to a console script installed inside ``venv_dir``.
+
+    Args:
+        venv_dir (Path): Root of a virtual environment.
+        name (str): Console-script name, without any extension.
+
+    Returns:
+        Path: Path to the script for the current OS.
+    """
+    if os.name == "nt":
+        return venv_dir / "Scripts" / f"{name}.exe"
+    return venv_dir / "bin" / name
+
+
+def write_config(config_path: Path, image_root: Path, port: int) -> None:
+    """Write a minimal server config for the smoke run.
+
+    Mirrors the shape ``docker-entrypoint.sh`` writes on first run, plus the
+    ``disable_background_workers`` lever so no ML model is ever fetched.
+
+    Args:
+        config_path (Path): Destination for the JSON config.
+        image_root (Path): Directory the server may use as its image root.
+        port (int): Loopback port to bind.
+    """
+    config = {
+        "host": "127.0.0.1",
+        "port": port,
+        "log_level": "info",
+        "log_file": None,
+        "require_ssl": False,
+        "cookie_samesite": "Lax",
+        "cookie_secure": False,
+        "image_root": str(image_root),
+        "default_device": "cpu",
+        "disable_background_workers": True,
+        "cors_origins": [],
+        "watch_folders": [],
+    }
+    config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+    logger.info("Wrote smoke config to %s (port=%d)", config_path, port)
+
+
+def get_json(url: str, timeout: float = 5.0) -> dict:
+    """GET ``url`` and decode the response as JSON.
+
+    Args:
+        url (str): Absolute URL to fetch.
+        timeout (float): Per-request timeout in seconds.
+
+    Returns:
+        dict: Decoded JSON body.
+    """
+    with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+        return json.loads(response.read().decode("utf-8"))
+
+
+def get_text(url: str, timeout: float = 5.0) -> tuple[int, str]:
+    """GET ``url`` and return its status code and body text.
+
+    Args:
+        url (str): Absolute URL to fetch.
+        timeout (float): Per-request timeout in seconds.
+
+    Returns:
+        tuple[int, str]: HTTP status code and decoded body.
+    """
+    with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+        return response.status, response.read().decode("utf-8", errors="replace")
+
+
+def dump_log(log_path: Path, reason: str) -> None:
+    """Log the server's captured output so a CI failure is self-explanatory.
+
+    Args:
+        log_path (Path): File the server's stdout/stderr was captured to.
+        reason (str): Why the log is being dumped.
+    """
+    logger.error("%s — captured server output follows:", reason)
+    try:
+        logger.error("%s", log_path.read_text(encoding="utf-8", errors="replace"))
+    except OSError as exc:
+        logger.error("Could not read the server log at %s: %s", log_path, exc)
+
+
+def wait_for_ready(base_url: str, process: subprocess.Popen, log_path: Path) -> dict:
+    """Poll ``/version`` until the server answers, or fail with diagnostics.
+
+    Args:
+        base_url (str): Server root, e.g. ``http://127.0.0.1:19538``.
+        process (subprocess.Popen): The running server process.
+        log_path (Path): File its output is being captured to.
+
+    Returns:
+        dict: The decoded ``/version`` payload.
+
+    Raises:
+        SmokeFailure: If the process exits early or never becomes ready.
+    """
+    deadline = time.monotonic() + READY_TIMEOUT_S
+    while time.monotonic() < deadline:
+        # A process that has already exited will never become ready, so stop
+        # waiting out the full timeout and report the real cause instead.
+        if process.poll() is not None:
+            dump_log(log_path, f"Server exited early with code {process.returncode}")
+            raise SmokeFailure(
+                f"Server process exited with code {process.returncode} before "
+                "serving /version."
+            )
+        try:
+            payload = get_json(f"{base_url}/version")
+        except (urllib.error.URLError, ConnectionError, TimeoutError, OSError):
+            time.sleep(1.0)
+            continue
+        except json.JSONDecodeError as exc:
+            dump_log(log_path, f"/version returned undecodable JSON: {exc}")
+            raise SmokeFailure("/version did not return JSON.") from exc
+        logger.info("Server ready; /version reported %s", payload)
+        return payload
+
+    dump_log(log_path, f"/version did not respond within {READY_TIMEOUT_S}s")
+    raise SmokeFailure(f"Server was not ready within {READY_TIMEOUT_S}s.")
+
+
+def assert_version_payload(payload: dict, expected_version: str | None) -> None:
+    """Assert ``/version`` reports a sane install.
+
+    Args:
+        payload (dict): Decoded ``/version`` body.
+        expected_version (str | None): Version the wheel should report, if known.
+
+    Raises:
+        SmokeFailure: If a field is missing or contradicts the built wheel.
+    """
+    reported = payload.get("version")
+    if not reported:
+        raise SmokeFailure(f"/version reported no version field: {payload!r}")
+
+    # Catches the packaging failure where the wheel ships a stale or absent
+    # version and every downstream upgrade check silently compares nothing.
+    if expected_version and reported != expected_version:
+        raise SmokeFailure(
+            f"/version reported {reported!r} but the built wheel is "
+            f"{expected_version!r}."
+        )
+
+    install_type = payload.get("install_type")
+    # A pip-installed wheel must not be mistaken for Docker or Electron: this
+    # value feeds telemetry, and 'other' means detection fell through.
+    if install_type != "pip":
+        raise SmokeFailure(
+            f"/version reported install_type={install_type!r}, expected 'pip'."
+        )
+    logger.info("Version payload OK (version=%s install_type=pip)", reported)
+
+
+def assert_spa_served(base_url: str, log_path: Path) -> None:
+    """Assert the packaged single-page app is served from the wheel.
+
+    Args:
+        base_url (str): Server root.
+        log_path (Path): File the server's output is being captured to.
+
+    Raises:
+        SmokeFailure: If the SPA shell is missing or not served.
+    """
+    try:
+        status, body = get_text(f"{base_url}/")
+    except (urllib.error.URLError, OSError) as exc:
+        dump_log(log_path, f"GET / failed: {exc}")
+        raise SmokeFailure("GET / failed.") from exc
+
+    if status != 200:
+        dump_log(log_path, f"GET / returned HTTP {status}")
+        raise SmokeFailure(f"GET / returned HTTP {status}, expected 200.")
+
+    # The built shell is tiny and its only stable marker is the mount point
+    # Vite leaves in place. Its absence means pixlstash/frontend/dist did not
+    # make it into the wheel — the package-data drift this check exists for.
+    if '<div id="app"' not in body:
+        dump_log(log_path, "GET / did not return the built SPA shell")
+        raise SmokeFailure(
+            "GET / did not contain the SPA mount point; the frontend is "
+            "probably missing from the wheel."
+        )
+    logger.info("SPA shell served from the installed wheel.")
+
+
+def stop_server(process: subprocess.Popen, log_path: Path) -> None:
+    """Ask the server to stop and assert it does so without being killed.
+
+    Args:
+        process (subprocess.Popen): The running server process.
+        log_path (Path): File its output is being captured to.
+
+    Raises:
+        SmokeFailure: If it has to be force-killed.
+    """
+    # Windows has no SIGTERM for a console app; CTRL_BREAK is the portable way
+    # to ask a process group started with CREATE_NEW_PROCESS_GROUP to stop.
+    if os.name == "nt":
+        process.send_signal(signal.CTRL_BREAK_EVENT)
+    else:
+        process.terminate()
+
+    try:
+        process.wait(timeout=SHUTDOWN_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=30)
+        dump_log(log_path, "Server ignored the shutdown request and was killed")
+        raise SmokeFailure(
+            f"Server did not exit within {SHUTDOWN_TIMEOUT_S}s of being asked "
+            "to stop; it had to be killed. That is the orphaned-process failure "
+            "the release plan checks for by hand."
+        ) from None
+
+    logger.info("Server stopped with exit code %s.", process.returncode)
+
+
+def run_smoke(venv_dir: Path, port: int, expected_version: str | None) -> None:
+    """Run the full install smoke against a venv that already has the wheel.
+
+    Args:
+        venv_dir (Path): Virtual environment with ``pixlstash`` installed.
+        port (int): Loopback port to bind.
+        expected_version (str | None): Version the wheel should report.
+
+    Raises:
+        SmokeFailure: On the first failed assertion.
+    """
+    server_bin = venv_script(venv_dir, "pixlstash-server")
+    if not server_bin.exists():
+        raise SmokeFailure(
+            f"Console script {server_bin} was not installed by the wheel."
+        )
+    logger.info("Found console script at %s", server_bin)
+
+    base_url = f"http://127.0.0.1:{port}"
+
+    with tempfile.TemporaryDirectory(prefix="pixlstash-smoke-") as tmp:
+        tmp_path = Path(tmp)
+        image_root = tmp_path / "images"
+        image_root.mkdir()
+        config_path = tmp_path / "server-config.json"
+        write_config(config_path, image_root, port)
+
+        log_path = tmp_path / "server.log"
+        # A dedicated config and HOME keep the smoke off any real vault on the
+        # machine, so a local run can never touch the developer's library.
+        env = dict(os.environ)
+        env["HOME"] = str(tmp_path)
+        env["USERPROFILE"] = str(tmp_path)
+        env.pop("PIXLSTASH_INSTALL_TYPE", None)
+
+        creation_flags = (
+            subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0  # type: ignore[attr-defined]
+        )
+
+        with log_path.open("w", encoding="utf-8") as log_file:
+            process = subprocess.Popen(
+                [str(server_bin), "--server-config", str(config_path)],
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                env=env,
+                creationflags=creation_flags,
+            )
+            try:
+                payload = wait_for_ready(base_url, process, log_path)
+                assert_version_payload(payload, expected_version)
+                assert_spa_served(base_url, log_path)
+                stop_server(process, log_path)
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait(timeout=30)
+
+        # Read back afterwards so a passing run still shows the boot log, which
+        # is what makes a later regression diffable against a green run.
+        logger.info(
+            "Boot log:\n%s", log_path.read_text(encoding="utf-8", errors="replace")
+        )
+
+
+def main() -> int:
+    """Parse arguments and run the smoke.
+
+    Returns:
+        int: Process exit code, 0 on success.
+    """
+    logging.basicConfig(
+        level=logging.INFO, format="%(levelname)s: %(message)s", stream=sys.stdout
+    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--venv",
+        required=True,
+        type=Path,
+        help="Virtual environment with the pixlstash wheel already installed.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=19538,
+        help="Loopback port to bind (default: 19538).",
+    )
+    parser.add_argument(
+        "--expected-version",
+        default=None,
+        help="Version the wheel should report from /version, if known.",
+    )
+    args = parser.parse_args()
+
+    try:
+        run_smoke(args.venv, args.port, args.expected_version)
+    except SmokeFailure as exc:
+        logger.error("SMOKE FAILED: %s", exc)
+        return 1
+
+    logger.info("SMOKE PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
CI builds the Electron app, both Docker images and the wheel, and never runs any of them. That gap is why `docs/release-test-plan.md` §1.1/§1.2/§1.4 are hand-run on three machines on release day.

## What this adds

**Electron unit tests now run** (`ci.yml`). 50 `node --test` tests across 7 files that were in no workflow at all — the release plan itself flagged them as "not wired into any workflow yet". Wired into the `build` aggregator so it blocks, following that job's existing "`skipped` must fail" rule.

They need no Electron binary: outside an Electron runtime `require("electron")` just returns a path string. `ELECTRON_SKIP_BINARY_DOWNLOAD` + `ELECTRON_OVERRIDE_DIST_PATH` skip the ~100 MB download. Verified from a clean `npm ci` — 50/50 pass without the binary, and it fails without the override, so both env vars are load-bearing.

**The CPU Docker image gets booted, not just built** (`docker-build.yml`). Boot → `/version` → assert `docker_variant=cpu` → assert the SPA is served → assert `Uvicorn running` with no traceback → assert clean SIGTERM exit. GPU leg stays build-only, since a hosted runner has no NVIDIA device.

**`pip install` + boot smoke on 4 configs** (`install-smoke.yml`, `scripts/smoke_install.py`). Ubuntu/macOS/Windows on 3.12 plus Ubuntu 3.10 as the documented floor. Release-prep and manual triggers only — the fast PR gate stays fast. The driver is Python rather than shell because of Windows (`Scripts` vs `bin`, `CTRL_BREAK` vs `SIGTERM`), and it boots with `disable_background_workers` so no ML weights are pulled.

## Also: `latest` has been the GPU image

`docker-publish.yml` had no `flavor:` key, so `docker/metadata-action` defaulted to `latest=auto` and synthesised a bare `latest` in **both** jobs. `build-cpu` and `build-gpu` run concurrently with no ordering, so whichever finished last owned it. At 1.8.5 that was GPU — `latest` and `latest-gpu` are currently the same 7.71 GB CUDA manifest, so the documented CPU quickstart hands users the GPU image (the CPU image is tag `1.8.5`, 0.98 GB, `variant=cpu`).

Fixed with `flavor: latest=false` on both metadata steps; `latest` now comes only from each job's explicit, stable-gated `type=raw` line.

**This does not fix the live tag.** `:latest` still resolves to the GPU manifest until something republishes — either a retag (`docker buildx imagetools create -t ...:latest ...:1.8.5`) or a `workflow_dispatch` re-run with `overwrite: true`. Docker Hub needs the same treatment.

## Verification

Verified locally: the electron job clean-room in both directions; the pip smoke end-to-end against a real built wheel (passes, and correctly fails on a wrong version and on a venv without the package); every Docker smoke assertion against a real running container; all workflow YAML parses; `ruff` clean; the 165 guardrail tests still pass.

**Not verified:** the Docker job's `load: true` build step — I could not rebuild the image locally. A `workflow_dispatch` run of `docker-build.yml` against this branch would settle it before merge. `install-smoke.yml` also cannot be dispatched until it reaches `main`, since GitHub only lists `workflow_dispatch`-only workflows that exist on the default branch.

## Security review

Done, no release blockers. Two LOW findings in this branch's own additions, both fixed here: the smoke container published an unauthenticated first-run server on all runner interfaces (now loopback-only), and a `chmod 777` bind mount (removed — the image's own `VOLUME` suffices). Plus SHA-pinned actions in the new workflow and `persist-credentials: false` on the checkouts in jobs that run `npm ci`.

Neither new workflow is fork-reachable; no new job requests write permissions or consumes a secret.