### PR TITLE
Observe the guest lookup, not every vault read

### DIFF
--- a/tests/test_authz_library_pin.py
+++ b/tests/test_authz_library_pin.py
@@ -149,9 +149,22 @@ class TestPinnedRoutes:
             vault_reads = []
             real_read = server.vault.db.run_immediate_read_task
 
-            def observed_read(*args, **kwargs):
-                vault_reads.append(True)
-                return real_read(*args, **kwargs)
+            # Record WHAT was read, not merely that something was. The vault
+            # has other readers: the WorkPlanner thread probes it for pending
+            # work every few seconds (QualityTask.count_missing_quality,
+            # MissingLikenessFinder._likeness_state, and siblings), and those
+            # probes have nothing to do with this request. A bare
+            # "nothing was read" assertion therefore fails on any machine slow
+            # enough for one to land inside the request — which is what CI is:
+            # this call took 0.63 s there and collected 15 unrelated reads.
+            #
+            # The claim under test is the one in the name: the guest lookup
+            # never ran. `_lookup_by_token` is the same sentinel
+            # test_writer_waits_for_request_paused_in_guest_lookup keys on, and
+            # that test waits for it, so a rename cannot quietly defang this.
+            def observed_read(callback, *args, **kwargs):
+                vault_reads.append(getattr(callback, "__name__", repr(callback)))
+                return real_read(callback, *args, **kwargs)
 
             monkeypatch.setattr(
                 server.vault.db, "run_immediate_read_task", observed_read
@@ -162,7 +175,9 @@ class TestPinnedRoutes:
                 cookies={"guest_session": "plausible-cookie"},
             )
             assert response.status_code == 403
-            assert vault_reads == []
+            assert "_lookup_by_token" not in vault_reads, (
+                f"the guest vault lookup ran before the pin refused: {vault_reads}"
+            )
 
     def test_writer_waits_for_request_paused_in_guest_lookup(
         self, server, tmp_path, monkeypatch


### PR DESCRIPTION
`backend shard 3` fails on `develop`:

```
FAILED tests/test_authz_library_pin.py::TestPinnedRoutes::
  test_library_mismatch_is_refused_before_any_guest_vault_lookup
  - assert [True, True, ...ue, True, ...] == []
    Left contains 15 more items
```

## Root cause

The production behaviour is correct — the request really does refuse before any guest lookup. The test was asserting something stronger and untrue: that **nothing in the process** read the vault while the request was in flight.

The vault has other readers. I instrumented the observer to record the callable and the thread, and the 15 reads all come from the **WorkPlanner** thread probing for pending work:

```
DURING REQUEST: []
IN THE NEXT 2s: [('WorkPlanner', 'QualityTask._find_pictures_missing_quality'),
                 ('WorkPlanner', 'QualityTask.count_missing_quality'),
                 ('WorkPlanner', 'LikenessParameterUtils.has_pending_work'),
                 ('WorkPlanner', 'MissingLikenessFinder._likeness_state'),
                 ('WorkPlanner', 'MissingComfyUIExtractionFinder._fetch_candidates'), …]
```

On this machine the request finishes before the first probe, so `vault_reads` is empty and it passes. On the runner the call took **0.63 s** and the probes landed inside the window. Nothing to do with the code under test; the assertion was timing-dependent from the day it was written.

## Fix

Record *what* was read and assert the guest lookup specifically — the claim in the test's own name. `_lookup_by_token` is the same sentinel `test_writer_waits_for_request_paused_in_guest_lookup` keys on, and that test *waits* for it under a 10 s timeout, so a rename cannot quietly defang this one.

## Verified both directions

- Negative (this test): 15 passed in the file; the assertion no longer sees unrelated background reads.
- Positive, so the assertion is not vacuous: with a token matching the **active** library, the same request returns 200 and the observer does record `_lookup_by_token` — `NAMES ['_lookup_by_token', 'find']`. The sentinel is genuinely reachable on the path this test claims it is absent from.