### PR TITLE
Regenerate backend_architecture.md for the libraries routes

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -496,6 +496,8 @@ Public guest scoring and shared-link endpoints.
 | POST   | /api/v1/dedup/verdicts/keep-separate                                          | dedup           | Record that a group is not duplicates                      |
 | POST   | /api/v1/dedup/verdicts/reopen                                                 | dedup           | Return a decided group to the queue                        |
 | POST   | /api/v1/dedup/verdicts/stack                                                  | dedup           | Stack a duplicate group                                    |
+| GET    | /api/v1/libraries                                                             | libraries       | List registered libraries                                  |
+| POST   | /api/v1/libraries/active                                                      | libraries       | Switch the active library                                  |
 | GET    | /api/v1/login                                                                 | auth            | Check Registration                                         |
 | POST   | /api/v1/login                                                                 | auth            | Login                                                      |
 | POST   | /api/v1/logout                                                                | auth            | Logout                                                     |
@@ -1371,6 +1373,7 @@ a promise that Tailscale is local for every authentication mechanism.
 | `RESTORE_STARTED`      | ✗ internal  |
 | `RESTORE_COMPLETED`    | ✗ internal  |
 | `RESTORE_FAILED`       | ✗ internal  |
+| `LIBRARY_SWITCHED`     | ✓ broadcast |
 <!-- AUTOGEN:end name="events" -->
 
 - Events are published from `Vault` whenever a task or domain operation completes; the broadcaster in `server.py` fans the filtered subset out to **owner-level** connected clients (see WebSocket authentication below).


### PR DESCRIPTION
`checks` fails on `develop` with:

```
FAIL: docs/backend_architecture.md is stale.
Run `python scripts/render_backend_architecture.py` to regenerate.
```

The multi-library hub work added `GET /api/v1/libraries`, `POST /api/v1/libraries/active` and the `LIBRARY_SWITCHED` event without re-running the generator. This is purely the generator's output; no hand-written prose changed.

Worth knowing: the check runs at step 6 of the `checks` job and **`Test Frontend Utilities` is step 7**, so while this is red the frontend suite is skipped on every PR and reports nothing.