### PR TITLE
Set the loose hub directory mode with chmod, not mkdir

### DIFF
--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -263,7 +263,13 @@ class TestFreshInstall:
         """
         os.chmod(tmp_path, 0o700)
         parent = tmp_path / "loose"
-        parent.mkdir(mode=0o775)
+        parent.mkdir()
+        # chmod, not mkdir(mode=): the mode argument is masked by the process
+        # umask, so 0o775 lands as 0o755 wherever the umask is 022 — which is
+        # the GitHub runner default. The directory then is not group-writable,
+        # nothing is loose, and the test failed with "DID NOT RAISE" for the
+        # one reason that is not a defect in the code under test.
+        os.chmod(parent, 0o775)
 
         with pytest.raises(HubPermissionError, match="group/world-writable"):
             HubDatabase(str(parent / "hub.db"))


### PR DESCRIPTION
`backend shard 1` fails on `develop`:

```
FAILED tests/test_hub_bootstrap.py::TestFreshInstall::
  test_existing_loose_hub_directory_is_reported_not_silently_repaired
  - Failed: DID NOT RAISE HubPermissionError
```

## Root cause

The test builds the "loose" directory with `parent.mkdir(mode=0o775)`. `mkdir`'s mode argument is masked by the process umask. GitHub runners default to umask 022, so the directory lands at **0755** — not group-writable, nothing loose, and the code under test correctly declines to raise. The production code is fine; the fixture never created the condition it asserts on.

It passes on a Debian/Ubuntu workstation because the default umask there is 002, which leaves 0775 intact. That is the whole difference between local green and CI red.

`chmod` is not umask-masked, so creating the directory and then setting the mode gives the same result on any machine. The trailing `assert ... == 0o775` becomes meaningful too, rather than asserting whatever the ambient umask allowed.

## Verified

`tests/test_hub_bootstrap.py` — 46 passed under `umask 022` **and** under `umask 002`. Before the change, the same file is 1 failed / 45 passed under 022 and 46 passed under 002, which is exactly the CI-versus-local split.