### PR TITLE
Default ImageGrid's backendUrl so thumbnails resolve

### DIFF
--- a/frontend/src/components/BackendUrlPropDefault.test.js
+++ b/frontend/src/components/BackendUrlPropDefault.test.js
@@ -1,0 +1,63 @@
+// `backendUrl` is defaulted, never threaded.
+//
+// App.vue used to pass `:backend-url="BACKEND_URL"` down 40 bindings. Commit
+// a956343d deleted the pass-downs and gave the prop `default: () => API_BASE_URL`
+// in each component instead — except ImageGrid.vue, which kept a bare
+// `backendUrl: String`. A prop with no default is `undefined`, so every URL the
+// grid builds by hand became "undefined/pictures/thumbnails/<id>.webp" and every
+// thumbnail in the library rendered as a broken-image icon. The same `undefined`
+// also silently short-circuited the `if (!props.backendUrl) return` guards that
+// load picture plugins and taggers.
+//
+// The bug is invisible in isolation: each component looks fine on its own, and
+// the parent that used to supply the value no longer exists. So the invariant is
+// asserted over the whole component tree rather than per component.
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// vitest runs from the frontend/ package root.
+const SRC = join(process.cwd(), "src");
+
+function vueFiles(dir) {
+  const found = [];
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) found.push(...vueFiles(path));
+    else if (name.endsWith(".vue")) found.push(path);
+  }
+  return found;
+}
+
+/** The `backendUrl:` entry of a `defineProps({...})` block, if the file has one. */
+function backendUrlPropDeclaration(source) {
+  const match = source.match(/^\s*backendUrl:\s*(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
+describe("every component that takes backendUrl defaults it", () => {
+  const components = vueFiles(SRC).map((path) => ({
+    path: path.slice(SRC.length),
+    source: readFileSync(path, "utf8"),
+  }));
+
+  it("finds components to check (the walk itself is not silently empty)", () => {
+    expect(components.length).toBeGreaterThan(50);
+    expect(
+      components.filter((c) => backendUrlPropDeclaration(c.source)).length,
+    ).toBeGreaterThan(10);
+  });
+
+  it("declares no bare `backendUrl: String`", () => {
+    const undefaulted = components
+      .filter((c) => {
+        const declaration = backendUrlPropDeclaration(c.source);
+        return declaration && !declaration.includes("default");
+      })
+      .map((c) => c.path);
+
+    // ImageGrid.vue was the one that shipped, and it broke every thumbnail.
+    expect(undefaulted).toEqual([]);
+  });
+});

--- a/frontend/src/components/panels/SelectionMenu.vue
+++ b/frontend/src/components/panels/SelectionMenu.vue
@@ -359,7 +359,6 @@ const props = defineProps({
   open: Boolean,
   selectedCount: Number,
   selectedImageIds: { type: Array, default: () => [] },
-  backendUrl: String,
   isReadOnly: Boolean,
   isScrapheapView: Boolean,
   groupingLockReason: { type: String, default: null },

--- a/frontend/src/components/views/ImageGrid.vue
+++ b/frontend/src/components/views/ImageGrid.vue
@@ -1180,7 +1180,11 @@ import ShareDialog from "../io/ShareDialog.vue";
 import SnapshotsWithDeletedDialog from "../widgets/SnapshotsWithDeletedDialog.vue";
 import DeleteForeverDialog from "../widgets/DeleteForeverDialog.vue";
 import KeepCoverOnlyDialog from "../widgets/KeepCoverOnlyDialog.vue";
-import { appendShareToken, isReadOnly } from "../../utils/apiClient";
+import {
+  API_BASE_URL,
+  appendShareToken,
+  isReadOnly,
+} from "../../utils/apiClient";
 import {
   getPictureMetadata,
   getThumbnails,
@@ -1325,7 +1329,10 @@ const emit = defineEmits([
 
 // Props
 const props = defineProps({
-  backendUrl: String,
+  // Defaulted, not threaded from App.vue. Without the default this is
+  // `undefined` and every URL built from it reads "undefined/pictures/…",
+  // which is every thumbnail in the grid.
+  backendUrl: { type: String, default: () => API_BASE_URL },
   activeCategoryLabel: { type: String, default: "Category" },
 });
 


### PR DESCRIPTION
Every thumbnail in the grid renders as a broken-image icon on `develop`.

## Root cause

`a956343d` ("Default backendUrl instead of threading it through the tree") deleted the 40 `:backend-url` pass-downs and gave the prop `default: () => API_BASE_URL` in each component — except `ImageGrid.vue`, which kept a bare `backendUrl: String`. A prop with no default is `undefined`, and the grid builds several URLs by hand:

- `ImageGrid.vue:6454` and `:6501` → `undefined/pictures/thumbnails/<id>.webp` — the broken icons.
- `:2552` / `:3035` → the same for full media URLs.
- `:1653`, `:1676`, `:1690`, `:1708`, `:1911`, `:6945` → `if (!props.backendUrl) return`, so picture plugins, taggers and ComfyUI runs silently no-op'd as well.

`SelectionMenu.vue` had the same bare declaration; nothing passes or reads it there any more, so it goes.

## Fix

Default it like the other twenty components, and add the guardrail the class needed: `BackendUrlPropDefault.test.js` walks every `.vue` under `src/` and fails on any `backendUrl:` prop declared without a default. Checked against the broken code — it names both files. Full frontend suite: 2601 passed.