### PR TITLE
Require Python 3.10 to fix test + telemetry worker security update

### DIFF
--- a/.github/release-assets.md
+++ b/.github/release-assets.md
@@ -22,7 +22,7 @@ is awkward there:
 
 | File | Platform | Size | Notes |
 |------|----------|------|-------|
-| `pixlstash-server-*-windows-x64.exe` | Windows | ~9 MB | Needs Python 3.10+; installs into a managed virtualenv. Digitally signed |
+| `pixlstash-server-*-windows-x64.exe` | Windows | ~9 MB | Needs Python 3.11+; installs into a managed virtualenv. Digitally signed |
 
 On **Linux and macOS**, where that is already easy, there is no separate
 download — use whichever fits your setup:

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -39,7 +39,7 @@ jobs:
           # The floor the README and the release plan both promise. A dependency
           # that quietly requires 3.11+ is invisible on the version everyone
           # develops against, and only surfaces as a user's failed install.
-          - { name: ubuntu / py3.10 (floor), os: ubuntu-latest, python: '3.10' }
+          - { name: ubuntu / py3.11 (floor), os: ubuntu-latest, python: '3.11' }
 
     steps:
       # Actions are pinned by commit SHA, not tag: a tag is mutable, so a

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -291,7 +291,7 @@ Modules **off** the server import path (`tagger_plugins/wd14.py`, `tagger_plugin
 | Config dirs | **platformdirs** |
 | Logging | **colorlog** |
 
-**Python**: 3.10+
+**Python**: 3.11+
 
 ---
 

--- a/docs/release-test-plan.md
+++ b/docs/release-test-plan.md
@@ -58,7 +58,7 @@ section is the only place they are executed.
 
 ### 1.1 pip + venv (PyPI)
 
-Requires Python 3.10+.
+Requires Python 3.11+.
 
 ```
 python -m venv venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,13 @@ classifiers = [
     "Intended Audience :: End Users/Desktop",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Environment :: GPU :: NVIDIA CUDA",    # NVIDIA CUDA support
     "Topic :: Multimedia :: Graphics",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "open_clip_torch>=3.3.0",
     # Hard floor: route_inventory.py needs fastapi.routing.iter_route_contexts,

--- a/website/telemetry-worker/package-lock.json
+++ b/website/telemetry-worker/package-lock.json
@@ -1461,9 +1461,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/website/telemetry-worker/package.json
+++ b/website/telemetry-worker/package.json
@@ -12,6 +12,9 @@
     "check:config": "WRANGLER_LOG_PATH=.wrangler/logs wrangler deploy --dry-run --outdir .wrangler/dry-run",
     "deploy": "wrangler deploy --no-x-provision --no-x-auto-create"
   },
+  "overrides": {
+    "undici": "7.29.0"
+  },
   "devDependencies": {
     "miniflare": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
     "wrangler": "4.118.0"


### PR DESCRIPTION
Neither are relevant to users. It wasn't really possible to install PixlStash on Python 3.10 before anyway and the telemetry worker is just the CloudFlare worker that counts the number of active installs. Included in this repo for transparency.