### PR TITLE
Stop Tab trapping focus in the tag panel (#755)

### DIFF
--- a/frontend/src/components/panels/TagPanelKeyboardTrap.test.js
+++ b/frontend/src/components/panels/TagPanelKeyboardTrap.test.js
@@ -1,0 +1,187 @@
+// Tab must never trap focus in the tag panel's suggestion field (issue #755,
+// WCAG 2.1.2 Level A).
+//
+// The trap was: Tab committed the highlighted suggestion to every selected
+// picture, the `startsWith` filter still matched the now-complete tag so the
+// list stayed open, and the handler called `preventDefault()` unconditionally
+// while it was open. On a failing write the field never cleared either, so every
+// Tab re-fired the failing request and focus could never leave by keyboard.
+//
+// The contract these tests pin: Tab fills, Enter commits, Escape dismisses the
+// list before it closes the panel, and a dismissed list lets Tab through.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const tagsApi = vi.hoisted(() => ({
+  listTags: vi.fn(async () => []),
+  addPictureTag: vi.fn(async () => ({})),
+  removePictureTag: vi.fn(async () => ({})),
+  bulkFetchTags: vi.fn(async () => []),
+  removeTagEverywhere: vi.fn(async () => ({})),
+  listTagPredictions: vi.fn(async () => []),
+  confirmTagPrediction: vi.fn(async () => ({})),
+  rejectTagPrediction: vi.fn(async () => ({})),
+}));
+
+vi.mock("../../api/tags", () => tagsApi);
+vi.mock("../../api/pictures", () => ({
+  resetPictureTags: vi.fn(async () => ({})),
+}));
+vi.mock("../../api/taggers", () => ({
+  listTaggers: vi.fn(async () => ({ plugins: [] })),
+}));
+vi.mock("../../api/config", () => ({ getUserConfig: vi.fn(async () => ({})) }));
+vi.mock("../../api/users", () => ({ getPenalisedTags: vi.fn(async () => []) }));
+
+import TbTagPanel from "./TbTagPanel.vue";
+
+const STUBS = { "v-icon": true, "v-btn": true, "v-progress-circular": true };
+
+beforeEach(() => {
+  Object.values(tagsApi).forEach((mock) => mock.mockReset());
+  tagsApi.listTags.mockResolvedValue([
+    { tag: "sunset", count: 9 },
+    { tag: "sunset-beach", count: 3 },
+  ]);
+  tagsApi.bulkFetchTags.mockResolvedValue([]);
+  tagsApi.listTagPredictions.mockResolvedValue({
+    tag_predictions: [],
+    meta: { acceptance_threshold: 0.95, label_thresholds: {} },
+  });
+  tagsApi.addPictureTag.mockResolvedValue({});
+});
+
+async function mountPanel() {
+  const wrapper = mount(TbTagPanel, {
+    props: {
+      backendUrl: "http://backend",
+      open: true,
+      selectedCount: 2,
+      selectedImageIds: [1, 2],
+      allGridImages: [{ id: 1 }, { id: 2 }],
+    },
+    attachTo: document.body,
+    global: { stubs: STUBS },
+  });
+  await flushPromises();
+  await flushPromises();
+  return wrapper;
+}
+
+function input(wrapper) {
+  return wrapper.find("input.tag-menu-input");
+}
+
+/** Dispatch a real key event so `defaultPrevented` reflects the handlers. */
+async function press(wrapper, key) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  input(wrapper).element.dispatchEvent(event);
+  await flushPromises();
+  return event;
+}
+
+async function type(wrapper, value) {
+  await input(wrapper).setValue(value);
+  await flushPromises();
+}
+
+const suggestions = () =>
+  document.querySelectorAll("#tb-tag-suggestions [role='option']");
+
+describe("the tag suggestion combobox", () => {
+  it("completes the field on Tab without writing to any picture", async () => {
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+    expect(suggestions()).toHaveLength(2);
+
+    const first = await press(wrapper, "Tab");
+
+    expect(first.defaultPrevented).toBe(true);
+    expect(input(wrapper).element.value).toBe("sunset");
+    expect(tagsApi.addPictureTag).not.toHaveBeenCalled();
+    // The completed tag still matches the startsWith filter, but the list is
+    // dismissed, so it must not be rendered.
+    expect(suggestions()).toHaveLength(0);
+    wrapper.unmount();
+  });
+
+  it("lets the second Tab move focus, even after the write failed", async () => {
+    tagsApi.addPictureTag.mockRejectedValue(new Error("write failed"));
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+
+    await press(wrapper, "Tab"); // completes to "sunset"
+    await press(wrapper, "Enter"); // commits, and the request fails
+    await flushPromises();
+
+    expect(tagsApi.addPictureTag).toHaveBeenCalled();
+    expect(wrapper.find(".plugin-menu-error").exists()).toBe(true);
+    // The failure leaves the typed tag in place on purpose, so the list could
+    // reopen; this is exactly the state that used to trap focus.
+    const escape = await press(wrapper, "Tab");
+    expect(escape.defaultPrevented).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("commits on Enter", async () => {
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+    await press(wrapper, "ArrowDown");
+    await press(wrapper, "Enter");
+    await flushPromises();
+
+    expect(tagsApi.addPictureTag.mock.calls.map((args) => args[1])).toEqual([
+      "sunset",
+      "sunset",
+    ]);
+    wrapper.unmount();
+  });
+
+  it("dismisses the list on the first Escape and closes the panel on the second", async () => {
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+    expect(suggestions()).toHaveLength(2);
+
+    await press(wrapper, "Escape");
+    expect(suggestions()).toHaveLength(0);
+    expect(wrapper.emitted("close")).toBeUndefined();
+
+    await press(wrapper, "Escape");
+    expect(wrapper.emitted("close")).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it("reopens a dismissed list on ArrowDown", async () => {
+    const wrapper = await mountPanel();
+    await type(wrapper, "suns");
+    await press(wrapper, "Escape");
+    expect(suggestions()).toHaveLength(0);
+
+    await press(wrapper, "ArrowDown");
+    expect(suggestions()).toHaveLength(2);
+    wrapper.unmount();
+  });
+
+  it("exposes the combobox state assistive tech needs", async () => {
+    const wrapper = await mountPanel();
+    const el = input(wrapper);
+    expect(el.attributes("role")).toBe("combobox");
+    expect(el.attributes("aria-autocomplete")).toBe("list");
+    expect(el.attributes("aria-expanded")).toBe("false");
+    expect(el.attributes("aria-activedescendant")).toBeUndefined();
+
+    await type(wrapper, "suns");
+    expect(el.attributes("aria-expanded")).toBe("true");
+    expect(el.attributes("aria-controls")).toBe("tb-tag-suggestions");
+
+    await press(wrapper, "ArrowDown");
+    expect(el.attributes("aria-activedescendant")).toBe("tb-tag-suggestion-0");
+    expect(suggestions()[0].getAttribute("aria-selected")).toBe("true");
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/components/panels/TbTagPanel.vue
+++ b/frontend/src/components/panels/TbTagPanel.vue
@@ -193,9 +193,18 @@
           class="tag-menu-input"
           placeholder="Tag name..."
           autocomplete="off"
+          aria-label="New tag"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-controls="tb-tag-suggestions"
+          :aria-expanded="suggestionsOpen ? 'true' : 'false'"
+          :aria-activedescendant="activeSuggestionId"
           @keydown.enter.prevent="applyTag"
           @keydown="handleTagKey"
         />
+        <p class="visually-hidden" role="status" aria-live="polite">
+          {{ suggestionStatus }}
+        </p>
         <div class="plugin-menu-actions">
           <button
             class="stack-btn"
@@ -206,8 +215,10 @@
             {{ tagLoading ? "Applying..." : "Apply to All" }}
           </button>
         </div>
-        <div v-if="tagError" class="plugin-menu-error">{{ tagError }}</div>
-        <div v-if="tagSuccess" class="plugin-menu-success">
+        <div v-if="tagError" class="plugin-menu-error" role="alert">
+          {{ tagError }}
+        </div>
+        <div v-if="tagSuccess" class="plugin-menu-success" role="status">
           {{ tagSuccess }}
         </div>
         <div v-if="!isReadOnly" class="tag-autogen-section">
@@ -283,27 +294,32 @@
   <!-- Autocomplete dropdown (teleported to body) -->
   <Teleport to="body">
     <div
-      v-if="tagSuggestions.length && tagInputRect"
+      v-if="suggestionsOpen && tagInputRect"
+      id="tb-tag-suggestions"
       class="sb-tag-autocomplete-dropdown"
+      role="listbox"
+      aria-label="Tag suggestions"
       :style="{
         top: `${tagInputRect.bottom + 4}px`,
         left: `${tagInputRect.left}px`,
         width: `${tagInputRect.width}px`,
       }"
     >
-      <button
+      <div
         v-for="(item, i) in tagSuggestions"
+        :id="`tb-tag-suggestion-${i}`"
         :key="item.tag"
         :class="[
           'sb-tag-autocomplete-item',
           { 'sb-tag-autocomplete-item--active': i === tagSuggestionIndex },
         ]"
-        type="button"
-        @click="selectTagSuggestion(item)"
+        role="option"
+        :aria-selected="i === tagSuggestionIndex"
+        @mousedown.prevent="selectTagSuggestion(item)"
       >
         {{ item.tag }}
         <span v-if="i === 0" class="sb-tag-autocomplete-tab-hint">TAB</span>
-      </button>
+      </div>
     </div>
   </Teleport>
 </template>
@@ -397,6 +413,11 @@ const tagSuccess = ref("");
 const allTagsSB = ref([]);
 let allTagsFetchedAt = 0;
 const tagSuggestionIndex = ref(-1);
+// The input value the suggestion list was last dismissed for. Comparing against
+// the live value means typing re-opens the list without a second watcher, and
+// completing the field from a suggestion leaves it dismissed even though the
+// startsWith filter still matches the completed tag.
+const dismissedFor = ref(null);
 const tagInputRect = ref(null);
 const tagActionLoading = ref([]);
 const fetchedTagData = ref([]);
@@ -774,14 +795,31 @@ const tagSuggestions = computed(() => {
     .slice(0, 8);
 });
 
+const suggestionsOpen = computed(
+  () =>
+    tagSuggestions.value.length > 0 && dismissedFor.value !== tagInput.value,
+);
+
+const activeSuggestionId = computed(() =>
+  suggestionsOpen.value && tagSuggestionIndex.value >= 0
+    ? `tb-tag-suggestion-${tagSuggestionIndex.value}`
+    : null,
+);
+
+const suggestionStatus = computed(() => {
+  if (!suggestionsOpen.value) return "";
+  const n = tagSuggestions.value.length;
+  return `${n} tag suggestion${n !== 1 ? "s" : ""}. Arrow keys to browse, Tab to complete, Enter to apply.`;
+});
+
 watch(tagInput, () => {
   tagSuggestionIndex.value = -1;
 });
 
 watch(
-  () => [tagInput.value, tagSuggestions.value.length],
+  () => [tagInput.value, suggestionsOpen.value],
   () => {
-    if (tagInput.value && tagSuggestions.value.length) {
+    if (tagInput.value && suggestionsOpen.value) {
       nextTick(() => {
         tagInputRect.value = tagInputRef.value
           ? tagInputRef.value.getBoundingClientRect()
@@ -801,6 +839,7 @@ watch(
       tagError.value = "";
       tagSuccess.value = "";
       tagSuggestionIndex.value = -1;
+      dismissedFor.value = null;
       fetchedTagData.value = [];
       fetchedPredictionData.value = [];
       tagDataCapped.value = false;
@@ -879,39 +918,57 @@ async function fetchTagsSB() {
   }
 }
 
-function selectTagSuggestion(item) {
+/** Complete the field from a suggestion and dismiss the list. Does not commit. */
+function fillFromSuggestion(item) {
   tagInput.value = typeof item === "string" ? item : item.tag;
   tagSuggestionIndex.value = -1;
+  dismissedFor.value = tagInput.value;
+}
+
+/** Clicking a suggestion is an explicit choice, so it fills and commits. */
+function selectTagSuggestion(item) {
+  fillFromSuggestion(item);
   nextTick(() => applyTag());
 }
 
 function handleTagKey(event) {
   if (event.key === "ArrowDown") {
-    if (tagSuggestions.value.length) {
-      event.preventDefault();
-      tagSuggestionIndex.value = Math.min(
-        tagSuggestionIndex.value + 1,
-        tagSuggestions.value.length - 1,
-      );
+    if (!tagSuggestions.value.length) return;
+    event.preventDefault();
+    if (!suggestionsOpen.value) {
+      // Re-open a dismissed list rather than moving inside a hidden one.
+      dismissedFor.value = null;
+      tagSuggestionIndex.value = 0;
+      return;
     }
+    tagSuggestionIndex.value = Math.min(
+      tagSuggestionIndex.value + 1,
+      tagSuggestions.value.length - 1,
+    );
   } else if (event.key === "ArrowUp") {
-    if (tagSuggestions.value.length) {
-      event.preventDefault();
-      tagSuggestionIndex.value = Math.max(tagSuggestionIndex.value - 1, -1);
-    }
+    if (!suggestionsOpen.value) return;
+    event.preventDefault();
+    tagSuggestionIndex.value = Math.max(tagSuggestionIndex.value - 1, -1);
   } else if (event.key === "Tab") {
-    if (tagSuggestions.value.length) {
-      event.preventDefault();
-      const idx = tagSuggestionIndex.value >= 0 ? tagSuggestionIndex.value : 0;
-      selectTagSuggestion(tagSuggestions.value[idx]);
-    }
+    // Tab completes the field, it never writes to the selection. With the list
+    // dismissed it falls through so focus leaves the field (WCAG 2.1.2).
+    if (!suggestionsOpen.value) return;
+    event.preventDefault();
+    const idx = tagSuggestionIndex.value >= 0 ? tagSuggestionIndex.value : 0;
+    fillFromSuggestion(tagSuggestions.value[idx]);
   } else if (event.key === "Escape") {
     event.preventDefault();
     event.stopPropagation();
     if (typeof event.stopImmediatePropagation === "function") {
       event.stopImmediatePropagation();
     }
-    emit("close");
+    // First Escape dismisses the suggestions, a second one closes the panel.
+    if (suggestionsOpen.value) {
+      dismissedFor.value = tagInput.value;
+      tagSuggestionIndex.value = -1;
+    } else {
+      emit("close");
+    }
   }
 }
 
@@ -920,11 +977,7 @@ async function applyTag() {
     tagSuggestionIndex.value >= 0 &&
     tagSuggestions.value.length > tagSuggestionIndex.value
   ) {
-    const item = tagSuggestions.value[tagSuggestionIndex.value];
-    tagInput.value = typeof item === "string" ? item : item.tag;
-    tagSuggestionIndex.value = -1;
-    nextTick(() => applyTag());
-    return;
+    fillFromSuggestion(tagSuggestions.value[tagSuggestionIndex.value]);
   }
   const tag = tagInput.value.trim();
   if (!tag) return;
@@ -1335,6 +1388,7 @@ defineExpose({ focus: () => tagInputRef.value?.focus() });
 .sb-tag-autocomplete-item {
   display: block;
   width: 100%;
+  cursor: pointer;
   text-align: left;
   padding: var(--space-2) var(--space-3);
   font-size: var(--text-sm);


### PR DESCRIPTION
Fixes #755.

`handleTagKey` called `preventDefault()` on every `Tab` while the suggestion list was non-empty, and `Tab` committed the highlighted tag to every selected picture. Because the filter is `startsWith`, the completed tag still matched itself and the list never emptied, so `Tab` could never move focus. On a failing write the field also never cleared, so each `Tab` re-fired the failing request. WCAG 2.1.2 (No Keyboard Trap), Level A.

## Change

- `Tab` completes the field from the highlighted suggestion and dismisses the list. It no longer commits.
- `Enter` commits. Clicking a suggestion still fills and commits, since that is an explicit choice.
- First `Escape` dismisses the list, second closes the panel. `ArrowDown` reopens a dismissed list.
- `Tab` with the list dismissed falls through, so focus always leaves the field.
- The control now exposes `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-autocomplete`, `aria-activedescendant`, a `role="listbox"` popup with `role="option"` children, and a polite status region. The error and success lines got `role="alert"` / `role="status"`.

Dismissal is one ref: the input value the list was last dismissed for. Typing changes the value and reopens the list with no extra watcher, while completing the field leaves it dismissed even though the completed tag still matches the filter.

## Not done

The issue asked for `tagInput` to be cleared in a `finally` rather than only on success. Left as is on purpose: clearing on failure discards the tag the user typed and leaves an error message naming a tag no longer on screen. The trap is closed by the `Tab` semantics, so the clear is not load-bearing.

## Verification

`frontend/src/components/panels/TagPanelKeyboardTrap.test.js`, 6 cases. Confirmed to fail 5/6 against the unfixed component. Full panel suite green (122 tests).