### PR TITLE
Update tag_task to use the unprocessable image registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,7 @@ jobs:
           tests/test_stacks_api.py
           tests/test_stacks_membership.py
           tests/test_tag_prediction_scope.py
+          tests/test_tag_task.py
           tests/test_tag_worker.py
           tests/test_thumbnail_cache_headers.py
           tests/test_token_identity.py

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -40,6 +40,53 @@ from pixlstash.tasks.base_task import BaseTask, QueueType, TaskPriority
 
 logger = get_logger(__name__)
 
+# Extensions loaded through the video frame extractor rather than PIL. Only a
+# hint for picking the *first* decoder to try: a file whose extension lies is
+# still resolved by the shared loader in `_load_pic`.
+_VIDEO_EXTS = frozenset({".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"})
+
+
+def _is_transient_load_error(exc: BaseException) -> bool:
+    """True when *exc* means the machine failed, not that the file is corrupt.
+
+    This is the gate on `mark_unprocessable`. A mark suppresses the picture in
+    `base_task_finder._filter_and_claim`, i.e. for **every** batch finder —
+    thumbnails, embeddings and quality as well as tagging — until the file's
+    mtime/size changes, and `vault._count_missing_*` subtracts suppressed ids
+    from the "remaining" counters, so the loss does not even show in the UI.
+    Marking a good picture because the machine ran out of file descriptors would
+    therefore disable it silently for the rest of the server session.
+
+    `OSError.errno` is the discriminator, and it is exact: a real filesystem or
+    resource failure carries one (``EMFILE`` 24, ``EIO`` 5, ``ESTALE`` 116),
+    while PIL's decode failures do not — both `UnidentifiedImageError` and the
+    ``"image file is truncated"`` `OSError` leave it `None`.
+    """
+    if isinstance(exc, MemoryError):
+        return True
+    return isinstance(exc, OSError) and exc.errno is not None
+
+
+def _file_is_readable(file_path: str) -> bool:
+    """True when the file's bytes can be read at all.
+
+    The last check before declaring a picture undecodable, for the decoders that
+    swallow their own errors: `extract_representative_video_frames` returns `[]`
+    whenever `cv2.VideoCapture` fails to open, which includes failing under file
+    descriptor exhaustion. Without this, that path marks a good video.
+    """
+    try:
+        with open(file_path, "rb") as handle:
+            handle.read(1)
+        return True
+    except OSError as exc:
+        logger.warning(
+            "TagTask: %s could not be read (%s); not marking it unprocessable",
+            file_path,
+            exc,
+        )
+        return False
+
 
 class TagTask(BaseTask):
     """Task that tags a batch of pictures and persists tag updates."""
@@ -146,42 +193,107 @@ class TagTask(BaseTask):
         if self._model_preload_thread is not None:
             self._model_preload_thread.join(timeout=5)
 
-    def _load_pic(self, pic) -> tuple[str, PILImage.Image|None]:
-        video_exts = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"}
-        file_path = ImageUtils.resolve_picture_path(
-            self._db.image_root, pic.file_path
-        )
+    _PRELOAD_WORKERS = 4
+
+    def _load_pic(self, pic) -> "tuple[str | None, PILImage.Image | None, bool]":
+        """Load *pic*'s image for tagging.
+
+        Args:
+            pic: The picture to load.
+
+        Returns:
+            ``(file_path, image, undecodable)``. ``undecodable`` is True **only**
+            when the file's bytes were readable and still could not be decoded by
+            any loader — the sole condition under which the caller may mark it in
+            the unprocessable registry (see `_is_transient_load_error` for why
+            that distinction has to be exact).
+
+        The extension only picks which decoder is tried first. Whatever it says,
+        a failure falls back to `ImageUtils.load_image_or_video`, the loader the
+        thumbnail, quality and embedding tasks use, so this path can never
+        suppress a picture those pipelines are able to read — a real mp4 named
+        `.png` is common enough with re-encoded downloads to matter.
+        """
+        file_path = ImageUtils.resolve_picture_path(self._db.image_root, pic.file_path)
+        if not file_path:
+            logger.warning(
+                "TagTask: picture %s has no resolvable file path",
+                getattr(pic, "id", None),
+            )
+            return None, None, False
+
         try:
             ext = os.path.splitext(str(file_path))[1].lower()
-            if ext in video_exts:
+            if ext in _VIDEO_EXTS:
                 frames = VideoUtils.extract_representative_video_frames(
                     str(file_path), count=1
                 )
-                if not frames:
-                    logger.debug(
-                        "TagTask load image failed for %s: no frames", str(file_path)
-                    )
-                    return file_path, None
-                return file_path, frames[0].convert("RGB")
-            return file_path, PILImage.open(file_path).convert("RGB")
+                if frames:
+                    return file_path, frames[0].convert("RGB"), False
+                logger.debug(
+                    "TagTask: no frames extracted from %s; trying the shared loader",
+                    file_path,
+                )
+            else:
+                return file_path, PILImage.open(file_path).convert("RGB"), False
         except Exception as exc:
+            if _is_transient_load_error(exc):
+                logger.warning(
+                    "TagTask: transient failure loading %s (%s); leaving it to retry",
+                    file_path,
+                    exc,
+                )
+                return file_path, None, False
             logger.debug(
-                "TagTask load image failed for %s: %s", str(file_path), exc
+                "TagTask: %s did not decode by extension (%s); trying the shared loader",
+                file_path,
+                exc,
             )
-            return file_path, None
 
-    _PRELOAD_WORKERS = 4
+        # The extension lied, or the primary decoder failed on a file that is not
+        # a resource problem. Ask the loader every suppressed pipeline uses before
+        # concluding anything; it logs its own cause at ERROR.
+        array = ImageUtils.load_image_or_video(str(file_path))
+        if array is not None:
+            return file_path, PILImage.fromarray(array), False
+        return file_path, None, _file_is_readable(str(file_path))
+
+    def _mark_unprocessable(self, pic, file_path) -> None:
+        """Record *pic* as undecodable so the finders stop re-selecting it (#585).
+
+        Mirrors `thumbnail_generation_task` / `quality_task`: the registry is
+        optional on the database object, and its absence degrades to a warning
+        rather than a crash. Only ever called for a genuinely undecodable file —
+        see `_load_pic`'s ``undecodable`` flag.
+        """
+        registry = getattr(self._db, "unprocessable_images", None)
+        if registry is not None:
+            registry.mark_unprocessable(
+                getattr(pic, "id", None),
+                str(file_path),
+                reason="tag source could not be decoded",
+            )
+        else:
+            logger.warning(
+                "TagTask: failed to load source for picture %s (%s)",
+                getattr(pic, "id", None),
+                str(file_path),
+            )
 
     def _preload_images(self) -> None:
         preloaded = {}
 
-        def _load_one(pic) -> tuple[str|None, PILImage.Image|None]:
+        def _load_one(pic) -> "tuple[str | None, PILImage.Image | None]":
             if self._preload_cancel.is_set():
                 return None, None
-            file_path, img = self._load_pic(pic)
+            # The preload never marks: it is best-effort warming, and the batch
+            # path re-loads and decides. Marking here would also race the cancel.
+            file_path, img, _undecodable = self._load_pic(pic)
             if img is None:
                 logger.debug(
-                    "Preload failed for %s (%s)", getattr(pic, "id", None), str(file_path)
+                    "Preload failed for %s (%s)",
+                    getattr(pic, "id", None),
+                    str(file_path),
                 )
             return file_path, img
 
@@ -585,55 +697,61 @@ class TagTask(BaseTask):
                             for face in faces
                             if face.bbox and getattr(face, "face_index", 0) >= 0
                         ]
-                        img = preloaded_images.get(file_path)
-                        if img is None:
-                            file_path, img = self._load_pic(pic)
+                        # Per-picture guard. Everything below can raise on data
+                        # this loop does not control: `Face.bbox` is json.loads of
+                        # a free-text column and `valid_faces` never length-checks
+                        # it, so a row that is not [x1,y1,x2,y2] raises IndexError
+                        # here and ValueError in expand_bbox_to_square. Without
+                        # this try, one such row escapes to the pass-level handler
+                        # below and costs EVERY remaining picture in the task its
+                        # quality crop, silently — they are still written as
+                        # tagged, so no finder re-selects them.
+                        try:
+                            img = preloaded_images.get(file_path)
                             if img is None:
-                                registry = getattr(self._db, "unprocessable_images", None)
-                                if registry is not None:
-                                    registry.mark_unprocessable(
-                                        getattr(pic, "id", None),
-                                        str(file_path),
-                                        reason="tag source could not be decoded",
-                                    )
-                                else:
-                                    logger.warning(
-                                        "TagTask: failed to load source for picture %s (%s)",
-                                        getattr(pic, "id", None),
-                                        str(file_path),
-                                    )
-                                continue
-                            preloaded_images[file_path] = img
-                        w, h = img.size
-                        if valid_faces:
-                            largest_face = max(
-                                valid_faces,
-                                key=lambda face: max(
-                                    0,
-                                    (float(face.bbox[2]) - float(face.bbox[0]))
-                                    * (float(face.bbox[3]) - float(face.bbox[1])),
-                                ),
+                                file_path, img, undecodable = self._load_pic(pic)
+                                if img is None:
+                                    if undecodable:
+                                        self._mark_unprocessable(pic, file_path)
+                                    continue
+                                preloaded_images[file_path] = img
+                            w, h = img.size
+                            if valid_faces:
+                                largest_face = max(
+                                    valid_faces,
+                                    key=lambda face: max(
+                                        0,
+                                        (float(face.bbox[2]) - float(face.bbox[0]))
+                                        * (float(face.bbox[3]) - float(face.bbox[1])),
+                                    ),
+                                )
+                                expanded = expand_bbox_to_square(
+                                    largest_face.bbox, w, h, target
+                                )
+                                key = f"{file_path}#face{largest_face.id}"
+                            else:
+                                # No face detected: fall back to a centre crop so
+                                # whole-image quality defects (blockiness, blur, jpeg
+                                # artifacts) still get a high-resolution pass instead of
+                                # relying only on the downscaled full-image pass. A
+                                # zero-size box at the image centre expands to the same
+                                # target-sized square the face path uses.
+                                centre_bbox = [w / 2.0, h / 2.0, w / 2.0, h / 2.0]
+                                expanded = expand_bbox_to_square(
+                                    centre_bbox, w, h, target
+                                )
+                                key = f"{file_path}#centre"
+                                centre_crop_paths.add(file_path)
+                            crop = img.crop(expanded)
+                            quality_items.append((key, crop))
+                            key_to_path[key] = file_path
+                        except Exception as exc:
+                            logger.warning(
+                                "Could not build the quality crop for picture %s (%s): %s",
+                                getattr(pic, "id", None),
+                                file_path,
+                                exc,
                             )
-                            expanded = expand_bbox_to_square(
-                                largest_face.bbox, w, h, target
-                            )
-                            key = f"{file_path}#face{largest_face.id}"
-                        else:
-                            # No face detected: fall back to a centre crop so
-                            # whole-image quality defects (blockiness, blur, jpeg
-                            # artifacts) still get a high-resolution pass instead of
-                            # relying only on the downscaled full-image pass. A
-                            # zero-size box at the image centre expands to the same
-                            # target-sized square the face path uses.
-                            centre_bbox = [w / 2.0, h / 2.0, w / 2.0, h / 2.0]
-                            expanded = expand_bbox_to_square(
-                                centre_bbox, w, h, target
-                            )
-                            key = f"{file_path}#centre"
-                            centre_crop_paths.add(file_path)
-                        crop = img.crop(expanded)
-                        quality_items.append((key, crop))
-                        key_to_path[key] = file_path
                     if quality_items:
                         # Single GPU pass: get quality tags AND raw scores for predictions.
                         crop_raw_scores: dict = {}

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -258,6 +258,79 @@ class TagTask(BaseTask):
             return file_path, PILImage.fromarray(array), False
         return file_path, None, _file_is_readable(str(file_path))
 
+    def _build_quality_crop(self, pic, faces, target, preloaded_images):
+        """Build the high-resolution quality crop for one picture.
+
+        Args:
+            pic: The picture to crop.
+            faces: That picture's `Face` rows, unfiltered.
+            target: Square side length the crop is expanded to.
+            preloaded_images: The task's path -> image cache; populated on a miss.
+
+        Returns:
+            ``(key, crop, file_path, is_centre_crop)``, or **None** when this
+            picture cannot contribute a crop. `is_centre_crop` marks the faceless
+            fallback, which is judged against the reduced whitelist.
+
+        **Never raises**, and that is the point of it being a separate method.
+        Everything here runs on data the caller does not control: `Face.bbox` is
+        `json.loads` of a free-text column, so a row that is not ``[x1,y1,x2,y2]``
+        raises `IndexError` in the `max()` key and `ValueError` in
+        `expand_bbox_to_square`, and a bbox whose JSON is malformed raises on
+        attribute access alone. Inline in the caller's loop, one such row escaped
+        to the pass-level handler and cost **every remaining picture in the task**
+        its quality crop — silently, because those pictures are still written as
+        tagged, so no finder re-selects them.
+        """
+        file_path = ImageUtils.resolve_picture_path(self._db.image_root, pic.file_path)
+        try:
+            valid_faces = [
+                face
+                for face in faces
+                if face.bbox and getattr(face, "face_index", 0) >= 0
+            ]
+            img = preloaded_images.get(file_path)
+            if img is None:
+                file_path, img, undecodable = self._load_pic(pic)
+                if img is None:
+                    if undecodable:
+                        self._mark_unprocessable(pic, file_path)
+                    return None
+                preloaded_images[file_path] = img
+            w, h = img.size
+            if valid_faces:
+                largest_face = max(
+                    valid_faces,
+                    key=lambda face: max(
+                        0,
+                        (float(face.bbox[2]) - float(face.bbox[0]))
+                        * (float(face.bbox[3]) - float(face.bbox[1])),
+                    ),
+                )
+                expanded = expand_bbox_to_square(largest_face.bbox, w, h, target)
+                return (
+                    f"{file_path}#face{largest_face.id}",
+                    img.crop(expanded),
+                    file_path,
+                    False,
+                )
+            # No face detected: fall back to a centre crop so whole-image quality
+            # defects (blockiness, blur, jpeg artifacts) still get a high-
+            # resolution pass instead of relying only on the downscaled full-image
+            # pass. A zero-size box at the image centre expands to the same
+            # target-sized square the face path uses.
+            centre_bbox = [w / 2.0, h / 2.0, w / 2.0, h / 2.0]
+            expanded = expand_bbox_to_square(centre_bbox, w, h, target)
+            return f"{file_path}#centre", img.crop(expanded), file_path, True
+        except Exception as exc:
+            logger.warning(
+                "Could not build the quality crop for picture %s (%s): %s",
+                getattr(pic, "id", None),
+                file_path,
+                exc,
+            )
+            return None
+
     def _mark_unprocessable(self, pic, file_path) -> None:
         """Record *pic* as undecodable so the finders stop re-selecting it (#585).
 
@@ -688,70 +761,19 @@ class TagTask(BaseTask):
                     # judged against the reduced CENTRE_CROP_TAG_WHITELIST (no face tags).
                     centre_crop_paths: set = set()
                     for pic in batch:
-                        file_path = ImageUtils.resolve_picture_path(
-                            self._db.image_root, pic.file_path
+                        built = self._build_quality_crop(
+                            pic,
+                            faces_by_pic.get(pic.id, []),
+                            target,
+                            preloaded_images,
                         )
-                        faces = faces_by_pic.get(pic.id, [])
-                        valid_faces = [
-                            face
-                            for face in faces
-                            if face.bbox and getattr(face, "face_index", 0) >= 0
-                        ]
-                        # Per-picture guard. Everything below can raise on data
-                        # this loop does not control: `Face.bbox` is json.loads of
-                        # a free-text column and `valid_faces` never length-checks
-                        # it, so a row that is not [x1,y1,x2,y2] raises IndexError
-                        # here and ValueError in expand_bbox_to_square. Without
-                        # this try, one such row escapes to the pass-level handler
-                        # below and costs EVERY remaining picture in the task its
-                        # quality crop, silently — they are still written as
-                        # tagged, so no finder re-selects them.
-                        try:
-                            img = preloaded_images.get(file_path)
-                            if img is None:
-                                file_path, img, undecodable = self._load_pic(pic)
-                                if img is None:
-                                    if undecodable:
-                                        self._mark_unprocessable(pic, file_path)
-                                    continue
-                                preloaded_images[file_path] = img
-                            w, h = img.size
-                            if valid_faces:
-                                largest_face = max(
-                                    valid_faces,
-                                    key=lambda face: max(
-                                        0,
-                                        (float(face.bbox[2]) - float(face.bbox[0]))
-                                        * (float(face.bbox[3]) - float(face.bbox[1])),
-                                    ),
-                                )
-                                expanded = expand_bbox_to_square(
-                                    largest_face.bbox, w, h, target
-                                )
-                                key = f"{file_path}#face{largest_face.id}"
-                            else:
-                                # No face detected: fall back to a centre crop so
-                                # whole-image quality defects (blockiness, blur, jpeg
-                                # artifacts) still get a high-resolution pass instead of
-                                # relying only on the downscaled full-image pass. A
-                                # zero-size box at the image centre expands to the same
-                                # target-sized square the face path uses.
-                                centre_bbox = [w / 2.0, h / 2.0, w / 2.0, h / 2.0]
-                                expanded = expand_bbox_to_square(
-                                    centre_bbox, w, h, target
-                                )
-                                key = f"{file_path}#centre"
-                                centre_crop_paths.add(file_path)
-                            crop = img.crop(expanded)
-                            quality_items.append((key, crop))
-                            key_to_path[key] = file_path
-                        except Exception as exc:
-                            logger.warning(
-                                "Could not build the quality crop for picture %s (%s): %s",
-                                getattr(pic, "id", None),
-                                file_path,
-                                exc,
-                            )
+                        if built is None:
+                            continue
+                        key, crop, file_path, is_centre_crop = built
+                        quality_items.append((key, crop))
+                        key_to_path[key] = file_path
+                        if is_centre_crop:
+                            centre_crop_paths.add(file_path)
                     if quality_items:
                         # Single GPU pass: get quality tags AND raw scores for predictions.
                         crop_raw_scores: dict = {}

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -159,7 +159,7 @@ class TagTask(BaseTask):
                 )
                 if not frames:
                     logger.debug(
-                        "TaskTask load image failed for %s: no frames", str(file_path)
+                        "TagTask load image failed for %s: no frames", str(file_path)
                     )
                     return file_path, None
                 return file_path, frames[0].convert("RGB")

--- a/pixlstash/tasks/tag_task.py
+++ b/pixlstash/tasks/tag_task.py
@@ -146,33 +146,44 @@ class TagTask(BaseTask):
         if self._model_preload_thread is not None:
             self._model_preload_thread.join(timeout=5)
 
+    def _load_pic(self, pic) -> tuple[str, PILImage.Image|None]:
+        video_exts = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"}
+        file_path = ImageUtils.resolve_picture_path(
+            self._db.image_root, pic.file_path
+        )
+        try:
+            ext = os.path.splitext(str(file_path))[1].lower()
+            if ext in video_exts:
+                frames = VideoUtils.extract_representative_video_frames(
+                    str(file_path), count=1
+                )
+                if not frames:
+                    logger.debug(
+                        "TaskTask load image failed for %s: no frames", str(file_path)
+                    )
+                    return file_path, None
+                return file_path, frames[0].convert("RGB")
+            return file_path, PILImage.open(file_path).convert("RGB")
+        except Exception as exc:
+            logger.debug(
+                "TagTask load image failed for %s: %s", str(file_path), exc
+            )
+            return file_path, None
+
     _PRELOAD_WORKERS = 4
 
     def _preload_images(self) -> None:
         preloaded = {}
-        video_exts = {".mp4", ".avi", ".mov", ".mkv", ".webm", ".flv", ".wmv"}
 
-        def _load_one(pic):
+        def _load_one(pic) -> tuple[str|None, PILImage.Image|None]:
             if self._preload_cancel.is_set():
                 return None, None
-            try:
-                file_path = ImageUtils.resolve_picture_path(
-                    self._db.image_root, pic.file_path
-                )
-                ext = os.path.splitext(str(file_path))[1].lower()
-                if ext in video_exts:
-                    frames = VideoUtils.extract_representative_video_frames(
-                        str(file_path), count=1
-                    )
-                    if not frames:
-                        return None, None
-                    return file_path, frames[0].convert("RGB")
-                return file_path, PILImage.open(file_path).convert("RGB")
-            except Exception as exc:
+            file_path, img = self._load_pic(pic)
+            if img is None:
                 logger.debug(
-                    "Preload failed for %s: %s", getattr(pic, "file_path", None), exc
+                    "Preload failed for %s (%s)", getattr(pic, "id", None), str(file_path)
                 )
-                return None, None
+            return file_path, img
 
         n_workers = min(self._PRELOAD_WORKERS, max(1, len(self._pictures)))
         with ThreadPoolExecutor(max_workers=n_workers) as pool:
@@ -574,67 +585,55 @@ class TagTask(BaseTask):
                             for face in faces
                             if face.bbox and getattr(face, "face_index", 0) >= 0
                         ]
-                        try:
-                            img = preloaded_images.get(file_path)
+                        img = preloaded_images.get(file_path)
+                        if img is None:
+                            file_path, img = self._load_pic(pic)
                             if img is None:
-                                ext = os.path.splitext(str(file_path))[1].lower()
-                                if ext in {
-                                    ".mp4",
-                                    ".avi",
-                                    ".mov",
-                                    ".mkv",
-                                    ".webm",
-                                    ".flv",
-                                    ".wmv",
-                                }:
-                                    frames = (
-                                        VideoUtils.extract_representative_video_frames(
-                                            str(file_path),
-                                            count=1,
-                                        )
+                                registry = getattr(self._db, "unprocessable_images", None)
+                                if registry is not None:
+                                    registry.mark_unprocessable(
+                                        getattr(pic, "id", None),
+                                        str(file_path),
+                                        reason="tag source could not be decoded",
                                     )
-                                    if not frames:
-                                        continue
-                                    img = frames[0].convert("RGB")
                                 else:
-                                    img = PILImage.open(file_path).convert("RGB")
-                                preloaded_images[file_path] = img
-                            w, h = img.size
-                            if valid_faces:
-                                largest_face = max(
-                                    valid_faces,
-                                    key=lambda face: max(
-                                        0,
-                                        (float(face.bbox[2]) - float(face.bbox[0]))
-                                        * (float(face.bbox[3]) - float(face.bbox[1])),
-                                    ),
-                                )
-                                expanded = expand_bbox_to_square(
-                                    largest_face.bbox, w, h, target
-                                )
-                                key = f"{file_path}#face{largest_face.id}"
-                            else:
-                                # No face detected: fall back to a centre crop so
-                                # whole-image quality defects (blockiness, blur, jpeg
-                                # artifacts) still get a high-resolution pass instead of
-                                # relying only on the downscaled full-image pass. A
-                                # zero-size box at the image centre expands to the same
-                                # target-sized square the face path uses.
-                                centre_bbox = [w / 2.0, h / 2.0, w / 2.0, h / 2.0]
-                                expanded = expand_bbox_to_square(
-                                    centre_bbox, w, h, target
-                                )
-                                key = f"{file_path}#centre"
-                                centre_crop_paths.add(file_path)
-                            crop = img.crop(expanded)
-                            quality_items.append((key, crop))
-                            key_to_path[key] = file_path
-                        except Exception as exc:
-                            logger.warning(
-                                "Could not load %s for quality crop pass: %s",
-                                file_path,
-                                exc,
+                                    logger.warning(
+                                        "TagTask: failed to load source for picture %s (%s)",
+                                        getattr(pic, "id", None),
+                                        str(file_path),
+                                    )
+                                continue
+                            preloaded_images[file_path] = img
+                        w, h = img.size
+                        if valid_faces:
+                            largest_face = max(
+                                valid_faces,
+                                key=lambda face: max(
+                                    0,
+                                    (float(face.bbox[2]) - float(face.bbox[0]))
+                                    * (float(face.bbox[3]) - float(face.bbox[1])),
+                                ),
                             )
+                            expanded = expand_bbox_to_square(
+                                largest_face.bbox, w, h, target
+                            )
+                            key = f"{file_path}#face{largest_face.id}"
+                        else:
+                            # No face detected: fall back to a centre crop so
+                            # whole-image quality defects (blockiness, blur, jpeg
+                            # artifacts) still get a high-resolution pass instead of
+                            # relying only on the downscaled full-image pass. A
+                            # zero-size box at the image centre expands to the same
+                            # target-sized square the face path uses.
+                            centre_bbox = [w / 2.0, h / 2.0, w / 2.0, h / 2.0]
+                            expanded = expand_bbox_to_square(
+                                centre_bbox, w, h, target
+                            )
+                            key = f"{file_path}#centre"
+                            centre_crop_paths.add(file_path)
+                        crop = img.crop(expanded)
+                        quality_items.append((key, crop))
+                        key_to_path[key] = file_path
                     if quality_items:
                         # Single GPU pass: get quality tags AND raw scores for predictions.
                         crop_raw_scores: dict = {}

--- a/tests/test_ci_shards.py
+++ b/tests/test_ci_shards.py
@@ -237,7 +237,6 @@ DEFERRED_FROM_GATE = frozenset(
         "test_tag_prediction_backfill.py",
         "test_tag_predictions_api.py",
         "test_tag_suggestions_api.py",
-        "test_tag_task.py",
         "test_tagger_plugin_registry.py",
         "test_tagger_runs_api.py",
         "test_user_settings_tagger_settings.py",

--- a/tests/test_tag_task.py
+++ b/tests/test_tag_task.py
@@ -245,3 +245,113 @@ def test_transient_error_classifier():
     assert not _is_transient_load_error(PILImage.UnidentifiedImageError("nope"))
     assert not _is_transient_load_error(OSError("image file is truncated"))
     assert not _is_transient_load_error(PILImage.DecompressionBombError("huge"))
+
+
+# --- The per-picture crop guard (PR #750 review blocker B2) ------------------
+
+
+class _FakeFace:
+    def __init__(self, face_id, bbox, face_index=0):
+        self.id = face_id
+        self.bbox = bbox
+        self.face_index = face_index
+
+
+def _png(tmp_path, name, size=(64, 48)):
+    from PIL import Image as PILImage
+
+    path = tmp_path / name
+    PILImage.new("RGB", size, "blue").save(path)
+    return path
+
+
+def test_a_malformed_bbox_costs_only_its_own_picture(tmp_path):
+    """The blocker: one bad face row must not cost the batch its crops.
+
+    `Face.bbox` is json.loads of a free-text column and is never length-checked,
+    so a row that is not [x1,y1,x2,y2] raises inside the crop build. Inline in
+    the caller's loop that escaped to the pass-level handler and every remaining
+    picture in the task silently lost its quality crop.
+    """
+    task = _task_for(_FakeDb(str(tmp_path)))
+    pics = [
+        Picture(id=1, file_path=str(_png(tmp_path, "first.png"))),
+        Picture(id=2, file_path=str(_png(tmp_path, "second.png"))),
+        Picture(id=3, file_path=str(_png(tmp_path, "third.png"))),
+    ]
+    faces_by_pic = {
+        1: [_FakeFace(11, [1, 2, 40, 30])],
+        2: [_FakeFace(22, [1, 2])],  # truncated: IndexError in the max() key
+        3: [_FakeFace(33, [3, 4, 44, 34])],
+    }
+    preloaded = {}
+
+    built = [
+        task._build_quality_crop(pic, faces_by_pic[pic.id], 32, preloaded)
+        for pic in pics
+    ]
+
+    assert built[1] is None, "the malformed row yields no crop"
+    assert built[0] is not None and built[2] is not None, (
+        "pictures either side of the bad row must still get their crops"
+    )
+    assert [b[0] for b in built if b] == [
+        f"{pics[0].file_path}#face11",
+        f"{pics[2].file_path}#face33",
+    ]
+
+
+def test_a_bbox_whose_json_is_corrupt_is_survived(tmp_path):
+    """Malformed bbox *JSON* raises on attribute access, before any indexing.
+
+    This one was unguarded even before the PR: the valid_faces comprehension sat
+    outside the old try, so json.loads blew up the whole pass.
+    """
+
+    class _CorruptBboxFace:
+        id = 44
+
+        @property
+        def bbox(self):
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+
+    task = _task_for(_FakeDb(str(tmp_path)))
+    pic = Picture(id=4, file_path=str(_png(tmp_path, "corrupt-bbox.png")))
+
+    assert task._build_quality_crop(pic, [_CorruptBboxFace()], 32, {}) is None
+
+
+def test_no_faces_falls_back_to_a_centre_crop(tmp_path):
+    """The faceless path still contributes, flagged for the reduced whitelist."""
+    task = _task_for(_FakeDb(str(tmp_path)))
+    pic = Picture(id=5, file_path=str(_png(tmp_path, "faceless.png")))
+
+    key, crop, file_path, is_centre_crop = task._build_quality_crop(pic, [], 32, {})
+
+    assert is_centre_crop is True
+    assert key == f"{file_path}#centre"
+    assert crop.size == (32, 32)
+
+
+def test_a_negative_face_index_is_not_a_face(tmp_path):
+    """face_index < 0 is filtered out, so the picture takes the centre crop."""
+    task = _task_for(_FakeDb(str(tmp_path)))
+    pic = Picture(id=6, file_path=str(_png(tmp_path, "negative-index.png")))
+
+    _key, _crop, _path, is_centre_crop = task._build_quality_crop(
+        pic, [_FakeFace(66, [1, 2, 40, 30], face_index=-1)], 32, {}
+    )
+
+    assert is_centre_crop is True
+
+
+def test_an_undecodable_picture_is_marked_once_from_the_crop_pass(tmp_path):
+    """The registry call still happens through the extracted seam."""
+    bad = tmp_path / "broken.png"
+    bad.write_bytes(b"nope")
+    registry = _RecordingRegistry()
+    task = _task_for(_FakeDb(str(tmp_path), registry))
+    pic = Picture(id=7, file_path=str(bad))
+
+    assert task._build_quality_crop(pic, [], 32, {}) is None
+    assert registry.marked == [(7, str(bad), "tag source could not be decoded")]

--- a/tests/test_tag_task.py
+++ b/tests/test_tag_task.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sqlalchemy import event
 from sqlalchemy.pool import NullPool
 from sqlmodel import SQLModel, Session, create_engine, select
@@ -124,3 +126,122 @@ def test_add_tags_bulk_honours_human_labels(tmp_path):
         )
         # 'watermark' is kept (human POS), 'blurry' is dropped (human NEG).
         assert saved_tags == {"woman", "watermark"}
+
+
+# --- Unprocessable-registry gating (PR #750 review blockers) -----------------
+
+
+class _FakeDb:
+    """Minimal stand-in for the vault database `_load_pic` and marking need."""
+
+    def __init__(self, image_root, registry=None):
+        self.image_root = image_root
+        if registry is not None:
+            self.unprocessable_images = registry
+
+
+class _RecordingRegistry:
+    def __init__(self):
+        self.marked = []
+
+    def mark_unprocessable(self, picture_id, file_path, *, reason=""):
+        self.marked.append((picture_id, file_path, reason))
+        return True
+
+
+def _task_for(db):
+    task = TagTask.__new__(TagTask)
+    task._db = db
+    return task
+
+
+def test_a_corrupt_file_is_marked_unprocessable(tmp_path):
+    """The positive direction: bytes readable, no decoder can make sense of them."""
+    bad = tmp_path / "corrupt.png"
+    bad.write_bytes(b"this is definitely not a PNG")
+    registry = _RecordingRegistry()
+    task = _task_for(_FakeDb(str(tmp_path), registry))
+    pic = Picture(id=1, file_path=str(bad))
+
+    file_path, img, undecodable = task._load_pic(pic)
+
+    assert img is None
+    assert undecodable is True, "a readable but undecodable file must be markable"
+    task._mark_unprocessable(pic, file_path)
+    assert registry.marked == [
+        (1, str(bad), "tag source could not be decoded"),
+    ]
+
+
+def test_a_transient_load_error_is_never_marked(tmp_path, monkeypatch):
+    """The negative direction, and the one that matters.
+
+    A mark suppresses the picture for EVERY batch finder until the file changes,
+    so an EMFILE while the preload pool holds handles must not disable a good
+    picture for the rest of the server session.
+    """
+    import errno
+
+    from PIL import Image as PILImage
+
+    good = tmp_path / "good.png"
+    PILImage.new("RGB", (8, 8), "red").save(good)
+
+    def _emfile(*_args, **_kwargs):
+        raise OSError(errno.EMFILE, "Too many open files")
+
+    monkeypatch.setattr(PILImage, "open", _emfile)
+    # The shared fallback loader would hit the same wall; it must not be reached.
+    monkeypatch.setattr(
+        "pixlstash.tasks.tag_task.ImageUtils.load_image_or_video",
+        lambda *_a, **_k: pytest.fail("transient error must not reach the fallback"),
+    )
+    task = _task_for(_FakeDb(str(tmp_path), _RecordingRegistry()))
+
+    _file_path, img, undecodable = task._load_pic(Picture(id=2, file_path=str(good)))
+
+    assert img is None
+    assert undecodable is False, "EMFILE is the machine failing, not the file"
+
+
+def test_a_mislabelled_video_is_loaded_not_suppressed(tmp_path, monkeypatch):
+    """A real video named `.png` is decodable by every other pipeline (#750 B3).
+
+    The tag path must not be stricter than the pipelines its mark suppresses, so
+    a PIL failure falls back to the shared loader before concluding anything.
+    """
+    import numpy as np
+
+    lying = tmp_path / "clip.png"
+    lying.write_bytes(b"\x00\x00\x00\x18ftypmp42 not really a png")
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    monkeypatch.setattr(
+        "pixlstash.tasks.tag_task.ImageUtils.load_image_or_video",
+        lambda *_a, **_k: frame,
+    )
+    registry = _RecordingRegistry()
+    task = _task_for(_FakeDb(str(tmp_path), registry))
+
+    _file_path, img, undecodable = task._load_pic(Picture(id=3, file_path=str(lying)))
+
+    assert img is not None, "the shared loader decoded it, so tagging must use it"
+    assert img.size == (4, 4)
+    assert undecodable is False
+    assert registry.marked == []
+
+
+def test_transient_error_classifier():
+    """`OSError.errno` is the discriminator; PIL's decode failures carry none."""
+    import errno
+
+    from PIL import Image as PILImage
+
+    from pixlstash.tasks.tag_task import _is_transient_load_error
+
+    assert _is_transient_load_error(OSError(errno.EMFILE, "Too many open files"))
+    assert _is_transient_load_error(OSError(errno.EIO, "I/O error"))
+    assert _is_transient_load_error(MemoryError())
+    # PIL raises both of these with errno unset: the file, not the machine.
+    assert not _is_transient_load_error(PILImage.UnidentifiedImageError("nope"))
+    assert not _is_transient_load_error(OSError("image file is truncated"))
+    assert not _is_transient_load_error(PILImage.DecompressionBombError("huge"))


### PR DESCRIPTION
Updated tag_task to add unprocessable images to the unprocessable image registry.

Additionally merged the preloading image loading and the not-preloaded image loading code to use a shared helper function as it was performing the same logic with special handling for videos.

Feel free to use any part or none of this fix if you would like to solve this another way.  Cheers!