### PR TITLE
Stop Tab trapping focus in the tag panel (#755)

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -409,6 +409,28 @@ The tab/category switch is **stateless** (see Key Design Principles). Concretely
   pictures on a global view → switch to the Projects/People/Sets tab → drag the
   selection onto a project or character to add them, with the global view still
   intact underneath.
+- **A drop target judges the payload KIND during dragover, from `types` alone.**
+  The JSON body is protected while a drag is in flight (`getData()` returns `""`
+  in Chrome and Firefox), so the kind travels as the *key*: every internal drag
+  writes `application/json` **plus** a marker type —
+  `application/x-pixlstash-pictures` or `application/x-pixlstash-faces`
+  (`utils/media.js`: `setInternalDragPayload`, `isPictureDrag`, `isFaceDrag`).
+  A new payload kind adds a marker; it does not add a field to the body.
+  Two rules follow, and both were once broken (issue #757):
+  - **Never `@dragover.prevent` on a drop target.** The modifier calls
+    `preventDefault()` before the handler body and regardless of what it
+    decides, which accepts every drag on the page. `preventDefault()` belongs
+    inside the handler, only for the kinds that row takes — `SideBar.acceptDrop`
+    returns `accept` / `reject` / `ignore` (`ignore` = an external file drag the
+    window-level importer still owns, so the row stays unpainted rather than
+    promising a refusal it will not perform).
+  - **A drop handler keys off `data.type`, never off the presence of
+    `imageIds`.** A face payload carries `imageIds` too (the pictures the faces
+    were found in), which is how face drags used to file themselves into sets.
+    `readDraggedImageIds` returns nothing unless the payload is `image-ids`.
+  A refused row shows the `.not-droppable` state (hatch + `mdi-cancel` glyph +
+  `--opacity-disabled`, never colour alone), so rejection is visible during the
+  drag instead of arriving as a toast afterwards.
 - **Anti-pattern (do not reintroduce):** a tab/mode `watch` that emits
   `select-*`, pushes a route, or resets a filter. That recouples the sidebar to
   the view and breaks the drag-to-assign flow. Keep navigation in entry-click
@@ -630,8 +652,12 @@ Both people modes take the opt-in `allowCreate` prop (default false; set by `Ima
 #### `StarRatingOverlay.vue` (133 lines)
 5-star score widget. Props: `score`, `readonly`. Emits: `set-score`. Used in `ImageOverlay` and `ImageGrid` cells.
 
-#### `ProgressOverlay.vue` (160 lines)
-Task progress overlay. Props: `status`, `progress`, `message`, `abortable`. Emits: `abort`. Terminal statuses: `completed`, `failed`, `cancelled`.
+#### `ProgressOverlay.vue`
+Task progress overlay, shared by export, plugin runs and smart-score sorts (all three mounted in `ImageGrid`). Props: `visible`, `status`, `message`, `percent`, `count`, `total`, `abortLabel`, `anchor`, `indeterminate`. Emits: `abort`. Terminal statuses: `completed`, `failed`, `cancelled`.
+
+**Multi-root by design (#758).** The card is behind `v-if="visible"`, but the `role="status"` live region is a second root *outside* it: a live region inserted at the same moment as its first text is not reliably announced, so hosting it inside the `v-if` loses the run's opening line. Consequence for callers: attribute fallthrough (`class`, `style`, `ref`) does not apply — pass anything positional through props or wrap the component.
+
+The rest of the accessibility contract: the bar is a real `role="progressbar"` with `aria-valuemin`/`aria-valuemax` and an `aria-valuenow` deliberately omitted while `indeterminate` (same call as `DedupScanBanner`); the card carries `aria-busy` until a terminal status; the live region's text is rounded to 10% steps so a per-item export announces ~10 times rather than thousands; failure adds an `mdi-alert-circle` glyph and the word "Failed" so it does not ride on the red card alone (WCAG 1.4.1); and the indeterminate animation parks at its start offset under `prefers-reduced-motion`.
 
 #### `PluginParametersUI.vue` (336 lines)
 Dynamic form renderer for **image plugin** JSON schemas. Props: `schema`, `modelValue`. Emits: `update:modelValue`. Uses `reactive` form values synced bidirectionally with props. **Not reused for tagger plugins** — those use `TaggerParametersUI.vue`.

--- a/frontend/src/components/editors/FolderTreeNode.vue
+++ b/frontend/src/components/editors/FolderTreeNode.vue
@@ -9,6 +9,9 @@ const props = defineProps({
   folderBrowseCache: { type: Object, required: true },
   expandedFolderIds: { type: Object, required: true }, // Set
   dropTargetKey: { type: String, default: null },
+  // True when the hovered row is the drop target but will not take the payload
+  // being dragged (a face drag over a reference folder, say).
+  dropRejected: { type: Boolean, default: false },
 });
 
 const emit = defineEmits([
@@ -52,7 +55,8 @@ function childImageCount() {
       class="sidebar-folder-row sidebar-folder-child-row"
       :class="{
         active: selectedFolderKey === 'path-' + entry.path,
-        droppable: dropTargetKey === 'path-' + entry.path,
+        droppable: dropTargetKey === 'path-' + entry.path && !dropRejected,
+        'not-droppable': dropTargetKey === 'path-' + entry.path && dropRejected,
       }"
       :title="`${entry.path} - drop dragged reference images here to move them`"
       @contextmenu.prevent="
@@ -106,6 +110,7 @@ function childImageCount() {
           :folder-browse-cache="folderBrowseCache"
           :expanded-folder-ids="expandedFolderIds"
           :drop-target-key="dropTargetKey"
+          :drop-rejected="dropRejected"
           @select="(key, payload) => emit('select', key, payload)"
           @toggle="(path) => emit('toggle', path)"
           @drag-over="(payload) => emit('drag-over', payload)"
@@ -195,6 +200,38 @@ function childImageCount() {
   filter: brightness(1.2);
   background: rgb(var(--v-theme-primary));
   color: rgb(var(--v-theme-on-primary));
+}
+
+/* Rejected drop target — same state as SideBar.css `.not-droppable`, repeated
+   here because this component's styles are scoped. */
+.sidebar-folder-row.not-droppable {
+  position: relative;
+  background: repeating-linear-gradient(
+    45deg,
+    transparent 0 var(--space-2),
+    rgba(var(--v-theme-border), 0.45) var(--space-2) var(--space-3)
+  );
+  outline: 1px dashed rgba(var(--v-theme-border), 0.7);
+  outline-offset: -1px;
+  border-radius: var(--radius-sm);
+  cursor: no-drop;
+}
+
+.sidebar-folder-row.not-droppable > * {
+  opacity: var(--opacity-disabled);
+}
+
+.sidebar-folder-row.not-droppable::after {
+  content: "\F073A"; /* mdi-cancel */
+  font-family: "Material Design Icons";
+  font-size: var(--text-sm);
+  line-height: 1;
+  position: absolute;
+  top: 50%;
+  right: var(--space-3);
+  transform: translateY(-50%);
+  color: rgb(var(--v-theme-sidebar-text));
+  pointer-events: none;
 }
 
 .sidebar-folder-status--active {

--- a/frontend/src/components/panels/SideBar.css
+++ b/frontend/src/components/panels/SideBar.css
@@ -1273,6 +1273,48 @@
   color: rgb(var(--v-theme-on-primary));
 }
 
+/* Rejected drop target — the row is under the pointer but will not take the
+   payload being dragged (a face bbox over a picture set, say). It must not be
+   mistaken for `.droppable`, and it must not rely on colour alone: the hatch
+   texture carries the state, the mdi-cancel glyph names it, and the disabled
+   fade (the one legal fade, visual-language.md §11) drops the row's own
+   content back. Shared by character/set rows, project rows and folder rows. */
+.sidebar-list-item.not-droppable,
+.sidebar-project-tree-row.not-droppable,
+.sidebar-folder-row.not-droppable {
+  position: relative;
+  background: repeating-linear-gradient(
+    45deg,
+    transparent 0 var(--space-2),
+    rgba(var(--v-theme-border), 0.45) var(--space-2) var(--space-3)
+  );
+  outline: 1px dashed rgba(var(--v-theme-border), 0.7);
+  outline-offset: -1px;
+  border-radius: var(--radius-sm);
+  cursor: no-drop;
+}
+
+.sidebar-list-item.not-droppable > *,
+.sidebar-project-tree-row.not-droppable > *,
+.sidebar-folder-row.not-droppable > * {
+  opacity: var(--opacity-disabled);
+}
+
+.sidebar-list-item.not-droppable::after,
+.sidebar-project-tree-row.not-droppable::after,
+.sidebar-folder-row.not-droppable::after {
+  content: "\F073A"; /* mdi-cancel */
+  font-family: "Material Design Icons";
+  font-size: var(--text-sm);
+  line-height: 1;
+  position: absolute;
+  top: 50%;
+  right: var(--space-3);
+  transform: translateY(-50%);
+  color: rgb(var(--v-theme-sidebar-text));
+  pointer-events: none;
+}
+
 .sidebar-header-spacer {
   flex: 1 1 auto;
 }

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -47,7 +47,12 @@ import {
 import { setPicturesProject } from "../../api/pictures";
 import { getSharedResourceIds, revokeTokensByResource } from "../../api/users";
 import { listSortMechanisms } from "../../api/session";
-import { extractSupportedImportFilesFromDataTransfer } from "../../utils/media.js";
+import {
+  extractSupportedImportFilesFromDataTransfer,
+  isFaceDrag,
+  isFileDrag,
+  isPictureDrag,
+} from "../../utils/media.js";
 import {
   characterCountUpdates,
   projectCountUpdates,
@@ -2436,14 +2441,18 @@ function showNotice(
   }, duration);
 }
 
-function dragOverSetItem(setId) {
+function dragOverSetItem(setId, event) {
   // Suppress the image-drop highlight while an entity is being dragged between
   // projects — that drag is not an image assignment.
   if (draggingEntityKind.value) return;
+  const verdict = acceptDrop(event, ["pictures", "files"]);
+  if (verdict === "ignore") return;
+  dropRejected.value = verdict === "reject";
   dragOverSet.value = setId;
 }
 
-function dragLeaveSetItem() {
+function dragLeaveSetItem(event) {
+  if (event && !leftDropRow(event)) return;
   dragOverSet.value = null;
 }
 
@@ -2906,18 +2915,9 @@ async function handleDropOnSet(setId, event) {
     imageImporterRef.value?.startImport(files, options);
     return;
   }
-  // Get the dragged image IDs from the drag event
-  let draggedIds = [];
-  try {
-    const data = JSON.parse(event.dataTransfer.getData("application/json"));
-    if (data.imageIds && Array.isArray(data.imageIds)) {
-      draggedIds = data.imageIds;
-    }
-  } catch (e) {
-    console.error("Could not parse drag data:", e);
-    return;
-  }
-
+  // Get the dragged image IDs from the drag event. A face drag is not a
+  // picture drag, and readDraggedImageIds() returns nothing for one.
+  const draggedIds = readDraggedImageIds(event);
   if (draggedIds.length === 0) {
     return;
   }
@@ -2948,29 +2948,37 @@ async function handleDropOnSet(setId, event) {
   }
 }
 
-function handleDragOverCharacter(id) {
+function handleDragOverCharacter(id, event) {
   // Suppress the image-drop highlight while an entity is being dragged between
   // projects — that drag is not an image assignment.
   if (draggingEntityKind.value) return;
+  const verdict = acceptDrop(event, ["pictures", "faces", "files"]);
+  if (verdict === "ignore") return;
+  dropRejected.value = verdict === "reject";
   dragOverCharacter.value = id;
 }
 
-function handleDragLeaveCharacter() {
+function handleDragLeaveCharacter(event) {
+  if (event && !leftDropRow(event)) return;
   dragOverCharacter.value = null;
 }
 
 // --- Project drop target (assign dragged pictures to a specific project) ---
 const dragOverProjectId = ref(null);
 
-function handleDragOverProject(id) {
+function handleDragOverProject(id, event) {
   // Suppress the picture-drop highlight while an entity (character/set) is
   // being dragged between projects — that drag is handled by the project
   // header's entity-move zone (onProjectHeaderDrop), not by a picture assign.
   if (draggingEntityKind.value) return;
+  const verdict = acceptDrop(event, ["pictures"]);
+  if (verdict === "ignore") return;
+  dropRejected.value = verdict === "reject";
   dragOverProjectId.value = id;
 }
 
-function handleDragLeaveProject() {
+function handleDragLeaveProject(event) {
+  if (event && !leftDropRow(event)) return;
   dragOverProjectId.value = null;
 }
 
@@ -2983,6 +2991,9 @@ function readDraggedImageIds(event) {
     const data = JSON.parse(
       event?.dataTransfer?.getData("application/json") || "{}",
     );
+    // A face drag carries imageIds too (the pictures the faces were found in),
+    // so the payload kind, not the presence of imageIds, decides.
+    if (data.type !== "image-ids") return [];
     return Array.isArray(data.imageIds) ? data.imageIds.filter(Boolean) : [];
   } catch (e) {
     console.error("Could not parse drag data:", e);
@@ -2990,16 +3001,58 @@ function readDraggedImageIds(event) {
   }
 }
 
+// Marks the currently hovered row as one that will not take this payload, so
+// the row can say no during the drag instead of after it (see .not-droppable).
+const dropRejected = ref(false);
+
+/**
+ * Decide whether a row takes this drag, and accept it if so.
+ *
+ * `@dragover.prevent` in the template cannot do this: the modifier calls
+ * preventDefault() before the handler runs, which accepts every payload on the
+ * page. preventDefault() therefore belongs here, only for the kinds listed.
+ *
+ * @param {DragEvent} event
+ * @param {string[]} kinds - any of "pictures", "faces", "files".
+ * @returns {"accept"|"reject"|"ignore"} - "ignore" means the drag is not ours
+ *   to judge (an external file drag the window-level importer still handles),
+ *   so the row stays unpainted rather than claiming it will refuse the drop.
+ */
+function acceptDrop(event, kinds) {
+  const dt = event?.dataTransfer;
+  const accepted =
+    (kinds.includes("pictures") && isPictureDrag(dt)) ||
+    (kinds.includes("faces") && isFaceDrag(dt)) ||
+    (kinds.includes("files") && isFileDrag(dt));
+  if (accepted) {
+    event.preventDefault();
+    if (dt) dt.dropEffect = "move";
+    return "accept";
+  }
+  return isInternalImageDrag(event) ? "reject" : "ignore";
+}
+
+// dragleave also fires when the pointer crosses from a row into one of its own
+// children, which flickers the highlight off; only a leave that lands outside
+// the row is a real leave.
+function leftDropRow(event) {
+  const row = event?.currentTarget;
+  if (!row?.contains) return true;
+  return !row.contains(event.relatedTarget);
+}
+
 function handleReferenceFolderDragOver(folderId, scopePath, event) {
-  if (draggingEntityKind.value || !isInternalImageDrag(event)) return;
-  event.preventDefault();
-  if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+  if (draggingEntityKind.value) return;
+  const verdict = acceptDrop(event, ["pictures"]);
+  if (verdict === "ignore") return;
+  dropRejected.value = verdict === "reject";
   dragOverReferenceTargetKey.value = scopePath
     ? `path-${scopePath}`
     : `rf-${folderId}`;
 }
 
-function handleReferenceFolderDragLeave(folderId, scopePath) {
+function handleReferenceFolderDragLeave(folderId, scopePath, event) {
+  if (event && !leftDropRow(event)) return;
   const key = scopePath ? `path-${scopePath}` : `rf-${folderId}`;
   if (dragOverReferenceTargetKey.value === key) {
     dragOverReferenceTargetKey.value = null;
@@ -3057,14 +3110,7 @@ async function onProjectDrop(projectId, event) {
   if (draggingEntityKind.value) return;
   if (projectId == null) return;
   // Internal grid drag carries the selected image ids as application/json.
-  let imageIds = [];
-  try {
-    const data = JSON.parse(event.dataTransfer.getData("application/json"));
-    if (Array.isArray(data.imageIds)) imageIds = data.imageIds;
-  } catch (e) {
-    console.error("Could not parse drag data for project drop:", e);
-    return;
-  }
+  const imageIds = readDraggedImageIds(event);
   if (!imageIds.length) return;
   try {
     // Picture↔Project is many-to-many (PictureProjectMember); membership is
@@ -4997,7 +5043,12 @@ defineExpose({
                 class="sidebar-folder-row sidebar-folder-root-row"
                 :class="{
                   active: selectedFolderKey === 'rf-' + rf.id,
-                  droppable: dragOverReferenceTargetKey === 'rf-' + rf.id,
+                  droppable:
+                    dragOverReferenceTargetKey === 'rf-' + rf.id &&
+                    !dropRejected,
+                  'not-droppable':
+                    dragOverReferenceTargetKey === 'rf-' + rf.id &&
+                    dropRejected,
                 }"
                 :title="
                   inDocker
@@ -5010,7 +5061,8 @@ defineExpose({
                   handleReferenceFolderDragOver(rf.id, null, $event)
                 "
                 @dragleave="
-                  !inDocker && handleReferenceFolderDragLeave(rf.id, null)
+                  !inDocker &&
+                  handleReferenceFolderDragLeave(rf.id, null, $event)
                 "
                 @drop.prevent="
                   !inDocker && handleReferenceFolderDrop(rf.id, null, $event)
@@ -5149,6 +5201,7 @@ defineExpose({
                       :folder-browse-cache="folderBrowseCache"
                       :expanded-folder-ids="expandedFolderIds"
                       :drop-target-key="dragOverReferenceTargetKey"
+                      :drop-rejected="dropRejected"
                       @select="handleFolderNodeSelect"
                       @toggle="handleFolderNodeToggle"
                       @drag-over="
@@ -5156,8 +5209,8 @@ defineExpose({
                           handleReferenceFolderDragOver(rfId, path, event)
                       "
                       @drag-leave="
-                        ({ rfId, path }) =>
-                          handleReferenceFolderDragLeave(rfId, path)
+                        ({ rfId, path, event }) =>
+                          handleReferenceFolderDragLeave(rfId, path, event)
                       "
                       @drop="
                         ({ rfId, path, event }) =>
@@ -5462,7 +5515,10 @@ defineExpose({
                             ? selectedCharacterIdSet.has(char.id)
                             : selectionStore.selectedCharacter === char.id) &&
                           selectionOwnsHighlight,
-                        droppable: dragOverCharacter === char.id,
+                        droppable:
+                          dragOverCharacter === char.id && !dropRejected,
+                        'not-droppable':
+                          dragOverCharacter === char.id && dropRejected,
                       },
                     ]"
                     :ref="(el) => registerCharacterRef(char.id, el)"
@@ -5473,8 +5529,8 @@ defineExpose({
                     @contextmenu.prevent="
                       openSidebarCtxMenu('character', char, $event)
                     "
-                    @dragover.prevent="handleDragOverCharacter(char.id)"
-                    @dragleave="handleDragLeaveCharacter"
+                    @dragover="handleDragOverCharacter(char.id, $event)"
+                    @dragleave="handleDragLeaveCharacter($event)"
                     @drop.prevent="
                       handleDropOnCharacter({
                         characterId: char.id,
@@ -5609,7 +5665,9 @@ defineExpose({
                         active:
                           selectedSetIdSet.has(pset.id) &&
                           selectionOwnsHighlight,
-                        droppable: dragOverSet === pset.id,
+                        droppable: dragOverSet === pset.id && !dropRejected,
+                        'not-droppable':
+                          dragOverSet === pset.id && dropRejected,
                       },
                     ]"
                     :ref="(el) => registerSetRef(pset.id, el)"
@@ -5620,8 +5678,8 @@ defineExpose({
                     @contextmenu.prevent="
                       openSidebarCtxMenu('set', pset, $event)
                     "
-                    @dragover.prevent="dragOverSetItem(pset.id)"
-                    @dragleave="dragLeaveSetItem"
+                    @dragover="dragOverSetItem(pset.id, $event)"
+                    @dragleave="dragLeaveSetItem($event)"
                     @drop.prevent="handleDropOnSet(pset.id, $event)"
                   >
                     <span class="sidebar-list-icon">
@@ -5741,7 +5799,9 @@ defineExpose({
                         selectionStore.selectedCharacter === ALL_PICTURES_ID &&
                         selectedSetIdSet.size === 0 &&
                         selectionOwnsHighlight,
-                      droppable: dragOverProjectId === p.id,
+                      droppable: dragOverProjectId === p.id && !dropRejected,
+                      'not-droppable':
+                        dragOverProjectId === p.id && dropRejected,
                       'project-move-target': moveDragOverProjectId === p.id,
                     },
                   ]"
@@ -5750,12 +5810,12 @@ defineExpose({
                   @contextmenu.prevent="
                     openSidebarCtxMenu('project', p, $event)
                   "
-                  @dragover.prevent="
-                    handleDragOverProject(p.id);
+                  @dragover="
+                    handleDragOverProject(p.id, $event);
                     onProjectHeaderDragOver(p.id, $event);
                   "
                   @dragleave="
-                    handleDragLeaveProject();
+                    handleDragLeaveProject($event);
                     onProjectHeaderDragLeave();
                   "
                   @drop.prevent="
@@ -5946,7 +6006,10 @@ defineExpose({
                                 : selectionStore.selectedCharacter ===
                                   char.id) &&
                               selectionOwnsHighlight,
-                            droppable: dragOverCharacter === char.id,
+                            droppable:
+                              dragOverCharacter === char.id && !dropRejected,
+                            'not-droppable':
+                              dragOverCharacter === char.id && dropRejected,
                           },
                         ]"
                         :draggable="!isReadOnly"
@@ -5965,8 +6028,8 @@ defineExpose({
                         @contextmenu.prevent="
                           openSidebarCtxMenu('character', char, $event)
                         "
-                        @dragover.prevent="handleDragOverCharacter(char.id)"
-                        @dragleave="handleDragLeaveCharacter"
+                        @dragover="handleDragOverCharacter(char.id, $event)"
+                        @dragleave="handleDragLeaveCharacter($event)"
                         @drop.prevent="
                           handleDropOnCharacter({
                             characterId: char.id,
@@ -6160,7 +6223,9 @@ defineExpose({
                             active:
                               selectedSetIdSet.has(pset.id) &&
                               selectionOwnsHighlight,
-                            droppable: dragOverSet === pset.id,
+                            droppable: dragOverSet === pset.id && !dropRejected,
+                            'not-droppable':
+                              dragOverSet === pset.id && dropRejected,
                           },
                         ]"
                         :draggable="!isReadOnly"
@@ -6173,8 +6238,8 @@ defineExpose({
                         @contextmenu.prevent="
                           openSidebarCtxMenu('set', pset, $event)
                         "
-                        @dragover.prevent="dragOverSetItem(pset.id)"
-                        @dragleave="dragLeaveSetItem"
+                        @dragover="dragOverSetItem(pset.id, $event)"
+                        @dragleave="dragLeaveSetItem($event)"
                         @drop.prevent="handleDropOnSet(pset.id, $event)"
                       >
                         <span class="sidebar-list-icon">

--- a/frontend/src/components/panels/SideBarDropPayloadTypes.test.js
+++ b/frontend/src/components/panels/SideBarDropPayloadTypes.test.js
@@ -1,0 +1,310 @@
+// Sidebar drop targets accept a payload kind or they refuse it (issue #757).
+//
+// Two defects lived here. The rows bound `@dragover.prevent`, and the modifier
+// runs preventDefault() BEFORE the handler body and regardless of what the
+// handler decides, so every row accepted every drag on the page and painted the
+// full `droppable` highlight for payloads it would do nothing with. And because
+// all internal payloads shared one MIME key (`application/json`, whose body is
+// unreadable during dragover), the drop handlers could only key off `imageIds`
+// — which a face-bbox payload also carries — so a face drag landed in a set as
+// if it were a picture drag.
+//
+// Both directions matter. Over-blocking a picture drag is its own regression,
+// so every assertion that a face drag is refused is paired with the picture
+// drag still being accepted on the same row.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount, flushPromises } from "@vue/test-utils";
+import { ref } from "vue";
+
+const apiGet = vi.fn();
+const apiPost = vi.fn();
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref: makeRef } = await import("vue");
+  return {
+    apiClient: {
+      get: (...args) => apiGet(...args),
+      post: (...args) => apiPost(...args),
+      patch: vi.fn().mockResolvedValue({ data: {} }),
+      put: vi.fn().mockResolvedValue({ data: {} }),
+      delete: vi.fn().mockResolvedValue({ data: {} }),
+    },
+    onSessionReset: () => () => {},
+    activateShareToken: vi.fn(),
+    appendShareToken: (url) => url,
+    checkLoginStatus: vi.fn(),
+    checkSession: vi.fn(),
+    isAuthenticated: makeRef(true),
+    isReadOnly: makeRef(false),
+    sessionContext: makeRef(null),
+    login: vi.fn(),
+    logout: vi.fn(),
+    newOperationBatchId: () => "cli-test",
+    operationBatchHeaders: () => undefined,
+    setRequestClientId: vi.fn(),
+    notifySessionReset: vi.fn(),
+    toBackendWebSocketUrl: () => "",
+    API_BASE_URL: "/api/v1",
+  };
+});
+
+vi.mock("vuetify/components", async () => {
+  const { vuetifyComponentStubs } = await import("../../testing/vuetifyStubs");
+  return vuetifyComponentStubs();
+});
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ query: {}, params: {}, path: "/", name: "all-pictures" }),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    currentRoute: ref({ query: {} }),
+  }),
+}));
+
+import { isReadOnly, sessionContext } from "../../utils/apiClient";
+import { FACE_DRAG_MIME, PICTURE_DRAG_MIME } from "../../utils/media.js";
+import SideBar from "./SideBar.vue";
+
+const ADA = { id: 7, name: "Ada", image_count: 3, project_image_count: 3 };
+const SET = { id: 11, name: "Shoot", image_count: 2 };
+const PROJECT = { id: 3, name: "Book", image_count: 118 };
+const REF_FOLDER = { id: 21, folder: "/photos/ref", label: "Ref" };
+
+function respond(url) {
+  const u = String(url ?? "");
+  if (u.includes("/reference-folders")) {
+    return { data: { folders: [REF_FOLDER], in_docker: false } };
+  }
+  if (u.includes("/characters")) return { data: [ADA] };
+  if (u.includes("/projects")) return { data: [PROJECT] };
+  if (u.includes("/picture_sets")) return { data: [SET] };
+  if (u.includes("/summary")) return { data: { image_count: 3 } };
+  return { data: [] };
+}
+
+async function mountSidebar() {
+  const wrapper = mount(SideBar, {
+    shallow: true,
+    props: { backendUrl: "/api/v1" },
+    global: {
+      config: {
+        compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
+      },
+    },
+  });
+  wrapper.vm.refreshSidebar();
+  for (let i = 0; i < 5; i += 1) await flushPromises();
+  return wrapper;
+}
+
+function rowByTitle(wrapper, prefix, selector = ".sidebar-list-item") {
+  const row = wrapper
+    .findAll(selector)
+    .find((el) => String(el.attributes("title") ?? "").startsWith(prefix));
+  if (!row) throw new Error(`no ${selector} titled ${prefix}`);
+  return row;
+}
+
+/** Switch sidebar tabs, which is where the other drop targets live. */
+async function openTab(wrapper, label) {
+  const tab = wrapper
+    .findAll("button.sidebar-view-tab")
+    .find((el) => el.text().includes(label));
+  if (!tab) throw new Error(`no ${label} tab`);
+  await tab.trigger("click");
+  for (let i = 0; i < 5; i += 1) await flushPromises();
+}
+
+/** A dataTransfer whose `types` is all a dragover handler may read. */
+function transfer(payload) {
+  const json = JSON.stringify(payload);
+  const marker =
+    payload.type === "face-bbox" ? FACE_DRAG_MIME : PICTURE_DRAG_MIME;
+  return {
+    types: ["application/json", marker],
+    dropEffect: "",
+    effectAllowed: "move",
+    files: [],
+    // Protected during dragover, readable on drop — the same asymmetry the
+    // browser enforces, so a handler that cheats fails here.
+    getData: (type) => (type === "application/json" ? json : ""),
+  };
+}
+
+/** Dispatch a real cancelable event so `defaultPrevented` can be asserted. */
+async function fire(row, name, dataTransfer) {
+  const event = new Event(name, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  row.element.dispatchEvent(event);
+  await flushPromises();
+  return event;
+}
+
+const PICTURES = { type: "image-ids", imageIds: [101, 102] };
+// The shape useMultiSelect sends: it carries imageIds too, which is exactly why
+// "has imageIds" was never a safe test for "is a picture drag".
+const FACES = {
+  type: "face-bbox",
+  faceIds: [55],
+  imageIds: [101],
+  faces: [{ imageId: 101, faceIdx: 0, faceId: 55 }],
+};
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  isReadOnly.value = false;
+  sessionContext.value = null;
+  apiGet.mockReset().mockImplementation((url) => Promise.resolve(respond(url)));
+  apiPost.mockReset().mockResolvedValue({ data: {} });
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("sidebar rows judge the drag payload during dragover", () => {
+  it("accepts a picture drag on a set row and highlights it", async () => {
+    const wrapper = await mountSidebar();
+    const row = rowByTitle(wrapper, `${SET.name} (`);
+
+    const event = await fire(row, "dragover", transfer(PICTURES));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(row.classes()).toContain("droppable");
+    expect(row.classes()).not.toContain("not-droppable");
+
+    wrapper.unmount();
+  });
+
+  it("refuses a face drag on a set row instead of inviting the drop", async () => {
+    const wrapper = await mountSidebar();
+    const row = rowByTitle(wrapper, `${SET.name} (`);
+
+    const event = await fire(row, "dragover", transfer(FACES));
+
+    // Not preventing default is what makes the browser refuse the drop.
+    expect(event.defaultPrevented).toBe(false);
+    expect(row.classes()).not.toContain("droppable");
+    expect(row.classes()).toContain("not-droppable");
+
+    wrapper.unmount();
+  });
+
+  it("accepts both pictures and faces on a character row", async () => {
+    const wrapper = await mountSidebar();
+    const row = rowByTitle(wrapper, `${ADA.name} (`);
+
+    for (const payload of [PICTURES, FACES]) {
+      const event = await fire(row, "dragover", transfer(payload));
+      expect(event.defaultPrevented).toBe(true);
+      expect(row.classes()).toContain("droppable");
+      await fire(row, "dragleave", transfer(payload));
+    }
+
+    wrapper.unmount();
+  });
+
+  it("takes pictures but not faces on a project row", async () => {
+    const wrapper = await mountSidebar();
+    await openTab(wrapper, "Projects");
+    const row = rowByTitle(
+      wrapper,
+      `${PROJECT.name} (`,
+      ".sidebar-project-tree-row",
+    );
+
+    const accepted = await fire(row, "dragover", transfer(PICTURES));
+    expect(accepted.defaultPrevented).toBe(true);
+    expect(row.classes()).toContain("droppable");
+
+    await fire(row, "dragleave", transfer(PICTURES));
+    const refused = await fire(row, "dragover", transfer(FACES));
+    expect(refused.defaultPrevented).toBe(false);
+    expect(row.classes()).toContain("not-droppable");
+
+    wrapper.unmount();
+  });
+
+  it("takes pictures but not faces on a reference-folder row", async () => {
+    const wrapper = await mountSidebar();
+    await openTab(wrapper, "Folders");
+    const row = rowByTitle(
+      wrapper,
+      REF_FOLDER.folder,
+      ".sidebar-folder-root-row",
+    );
+
+    const accepted = await fire(row, "dragover", transfer(PICTURES));
+    expect(accepted.defaultPrevented).toBe(true);
+    expect(row.classes()).toContain("droppable");
+
+    await fire(row, "dragleave", transfer(PICTURES));
+    const refused = await fire(row, "dragover", transfer(FACES));
+    expect(refused.defaultPrevented).toBe(false);
+    expect(row.classes()).toContain("not-droppable");
+
+    wrapper.unmount();
+  });
+
+  it("keeps the highlight when the pointer crosses into a child element", async () => {
+    // dragleave fires on the way into the row's own label/icon; only a leave
+    // that lands outside the row is a real leave.
+    const wrapper = await mountSidebar();
+    const row = rowByTitle(wrapper, `${SET.name} (`);
+    await fire(row, "dragover", transfer(PICTURES));
+    expect(row.classes()).toContain("droppable");
+
+    const child = row.element.querySelector("*") ?? row.element;
+    const leave = new Event("dragleave", { bubbles: true, cancelable: true });
+    Object.defineProperty(leave, "relatedTarget", { value: child });
+    row.element.dispatchEvent(leave);
+    await flushPromises();
+
+    expect(row.classes()).toContain("droppable");
+
+    // Leaving the row for good does clear it.
+    const out = new Event("dragleave", { bubbles: true, cancelable: true });
+    Object.defineProperty(out, "relatedTarget", { value: document.body });
+    row.element.dispatchEvent(out);
+    await flushPromises();
+
+    expect(row.classes()).not.toContain("droppable");
+
+    wrapper.unmount();
+  });
+});
+
+describe("sidebar drops read the payload kind, not just imageIds", () => {
+  it("adds pictures to a set when the payload is a picture drag", async () => {
+    const wrapper = await mountSidebar();
+    const row = rowByTitle(wrapper, `${SET.name} (`);
+
+    await fire(row, "drop", transfer(PICTURES));
+
+    expect(wrapper.emitted("images-moved")?.[0]?.[0]).toEqual({
+      imageIds: PICTURES.imageIds,
+    });
+
+    wrapper.unmount();
+  });
+
+  it("files nothing into a set when the payload is a face drag", async () => {
+    const wrapper = await mountSidebar();
+    const row = rowByTitle(wrapper, `${SET.name} (`);
+
+    await fire(row, "drop", transfer(FACES));
+
+    expect(wrapper.emitted("images-moved")).toBeUndefined();
+    const setPosts = apiPost.mock.calls.filter(([url]) =>
+      String(url ?? "").includes("picture_sets"),
+    );
+    expect(setPosts).toEqual([]);
+
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/panels/TagPanelKeyboardTrap.test.js
+++ b/frontend/src/components/panels/TagPanelKeyboardTrap.test.js
@@ -1,0 +1,187 @@
+// Tab must never trap focus in the tag panel's suggestion field (issue #755,
+// WCAG 2.1.2 Level A).
+//
+// The trap was: Tab committed the highlighted suggestion to every selected
+// picture, the `startsWith` filter still matched the now-complete tag so the
+// list stayed open, and the handler called `preventDefault()` unconditionally
+// while it was open. On a failing write the field never cleared either, so every
+// Tab re-fired the failing request and focus could never leave by keyboard.
+//
+// The contract these tests pin: Tab fills, Enter commits, Escape dismisses the
+// list before it closes the panel, and a dismissed list lets Tab through.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const tagsApi = vi.hoisted(() => ({
+  listTags: vi.fn(async () => []),
+  addPictureTag: vi.fn(async () => ({})),
+  removePictureTag: vi.fn(async () => ({})),
+  bulkFetchTags: vi.fn(async () => []),
+  removeTagEverywhere: vi.fn(async () => ({})),
+  listTagPredictions: vi.fn(async () => []),
+  confirmTagPrediction: vi.fn(async () => ({})),
+  rejectTagPrediction: vi.fn(async () => ({})),
+}));
+
+vi.mock("../../api/tags", () => tagsApi);
+vi.mock("../../api/pictures", () => ({
+  resetPictureTags: vi.fn(async () => ({})),
+}));
+vi.mock("../../api/taggers", () => ({
+  listTaggers: vi.fn(async () => ({ plugins: [] })),
+}));
+vi.mock("../../api/config", () => ({ getUserConfig: vi.fn(async () => ({})) }));
+vi.mock("../../api/users", () => ({ getPenalisedTags: vi.fn(async () => []) }));
+
+import TbTagPanel from "./TbTagPanel.vue";
+
+const STUBS = { "v-icon": true, "v-btn": true, "v-progress-circular": true };
+
+beforeEach(() => {
+  Object.values(tagsApi).forEach((mock) => mock.mockReset());
+  tagsApi.listTags.mockResolvedValue([
+    { tag: "sunset", count: 9 },
+    { tag: "sunset-beach", count: 3 },
+  ]);
+  tagsApi.bulkFetchTags.mockResolvedValue([]);
+  tagsApi.listTagPredictions.mockResolvedValue({
+    tag_predictions: [],
+    meta: { acceptance_threshold: 0.95, label_thresholds: {} },
+  });
+  tagsApi.addPictureTag.mockResolvedValue({});
+});
+
+async function mountPanel() {
+  const wrapper = mount(TbTagPanel, {
+    props: {
+      backendUrl: "http://backend",
+      open: true,
+      selectedCount: 2,
+      selectedImageIds: [1, 2],
+      allGridImages: [{ id: 1 }, { id: 2 }],
+    },
+    attachTo: document.body,
+    global: { stubs: STUBS },
+  });
+  await flushPromises();
+  await flushPromises();
+  return wrapper;
+}
+
+function input(wrapper) {
+  return wrapper.find("input.tag-menu-input");
+}
+
+/** Dispatch a real key event so `defaultPrevented` reflects the handlers. */
+async function press(wrapper, key) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  input(wrapper).element.dispatchEvent(event);
+  await flushPromises();
+  return event;
+}
+
+async function type(wrapper, value) {
+  await input(wrapper).setValue(value);
+  await flushPromises();
+}
+
+const suggestions = () =>
+  document.querySelectorAll("#tb-tag-suggestions [role='option']");
+
+describe("the tag suggestion combobox", () => {
+  it("completes the field on Tab without writing to any picture", async () => {
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+    expect(suggestions()).toHaveLength(2);
+
+    const first = await press(wrapper, "Tab");
+
+    expect(first.defaultPrevented).toBe(true);
+    expect(input(wrapper).element.value).toBe("sunset");
+    expect(tagsApi.addPictureTag).not.toHaveBeenCalled();
+    // The completed tag still matches the startsWith filter, but the list is
+    // dismissed, so it must not be rendered.
+    expect(suggestions()).toHaveLength(0);
+    wrapper.unmount();
+  });
+
+  it("lets the second Tab move focus, even after the write failed", async () => {
+    tagsApi.addPictureTag.mockRejectedValue(new Error("write failed"));
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+
+    await press(wrapper, "Tab"); // completes to "sunset"
+    await press(wrapper, "Enter"); // commits, and the request fails
+    await flushPromises();
+
+    expect(tagsApi.addPictureTag).toHaveBeenCalled();
+    expect(wrapper.find(".plugin-menu-error").exists()).toBe(true);
+    // The failure leaves the typed tag in place on purpose, so the list could
+    // reopen; this is exactly the state that used to trap focus.
+    const escape = await press(wrapper, "Tab");
+    expect(escape.defaultPrevented).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("commits on Enter", async () => {
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+    await press(wrapper, "ArrowDown");
+    await press(wrapper, "Enter");
+    await flushPromises();
+
+    expect(tagsApi.addPictureTag.mock.calls.map((args) => args[1])).toEqual([
+      "sunset",
+      "sunset",
+    ]);
+    wrapper.unmount();
+  });
+
+  it("dismisses the list on the first Escape and closes the panel on the second", async () => {
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+    expect(suggestions()).toHaveLength(2);
+
+    await press(wrapper, "Escape");
+    expect(suggestions()).toHaveLength(0);
+    expect(wrapper.emitted("close")).toBeUndefined();
+
+    await press(wrapper, "Escape");
+    expect(wrapper.emitted("close")).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it("reopens a dismissed list on ArrowDown", async () => {
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+    await press(wrapper, "Escape");
+    expect(suggestions()).toHaveLength(0);
+
+    await press(wrapper, "ArrowDown");
+    expect(suggestions()).toHaveLength(2);
+    wrapper.unmount();
+  });
+
+  it("exposes the combobox state assistive tech needs", async () => {
+    const wrapper = await mountPanel();
+    const el = input(wrapper);
+    expect(el.attributes("role")).toBe("combobox");
+    expect(el.attributes("aria-autocomplete")).toBe("list");
+    expect(el.attributes("aria-expanded")).toBe("false");
+    expect(el.attributes("aria-activedescendant")).toBeUndefined();
+
+    await type(wrapper, "suns");
+    expect(el.attributes("aria-expanded")).toBe("true");
+    expect(el.attributes("aria-controls")).toBe("tb-tag-suggestions");
+
+    await press(wrapper, "ArrowDown");
+    expect(el.attributes("aria-activedescendant")).toBe("tb-tag-suggestion-0");
+    expect(suggestions()[0].getAttribute("aria-selected")).toBe("true");
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/panels/TbTagPanel.vue
+++ b/frontend/src/components/panels/TbTagPanel.vue
@@ -193,9 +193,18 @@
           class="tag-menu-input"
           placeholder="Tag name..."
           autocomplete="off"
+          aria-label="New tag"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-controls="tb-tag-suggestions"
+          :aria-expanded="suggestionsOpen ? 'true' : 'false'"
+          :aria-activedescendant="activeSuggestionId"
           @keydown.enter.prevent="applyTag"
           @keydown="handleTagKey"
         />
+        <p class="visually-hidden" role="status" aria-live="polite">
+          {{ suggestionStatus }}
+        </p>
         <div class="plugin-menu-actions">
           <button
             class="stack-btn"
@@ -206,8 +215,10 @@
             {{ tagLoading ? "Applying..." : "Apply to All" }}
           </button>
         </div>
-        <div v-if="tagError" class="plugin-menu-error">{{ tagError }}</div>
-        <div v-if="tagSuccess" class="plugin-menu-success">
+        <div v-if="tagError" class="plugin-menu-error" role="alert">
+          {{ tagError }}
+        </div>
+        <div v-if="tagSuccess" class="plugin-menu-success" role="status">
           {{ tagSuccess }}
         </div>
         <div v-if="!isReadOnly" class="tag-autogen-section">
@@ -283,27 +294,32 @@
   <!-- Autocomplete dropdown (teleported to body) -->
   <Teleport to="body">
     <div
-      v-if="tagSuggestions.length && tagInputRect"
+      v-if="suggestionsOpen && tagInputRect"
+      id="tb-tag-suggestions"
       class="sb-tag-autocomplete-dropdown"
+      role="listbox"
+      aria-label="Tag suggestions"
       :style="{
         top: `${tagInputRect.bottom + 4}px`,
         left: `${tagInputRect.left}px`,
         width: `${tagInputRect.width}px`,
       }"
     >
-      <button
+      <div
         v-for="(item, i) in tagSuggestions"
+        :id="`tb-tag-suggestion-${i}`"
         :key="item.tag"
         :class="[
           'sb-tag-autocomplete-item',
           { 'sb-tag-autocomplete-item--active': i === tagSuggestionIndex },
         ]"
-        type="button"
-        @click="selectTagSuggestion(item)"
+        role="option"
+        :aria-selected="i === tagSuggestionIndex"
+        @mousedown.prevent="selectTagSuggestion(item)"
       >
         {{ item.tag }}
         <span v-if="i === 0" class="sb-tag-autocomplete-tab-hint">TAB</span>
-      </button>
+      </div>
     </div>
   </Teleport>
 </template>
@@ -397,6 +413,11 @@ const tagSuccess = ref("");
 const allTagsSB = ref([]);
 let allTagsFetchedAt = 0;
 const tagSuggestionIndex = ref(-1);
+// The input value the suggestion list was last dismissed for. Comparing against
+// the live value means typing re-opens the list without a second watcher, and
+// completing the field from a suggestion leaves it dismissed even though the
+// startsWith filter still matches the completed tag.
+const dismissedFor = ref(null);
 const tagInputRect = ref(null);
 const tagActionLoading = ref([]);
 const fetchedTagData = ref([]);
@@ -774,14 +795,31 @@ const tagSuggestions = computed(() => {
     .slice(0, 8);
 });
 
+const suggestionsOpen = computed(
+  () =>
+    tagSuggestions.value.length > 0 && dismissedFor.value !== tagInput.value,
+);
+
+const activeSuggestionId = computed(() =>
+  suggestionsOpen.value && tagSuggestionIndex.value >= 0
+    ? `tb-tag-suggestion-${tagSuggestionIndex.value}`
+    : null,
+);
+
+const suggestionStatus = computed(() => {
+  if (!suggestionsOpen.value) return "";
+  const n = tagSuggestions.value.length;
+  return `${n} tag suggestion${n !== 1 ? "s" : ""}. Arrow keys to browse, Tab to complete, Enter to apply.`;
+});
+
 watch(tagInput, () => {
   tagSuggestionIndex.value = -1;
 });
 
 watch(
-  () => [tagInput.value, tagSuggestions.value.length],
+  () => [tagInput.value, suggestionsOpen.value],
   () => {
-    if (tagInput.value && tagSuggestions.value.length) {
+    if (tagInput.value && suggestionsOpen.value) {
       nextTick(() => {
         tagInputRect.value = tagInputRef.value
           ? tagInputRef.value.getBoundingClientRect()
@@ -801,6 +839,7 @@ watch(
       tagError.value = "";
       tagSuccess.value = "";
       tagSuggestionIndex.value = -1;
+      dismissedFor.value = null;
       fetchedTagData.value = [];
       fetchedPredictionData.value = [];
       tagDataCapped.value = false;
@@ -879,39 +918,57 @@ async function fetchTagsSB() {
   }
 }
 
-function selectTagSuggestion(item) {
+/** Complete the field from a suggestion and dismiss the list. Does not commit. */
+function fillFromSuggestion(item) {
   tagInput.value = typeof item === "string" ? item : item.tag;
   tagSuggestionIndex.value = -1;
+  dismissedFor.value = tagInput.value;
+}
+
+/** Clicking a suggestion is an explicit choice, so it fills and commits. */
+function selectTagSuggestion(item) {
+  fillFromSuggestion(item);
   nextTick(() => applyTag());
 }
 
 function handleTagKey(event) {
   if (event.key === "ArrowDown") {
-    if (tagSuggestions.value.length) {
-      event.preventDefault();
-      tagSuggestionIndex.value = Math.min(
-        tagSuggestionIndex.value + 1,
-        tagSuggestions.value.length - 1,
-      );
+    if (!tagSuggestions.value.length) return;
+    event.preventDefault();
+    if (!suggestionsOpen.value) {
+      // Re-open a dismissed list rather than moving inside a hidden one.
+      dismissedFor.value = null;
+      tagSuggestionIndex.value = 0;
+      return;
     }
+    tagSuggestionIndex.value = Math.min(
+      tagSuggestionIndex.value + 1,
+      tagSuggestions.value.length - 1,
+    );
   } else if (event.key === "ArrowUp") {
-    if (tagSuggestions.value.length) {
-      event.preventDefault();
-      tagSuggestionIndex.value = Math.max(tagSuggestionIndex.value - 1, -1);
-    }
+    if (!suggestionsOpen.value) return;
+    event.preventDefault();
+    tagSuggestionIndex.value = Math.max(tagSuggestionIndex.value - 1, -1);
   } else if (event.key === "Tab") {
-    if (tagSuggestions.value.length) {
-      event.preventDefault();
-      const idx = tagSuggestionIndex.value >= 0 ? tagSuggestionIndex.value : 0;
-      selectTagSuggestion(tagSuggestions.value[idx]);
-    }
+    // Tab completes the field, it never writes to the selection. With the list
+    // dismissed it falls through so focus leaves the field (WCAG 2.1.2).
+    if (!suggestionsOpen.value) return;
+    event.preventDefault();
+    const idx = tagSuggestionIndex.value >= 0 ? tagSuggestionIndex.value : 0;
+    fillFromSuggestion(tagSuggestions.value[idx]);
   } else if (event.key === "Escape") {
     event.preventDefault();
     event.stopPropagation();
     if (typeof event.stopImmediatePropagation === "function") {
       event.stopImmediatePropagation();
     }
-    emit("close");
+    // First Escape dismisses the suggestions, a second one closes the panel.
+    if (suggestionsOpen.value) {
+      dismissedFor.value = tagInput.value;
+      tagSuggestionIndex.value = -1;
+    } else {
+      emit("close");
+    }
   }
 }
 
@@ -920,11 +977,7 @@ async function applyTag() {
     tagSuggestionIndex.value >= 0 &&
     tagSuggestions.value.length > tagSuggestionIndex.value
   ) {
-    const item = tagSuggestions.value[tagSuggestionIndex.value];
-    tagInput.value = typeof item === "string" ? item : item.tag;
-    tagSuggestionIndex.value = -1;
-    nextTick(() => applyTag());
-    return;
+    fillFromSuggestion(tagSuggestions.value[tagSuggestionIndex.value]);
   }
   const tag = tagInput.value.trim();
   if (!tag) return;
@@ -1335,6 +1388,7 @@ defineExpose({ focus: () => tagInputRef.value?.focus() });
 .sb-tag-autocomplete-item {
   display: block;
   width: 100%;
+  cursor: pointer;
   text-align: left;
   padding: var(--space-2) var(--space-3);
   font-size: var(--text-sm);

--- a/frontend/src/components/views/ImageOverlay.vue
+++ b/frontend/src/components/views/ImageOverlay.vue
@@ -805,6 +805,7 @@ import {
   MediaFormat,
   mediaMimeType,
   safeDownloadName,
+  setInternalDragPayload,
 } from "../../utils/media.js";
 import { API_BASE_URL, appendShareToken, isReadOnly } from "../../utils/apiClient";
 import {
@@ -2531,10 +2532,7 @@ function handleMediaDragStart(event) {
     // open image be dropped onto a sidebar character/set/project to assign it,
     // and stops the window-level handler from mistaking the drag for an
     // external file import. See isInternalImageDrag().
-    dt.setData(
-      "application/json",
-      JSON.stringify({ type: "image-ids", imageIds: [id] }),
-    );
+    setInternalDragPayload(dt, { type: "image-ids", imageIds: [id] });
     // Deterministic drag-out to the OS file manager. The browser's native
     // <img>/<video> drag only yields a real file for some formats (and never
     // for a <video>), which is why drag-out worked for some files and not

--- a/frontend/src/composables/useGridDragDrop.js
+++ b/frontend/src/composables/useGridDragDrop.js
@@ -3,6 +3,7 @@ import {
   extractSupportedImportFilesFromDataTransfer,
   isFileDrag,
   isVideo,
+  setInternalDragPayload,
 } from "../utils/media.js";
 import { useNoticeStore } from "../stores/useNoticeStore";
 import { useSelectionStore } from "../stores/useSelectionStore";
@@ -110,8 +111,10 @@ export function useGridDragDrop(
   function setupMultiExportDrag(event, ids) {
     if (!event?.dataTransfer || !Array.isArray(ids) || ids.length < 2) return;
     try {
-      const dragData = { type: "image-ids", imageIds: ids };
-      event.dataTransfer.setData("application/json", JSON.stringify(dragData));
+      setInternalDragPayload(event.dataTransfer, {
+        type: "image-ids",
+        imageIds: ids,
+      });
     } catch (err) {
       console.error("[ERROR] Failed to set drag data:", err);
     }
@@ -278,10 +281,10 @@ export function useGridDragDrop(
 
   function setDragDataForImageIds(event, imageIds) {
     if (!event?.dataTransfer) return;
-    event.dataTransfer.setData(
-      "application/json",
-      JSON.stringify({ type: "image-ids", imageIds }),
-    );
+    setInternalDragPayload(event.dataTransfer, {
+      type: "image-ids",
+      imageIds,
+    });
   }
 
   function handleThumbnailNativeDragStart(img, event) {

--- a/frontend/src/composables/useMultiSelect.js
+++ b/frontend/src/composables/useMultiSelect.js
@@ -1,4 +1,9 @@
 import { ref, watch } from "vue";
+import {
+  FACE_DRAG_MIME,
+  PICTURE_DRAG_MIME,
+  setInternalDragPayload,
+} from "../utils/media.js";
 
 /**
  * Manages multi-image selection, touch selection mode, and face bbox selection.
@@ -148,18 +153,23 @@ export function useMultiSelect() {
       existingData[type] = event.dataTransfer.getData(type);
     }
 
-    // Set the application/json data
-    const dragDataStr = JSON.stringify({
+    // Set the application/json data plus the face marker type
+    setInternalDragPayload(event.dataTransfer, {
       type: "face-bbox",
       faceIds: facesToDrag.map((f) => f.faceId),
       imageIds: Array.from(new Set(facesToDrag.map((f) => f.imageId))),
       faces: facesToDrag,
     });
-    event.dataTransfer.setData("application/json", dragDataStr);
 
-    // Restore other data types
+    // Restore other data types. The payload keys are deliberately not restored:
+    // this drag is faces, and a leftover picture marker would make it read as
+    // both to the sidebar drop targets.
     for (const [type, data] of Object.entries(existingData)) {
-      if (type !== "application/json") {
+      if (
+        type !== "application/json" &&
+        type !== PICTURE_DRAG_MIME &&
+        type !== FACE_DRAG_MIME
+      ) {
         event.dataTransfer.setData(type, data);
       }
     }

--- a/frontend/src/utils/media.js
+++ b/frontend/src/utils/media.js
@@ -288,6 +288,44 @@ export function isInternalImageDrag(dataTransfer) {
   return types.includes('application/json');
 }
 
+/**
+ * Marker types that carry the *kind* of an internal drag payload.
+ *
+ * Every internal payload travels as `application/json`, whose body is protected
+ * during `dragover` (getData() returns "" in Chrome and Firefox); only `types`
+ * is readable. The discriminator therefore has to be the key, not a field in
+ * the body, or a drop target cannot tell a picture drag from a face drag until
+ * the drop has already happened.
+ */
+export const PICTURE_DRAG_MIME = 'application/x-pixlstash-pictures';
+export const FACE_DRAG_MIME = 'application/x-pixlstash-faces';
+
+/**
+ * Write an internal drag payload: the JSON body every drop handler reads, plus
+ * the marker type its kind is recognised by during dragover.
+ */
+export function setInternalDragPayload(dataTransfer, payload) {
+  if (!dataTransfer || !payload) return;
+  const marker =
+      payload.type === 'face-bbox' ? FACE_DRAG_MIME : PICTURE_DRAG_MIME;
+  dataTransfer.setData('application/json', JSON.stringify(payload));
+  dataTransfer.setData(marker, payload.type);
+}
+
+/** True when the drag carries pictures (grid thumbnails, the open overlay). */
+export function isPictureDrag(dataTransfer) {
+  if (!dataTransfer) return false;
+  const types = dataTransfer.types ? Array.from(dataTransfer.types) : [];
+  return types.includes(PICTURE_DRAG_MIME);
+}
+
+/** True when the drag carries face bounding boxes. */
+export function isFaceDrag(dataTransfer) {
+  if (!dataTransfer) return false;
+  const types = dataTransfer.types ? Array.from(dataTransfer.types) : [];
+  return types.includes(FACE_DRAG_MIME);
+}
+
 export function isVideo(img) {
   if (!img) return false;
   const format = MediaFormat(img);

--- a/frontend/src/utils/media.test.js
+++ b/frontend/src/utils/media.test.js
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { buildMediaUrl, isFileDrag, isInternalImageDrag } from './media.js'
+import {
+  buildMediaUrl,
+  isFaceDrag,
+  isFileDrag,
+  isInternalImageDrag,
+  isPictureDrag,
+  setInternalDragPayload,
+  FACE_DRAG_MIME,
+  PICTURE_DRAG_MIME,
+} from './media.js'
 
 // Minimal DataTransfer stand-in: only `types` (array) and `files` (array-like)
 // are read by the drag predicates.
@@ -40,6 +49,63 @@ describe('isFileDrag', () => {
 
   it('is false for an internal-only drag', () => {
     expect(isFileDrag(dt({ types: ['application/json'] }))).toBe(false)
+  })
+})
+
+// A drop target may only read `types` during dragover, so the payload kind has
+// to be a key. Before this, a face drag and a picture drag were indistinguisable
+// until the drop had already happened (issue #757).
+describe('internal drag payload markers', () => {
+  function writer() {
+    const store = {}
+    return {
+      store,
+      dataTransfer: {
+        setData: (type, value) => {
+          store[type] = value
+        },
+        get types() {
+          return Object.keys(store)
+        },
+      },
+    }
+  }
+
+  it('marks a picture payload so dragover can recognise it', () => {
+    const { store, dataTransfer } = writer()
+    setInternalDragPayload(dataTransfer, { type: 'image-ids', imageIds: [1] })
+
+    expect(JSON.parse(store['application/json'])).toEqual({
+      type: 'image-ids',
+      imageIds: [1],
+    })
+    expect(isPictureDrag(dataTransfer)).toBe(true)
+    expect(isFaceDrag(dataTransfer)).toBe(false)
+    expect(isInternalImageDrag(dataTransfer)).toBe(true)
+  })
+
+  it('marks a face payload distinctly, despite it carrying imageIds too', () => {
+    const { dataTransfer } = writer()
+    setInternalDragPayload(dataTransfer, {
+      type: 'face-bbox',
+      faceIds: [9],
+      imageIds: [1],
+    })
+
+    expect(isFaceDrag(dataTransfer)).toBe(true)
+    expect(isPictureDrag(dataTransfer)).toBe(false)
+    expect(isInternalImageDrag(dataTransfer)).toBe(true)
+  })
+
+  it('reports neither kind for an external file drag', () => {
+    expect(isPictureDrag(dt({ types: ['Files'] }))).toBe(false)
+    expect(isFaceDrag(dt({ types: ['Files'] }))).toBe(false)
+    expect(isPictureDrag(null)).toBe(false)
+    expect(isFaceDrag(null)).toBe(false)
+  })
+
+  it('keeps the two marker types apart', () => {
+    expect(PICTURE_DRAG_MIME).not.toBe(FACE_DRAG_MIME)
   })
 })
 


### PR DESCRIPTION
Fixes #755.

`handleTagKey` called `preventDefault()` on every `Tab` while the suggestion list was non-empty, and `Tab` committed the highlighted tag to every selected picture. Because the filter is `startsWith`, the completed tag still matched itself and the list never emptied, so `Tab` could never move focus. On a failing write the field also never cleared, so each `Tab` re-fired the failing request. WCAG 2.1.2 (No Keyboard Trap), Level A.

## Change

- `Tab` completes the field from the highlighted suggestion and dismisses the list. It no longer commits.
- `Enter` commits. Clicking a suggestion still fills and commits, since that is an explicit choice.
- First `Escape` dismisses the list, second closes the panel. `ArrowDown` reopens a dismissed list.
- `Tab` with the list dismissed falls through, so focus always leaves the field.
- The control now exposes `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-autocomplete`, `aria-activedescendant`, a `role="listbox"` popup with `role="option"` children, and a polite status region. The error and success lines got `role="alert"` / `role="status"`.

Dismissal is one ref: the input value the list was last dismissed for. Typing changes the value and reopens the list with no extra watcher, while completing the field leaves it dismissed even though the completed tag still matches the filter.

## Not done

The issue asked for `tagInput` to be cleared in a `finally` rather than only on success. Left as is on purpose: clearing on failure discards the tag the user typed and leaves an error message naming a tag no longer on screen. The trap is closed by the `Tab` semantics, so the clear is not load-bearing.

## Verification

`frontend/src/components/panels/TagPanelKeyboardTrap.test.js`, 6 cases. Confirmed to fail 5/6 against the unfixed component. Full panel suite green (122 tests).