### PR TITLE
Re-land: suspend SQLite FK enforcement during migrations

### DIFF
--- a/pixlstash/migrations/env.py
+++ b/pixlstash/migrations/env.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from contextlib import contextmanager
 from logging.config import fileConfig
 from pathlib import Path
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, pool, text
 from sqlmodel import SQLModel
 
 # Import models to register SQLModel metadata
@@ -38,6 +39,53 @@ def _get_database_url() -> str:
     return config.get_main_option("sqlalchemy.url")
 
 
+@contextmanager
+def _foreign_keys_suspended(connection):
+    """Suspend SQLite FK enforcement for the duration of a migration run.
+
+    ``op.batch_alter_table`` is the only way to drop or alter a column on
+    SQLite: it builds a new table, copies the rows across, ``DROP``s the
+    original and renames. With ``PRAGMA foreign_keys=ON`` — which the vault
+    engine sets (``database.init_database``) — that ``DROP`` raises
+    "FOREIGN KEY constraint failed" the moment any row references the table
+    being rebuilt, so migration 0080's rebuild of ``picture`` fails on every
+    database that actually holds pictures (the committed e2e fixture, and any
+    real library upgrading from before 0080). A fresh database has no rows to
+    reference, which is why the test suite never saw it.
+
+    Suspending enforcement around the rebuild is SQLite's own documented
+    procedure for altering a table (sqlite.org/lang_altertable.html, steps 1
+    and 11), not a workaround. Because it is genuinely unsafe to leave a
+    migration's output unchecked, ``PRAGMA foreign_key_check`` runs afterwards
+    and refuses to let a run that broke referential integrity pass silently.
+
+    The PRAGMA has to be issued outside a transaction to take effect, hence the
+    commit on the way in; pysqlite does not emit ``BEGIN`` for DDL or PRAGMA,
+    so this is the last statement before Alembic opens its own transaction.
+    """
+    if connection.dialect.name != "sqlite":
+        yield
+        return
+
+    connection.commit()
+    was_enabled = bool(connection.execute(text("PRAGMA foreign_keys")).scalar())
+    connection.execute(text("PRAGMA foreign_keys=OFF"))
+    connection.commit()
+    try:
+        yield
+    finally:
+        connection.commit()
+        if was_enabled:
+            connection.execute(text("PRAGMA foreign_keys=ON"))
+            connection.commit()
+            violations = connection.execute(text("PRAGMA foreign_key_check")).all()
+            if violations:
+                raise RuntimeError(
+                    "Migrations left dangling foreign keys "
+                    f"({len(violations)} rows); first: {violations[0]}"
+                )
+
+
 def run_migrations_offline() -> None:
     url = _get_database_url()
     context.configure(
@@ -62,8 +110,9 @@ def run_migrations_online() -> None:
             compare_type=True,
             render_as_batch=True,
         )
-        with context.begin_transaction():
-            context.run_migrations()
+        with _foreign_keys_suspended(supplied_connection):
+            with context.begin_transaction():
+                context.run_migrations()
         return
 
     configuration = config.get_section(config.config_ini_section)
@@ -82,8 +131,9 @@ def run_migrations_online() -> None:
             render_as_batch=True,
         )
 
-        with context.begin_transaction():
-            context.run_migrations()
+        with _foreign_keys_suspended(connection):
+            with context.begin_transaction():
+                context.run_migrations()
 
 
 if context.is_offline_mode():

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -4,10 +4,13 @@ and on an upgrade from the pre-snapshots (v1.4.1) schema with real data."""
 import contextlib
 import hashlib
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
 import tempfile
+
+from sqlmodel import text
 
 
 _MIGRATIONS_DIR = os.path.join(os.path.dirname(__file__), "..", "pixlstash")
@@ -1090,3 +1093,59 @@ def test_alembic_0094_adds_telemetry_consent_columns_defaulting_off():
             )
         finally:
             conn.close()
+
+
+_E2E_FIXTURE = os.path.join(_PROJECT_ROOT, "test-data", "images", "vault.db")
+
+
+def test_a_populated_library_upgrades_through_the_picture_table_rebuild():
+    """A vault with rows must survive migration 0080's rebuild of ``picture``.
+
+    ``op.batch_alter_table`` is the only way SQLite can drop a column: it
+    copies the table, ``DROP``s the original and renames. The vault engine runs
+    with ``PRAGMA foreign_keys=ON`` (``database.init_database``), so that
+    ``DROP`` raises "FOREIGN KEY constraint failed" as soon as any row
+    references the table — which is every real library, and the committed e2e
+    fixture. It brought the whole `e2e` lane down: the server could not boot.
+
+    A fresh database has nothing referencing ``picture``, so `upgrade head` on
+    an empty file passes either way; only a populated upgrade catches this.
+    The fixture is used because it is the artefact that actually failed, and
+    the e2e job already treats its absence as a coverage failure.
+
+    Goes through ``VaultDatabase`` deliberately: the standalone
+    ``PIXLSTASH_DB_URL`` path builds its engine from ``alembic.ini`` with no
+    connect listener, so FK enforcement is off there and the defect is
+    invisible.
+    """
+    from pixlstash.database import VaultDatabase
+
+    assert os.path.isfile(_E2E_FIXTURE), (
+        f"committed e2e fixture missing at {_E2E_FIXTURE}"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "vault.db")
+        shutil.copyfile(_E2E_FIXTURE, db_path)
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
+            before = conn.execute("SELECT COUNT(*) FROM picture").fetchone()[0]
+        assert before > 0, "fixture must carry pictures for this to mean anything"
+
+        db = VaultDatabase(db_path)
+        try:
+            with contextlib.closing(sqlite3.connect(db_path)) as conn:
+                after = conn.execute("SELECT COUNT(*) FROM picture").fetchone()[0]
+                # The rebuild copies rows; losing them would be the other
+                # failure mode of suspending enforcement around it.
+                assert after == before
+                violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+                assert violations == []
+
+            # Enforcement must be back on for the connection the app then uses;
+            # a suspension that leaked would disable it for the whole session.
+            enabled = db.run_immediate_read_task(
+                lambda session: session.exec(text("PRAGMA foreign_keys")).one()[0]
+            )
+            assert enabled == 1
+        finally:
+            db.close()


### PR DESCRIPTION
Straight cherry-pick of `b9fc9ca9`, unchanged. It is the fix reviewed in #771, which never reached `develop`.

## What happened

#771 was stacked on #767's branch. #767 merged into `develop` at commit `fa5502e4`; #771 then merged into `fix/grid-backend-url-default` **after** that, producing `132a24ca` on a branch nobody merges again. GitHub marks #771 "merged", so it looks landed, but `origin/develop:pixlstash/migrations/env.py` still has no `_foreign_keys_suspended`. That was my sequencing error in stacking it.

## Why it still matters

Without it the `e2e` lane cannot start its backend at all:

```
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) FOREIGN KEY constraint failed
[SQL: DROP TABLE picture]
Error: Process from config.webServer was not able to start. Exit code: 1
```

`op.batch_alter_table` rebuilds a table by copy-drop-rename, and the vault engine runs `PRAGMA foreign_keys=ON`, so migration 0080 fails on any database that holds pictures — the committed e2e fixture and every real library. Fixed in `migrations/env.py`, the one chokepoint, per SQLite's documented table-rebuild procedure, with `PRAGMA foreign_key_check` afterwards so it cannot mask real damage.

Re-verified on top of the current `develop`: `test_a_populated_library_upgrades_through_the_picture_table_rebuild` passes, and fails without the `env.py` change.