### PR TITLE
Guard os.fchmod so the hub opens on Windows

### DIFF
--- a/pixlstash/hub/db.py
+++ b/pixlstash/hub/db.py
@@ -105,7 +105,11 @@ def _prepare_hub_file(path: str, *, repair: bool) -> tuple[bool, tuple[int, int]
             raise HubPermissionError(
                 f"New hub file {path} is not owned by the current user."
             )
-        os.fchmod(fd, HUB_FILE_MODE)
+        # POSIX-only, like the getuid check above and the O_NOFOLLOW flag:
+        # Windows has no fchmod, and its ACLs do not carry these bits anyway.
+        # The mode passed to os.open() already applied where it means anything.
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, HUB_FILE_MODE)
     finally:
         os.close(fd)
     return True, (info.st_dev, info.st_ino)

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -157,6 +157,23 @@ class TestHubFileSecurity:
         assert seen_modes
         assert seen_modes[0] == 0o600
 
+    def test_the_hub_opens_on_a_platform_without_fchmod(self, tmp_path, monkeypatch):
+        """Windows has no ``os.fchmod``, and every backend test opens a hub.
+
+        The unguarded call made `AttributeError: module 'os' has no attribute
+        'fchmod'` the failure of every test in both Windows CI shards. Linux is
+        the only place this can be caught before Windows CI runs, so the
+        platform difference is simulated rather than waited for.
+        """
+        monkeypatch.delattr(os, "fchmod", raising=False)
+        path = str(tmp_path / "hub.db")
+
+        HubDatabase(path).close()
+
+        # Where the bits mean something they must still be exactly 0600: the
+        # mode handed to os.open() carries them when fchmod cannot.
+        assert stat.S_IMODE(os.lstat(path).st_mode) == 0o600
+
     def test_a_symlink_hub_is_refused_without_touching_its_target(self, tmp_path):
         target = tmp_path / "target.db"
         target.write_bytes(b"do not open")


### PR DESCRIPTION
Both `backend-windows` shards fail on `develop`, and `build-windows` gates on them. Every failure in both shards is the same one:

```
E   AttributeError: module 'os' has no attribute 'fchmod'. Did you mean: 'chmod'?
pixlstash\hub\db.py:108: AttributeError
```

`os.fchmod` is POSIX-only. `_prepare_hub_file` calls it unguarded, and every backend test opens a hub, so the whole Windows suite goes down with it — no other failure appears in either shard's log.

The surrounding code already handles this platform difference twice, four lines apart: `hasattr(os, "O_NOFOLLOW")` on the open flags and `hasattr(os, "getuid")` on the ownership check. `fchmod` was missed. The mode is already handed to `os.open()`, which carries it where the bits mean anything, so the guard loses nothing on POSIX.

Introduced with the hub work (`df9cc4ba` / `72a0c8ed`).

## Test

`test_the_hub_opens_on_a_platform_without_fchmod` deletes the attribute with `monkeypatch.delattr` and asserts the hub still opens **and** still lands at exactly 0600. Linux is the only place this can be caught before Windows CI runs. Verified it fails without the guard.