### PR TITLE
Drop the duplicate electron job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,14 @@ jobs:
           npm ci
           npm test
 
+      # `npm run lint` is `tsc --noEmit`. `npm test` compiles with
+      # tsconfig.test.json, which only covers src/ + test/; the lint pass is
+      # what type-checks the main-process build as electron-builder will.
       - name: Test Electron shell
         working-directory: electron
         run: |
           npm ci
+          npm run lint
           npm test
 
       - name: Install telemetry Worker dependencies
@@ -436,7 +440,7 @@ jobs:
   build:
     name: build
     if: always()
-    needs: [checks, backend, backend_release_sweep, e2e, electron]
+    needs: [checks, backend, backend_release_sweep, e2e]
     runs-on: ubuntu-latest
     steps:
       # Each dependency is checked against what IT is allowed to report, not
@@ -466,18 +470,16 @@ jobs:
           BACKEND_RESULT: ${{ needs.backend.result }}
           SWEEP_RESULT: ${{ needs.backend_release_sweep.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
-          ELECTRON_RESULT: ${{ needs.electron.result }}
         run: |
           set -euo pipefail
-          echo "checks=$CHECKS_RESULT backend=$BACKEND_RESULT sweep=$SWEEP_RESULT e2e=$E2E_RESULT electron=$ELECTRON_RESULT"
+          echo "checks=$CHECKS_RESULT backend=$BACKEND_RESULT sweep=$SWEEP_RESULT e2e=$E2E_RESULT"
 
           failed=0
-          for job in checks backend e2e electron; do
+          for job in checks backend e2e; do
             case "$job" in
               checks) result="$CHECKS_RESULT" ;;
               backend) result="$BACKEND_RESULT" ;;
               e2e) result="$E2E_RESULT" ;;
-              electron) result="$ELECTRON_RESULT" ;;
             esac
             if [ "$result" != "success" ]; then
               echo "::error::Blocking job '$job' reported '$result' (must be 'success')."
@@ -572,70 +574,6 @@ jobs:
           name: playwright-report
           path: frontend/playwright-report
           retention-days: 7
-
-  # ---------------------------------------------------------------------------
-  # Electron main-process unit tests (electron/test/, `node --test` over the
-  # compiled TypeScript). They cover the logic behind real desktop incidents:
-  # overlay install args, the CPU fallback state machine, backends location,
-  # forced-backend parsing, hardware-detector injection, and the media IPC
-  # boundary. Until now they ran only when someone remembered to type
-  # `cd electron && npm test`, so a regression in any of it reached a release
-  # candidate unchallenged — docs/release-test-plan.md called this out as "not
-  # wired into any workflow yet".
-  #
-  # The Electron BINARY is never needed here. These are plain Node tests, and
-  # `require('electron')` outside an Electron runtime returns the path to the
-  # executable, not the Electron API — so `app`/`ipcRenderer` are already
-  # undefined when these tests run locally, and nothing touches them at import
-  # time. That makes the ~100 MB download pure cost:
-  #   - ELECTRON_SKIP_BINARY_DOWNLOAD stops `npm ci` fetching it, but it leaves
-  #     node_modules/electron/path.txt absent, and that package's index.js
-  #     re-attempts the download AT REQUIRE TIME when the file is missing.
-  #   - ELECTRON_OVERRIDE_DIST_PATH is checked BEFORE that existence test, so
-  #     the require resolves to a string and returns without any filesystem or
-  #     network access. The path is never opened; it does not need to exist.
-  # Both are required — either one alone still downloads.
-  # ---------------------------------------------------------------------------
-  electron:
-    name: electron
-    runs-on: ubuntu-latest
-    steps:
-      # persist-credentials: false — the `npm ci` below executes dependency
-      # lifecycle scripts, and checkout otherwise leaves the job token in
-      # .git/config where they can read it. No git operation follows.
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      # Node 22, not the 20 used by the e2e job. `npm test` runs
-      # `node --test "dist-test/test/*.test.js"` with the glob QUOTED, so the
-      # shell does not expand it and the test runner has to — and runner-side
-      # glob support only arrived in Node 22. On 20 this fails with
-      # "Could not find .../dist-test/test/*.test.js" and zero tests run.
-      # 22 also matches electron.yml's build job, @types/node, and the
-      # Dockerfile's frontend builder.
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: electron/package-lock.json
-
-      - name: Install electron deps
-        working-directory: electron
-        env:
-          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
-        run: npm ci
-
-      - name: Typecheck
-        working-directory: electron
-        run: npm run lint
-
-      - name: Run electron unit tests
-        working-directory: electron
-        env:
-          ELECTRON_OVERRIDE_DIST_PATH: /nonexistent/electron-dist
-        run: npm test
 
   # ---------------------------------------------------------------------------
   # Windows only validates OS-sensitive behaviour (file/path/process handling,


### PR DESCRIPTION
The checks job has run electron npm test since 9a2157d9; the release test plan claiming otherwise was stale. Keep the typecheck by adding npm run lint to the existing step.