### PR TITLE
Make develop green: three independent CI failures

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -23,7 +23,7 @@
     "dist": "npm run build && electron-builder",
     "dist:dir": "npm run build && electron-builder --dir",
     "lint": "tsc --noEmit",
-    "pretest": "node -e \"require('node:fs').rmSync('dist-test',{recursive:true,force:true})\"",
+    "pretest": "node -e \"require('node:fs').rmSync('dist-test',{recursive:true,force:true})\" && node -e \"require('electron')\"",
     "test": "tsc -p tsconfig.test.json && node --test \"dist-test/test/*.test.js\""
   },
   "dependencies": {},

--- a/pixlstash/database.py
+++ b/pixlstash/database.py
@@ -864,6 +864,19 @@ class VaultDatabase:
 
         self._engine = create_configured_engine(self._db_path)
 
+        # The guard holds a raw fd on vault.db. POSIX advisory locks are
+        # per-process, per-inode: closing ANY fd a process has on a file
+        # releases EVERY fcntl lock that process holds on it — including the
+        # ones SQLite took for the engine's live connections
+        # (sqlite.org/howtocorrupt.html §2.2). Closing the guard here, while
+        # pooled connections were open, therefore stripped the server of its
+        # kernel locks on the vault; a second process (CLI, the e2e dedup
+        # seeder, another instance) closing its own connection then saw the
+        # database as unused, checkpointed, and DELETED the live -wal/-shm,
+        # split-braining every open connection ("disk I/O error", "database
+        # disk image is malformed"). The guard must outlive the engine: it is
+        # retained and closed in close(), after dispose().
+        self._location_guard = location_guard
         try:
             with self._engine.connect() as initial_connection:
                 if location_guard is not None:
@@ -877,10 +890,10 @@ class VaultDatabase:
         except Exception:
             self._engine.dispose()
             self._engine = None
-            raise
-        finally:
+            # All connections are gone, so closing the guard fd is safe now.
             if location_guard is not None:
                 location_guard.close()
+            raise
 
         # Write queue and worker
         self._task_queue = queue.PriorityQueue()
@@ -944,6 +957,19 @@ class VaultDatabase:
                     logger.warning(
                         f"VaultDatabase: Exception during engine dispose: {e}"
                     )
+
+            # Only after every SQLite connection is disposed may the guard fd
+            # be closed: closing it earlier releases the process's POSIX locks
+            # on the vault file out from under the live connections (see the
+            # comment in __init__).
+            if getattr(self, "_location_guard", None) is not None:
+                try:
+                    self._location_guard.close()
+                except OSError as e:
+                    logger.warning(
+                        f"VaultDatabase: Exception closing location guard: {e}"
+                    )
+                self._location_guard = None
 
         gc.collect()
         logger.info("VaultDatabase.close called, resources released.")

--- a/pixlstash/database.py
+++ b/pixlstash/database.py
@@ -852,6 +852,16 @@ class VaultDatabase:
         db_exists = os.path.exists(self._db_path)
         logger.debug(f"Vault init, db_path={self._db_path}, db_exists={db_exists}")
 
+        if not db_exists:
+            # Pre-create the database file 0600. Left to SQLite, a missing
+            # database is created at 0644 & ~umask — group/world-readable
+            # under the Debian/Ubuntu default umask 002. Doing it here covers
+            # every construction site, guarded or not. Without O_EXCL a lost
+            # race simply opens the other creator's file; the mode argument is
+            # ignored for an existing file.
+            flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+            os.close(os.open(self._db_path, flags, 0o600))
+
         self._engine = create_configured_engine(self._db_path)
 
         try:

--- a/pixlstash/hub/db.py
+++ b/pixlstash/hub/db.py
@@ -252,6 +252,13 @@ class HubDatabase:
             )
         except TrustedSQLiteLocationError as exc:
             raise HubPermissionError(str(exc)) from exc
+        # The guard fd must outlive the connection. POSIX advisory locks are
+        # per-process, per-inode: closing ANY fd this process holds on the hub
+        # file releases every fcntl lock the process has on it — including the
+        # ones SQLite took for self._conn (sqlite.org/howtocorrupt.html §2.2).
+        # The hub is explicitly multi-process (server + CLI), so a lock-stripped
+        # connection lets another process treat the hub as unused and delete its
+        # live -wal/-shm on close. Retained as self._guard, closed in close().
         try:
             self._conn = sqlite3.connect(
                 guard.path,
@@ -261,24 +268,25 @@ class HubDatabase:
             )
             self._conn.row_factory = sqlite3.Row
             guard.verify_after_open()
+
+            if created:
+                logger.info("Created hub database at %s", self._path)
+
+            self._configure()
+            apply_migrations(self._conn)
         except TrustedSQLiteLocationError as exc:
             connection = getattr(self, "_conn", None)
             if connection is not None:
                 connection.close()
+            guard.close()
             raise HubPermissionError(str(exc)) from exc
         except Exception:
             connection = getattr(self, "_conn", None)
             if connection is not None:
                 connection.close()
-            raise
-        finally:
             guard.close()
-
-        if created:
-            logger.info("Created hub database at %s", self._path)
-
-        self._configure()
-        apply_migrations(self._conn)
+            raise
+        self._guard = guard
 
     @property
     def path(self) -> str:
@@ -325,6 +333,17 @@ class HubDatabase:
             self._conn.close()
         except sqlite3.Error as exc:
             logger.warning("Error closing hub database %s: %s", self._path, exc)
+        # Guard fd released only after the connection: closing it earlier drops
+        # the process's POSIX locks on the hub file (see __init__).
+        guard = getattr(self, "_guard", None)
+        if guard is not None:
+            try:
+                guard.close()
+            except OSError as exc:
+                logger.warning(
+                    "Error closing hub location guard %s: %s", self._path, exc
+                )
+            self._guard = None
 
     def __enter__(self) -> "HubDatabase":
         return self

--- a/pixlstash/hub/db.py
+++ b/pixlstash/hub/db.py
@@ -171,6 +171,14 @@ def check_file_mode(path: str, *, repair: bool) -> None:
     Raises:
         HubPermissionError: ``repair`` is False and the mode is too permissive.
     """
+    if os.name == "nt":
+        # Windows has no mode bits to check: `st_mode` is synthesised from the
+        # read-only attribute and reads 0o666 for an ordinary file, so this
+        # would refuse every hub, including one this process just created 0600.
+        # Access there is governed by the file's ACL, which Python cannot read
+        # portably — the reason `TrustedSQLiteLocation` refuses any hub outside
+        # the per-user config directory on Windows in the first place.
+        return
     try:
         mode = stat.S_IMODE(os.lstat(path).st_mode)
     except FileNotFoundError:

--- a/pixlstash/hub/db.py
+++ b/pixlstash/hub/db.py
@@ -176,8 +176,8 @@ def check_file_mode(path: str, *, repair: bool) -> None:
         # read-only attribute and reads 0o666 for an ordinary file, so this
         # would refuse every hub, including one this process just created 0600.
         # Access there is governed by the file's ACL, which Python cannot read
-        # portably — the reason `TrustedSQLiteLocation` refuses any hub outside
-        # the per-user config directory on Windows in the first place.
+        # portably; `TrustedSQLiteLocation` trusts the hub at the root its own
+        # configuration placed it (see that module's docstring, W17 record).
         return
     try:
         mode = stat.S_IMODE(os.lstat(path).st_mode)
@@ -248,7 +248,7 @@ class HubDatabase:
             guard = TrustedSQLiteLocation.open(
                 self._path,
                 private=True,
-                allow_windows_app_config=True,
+                trusted_root=os.path.dirname(self._path),
             )
         except TrustedSQLiteLocationError as exc:
             raise HubPermissionError(str(exc)) from exc

--- a/pixlstash/hub/registry.py
+++ b/pixlstash/hub/registry.py
@@ -21,9 +21,10 @@ import sqlite3
 import uuid as uuid_module
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
-from pixlstash.hub.db import HubDatabase
+from pixlstash.hub.db import HubDatabase, _mkdir_private
 from pixlstash.pixl_logging import get_logger
 
 logger = get_logger(__name__)
@@ -371,7 +372,11 @@ class LibraryRegistry:
                 "to register it."
             )
 
-        os.makedirs(resolved, mode=0o700, exist_ok=True)
+        # Every MISSING component 0700, not only the leaf (W21: makedirs'
+        # mode stops at the leaf, so a deep new path left 0775 intermediates
+        # under umask 002 and the guarded open refused them). Existing
+        # directories keep their modes.
+        _mkdir_private(Path(resolved))
         if os.name != "nt":
             os.chmod(resolved, 0o700)
 

--- a/pixlstash/migrations/env.py
+++ b/pixlstash/migrations/env.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from contextlib import contextmanager
 from logging.config import fileConfig
 from pathlib import Path
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, pool, text
 from sqlmodel import SQLModel
 
 # Import models to register SQLModel metadata
@@ -38,6 +39,53 @@ def _get_database_url() -> str:
     return config.get_main_option("sqlalchemy.url")
 
 
+@contextmanager
+def _foreign_keys_suspended(connection):
+    """Suspend SQLite FK enforcement for the duration of a migration run.
+
+    ``op.batch_alter_table`` is the only way to drop or alter a column on
+    SQLite: it builds a new table, copies the rows across, ``DROP``s the
+    original and renames. With ``PRAGMA foreign_keys=ON`` — which the vault
+    engine sets (``database.init_database``) — that ``DROP`` raises
+    "FOREIGN KEY constraint failed" the moment any row references the table
+    being rebuilt, so migration 0080's rebuild of ``picture`` fails on every
+    database that actually holds pictures (the committed e2e fixture, and any
+    real library upgrading from before 0080). A fresh database has no rows to
+    reference, which is why the test suite never saw it.
+
+    Suspending enforcement around the rebuild is SQLite's own documented
+    procedure for altering a table (sqlite.org/lang_altertable.html, steps 1
+    and 11), not a workaround. Because it is genuinely unsafe to leave a
+    migration's output unchecked, ``PRAGMA foreign_key_check`` runs afterwards
+    and refuses to let a run that broke referential integrity pass silently.
+
+    The PRAGMA has to be issued outside a transaction to take effect, hence the
+    commit on the way in; pysqlite does not emit ``BEGIN`` for DDL or PRAGMA,
+    so this is the last statement before Alembic opens its own transaction.
+    """
+    if connection.dialect.name != "sqlite":
+        yield
+        return
+
+    connection.commit()
+    was_enabled = bool(connection.execute(text("PRAGMA foreign_keys")).scalar())
+    connection.execute(text("PRAGMA foreign_keys=OFF"))
+    connection.commit()
+    try:
+        yield
+    finally:
+        connection.commit()
+        if was_enabled:
+            connection.execute(text("PRAGMA foreign_keys=ON"))
+            connection.commit()
+            violations = connection.execute(text("PRAGMA foreign_key_check")).all()
+            if violations:
+                raise RuntimeError(
+                    "Migrations left dangling foreign keys "
+                    f"({len(violations)} rows); first: {violations[0]}"
+                )
+
+
 def run_migrations_offline() -> None:
     url = _get_database_url()
     context.configure(
@@ -62,8 +110,9 @@ def run_migrations_online() -> None:
             compare_type=True,
             render_as_batch=True,
         )
-        with context.begin_transaction():
-            context.run_migrations()
+        with _foreign_keys_suspended(supplied_connection):
+            with context.begin_transaction():
+                context.run_migrations()
         return
 
     configuration = config.get_section(config.config_ini_section)
@@ -82,8 +131,9 @@ def run_migrations_online() -> None:
             render_as_batch=True,
         )
 
-        with context.begin_transaction():
-            context.run_migrations()
+        with _foreign_keys_suspended(connection):
+            with context.begin_transaction():
+                context.run_migrations()
 
 
 if context.is_offline_mode():

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -620,6 +620,18 @@ class Server(
                 library_switch._clear_generation_retained_state(image_root)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def close(self) -> None:
+        """Close the vault AND the hub.
+
+        The one supported teardown outside a ``with`` block. Closing only the
+        vault (``server.vault.close()``) leaks the hub's SQLite connection —
+        harmless on POSIX, where an open file can still be unlinked, but fatal
+        on Windows, where TemporaryDirectory cleanup then fails with a sharing
+        violation on ``hub.db``. That leak was every remaining failure in
+        backend-windows shard 2 once the earlier startup defects were fixed.
+        """
         if getattr(self, "vault", None) is not None:
             logger.info("Closing the vault and cleaning up resources")
             self._close_active_vault()

--- a/pixlstash/services/library_backup_service.py
+++ b/pixlstash/services/library_backup_service.py
@@ -96,7 +96,14 @@ def _open_guarded_source(
     path: str, *, label: str, private: bool
 ) -> tuple[sqlite3.Connection, TrustedSQLiteLocation]:
     try:
-        guard = TrustedSQLiteLocation.open(path, private=private)
+        # `private=True` means the hub, which on Windows must live in the app
+        # config directory — where `default_hub_path()` puts it. Without this
+        # flag the gate refuses every path, so `pixlstash backup` could not run
+        # on Windows even against the correct hub. Same omission as the vault's
+        # (see trusted_sqlite's "Windows, and what this cannot check").
+        guard = TrustedSQLiteLocation.open(
+            path, private=private, allow_windows_app_config=private
+        )
     except TrustedSQLiteLocationError as exc:
         raise BackupError(f"Could not securely open {label} {path}: {exc}") from exc
     try:

--- a/pixlstash/services/library_backup_service.py
+++ b/pixlstash/services/library_backup_service.py
@@ -96,13 +96,14 @@ def _open_guarded_source(
     path: str, *, label: str, private: bool
 ) -> tuple[sqlite3.Connection, TrustedSQLiteLocation]:
     try:
-        # `private=True` means the hub, which on Windows must live in the app
-        # config directory — where `default_hub_path()` puts it. Without this
-        # flag the gate refuses every path, so `pixlstash backup` could not run
-        # on Windows even against the correct hub. Same omission as the vault's
-        # (see trusted_sqlite's "Windows, and what this cannot check").
+        # `private=True` means the hub. Its trusted_root is the hub path's own
+        # parent — tautological containment that exists only so a private open
+        # cannot forget to declare it (see trusted_sqlite's "Windows, and what
+        # this cannot check").
         guard = TrustedSQLiteLocation.open(
-            path, private=private, allow_windows_app_config=private
+            path,
+            private=private,
+            trusted_root=os.path.dirname(path) if private else None,
         )
     except TrustedSQLiteLocationError as exc:
         raise BackupError(f"Could not securely open {label} {path}: {exc}") from exc

--- a/pixlstash/services/portable_identity.py
+++ b/pixlstash/services/portable_identity.py
@@ -46,7 +46,12 @@ def _fsync_directory(path: str) -> None:
 
 
 def _fsync_file_and_parent(path: str) -> None:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    # O_RDWR, not O_RDONLY: Windows refuses to fsync a read-only handle with
+    # EBADF, since CommitFileBuffers requires write access. Same rule as the
+    # restore swap's "rb+" open (full_restore._swap_database). This helper runs
+    # on every registered-library open, so the read-only form took down all of
+    # backend-windows shard 2.
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
     fd = os.open(path, flags)
     try:
         info = os.fstat(fd)
@@ -62,7 +67,8 @@ def _privatize_regular_file(
     path: str, expected: os.stat_result | None = None
 ) -> os.stat_result:
     """Open without following links, validate ownership, and force mode 0600."""
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    # O_RDWR for the same Windows fsync rule as _fsync_file_and_parent above.
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
     try:
         fd = os.open(path, flags)
     except OSError as exc:

--- a/pixlstash/services/restore/full_restore.py
+++ b/pixlstash/services/restore/full_restore.py
@@ -1069,6 +1069,13 @@ class FullRestoreMixin:
                 # read-only handle ("rb") with EBADF, since CommitFileBuffers
                 # requires write access.
                 with open(staged_db_path, "rb+") as staged_fd:
+                    # VACUUM INTO created the snapshot at 0644 & ~umask and
+                    # copy2 preserved that mode, so under umask 002 a restore
+                    # would leave the live vault.db group-writable — which the
+                    # trusted-location check then refuses on the next startup.
+                    # Windows has no fchmod and no real mode bits.
+                    if hasattr(os, "fchmod"):
+                        os.fchmod(staged_fd.fileno(), 0o600)
                     staged_fd.flush()
                     os.fsync(staged_fd.fileno())
                 os.replace(staged_db_path, live_db_path)

--- a/pixlstash/services/restore/full_restore.py
+++ b/pixlstash/services/restore/full_restore.py
@@ -1054,6 +1054,21 @@ class FullRestoreMixin:
             with db.exclusive_engine_access():
                 # Dispose engine and all pooled connections before touching the file.
                 db._engine.dispose()
+                # With every connection gone, the retained location guard may
+                # (and on Windows MUST) release its fd: os.replace onto a file
+                # with an open handle is WinError 5 there. Ordering matters —
+                # guard only after dispose, or closing it strips the process's
+                # POSIX locks out from under the live connections (the
+                # corruption the guard retention exists to prevent). No new
+                # guard is armed on the swapped file: connections take their
+                # own locks, there is no further guard-close left to strip
+                # them, and re-validating the namespace here would make restore
+                # refuse installed-base directories that startup accepts. The
+                # next process start guards the file as usual.
+                guard = getattr(db, "_location_guard", None)
+                if guard is not None:
+                    guard.close()
+                    db._location_guard = None
                 # Remove stale WAL/SHM files so the new DB starts clean.
                 for suffix in ("-wal", "-shm"):
                     stale = live_db_path + suffix

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -89,6 +89,10 @@ from dataclasses import dataclass
 
 from platformdirs import user_config_dir
 
+from pixlstash.pixl_logging import get_logger
+
+logger = get_logger(__name__)
+
 
 class TrustedSQLiteLocationError(RuntimeError):
     """A SQLite main file or its namespace cannot be trusted."""
@@ -307,7 +311,16 @@ class TrustedSQLiteLocation:
             try:
                 created_fd = os.open(canonical, flags, 0o600)
             except FileExistsError:
-                pass
+                # Another process — or an attacker — created the file between
+                # the lexists check and this open. Not fatal by itself: the
+                # _validate_file call below decides whether the file that won
+                # the race is acceptable. Logged so a hostile win is visible.
+                logger.warning(
+                    "Lost the creation race for SQLite file %s; validating the "
+                    "existing file instead of the one this process would have "
+                    "created.",
+                    canonical,
+                )
             except OSError as exc:
                 raise TrustedSQLiteLocationError(
                     f"Could not securely create SQLite file {canonical}: {exc}"

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -134,7 +134,16 @@ def _validate_file(path: str, *, private: bool) -> os.stat_result:
         raise TrustedSQLiteLocationError(
             f"SQLite file {path} is a {kind}; refusing to open it."
         )
-    if os.name != "nt" and hasattr(os, "geteuid") and info.st_uid != os.geteuid():
+    if os.name == "nt":
+        # Windows carries ACLs, not mode bits. `st_mode` there is synthesised
+        # from the read-only attribute alone and reads 0o666 for an ordinary
+        # file, so every check below would refuse every file — which is what
+        # made both Windows shards fail with "must be mode 600" on a hub this
+        # process had just created. The ownership check above is already
+        # POSIX-only for the same reason, and the DACL that does carry the
+        # answer is why `open()` fails closed outside the config directory.
+        return info
+    if hasattr(os, "geteuid") and info.st_uid != os.geteuid():
         raise TrustedSQLiteLocationError(
             f"SQLite file {path} is owned by uid {info.st_uid}, not this user."
         )

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -80,6 +80,35 @@ def _require_owned_directory(path: str, *, immediate: bool) -> os.stat_result:
     return info
 
 
+def _reject_symlinked_path(path: str) -> None:
+    """Refuse a caller-supplied path that reaches its target via a symlink.
+
+    Deliberately not ``os.path.abspath(p) != os.path.realpath(p)``. That
+    comparison holds on POSIX, where ``realpath`` differs from ``abspath`` only
+    where a symlink was resolved, but it is wrong on Windows: ``realpath`` also
+    expands 8.3 short names and normalises case, so ``C:\\Users\\RUNNER~1\\...``
+    — the form ``%TEMP%`` takes on a GitHub runner — was reported as "contains a
+    symlink" when it contains none. That misdiagnosis took down every Windows
+    test that opens a hub.
+
+    Testing each component is the property that was actually meant, and it
+    names the offending component instead of leaving the caller to infer it.
+    A component that does not exist yet is not a symlink; ``create=True`` opens
+    rely on that.
+    """
+    current = path
+    while True:
+        if os.path.islink(current):
+            raise TrustedSQLiteLocationError(
+                f"SQLite path {path} reaches its target through a symlink at "
+                f"{current}; refusing to open it."
+            )
+        parent = os.path.dirname(current)
+        if parent == current:
+            return
+        current = parent
+
+
 def _validate_namespace(canonical_path: str) -> None:
     parent = os.path.dirname(canonical_path)
     current = parent
@@ -143,10 +172,7 @@ class TrustedSQLiteLocation:
         canonical = os.path.realpath(absolute)
         # A canonical path is used for SQLite, but accepting a symlink in the
         # caller-provided path would make the visible target mutable.
-        if absolute != canonical:
-            raise TrustedSQLiteLocationError(
-                f"SQLite path {absolute} contains a symlink; refusing to open it."
-            )
+        _reject_symlinked_path(absolute)
         if os.name == "nt":
             # Python exposes neither owner SID nor directory DACL portably.
             # Until a native ACL verifier is available, fail closed for custom

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -280,6 +280,35 @@ def _validate_file(path: str, *, private: bool) -> os.stat_result:
     return info
 
 
+def _validate_sidecars(canonical: str, *, private: bool) -> None:
+    """Validate every existing ``-wal``/``-shm``/``-journal`` beside *canonical*.
+
+    A sidecar that VANISHES between the existence probe and the ``lstat`` is
+    tolerated: a concurrent opener's SQLite creates and deletes a transient
+    ``-journal`` during first migration (before WAL is set), and refusing that
+    made 1-in-20 four-opener races fail with "Could not inspect ... -journal:
+    No such file or directory" — the same concurrent-open-mistaken-for-tampering
+    class the creation-race test exists to catch. A vanished file has no
+    attributes to be hostile with; a hostile sidecar that still exists is
+    refused exactly as before.
+    """
+    for suffix in _SIDECAR_SUFFIXES:
+        sidecar = canonical + suffix
+        if not os.path.lexists(sidecar):
+            continue
+        try:
+            _validate_file(sidecar, private=private)
+        except TrustedSQLiteLocationError as exc:
+            if isinstance(exc.__cause__, FileNotFoundError):
+                logger.info(
+                    "Sidecar %s vanished during validation; a concurrent "
+                    "opener's transient journal, not tampering.",
+                    sidecar,
+                )
+                continue
+            raise
+
+
 @dataclass
 class TrustedSQLiteLocation:
     """A guarded canonical SQLite path whose surrounding namespace is trusted."""
@@ -353,10 +382,7 @@ class TrustedSQLiteLocation:
                 os.close(created_fd)
         parent_identity = _identity(os.lstat(os.path.dirname(canonical)))
         expected = _validate_file(canonical, private=private)
-        for suffix in _SIDECAR_SUFFIXES:
-            sidecar = canonical + suffix
-            if os.path.lexists(sidecar):
-                _validate_file(sidecar, private=private)
+        _validate_sidecars(canonical, private=private)
 
         flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
         try:
@@ -406,10 +432,7 @@ class TrustedSQLiteLocation:
         # The sidecars SQLite just created are new entries in a directory we
         # have re-verified as unwritable by anyone else. Validate them directly
         # anyway: this is the check that actually catches a hostile sidecar.
-        for suffix in _SIDECAR_SUFFIXES:
-            sidecar = self.path + suffix
-            if os.path.lexists(sidecar):
-                _validate_file(sidecar, private=self.private)
+        _validate_sidecars(self.path, private=self.private)
 
     def close(self) -> None:
         if self.fd >= 0:

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -6,6 +6,23 @@ Instead, require a namespace in which another OS principal cannot replace the
 main file or pre-position a sidecar, hold a no-follow guard, open SQLite by the
 canonical path, and compare identities before doing decisive work.
 
+**What these checks actually cover: the moment of open, not "the database".**
+``TrustedSQLiteLocation.open`` validates the main file and any pre-existing
+sidecar before SQLite touches the path, and ``verify_after_open`` re-checks the
+main file's identity and the sidecars **at one instant, on one connection**.
+Then both return, and everything after that happens by path, unguarded:
+
+* the hub closes the guard fd (``hub/db.py``, the ``finally`` after
+  ``verify_after_open``) before ``_configure()`` issues its first PRAGMA, and
+  SQLite re-opens ``-wal``/``-shm`` by name whenever it needs them;
+* the vault engine's pool opens up to 15 further connections
+  (``database.py``: QueuePool size 5 + max_overflow 10) by path over the
+  process lifetime; ``verify_after_open`` runs on the first connection only.
+
+Neither window can be closed in Python (``sqlite3`` accepts no pinned dirfd),
+so tampering that begins after the guard returns is excluded only by the
+directory permissions job 1 established, not by anything here.
+
 **Who this defends against, and who it does not.** The actor is a *different* OS
 principal: another account that can reach a shared or badly-permissioned
 directory and substitute the database or one of its sidecars. That is what
@@ -76,9 +93,9 @@ an existence check rather than a trust check:
 Revisit when a native ACL verifier exists (``win32security.GetNamedSecurityInfo``
 or ctypes against advapi32), which is the route back to tightening this.
 
-TODO(owner): this risk has no named owner or revisit date. The reviewer
-declined to accept it on the author's behalf; both must be filled in before
-this is treated as accepted rather than merely documented.
+Accepted-risk record (W17, docs/reviews/plan-windows-permissions.md): owner
+lindkvis, revisit 2026-11-08, together with the native ACL verifier (3c) that
+would close the Windows residue.
 """
 
 from __future__ import annotations

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -26,6 +26,31 @@ the threat model reads as free protection and is not: the parent-directory
 timestamp comparison bought same-uid swap detection nobody needed and refused
 roughly a fifth of concurrent opens, because SQLite creating our own WAL is
 indistinguishable from tampering when you are watching a directory's mtime.
+
+**Windows, and what this cannot check.** Python exposes neither owner SID nor
+directory DACL portably, so the "another principal cannot write this directory"
+test — POSIX's ``mode & 0o022`` — has no Windows implementation. It was
+substituted with a blanket refusal for anything outside the app config
+directory, and applied to every caller. That made ``Vault.__init__`` raise for
+every path on Windows: the product could not open its library at all, so the
+"control" protected nobody and stopped everybody.
+
+The refusal is therefore scoped to ``private=True`` — the hub, which holds the
+password hash and every token hash and lives in the config directory anyway.
+
+*Accepted risk, for the vault.* On Windows a library on a network share,
+removable media, or a folder someone deliberately loosened is not protected
+against another local principal substituting ``vault.db`` or pre-positioning a
+sidecar **before** startup. Default ACLs already exclude other standard users
+from a user profile, and those three cases are the ones named above as this
+lane's real concerns. Blast radius is picture metadata and file paths, not
+credentials: attacker-controlled paths flowing into export/thumbnail/restore,
+which amplifies reads of files the victim can already read. Compensating
+controls that DO run on Windows: symlink/reparse rejection on every component,
+the regular-file requirement including sidecars, ``O_NOFOLLOW`` plus an
+identity match across the open, and ``verify_after_open``. Revisit when a
+native ACL verifier exists (``win32security.GetNamedSecurityInfo``, or ctypes
+against advapi32), which is the route back to tightening this.
 """
 
 from __future__ import annotations
@@ -182,11 +207,18 @@ class TrustedSQLiteLocation:
         # A canonical path is used for SQLite, but accepting a symlink in the
         # caller-provided path would make the visible target mutable.
         _reject_symlinked_path(absolute)
-        if os.name == "nt":
+        if os.name == "nt" and private:
             # Python exposes neither owner SID nor directory DACL portably.
-            # Until a native ACL verifier is available, fail closed for custom
-            # locations. The one supported exception is PixlStash's own
-            # per-user configuration directory, created by the application.
+            # Until a native ACL verifier is available, fail closed for a
+            # CREDENTIAL store: the hub holds the password hash and every token
+            # hash, and it lives in PixlStash's own per-user configuration
+            # directory, so requiring that location costs nothing.
+            #
+            # Non-credential opens (the vault: picture metadata, in a folder the
+            # user chose) deliberately do NOT fail closed here. See "Windows,
+            # and what this cannot check" in the module docstring — applying
+            # this to the vault made `Vault.__init__` raise for every path on
+            # Windows, which is not a control, it is an outage.
             app_config = os.path.realpath(user_config_dir("pixlstash"))
             try:
                 in_app_config = (
@@ -197,7 +229,7 @@ class TrustedSQLiteLocation:
             if not (allow_windows_app_config and in_app_config):
                 raise TrustedSQLiteLocationError(
                     "Cannot verify the Windows DACL for this custom SQLite "
-                    "location; refusing a security-sensitive open."
+                    "credential location; refusing a security-sensitive open."
                 )
         _validate_namespace(canonical)
         if create and not os.path.lexists(canonical):

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -43,14 +43,42 @@ removable media, or a folder someone deliberately loosened is not protected
 against another local principal substituting ``vault.db`` or pre-positioning a
 sidecar **before** startup. Default ACLs already exclude other standard users
 from a user profile, and those three cases are the ones named above as this
-lane's real concerns. Blast radius is picture metadata and file paths, not
-credentials: attacker-controlled paths flowing into export/thumbnail/restore,
-which amplifies reads of files the victim can already read. Compensating
-controls that DO run on Windows: symlink/reparse rejection on every component,
-the regular-file requirement including sidecars, ``O_NOFOLLOW`` plus an
-identity match across the open, and ``verify_after_open``. Revisit when a
-native ACL verifier exists (``win32security.GetNamedSecurityInfo``, or ctypes
-against advapi32), which is the route back to tightening this.
+lane's real concerns.
+
+**Blast radius, stated accurately** (an independent review corrected an earlier
+version of this note that claimed it was reads only):
+
+* The vault is **authorization-bearing**. ``authz/membership.py`` answers
+  "is this picture in that project?" out of the vault, so a substituted vault
+  is a substituted ACL: a scoped share token can be widened to the whole
+  library. The hub authenticates; the vault authorises.
+* ``Picture.file_path`` is attacker-chosen after a substitution, and an
+  absolute path is currently returned verbatim by
+  ``image_utils.resolve_picture_path``. That reaches unattended file **deletes**
+  (snapshot GFS retention, scrapheap purge), sidecar **writes** whose name and
+  suffix come from the row, and file **reads** served over HTTP including the
+  share route. Containing that resolver shrinks this risk on **every** platform
+  and is tracked separately — it is the fix that actually matters.
+* Live credentials are not here: the password hash and token hashes are in the
+  hub. The vault does hold ``guest_session.cookie_token`` and dormant
+  ``user``/``usertoken`` tables the baseline still creates.
+
+*Compensating controls that genuinely run on Windows* — the list is shorter
+than it looks, because ``O_NOFOLLOW`` does not exist there and
+``_require_owned_directory`` returns early on ``nt``, making the ancestor walk
+an existence check rather than a trust check:
+
+1. symlink **and junction** rejection on every component (``_is_redirect``);
+2. the regular-file requirement, on the target and on every sidecar;
+3. the ``(st_dev, st_ino)`` identity match across the open, plus
+   ``verify_after_open``.
+
+Revisit when a native ACL verifier exists (``win32security.GetNamedSecurityInfo``
+or ctypes against advapi32), which is the route back to tightening this.
+
+TODO(owner): this risk has no named owner or revisit date. The reviewer
+declined to accept it on the author's behalf; both must be filled in before
+this is treated as accepted rather than merely documented.
 """
 
 from __future__ import annotations
@@ -105,6 +133,43 @@ def _require_owned_directory(path: str, *, immediate: bool) -> os.stat_result:
     return info
 
 
+def _is_redirect(path: str) -> bool:
+    """True when *path* is a symlink, or a Windows junction.
+
+    ``os.path.islink`` is not sufficient on Windows: it returns **False** for a
+    directory junction, while ``os.path.realpath`` resolves one. Checking only
+    ``islink`` there would refuse the *privileged* redirect and accept the
+    unprivileged one — creating a symlink needs
+    ``SeCreateSymbolicLinkPrivilege`` (admin or Developer Mode), creating a
+    junction needs nothing but write access to the directory (``mklink /J``).
+    That is the redirection primitive an unprivileged local account actually
+    has, so it is the one that matters most here.
+
+    ``os.path.isjunction`` would say this in one call but is 3.12+, and the
+    floor is 3.11 (``pyproject.toml``), so read the reparse tag. The constants
+    and ``st_reparse_tag`` are Windows-only, hence ``getattr``: the tests
+    simulate ``nt`` while running on Linux, where neither exists.
+    """
+    if os.path.islink(path):
+        return True
+    if os.name != "nt":
+        return False
+    tags = {
+        tag
+        for tag in (
+            getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", None),
+            getattr(stat, "IO_REPARSE_TAG_SYMLINK", None),
+        )
+        if tag is not None
+    }
+    try:
+        return getattr(os.lstat(path), "st_reparse_tag", None) in tags
+    except OSError:
+        # A component that does not exist yet cannot redirect anywhere;
+        # `create=True` opens depend on this.
+        return False
+
+
 def _reject_symlinked_path(path: str) -> None:
     """Refuse a caller-supplied path that reaches its target via a symlink.
 
@@ -120,13 +185,18 @@ def _reject_symlinked_path(path: str) -> None:
     names the offending component instead of leaving the caller to infer it.
     A component that does not exist yet is not a symlink; ``create=True`` opens
     rely on that.
+
+    The old comparison did catch one thing a bare ``islink`` walk does not: a
+    Windows **junction**, which ``realpath`` resolves and ``islink`` reports as
+    False. Dropping that would have been a straight downgrade, since a junction
+    is the redirect an unprivileged account can create — see ``_is_redirect``.
     """
     current = path
     while True:
-        if os.path.islink(current):
+        if _is_redirect(current):
             raise TrustedSQLiteLocationError(
-                f"SQLite path {path} reaches its target through a symlink at "
-                f"{current}; refusing to open it."
+                f"SQLite path {path} reaches its target through a symlink or "
+                f"junction at {current}; refusing to open it."
             )
         parent = os.path.dirname(current)
         if parent == current:

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -46,14 +46,22 @@ indistinguishable from tampering when you are watching a directory's mtime.
 
 **Windows, and what this cannot check.** Python exposes neither owner SID nor
 directory DACL portably, so the "another principal cannot write this directory"
-test — POSIX's ``mode & 0o022`` — has no Windows implementation. It was
-substituted with a blanket refusal for anything outside the app config
-directory, and applied to every caller. That made ``Vault.__init__`` raise for
-every path on Windows: the product could not open its library at all, so the
-"control" protected nobody and stopped everybody.
+test — POSIX's ``mode & 0o022`` — has no Windows implementation. An earlier
+revision substituted a blanket refusal of any ``private=True`` open outside
+``user_config_dir("pixlstash")``. That predicate was false for every desktop
+install — the Electron shell derives the hub path from its own config under
+``%APPDATA%\\pixlstash-desktop`` while ``user_config_dir`` resolves under
+``%LOCALAPPDATA%`` — so the server never started on Windows (W6/W7/W18). The
+DACL refusal is gone.
 
-The refusal is therefore scoped to ``private=True`` — the hub, which holds the
-password hash and every token hash and lives in the config directory anyway.
+A ``private=True`` open now requires a mandatory, no-default ``trusted_root``:
+the parent directory the caller derived the hub path from. The only check is
+containment — the canonical file must be inside that root. In correct code the
+containment is tautologically true; the parameter exists so that *forgetting*
+it fails at the first test run instead of silently opting out in production
+(the root cause of W4-W7). It does not second-guess where the owner put the
+hub: the hub is trusted at the root its own configuration placed it, with no
+DACL verification until the native verifier (3c) exists.
 
 *Accepted risk, for the vault.* On Windows a library on a network share,
 removable media, or a folder someone deliberately loosened is not protected
@@ -103,8 +111,6 @@ from __future__ import annotations
 import os
 import stat
 from dataclasses import dataclass
-
-from platformdirs import user_config_dir
 
 from pixlstash.pixl_logging import get_logger
 
@@ -256,8 +262,8 @@ def _validate_file(path: str, *, private: bool) -> os.stat_result:
         # file, so every check below would refuse every file — which is what
         # made both Windows shards fail with "must be mode 600" on a hub this
         # process had just created. The ownership check above is already
-        # POSIX-only for the same reason, and the DACL that does carry the
-        # answer is why `open()` fails closed outside the config directory.
+        # POSIX-only for the same reason; the DACL that does carry the answer
+        # is unreadable from portable Python (module docstring, W17 record).
         return info
     if hasattr(os, "geteuid") and info.st_uid != os.geteuid():
         raise TrustedSQLiteLocationError(
@@ -291,36 +297,37 @@ class TrustedSQLiteLocation:
         *,
         private: bool = False,
         create: bool = False,
-        allow_windows_app_config: bool = False,
+        trusted_root: str | None = None,
     ) -> "TrustedSQLiteLocation":
+        if private and trusted_root is None:
+            raise TypeError(
+                "private=True requires trusted_root=: pass the directory the "
+                "credential store's path was derived from (its own parent). "
+                "See 'Windows, and what this cannot check' in the module "
+                "docstring."
+            )
         absolute = os.path.abspath(os.path.expanduser(path))
         canonical = os.path.realpath(absolute)
         # A canonical path is used for SQLite, but accepting a symlink in the
         # caller-provided path would make the visible target mutable.
         _reject_symlinked_path(absolute)
-        if os.name == "nt" and private:
-            # Python exposes neither owner SID nor directory DACL portably.
-            # Until a native ACL verifier is available, fail closed for a
-            # CREDENTIAL store: the hub holds the password hash and every token
-            # hash, and it lives in PixlStash's own per-user configuration
-            # directory, so requiring that location costs nothing.
-            #
-            # Non-credential opens (the vault: picture metadata, in a folder the
-            # user chose) deliberately do NOT fail closed here. See "Windows,
-            # and what this cannot check" in the module docstring — applying
-            # this to the vault made `Vault.__init__` raise for every path on
-            # Windows, which is not a control, it is an outage.
-            app_config = os.path.realpath(user_config_dir("pixlstash"))
+        if private:
+            # Containment in the root the caller derived the path from. In
+            # correct code this is tautologically true; it exists so a caller
+            # cannot silently opt out of declaring where the credential store
+            # is trusted (the module docstring's W4-W7 root cause). It is not
+            # a policy on where the owner may put the hub.
+            root = os.path.realpath(os.path.abspath(os.path.expanduser(trusted_root)))
             try:
-                in_app_config = (
-                    os.path.commonpath((canonical, app_config)) == app_config
-                )
+                contained = os.path.commonpath((canonical, root)) == root
             except ValueError:
-                in_app_config = False
-            if not (allow_windows_app_config and in_app_config):
+                # Different drives (or mixed absolute/relative on Windows)
+                # share no common path, so the file is not inside the root.
+                contained = False
+            if not contained:
                 raise TrustedSQLiteLocationError(
-                    "Cannot verify the Windows DACL for this custom SQLite "
-                    "credential location; refusing a security-sensitive open."
+                    f"SQLite credential file {canonical} is outside its "
+                    f"trusted root {root}; refusing a security-sensitive open."
                 )
         _validate_namespace(canonical)
         if create and not os.path.lexists(canonical):

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -104,7 +104,11 @@ class Vault:
         logger.debug(f"Image root: {self.image_root}")
         assert self.image_root is not None, "image_root cannot be None"
         logger.debug(f"Using image_root: {self.image_root}")
-        os.makedirs(self.image_root, exist_ok=True)
+        # Mode applies on creation only: makedirs never touches an existing
+        # directory, and it must not — the user may deliberately share their
+        # image folder with a media server or sync agent. (On POSIX the mode
+        # covers only the leaf; pre-existing parents keep their modes.)
+        os.makedirs(self.image_root, mode=0o700, exist_ok=True)
         assert os.path.exists(self.image_root), (
             f"Image root path does not exist: {self.image_root}"
         )

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -8,6 +8,7 @@ import time
 import threading
 import numpy as np
 
+from pathlib import Path
 from typing import Optional
 from concurrent.futures import Future
 
@@ -28,6 +29,7 @@ from .db_models import (
     TAG_SENTINEL_ESCAPE_CHAR,
 )
 from .pixl_logging import get_logger
+from pixlstash.hub.db import _mkdir_private
 from pixlstash.inference.engine import InferenceEngine
 from .utils.image_processing.image_utils import ImageUtils
 from .tasks.face_extraction_task import FaceExtractionTask
@@ -104,11 +106,13 @@ class Vault:
         logger.debug(f"Image root: {self.image_root}")
         assert self.image_root is not None, "image_root cannot be None"
         logger.debug(f"Using image_root: {self.image_root}")
-        # Mode applies on creation only: makedirs never touches an existing
-        # directory, and it must not — the user may deliberately share their
-        # image folder with a media server or sync agent. (On POSIX the mode
-        # covers only the leaf; pre-existing parents keep their modes.)
-        os.makedirs(self.image_root, mode=0o700, exist_ok=True)
+        # Creation only: existing directories keep their modes, whatever they
+        # are — the user may deliberately share their image folder with a media
+        # server or sync agent. Not makedirs(mode=0o700): since Python 3.7 that
+        # mode reaches only the LEAF, so intermediates of a deep new image_root
+        # came out 0775 under Ubuntu's umask 002 and the guarded open then
+        # refused the namespace the app itself had just created (W21).
+        _mkdir_private(Path(self.image_root))
         assert os.path.exists(self.image_root), (
             f"Image root path does not exist: {self.image_root}"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,15 @@ Pytest configuration and fixtures for test suite.
 import gc
 import json
 import math
+import os
 import socket
 import statistics
+import tempfile
 import warnings
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+import pytest
 from _pytest.config.exceptions import UsageError
 from fastapi.testclient import TestClient
 from pixlstash.server import Server
@@ -43,6 +46,36 @@ _TEST_DURATIONS_PATH = Path(__file__).resolve().parent / "ci_test_durations.json
 # 648 tests on one shard against ~153 on each of the others. The load was
 # balanced and the count was absurd, and the count is not free either.
 _PER_TEST_OVERHEAD_SECONDS = 0.005
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _windows_temp_is_a_trusted_hub_location():
+    """Let Windows tests open a hub from a temporary directory.
+
+    ``TrustedSQLiteLocation`` cannot verify a Windows DACL from Python, so it
+    fails closed for every location outside PixlStash's own per-user config
+    directory (``trusted_sqlite.py``, the ``os.name == "nt"`` branch). That is
+    the right production policy and this does not change it — but it means no
+    test that builds a ``Server`` under ``tmp_path`` can open its hub on
+    Windows, which is every such test.
+
+    So for the duration of a Windows test session, the system temp directory is
+    the config directory. Nothing here runs on POSIX, where the real ownership
+    and mode checks are exercised as written, and nothing production reads this.
+    """
+    if os.name != "nt":
+        yield
+        return
+
+    from pixlstash import trusted_sqlite
+
+    temp_root = os.path.realpath(tempfile.gettempdir())
+    original = trusted_sqlite.user_config_dir
+    trusted_sqlite.user_config_dir = lambda *_args, **_kwargs: temp_root
+    try:
+        yield
+    finally:
+        trusted_sqlite.user_config_dir = original
 
 
 def _normalize_test_path(path: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,15 +5,12 @@ Pytest configuration and fixtures for test suite.
 import gc
 import json
 import math
-import os
 import socket
 import statistics
-import tempfile
 import warnings
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-import pytest
 from _pytest.config.exceptions import UsageError
 from fastapi.testclient import TestClient
 from pixlstash.server import Server
@@ -46,36 +43,6 @@ _TEST_DURATIONS_PATH = Path(__file__).resolve().parent / "ci_test_durations.json
 # 648 tests on one shard against ~153 on each of the others. The load was
 # balanced and the count was absurd, and the count is not free either.
 _PER_TEST_OVERHEAD_SECONDS = 0.005
-
-
-@pytest.fixture(autouse=True, scope="session")
-def _windows_temp_is_a_trusted_hub_location():
-    """Let Windows tests open a hub from a temporary directory.
-
-    ``TrustedSQLiteLocation`` cannot verify a Windows DACL from Python, so it
-    fails closed for every location outside PixlStash's own per-user config
-    directory (``trusted_sqlite.py``, the ``os.name == "nt"`` branch). That is
-    the right production policy and this does not change it — but it means no
-    test that builds a ``Server`` under ``tmp_path`` can open its hub on
-    Windows, which is every such test.
-
-    So for the duration of a Windows test session, the system temp directory is
-    the config directory. Nothing here runs on POSIX, where the real ownership
-    and mode checks are exercised as written, and nothing production reads this.
-    """
-    if os.name != "nt":
-        yield
-        return
-
-    from pixlstash import trusted_sqlite
-
-    temp_root = os.path.realpath(tempfile.gettempdir())
-    original = trusted_sqlite.user_config_dir
-    trusted_sqlite.user_config_dir = lambda *_args, **_kwargs: temp_root
-    try:
-        yield
-    finally:
-        trusted_sqlite.user_config_dir = original
 
 
 def _normalize_test_path(path: str):

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -60,7 +60,7 @@ def test_logout_clears_session():
         resp = client.get("/check-session")
         assert resp.status_code == 401
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -72,7 +72,7 @@ def test_check_session_unauthenticated():
         resp = client.get("/check-session")
         assert resp.status_code == 401
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -96,7 +96,7 @@ def test_api_token_lifecycle():
         assert resp.status_code == 200
         assert not any(t["id"] == token_id for t in resp.json())
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -108,7 +108,7 @@ def test_get_user_config():
         assert resp.status_code == 200
         assert isinstance(resp.json(), dict)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -123,7 +123,7 @@ def test_patch_user_config():
         assert resp.status_code == 200
         assert resp.json().get("theme_mode") == "dark"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -144,7 +144,7 @@ def test_initial_telemetry_choice_is_one_atomic_config_patch():
         for key, value in choice.items():
             assert config[key] is value
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -177,7 +177,7 @@ def test_decline_then_delayed_opt_in_stays_out_of_new_cohort(monkeypatch):
         assert opt_in.status_code == 200
         assert marked == [server.server_config_path]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -198,7 +198,7 @@ def test_patch_user_config_penalised_tags_wakes_workers_without_error():
         assert penalised.get("artifact") == 3
         assert penalised.get("blurry") == 3
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -236,7 +236,7 @@ def test_smart_score_stats_refresh_after_picture_change_event():
         assert second_map.get("Unscored", 0) == 0
         assert second_map.get("4-5", 0) >= 1
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -316,7 +316,7 @@ def test_get_watch_folders():
         assert "watch_folders" in data
         assert isinstance(data["watch_folders"], list)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -332,7 +332,7 @@ def test_get_sort_mechanisms():
         stack_time = next(item for item in data if item["key"] == "STACK_UPDATED_AT")
         assert stack_time["description"] == "Recently changed stacks"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -352,7 +352,7 @@ def test_sort_stability():
         ids2 = [p["id"] for p in resp2.json()]
         assert ids1 == ids2
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -373,7 +373,7 @@ def test_filter_pictures_by_tag():
         assert len(pics) == 1
         assert pics[0]["id"] == pic_id
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -389,7 +389,7 @@ def test_picture_metadata_fields():
         assert data.get("id") == pic_id
         assert "format" in data
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -403,7 +403,7 @@ def test_thumbnail_returns_image():
         assert resp.status_code == 200
         assert "image" in resp.headers.get("content-type", "")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -431,7 +431,7 @@ def test_add_remove_tag_to_picture():
         tags_after = resp.json().get("tags", [])
         assert not any(t["tag"] == "mytesttag" for t in tags_after)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -450,7 +450,7 @@ def test_patch_picture_with_tags_key_does_not_500():
         tags = client.get(f"/pictures/{pic_id}/tags").json().get("tags", [])
         assert {t["tag"] for t in tags} == {"alpha", "beta"}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -469,7 +469,7 @@ def test_get_all_tags_with_counts():
         assert matching, "Expected tag not found in /tags response"
         assert matching[0]["count"] >= 1
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -493,7 +493,7 @@ def test_bulk_tag_fetch():
         assert pic_id1 in returned_ids
         assert pic_id2 in returned_ids
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -510,6 +510,6 @@ def test_patch_picture_score():
         assert resp.status_code == 200
         assert resp.json()["score"] == 7
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -761,7 +761,7 @@ def built_app():
     try:
         yield server.api
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 

--- a/tests/test_authz_library_pin.py
+++ b/tests/test_authz_library_pin.py
@@ -149,9 +149,22 @@ class TestPinnedRoutes:
             vault_reads = []
             real_read = server.vault.db.run_immediate_read_task
 
-            def observed_read(*args, **kwargs):
-                vault_reads.append(True)
-                return real_read(*args, **kwargs)
+            # Record WHAT was read, not merely that something was. The vault
+            # has other readers: the WorkPlanner thread probes it for pending
+            # work every few seconds (QualityTask.count_missing_quality,
+            # MissingLikenessFinder._likeness_state, and siblings), and those
+            # probes have nothing to do with this request. A bare
+            # "nothing was read" assertion therefore fails on any machine slow
+            # enough for one to land inside the request — which is what CI is:
+            # this call took 0.63 s there and collected 15 unrelated reads.
+            #
+            # The claim under test is the one in the name: the guest lookup
+            # never ran. `_lookup_by_token` is the same sentinel
+            # test_writer_waits_for_request_paused_in_guest_lookup keys on, and
+            # that test waits for it, so a rename cannot quietly defang this.
+            def observed_read(callback, *args, **kwargs):
+                vault_reads.append(getattr(callback, "__name__", repr(callback)))
+                return real_read(callback, *args, **kwargs)
 
             monkeypatch.setattr(
                 server.vault.db, "run_immediate_read_task", observed_read
@@ -162,7 +175,9 @@ class TestPinnedRoutes:
                 cookies={"guest_session": "plausible-cookie"},
             )
             assert response.status_code == 403
-            assert vault_reads == []
+            assert "_lookup_by_token" not in vault_reads, (
+                f"the guest vault lookup ran before the pin refused: {vault_reads}"
+            )
 
     def test_writer_waits_for_request_paused_in_guest_lookup(
         self, server, tmp_path, monkeypatch

--- a/tests/test_characters_api.py
+++ b/tests/test_characters_api.py
@@ -39,7 +39,7 @@ def test_create_character():
         assert char["name"] == "Alice"
         assert char["id"] is not None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -55,7 +55,7 @@ def test_get_character_by_id():
         assert resp.json()["id"] == char_id
         assert resp.json()["name"] == "Bob"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -81,7 +81,7 @@ def test_patch_character_name_and_description():
         assert resp.status_code == 200
         assert resp.json()["name"] == "Charles"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -101,7 +101,7 @@ def test_delete_character_returns_success():
         if resp.status_code == 200:
             assert resp.json() is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -116,7 +116,7 @@ def test_character_reference_pictures_empty_without_faces():
         assert resp.status_code == 200
         assert resp.json()["reference_picture_ids"] == []
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -127,7 +127,7 @@ def test_delete_nonexistent_character_returns_404():
         resp = client.delete("/characters/99999")
         assert resp.status_code == 404
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -153,7 +153,7 @@ def test_get_characters_filtered_by_numeric_project_id():
         assert "InProject" in names
         assert "NotInProject" not in names
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -179,7 +179,7 @@ def test_get_characters_filtered_by_unassigned():
         assert "Unassigned" in names
         assert "Assigned" not in names
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -190,7 +190,7 @@ def test_get_characters_invalid_project_id_returns_400():
         resp = client.get("/characters?project_id=not-a-number")
         assert resp.status_code == 400
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -259,7 +259,7 @@ def test_character_scoped_token_may_not_filter_by_project():
         assert resp.status_code == 200, resp.text
         assert char_id in [c["id"] for c in resp.json()]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -335,7 +335,7 @@ def test_moving_character_to_new_project_disassociates_pictures_from_old():
         assert pic_id in _project_picture_ids(client, project_b)
         assert pic_id not in _project_picture_ids(client, project_a)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -383,7 +383,7 @@ def test_moving_character_keeps_pictures_shared_with_another_character_in_old_pr
         assert pic_id in _project_picture_ids(client, project_b)
         assert pic_id in _project_picture_ids(client, project_a)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -408,6 +408,6 @@ def test_batch_character_membership_returns_assignments():
         assert data["character_assignments"] == {str(char_id): [pic_id]}
         assert data["pictures_with_faces"] == [pic_id]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_dedup_mixed_stacks.py
+++ b/tests/test_dedup_mixed_stacks.py
@@ -207,7 +207,7 @@ def _env():
 
 
 def _teardown(temp_dir, server):
-    server.vault.close()
+    server.close()
     temp_dir.cleanup()
     gc.collect()
 

--- a/tests/test_dedup_sweep_api.py
+++ b/tests/test_dedup_sweep_api.py
@@ -163,7 +163,7 @@ def _env():
 
 
 def _teardown(temp_dir, server):
-    server.vault.close()
+    server.close()
     temp_dir.cleanup()
     gc.collect()
 

--- a/tests/test_dedup_sweep_service.py
+++ b/tests/test_dedup_sweep_service.py
@@ -55,7 +55,7 @@ def server():
     try:
         yield srv
     finally:
-        srv.vault.close()
+        srv.close()
         temp_dir.cleanup()
         gc.collect()
 

--- a/tests/test_dedup_tier_service.py
+++ b/tests/test_dedup_tier_service.py
@@ -79,7 +79,7 @@ def server():
     try:
         yield srv
     finally:
-        srv.vault.close()
+        srv.close()
         temp_dir.cleanup()
         gc.collect()
 

--- a/tests/test_dedup_tiers_api.py
+++ b/tests/test_dedup_tiers_api.py
@@ -142,7 +142,7 @@ def _env():
 
 
 def _teardown(temp_dir, server):
-    server.vault.close()
+    server.close()
     temp_dir.cleanup()
     gc.collect()
 

--- a/tests/test_dedup_verdict_service.py
+++ b/tests/test_dedup_verdict_service.py
@@ -62,7 +62,7 @@ def server():
     try:
         yield srv
     finally:
-        srv.vault.close()
+        srv.close()
         temp_dir.cleanup()
         gc.collect()
 

--- a/tests/test_export_api.py
+++ b/tests/test_export_api.py
@@ -84,7 +84,7 @@ def test_pictures_export_produces_valid_zip():
         buf = BytesIO(resp.content)
         assert zipfile.is_zipfile(buf)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -105,7 +105,7 @@ def test_project_export_produces_valid_zip():
             names = zf.namelist()
         assert any("project.json" in n for n in names)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -164,6 +164,6 @@ def test_export_status_unknown_task_returns_404():
         )
         assert resp.status_code == 404
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -22,6 +22,7 @@ from pixlstash.hub.bootstrap import (
 )
 from pixlstash.hub.db import HubDatabase, HubPermissionError
 from pixlstash.hub.registry import LibraryRegistry, read_vault_uuid
+from pixlstash.vault import Vault
 
 
 def make_vault(folder, *, username="owner", password_hash="a-real-hash", tokens=1):
@@ -251,6 +252,47 @@ class TestFreshInstall:
             hub.close()
         finally:
             os.umask(0o022)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_fresh_image_root_and_vault_db_are_private_under_a_group_umask(
+        self, tmp_path
+    ):
+        """A fresh unregistered vault must be private under umask 002.
+
+        Two creations under one umask: ``Vault.__init__`` makes the image_root
+        (0775 with the default makedirs mode), and — via the unguarded
+        no-hub branch — a ``VaultDatabase`` whose file SQLite would otherwise
+        create at 0664. Both must come out owner-only.
+        """
+        old_umask = os.umask(0o002)
+        try:
+            image_root = tmp_path / "fresh-root"
+            with Vault(str(image_root), disable_background_workers=True):
+                pass
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(os.lstat(image_root).st_mode) == 0o700
+        assert stat.S_IMODE(os.lstat(image_root / "vault.db").st_mode) == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_an_existing_loose_image_root_keeps_its_mode(self, tmp_path):
+        """Creation-only: the user's own shared folder is never tightened.
+
+        A deliberately group-accessible image_root (shared with a media server
+        or sync agent) must keep its mode across ``Vault.__init__``; only
+        directories the vault actually creates are 0700.
+        """
+        image_root = tmp_path / "shared-root"
+        image_root.mkdir()
+        os.chmod(image_root, 0o775)
+
+        with Vault(str(image_root), disable_background_workers=True):
+            pass
+
+        assert stat.S_IMODE(os.lstat(image_root).st_mode) == 0o775
+        # The database inside it is still ours alone.
+        assert stat.S_IMODE(os.lstat(image_root / "vault.db").st_mode) == 0o600
 
     def test_existing_loose_hub_directory_is_reported_not_silently_repaired(
         self, tmp_path

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -1192,6 +1192,51 @@ def _assert_portable_identity_absent(path, marker):
 
 
 class TestPortableIdentityScrub:
+    def test_every_fsynced_fd_is_opened_with_write_access(self, tmp_path, monkeypatch):
+        """Windows refuses to fsync a read-only handle (EBADF).
+
+        CommitFileBuffers requires write access, so an ``O_RDONLY`` fd that is
+        later fsynced works on Linux and fails on Windows — which is how the
+        read-only opens in this module took down every test in backend-windows
+        shard 2, through ``finalize_library_connection`` on every registered
+        vault open. Linux cannot reproduce the EBADF, but it can assert the
+        invariant that prevents it: any fd this module fsyncs must have been
+        opened with write access. (Directory fds are exempt; those helpers
+        already return early on ``nt``.)
+        """
+        from pixlstash.services import portable_identity
+
+        marker = "FSYNC-FLAGS-PROBE"
+        path = tmp_path / "vault.db"
+        connection = _make_portable_identity_db(path, marker)
+
+        readonly_fds = set()
+        real_open = os.open
+
+        def observing_open(target, flags, *args, **kwargs):
+            fd = real_open(target, flags, *args, **kwargs)
+            if not os.path.isdir(target) and (flags & os.O_ACCMODE) == os.O_RDONLY:
+                readonly_fds.add(fd)
+            return fd
+
+        fsynced_readonly = []
+        real_fsync = os.fsync
+
+        def observing_fsync(fd):
+            if fd in readonly_fds:
+                fsynced_readonly.append(fd)
+            return real_fsync(fd)
+
+        monkeypatch.setattr(os, "open", observing_open)
+        monkeypatch.setattr(os, "fsync", observing_fsync)
+
+        portable_identity.sanitize_vault_connection(connection, str(path))
+        connection.close()
+
+        assert fsynced_readonly == [], "fsync on a read-only fd raises EBADF on Windows"
+        # The scrub itself must still have done its job (the other direction).
+        _assert_portable_identity_absent(path, marker)
+
     def test_live_scrub_erases_rows_wal_and_plaintext_markers(self, tmp_path):
         from pixlstash.services.portable_identity import sanitize_vault_connection
 

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -263,7 +263,13 @@ class TestFreshInstall:
         """
         os.chmod(tmp_path, 0o700)
         parent = tmp_path / "loose"
-        parent.mkdir(mode=0o775)
+        parent.mkdir()
+        # chmod, not mkdir(mode=): the mode argument is masked by the process
+        # umask, so 0o775 lands as 0o755 wherever the umask is 022 — which is
+        # the GitHub runner default. The directory then is not group-writable,
+        # nothing is loose, and the test failed with "DID NOT RAISE" for the
+        # one reason that is not a defect in the code under test.
+        os.chmod(parent, 0o775)
 
         with pytest.raises(HubPermissionError, match="group/world-writable"):
             HubDatabase(str(parent / "hub.db"))

--- a/tests/test_hub_bootstrap.py
+++ b/tests/test_hub_bootstrap.py
@@ -22,6 +22,7 @@ from pixlstash.hub.bootstrap import (
 )
 from pixlstash.hub.db import HubDatabase, HubPermissionError
 from pixlstash.hub.registry import LibraryRegistry, read_vault_uuid
+from pixlstash.trusted_sqlite import TrustedSQLiteLocation, TrustedSQLiteLocationError
 from pixlstash.vault import Vault
 
 
@@ -293,6 +294,58 @@ class TestFreshInstall:
         assert stat.S_IMODE(os.lstat(image_root).st_mode) == 0o775
         # The database inside it is still ours alone.
         assert stat.S_IMODE(os.lstat(image_root / "vault.db").st_mode) == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_a_deep_fresh_image_root_is_private_at_every_created_component(
+        self, tmp_path
+    ):
+        """W21: ``makedirs(mode=)`` reaches only the leaf since Python 3.7.
+
+        A two-level-deep new image_root under umask 002 used to leave the
+        intermediate at 0775, and ``_validate_namespace`` then refused the
+        namespace the app itself had just created. Every created component
+        must be 0700 and the guarded open must accept the result.
+        """
+        old_umask = os.umask(0o002)
+        try:
+            os.chmod(tmp_path, 0o700)
+            image_root = tmp_path / "deep" / "nested"
+            with Vault(str(image_root), disable_background_workers=True):
+                pass
+        finally:
+            os.umask(old_umask)
+
+        for directory in (image_root.parent, image_root):
+            mode = stat.S_IMODE(os.lstat(directory).st_mode)
+            assert mode == 0o700, f"{directory} is {oct(mode)}, expected 0o700"
+        TrustedSQLiteLocation.open(str(image_root / "vault.db")).close()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_a_loose_existing_ancestor_is_kept_and_still_refused(self, tmp_path):
+        """Creation only: the fix never chmods a directory the owner already had.
+
+        The loose ancestor keeps its 0775 (owner's folder, owner's business),
+        and the guarded open goes on refusing the namespace — that refusal is
+        pre-existing behaviour, asserted here so the fix cannot drift into
+        repairing directories it did not create.
+        """
+        os.chmod(tmp_path, 0o700)
+        loose = tmp_path / "loose"
+        loose.mkdir()
+        os.chmod(loose, 0o775)
+
+        old_umask = os.umask(0o002)
+        try:
+            image_root = loose / "new-library"
+            with Vault(str(image_root), disable_background_workers=True):
+                pass
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(os.lstat(loose).st_mode) == 0o775
+        assert stat.S_IMODE(os.lstat(image_root).st_mode) == 0o700
+        with pytest.raises(TrustedSQLiteLocationError, match="group/world-writable"):
+            TrustedSQLiteLocation.open(str(image_root / "vault.db"))
 
     def test_existing_loose_hub_directory_is_reported_not_silently_repaired(
         self, tmp_path

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -7,6 +7,7 @@ the claim the hub schema's shape exists to support.
 """
 
 import os
+import re
 import sqlite3
 import stat
 import threading
@@ -600,6 +601,168 @@ class TestWindowsHasNoModeBits:
 
         with pytest.raises(HubPermissionError):
             check_file_mode(str(path), repair=False)
+
+
+class TestHostileSidecarRefusal:
+    """W8: a pre-positioned ``-wal``/``-shm``/``-journal`` must be refused.
+
+    An attacker with directory write never touches ``hub.db``: they write
+    ``hub.db-wal``. SQLite replays that WAL on open and it overrides arbitrary
+    pages of the main database. The main file's ``(st_dev, st_ino)`` is
+    unchanged, no symlink is involved, and ``S_ISREG`` is true on both files,
+    so the identity and redirection checks all pass. The only refusal is the
+    sidecar loop in :meth:`TrustedSQLiteLocation.open`, which runs
+    ``_validate_file`` on every existing sidecar.
+
+    Two traps these tests are built to avoid, per the signed plan:
+
+    * The refusal must come from ``TrustedSQLiteLocation.open()``, BEFORE any
+      ``sqlite3.connect``: ``HubDatabase`` calls ``verify_after_open()`` only
+      *after* connecting, when SQLite has already replayed the hostile WAL.
+    * The directory must be self-owned and 0700, and the hostility must live
+      in the sidecar's own attributes. A loose *directory* is refused by
+      ``_validate_namespace`` first, so the naive test goes green off the
+      wrong control and proves nothing about the sidecar check. For the same
+      reason the foreign-uid case fakes the sidecar's ``st_uid`` rather than
+      monkeypatching ``os.geteuid``: a faked geteuid flips the directory- and
+      main-file ownership checks first, and the test would keep passing with
+      the sidecar loop deleted.
+
+    RESIDUE: Windows, where this attack matters most, is NOT covered here
+    and cannot be: ``_validate_file`` returns unconditionally on ``nt``
+    because ``st_mode``/``st_uid`` are synthesised there (W2), so under the
+    suite's ``nt`` simulation there is no sidecar check to exercise or to
+    break. The last test below asserts that acceptance so the gap stays
+    visible. Closing it requires the native DACL verifier (plan item 3c,
+    ctypes ``GetNamedSecurityInfoW``); tracked in the W17 accepted-risk
+    record, owner lindkvis, revisit 2026-11-08.
+    """
+
+    @staticmethod
+    def _hub_with_sidecar(tmp_path, suffix, mode):
+        """A migrated hub in a self-owned 0700 directory, plus one sidecar."""
+        directory = tmp_path / "hub"
+        directory.mkdir(mode=0o700)
+        path = str(directory / "hub.db")
+        HubDatabase(path).close()
+        # Drop whatever sidecars SQLite left behind so the one under test is
+        # the only one present.
+        for leftover in trusted_sqlite._SIDECAR_SUFFIXES:
+            if os.path.lexists(path + leftover):
+                os.remove(path + leftover)
+        sidecar = path + suffix
+        with open(sidecar, "wb") as handle:
+            handle.write(b"hostile frames")
+        os.chmod(sidecar, mode)
+        return path, sidecar
+
+    @pytest.mark.parametrize("suffix", trusted_sqlite._SIDECAR_SUFFIXES)
+    def test_a_loose_mode_sidecar_is_refused_by_the_guard(self, tmp_path, suffix):
+        """Mode 0o666 on the sidecar alone must refuse the open.
+
+        The error must name the sidecar: a refusal naming the directory or the
+        main file would mean a different control fired and this attack is
+        still uncovered.
+        """
+        path, sidecar = self._hub_with_sidecar(tmp_path, suffix, 0o666)
+
+        with pytest.raises(TrustedSQLiteLocationError, match=re.escape(sidecar)):
+            TrustedSQLiteLocation.open(path, private=True)
+
+    @pytest.mark.parametrize("suffix", trusted_sqlite._SIDECAR_SUFFIXES)
+    def test_the_refusal_happens_before_sqlite_connects(
+        self, tmp_path, monkeypatch, suffix
+    ):
+        """SQLite must never see the path: replay happens inside connect().
+
+        Asserting that ``verify_after_open`` raises would be theatre; by then
+        the hostile WAL is already in the database. Zero connect calls is the
+        property that matters.
+        """
+        path, _sidecar = self._hub_with_sidecar(tmp_path, suffix, 0o666)
+        real_connect = sqlite3.connect
+        connects = []
+
+        def spying_connect(database, *args, **kwargs):
+            connects.append(str(database))
+            return real_connect(database, *args, **kwargs)
+
+        monkeypatch.setattr(sqlite3, "connect", spying_connect)
+
+        with pytest.raises(HubPermissionError):
+            HubDatabase(path)
+
+        assert connects == []
+
+    @pytest.mark.parametrize("suffix", trusted_sqlite._SIDECAR_SUFFIXES)
+    def test_a_foreign_owned_sidecar_is_refused(self, tmp_path, monkeypatch, suffix):
+        """A 0600 sidecar owned by someone else must still be refused.
+
+        The foreign uid is faked on the sidecar's ``lstat`` result (the
+        attacker's artifact), not via ``os.geteuid``, for the reason in the
+        class docstring.
+        """
+        path, sidecar = self._hub_with_sidecar(tmp_path, suffix, 0o600)
+        real_lstat = os.lstat
+
+        class _ForeignOwnerStat:
+            def __init__(self, info):
+                self._info = info
+                self.st_uid = info.st_uid + 1
+
+            def __getattr__(self, name):
+                return getattr(self._info, name)
+
+        monkeypatch.setattr(
+            os,
+            "lstat",
+            lambda p, *a, **k: (
+                _ForeignOwnerStat(real_lstat(p, *a, **k))
+                if str(p) == sidecar
+                else real_lstat(p, *a, **k)
+            ),
+        )
+
+        with pytest.raises(TrustedSQLiteLocationError, match="not this user"):
+            TrustedSQLiteLocation.open(path, private=True)
+
+    @pytest.mark.parametrize("suffix", trusted_sqlite._SIDECAR_SUFFIXES)
+    def test_a_self_owned_0600_sidecar_still_opens(self, tmp_path, suffix):
+        """The other direction: refusing our own sidecars breaks every WAL DB."""
+        path, _sidecar = self._hub_with_sidecar(tmp_path, suffix, 0o600)
+
+        TrustedSQLiteLocation.open(path, private=True).close()
+
+    def test_sqlites_own_live_sidecars_still_open_end_to_end(self, tmp_path):
+        """With a live WAL connection holding real ``-wal``/``-shm`` files, a
+        guard open and a full second HubDatabase open must both succeed."""
+        directory = tmp_path / "hub"
+        directory.mkdir(mode=0o700)
+        path = str(directory / "hub.db")
+        first = HubDatabase(path)
+        try:
+            assert os.path.exists(path + "-wal")
+
+            TrustedSQLiteLocation.open(path, private=True).close()
+            HubDatabase(path).close()
+        finally:
+            first.close()
+
+    def test_windows_accepts_the_sidecar_it_cannot_judge(self, tmp_path, monkeypatch):
+        """On ``nt`` a hostile-looking sidecar is ACCEPTED, asserted rather than hidden.
+
+        ``st_mode`` there is synthesised (0o666 for any writable file) and
+        ``st_uid`` is meaningless, so ``_validate_file`` returns before either
+        check (W2). This pins the residue described in the class docstring: if
+        someone adds a real Windows sidecar check (plan item 3c), this test
+        fails and gets replaced by real coverage.
+        """
+        sidecar = tmp_path / "hub.db-wal"
+        sidecar.write_bytes(b"hostile frames")
+        os.chmod(sidecar, 0o666)
+        monkeypatch.setattr(os, "name", "nt")
+
+        _validate_file(str(sidecar), private=True)
 
 
 class TestAuthServiceOnTheHub:

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -619,6 +619,13 @@ class TestWindowsHasNoModeBits:
 class TestHostileSidecarRefusal:
     """W8: a pre-positioned ``-wal``/``-shm``/``-journal`` must be refused.
 
+    One tolerance, pinned by ``test_a_sidecar_that_vanishes_mid_validation…``:
+    a sidecar that disappears between the existence probe and its ``lstat`` is
+    a concurrent opener's transient journal, not an attack, and must not
+    refuse the open (it failed 1-in-20 four-opener races in CI before the
+    tolerance existed). A hostile sidecar that still exists is refused
+    exactly as the rest of this class asserts.
+
     An attacker with directory write never touches ``hub.db``: they write
     ``hub.db-wal``. SQLite replays that WAL on open and it overrides arbitrary
     pages of the main database. The main file's ``(st_dev, st_ino)`` is
@@ -784,6 +791,36 @@ class TestHostileSidecarRefusal:
         monkeypatch.setattr(os, "name", "nt")
 
         _validate_file(str(sidecar), private=True)
+
+    def test_a_sidecar_that_vanishes_mid_validation_does_not_refuse_the_open(
+        self, tmp_path, monkeypatch
+    ):
+        """The 1-in-20 CI race, made deterministic.
+
+        A concurrent opener's SQLite creates and deletes a transient
+        ``-journal`` during first migration. When it vanished between the
+        ``lexists`` probe and ``_validate_file``'s ``lstat``, the resulting
+        FileNotFoundError was wrapped as "Could not inspect" and the healthy
+        opener was refused — concurrency mistaken for tampering, the same
+        class the creation-race test pins. Simulated here by making the probe
+        claim the journal exists when it does not.
+        """
+        directory = tmp_path / "hub"
+        directory.mkdir(mode=0o700)
+        path = str(directory / "hub.db")
+        journal = path + "-journal"
+        real_lexists = os.path.lexists
+
+        monkeypatch.setattr(
+            os.path,
+            "lexists",
+            lambda p: True if str(p) == journal else real_lexists(p),
+        )
+
+        guard = TrustedSQLiteLocation.open(
+            path, private=True, create=True, trusted_root=str(directory)
+        )
+        guard.close()
 
 
 class TestAuthServiceOnTheHub:

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -239,6 +239,45 @@ class TestHubFileSecurity:
             f"{failures[:3]}"
         )
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_a_lost_creation_race_is_logged_and_the_winner_still_opens(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Losing the create race to a legitimate file is loud, not silent.
+
+        The file appears between the ``lexists`` probe and the ``O_EXCL``
+        create. A self-owned 0600 winner must still open (the positive
+        direction), and the lost race must leave a warning in the log rather
+        than an ``except: pass``.
+        """
+        path = tmp_path / "hub.db"
+        os.close(os.open(path, os.O_RDWR | os.O_CREAT, 0o600))
+        monkeypatch.setattr(os.path, "lexists", lambda _p: False)
+
+        with caplog.at_level("WARNING", logger="pixlstash.trusted_sqlite"):
+            guard = TrustedSQLiteLocation.open(str(path), private=True, create=True)
+        guard.close()
+
+        assert any(
+            "Lost the creation race" in record.message for record in caplog.records
+        )
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_a_hostile_file_that_wins_the_creation_race_is_still_refused(
+        self, tmp_path, monkeypatch
+    ):
+        """The logged race branch must fall through to validation, not accept.
+
+        A loose-mode file that won the race is exactly what the old silent
+        ``pass`` could have hidden; ``_validate_file`` must still refuse it.
+        """
+        path = tmp_path / "hub.db"
+        os.close(os.open(path, os.O_RDWR | os.O_CREAT, 0o644))
+        monkeypatch.setattr(os.path, "lexists", lambda _p: False)
+
+        with pytest.raises(TrustedSQLiteLocationError, match="mode 600"):
+            TrustedSQLiteLocation.open(str(path), private=True, create=True)
+
     def test_path_replacement_during_sqlite_open_is_refused_before_schema_writes(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -446,6 +446,54 @@ class TestTrustedPathSymlinkCheck:
         )
         guard.close()
 
+    def test_a_windows_junction_is_refused_like_a_symlink(self, tmp_path, monkeypatch):
+        """The regression an independent review caught in this very check.
+
+        ``os.path.islink`` is False for a directory junction, so swapping the
+        old ``abspath != realpath`` comparison for an islink walk quietly
+        stopped refusing them. That is the wrong way round: a symlink on
+        Windows needs ``SeCreateSymbolicLinkPrivilege``, a junction needs only
+        write access to the directory, so the check was refusing the redirect
+        an attacker cannot make and accepting the one they can.
+
+        No junction can exist on Linux, so the reparse tag is simulated. A real
+        ``mklink /J`` test belongs on the Windows lane; this at least fails on
+        the Linux lane if the branch is deleted.
+        """
+        directory = tmp_path / "hub"
+        directory.mkdir(mode=0o700)
+        target = str(directory / "hub.db")
+        mount_point_tag = 0xA0000003  # IO_REPARSE_TAG_MOUNT_POINT
+
+        real_lstat = os.lstat
+
+        class _JunctionStat:
+            def __init__(self, info):
+                self._info = info
+                self.st_reparse_tag = mount_point_tag
+
+            def __getattr__(self, name):
+                return getattr(self._info, name)
+
+        monkeypatch.setattr(os, "name", "nt")
+        # raising=False: the constant is Windows-only, so it does not exist to
+        # be replaced on the machine running this test.
+        monkeypatch.setattr(
+            stat, "IO_REPARSE_TAG_MOUNT_POINT", mount_point_tag, raising=False
+        )
+        monkeypatch.setattr(
+            os,
+            "lstat",
+            lambda p, *a, **k: (
+                _JunctionStat(real_lstat(p, *a, **k))
+                if str(p) == str(directory)
+                else real_lstat(p, *a, **k)
+            ),
+        )
+
+        with pytest.raises(TrustedSQLiteLocationError, match="junction"):
+            _reject_symlinked_path(target)
+
     def test_the_verdict_never_consults_realpath(self, tmp_path, monkeypatch):
         """No 8.3 name exists on Linux, so assert the cause, not the symptom.
 

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -18,13 +18,14 @@ from pixlstash.auth import AuthService
 from pixlstash.db_models import User
 from pixlstash.db_models.user_token import UserToken
 from pixlstash.hub.db import HubDatabase
-from pixlstash.hub.db import HubPermissionError
+from pixlstash.hub.db import HubPermissionError, check_file_mode
 from pixlstash.hub.engine import HubEngine
 from pixlstash import trusted_sqlite
 from pixlstash.trusted_sqlite import (
     TrustedSQLiteLocation,
     TrustedSQLiteLocationError,
     _reject_symlinked_path,
+    _validate_file,
 )
 
 
@@ -442,6 +443,54 @@ class TestTrustedPathSymlinkCheck:
         monkeypatch.setattr(os.path, "realpath", explode)
 
         _reject_symlinked_path(str(directory / "hub.db"))
+
+
+class TestWindowsHasNoModeBits:
+    """POSIX permission assertions must not run where they cannot hold.
+
+    Windows synthesises ``st_mode`` from the read-only attribute alone, so an
+    ordinary file reads 0o666 and no chmod can make it 0o600. Asserting the
+    mode there refuses *every* hub, including one this process created moments
+    earlier — which is how both Windows shards failed with "SQLite credential
+    file ... must be mode 600" on a freshly created file.
+
+    Both directions, because these are credential-file checks: they must go on
+    holding on POSIX, where the bits are real.
+    """
+
+    def test_validate_file_accepts_the_synthetic_windows_mode(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "hub.db"
+        path.touch()
+        os.chmod(path, 0o666)
+        monkeypatch.setattr(os, "name", "nt")
+
+        _validate_file(str(path), private=True)
+
+    def test_validate_file_still_refuses_that_mode_on_posix(self, tmp_path):
+        path = tmp_path / "hub.db"
+        path.touch()
+        os.chmod(path, 0o666)
+
+        with pytest.raises(TrustedSQLiteLocationError, match="mode 600"):
+            _validate_file(str(path), private=True)
+
+    def test_check_file_mode_is_a_no_op_on_windows(self, tmp_path, monkeypatch):
+        path = tmp_path / "hub.db"
+        path.touch()
+        os.chmod(path, 0o666)
+        monkeypatch.setattr(os, "name", "nt")
+
+        check_file_mode(str(path), repair=False)
+
+    def test_check_file_mode_still_reports_a_loose_hub_on_posix(self, tmp_path):
+        path = tmp_path / "hub.db"
+        path.touch()
+        os.chmod(path, 0o666)
+
+        with pytest.raises(HubPermissionError):
+            check_file_mode(str(path), repair=False)
 
 
 class TestAuthServiceOnTheHub:

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -256,7 +256,9 @@ class TestHubFileSecurity:
         monkeypatch.setattr(os.path, "lexists", lambda _p: False)
 
         with caplog.at_level("WARNING", logger="pixlstash.trusted_sqlite"):
-            guard = TrustedSQLiteLocation.open(str(path), private=True, create=True)
+            guard = TrustedSQLiteLocation.open(
+                str(path), private=True, create=True, trusted_root=str(tmp_path)
+            )
         guard.close()
 
         assert any(
@@ -277,7 +279,9 @@ class TestHubFileSecurity:
         monkeypatch.setattr(os.path, "lexists", lambda _p: False)
 
         with pytest.raises(TrustedSQLiteLocationError, match="mode 600"):
-            TrustedSQLiteLocation.open(str(path), private=True, create=True)
+            TrustedSQLiteLocation.open(
+                str(path), private=True, create=True, trusted_root=str(tmp_path)
+            )
 
     def test_path_replacement_during_sqlite_open_is_refused_before_schema_writes(
         self, tmp_path, monkeypatch
@@ -369,7 +373,9 @@ class TestHubFileSecurity:
         directory = tmp_path / "hub"
         directory.mkdir(mode=0o700)
         path = str(directory / "hub.db")
-        guard = TrustedSQLiteLocation.open(path, private=True, create=True)
+        guard = TrustedSQLiteLocation.open(
+            path, private=True, create=True, trusted_root=str(directory)
+        )
         try:
             guard.verify_after_open()  # clean while the directory is private
 
@@ -402,7 +408,9 @@ class TestTrustedPathSymlinkCheck:
         link.symlink_to(real, target_is_directory=True)
 
         with pytest.raises(TrustedSQLiteLocationError, match="symlink"):
-            TrustedSQLiteLocation.open(str(link / "hub.db"), private=True, create=True)
+            TrustedSQLiteLocation.open(
+                str(link / "hub.db"), private=True, create=True, trusted_root=str(link)
+            )
 
     def test_a_symlinked_file_is_still_refused(self, tmp_path):
         directory = tmp_path / "hub"
@@ -413,78 +421,83 @@ class TestTrustedPathSymlinkCheck:
         link.symlink_to(target)
 
         with pytest.raises(TrustedSQLiteLocationError, match="symlink"):
-            TrustedSQLiteLocation.open(str(link), private=True)
+            TrustedSQLiteLocation.open(
+                str(link), private=True, trusted_root=str(directory)
+            )
 
     def test_a_windows_vault_outside_the_config_directory_is_allowed(
         self, tmp_path, monkeypatch
     ):
         """The vault's own call shape: not a credential store, so not gated.
 
-        ``vault.py`` opens with ``private=False`` and the default
-        ``allow_windows_app_config=False``. Under the old blanket refusal that
-        combination raised for *every* path on Windows — including inside the
-        config directory, since the flag alone decided — so no Windows install
-        could open its library. Both directions matter here more than usual:
-        the test below must keep failing closed for the credential store.
+        ``vault.py`` opens with ``private=False`` and no ``trusted_root``.
+        Under the old blanket refusal that raised for *every* path on Windows,
+        so no Windows install could open its library (W4). Pin the fix: a
+        non-private open works anywhere the namespace checks allow.
         """
         directory = tmp_path / "library"
         directory.mkdir(mode=0o700)
         monkeypatch.setattr(os, "name", "nt")
-        monkeypatch.setattr(
-            trusted_sqlite, "user_config_dir", lambda *_a, **_k: str(tmp_path / "conf")
-        )
 
         guard = TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
         guard.close()
 
-    def test_a_windows_location_outside_the_config_directory_is_refused(
+    def test_a_windows_hub_at_an_electron_style_path_opens_with_its_own_root(
         self, tmp_path, monkeypatch
     ):
-        """The Windows fail-closed policy had no test at all.
+        """The W6/W7/W18 outage regression.
 
-        It matters more now: the session fixture in conftest points
-        ``user_config_dir`` at the system temp directory so Windows tests can
-        open a hub under ``tmp_path``. That is test scaffolding, and scaffolding
-        that widens a security boundary needs the boundary asserted somewhere or
-        it can be widened further by accident.
+        The desktop shell derives the hub path from ``--server-config`` under
+        ``%APPDATA%\\pixlstash-desktop`` — never inside
+        ``user_config_dir("pixlstash")`` — so the old DACL predicate refused
+        every desktop install and the server could not start on Windows. A
+        private open with ``trusted_root`` set to the hub's own parent must
+        succeed regardless of where that parent is.
+        """
+        appdata = tmp_path / "AppData" / "Roaming" / "pixlstash-desktop"
+        appdata.mkdir(parents=True, mode=0o700)
+        monkeypatch.setattr(os, "name", "nt")
 
-        ``os.name`` is patched rather than skipping off Windows, the same way
-        the fchmod test simulates its platform: a policy asserted only on the
-        lane that already fails is a policy nobody sees.
+        guard = TrustedSQLiteLocation.open(
+            str(appdata / "hub.db"),
+            private=True,
+            create=True,
+            trusted_root=str(appdata),
+        )
+        guard.close()
+
+    def test_a_private_open_without_a_trusted_root_cannot_be_forgotten(self, tmp_path):
+        """W15: forgetting the argument fails the first test run, loudly.
+
+        Every one of W4-W7 was a caller silently opting out of a keyword. The
+        mandatory ``trusted_root`` turns that omission into an immediate
+        ``TypeError`` instead of a production refusal months later.
+        """
+        with pytest.raises(TypeError, match="trusted_root"):
+            TrustedSQLiteLocation.open(
+                str(tmp_path / "hub.db"), private=True, create=True
+            )
+
+    def test_a_private_file_outside_its_trusted_root_is_refused(self, tmp_path):
+        """The containment tautology holds in both directions.
+
+        ``trusted_root`` is derived from the hub path's own parent, so in
+        correct code the check always passes; a caller wiring it to the wrong
+        directory is the only way to get here, and that is a bug worth failing
+        closed on.
         """
         directory = tmp_path / "hub"
         directory.mkdir(mode=0o700)
-        monkeypatch.setattr(os, "name", "nt")
-        monkeypatch.setattr(
-            trusted_sqlite, "user_config_dir", lambda *_a, **_k: str(tmp_path / "conf")
-        )
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir(mode=0o700)
 
-        with pytest.raises(TrustedSQLiteLocationError, match="DACL"):
+        with pytest.raises(TrustedSQLiteLocationError, match="trusted root"):
             TrustedSQLiteLocation.open(
                 str(directory / "hub.db"),
                 private=True,
                 create=True,
-                allow_windows_app_config=True,
+                trusted_root=str(elsewhere),
             )
-
-    def test_a_windows_location_inside_the_config_directory_is_allowed(
-        self, tmp_path, monkeypatch
-    ):
-        """The other direction: over-blocking would lock every Windows user out."""
-        config = tmp_path / "conf"
-        config.mkdir(mode=0o700)
-        monkeypatch.setattr(os, "name", "nt")
-        monkeypatch.setattr(
-            trusted_sqlite, "user_config_dir", lambda *_a, **_k: str(config)
-        )
-
-        guard = TrustedSQLiteLocation.open(
-            str(config / "hub.db"),
-            private=True,
-            create=True,
-            allow_windows_app_config=True,
-        )
-        guard.close()
 
     def test_a_windows_junction_is_refused_like_a_symlink(self, tmp_path, monkeypatch):
         """The regression an independent review caught in this very check.
@@ -667,7 +680,9 @@ class TestHostileSidecarRefusal:
         path, sidecar = self._hub_with_sidecar(tmp_path, suffix, 0o666)
 
         with pytest.raises(TrustedSQLiteLocationError, match=re.escape(sidecar)):
-            TrustedSQLiteLocation.open(path, private=True)
+            TrustedSQLiteLocation.open(
+                path, private=True, trusted_root=os.path.dirname(path)
+            )
 
     @pytest.mark.parametrize("suffix", trusted_sqlite._SIDECAR_SUFFIXES)
     def test_the_refusal_happens_before_sqlite_connects(
@@ -724,14 +739,18 @@ class TestHostileSidecarRefusal:
         )
 
         with pytest.raises(TrustedSQLiteLocationError, match="not this user"):
-            TrustedSQLiteLocation.open(path, private=True)
+            TrustedSQLiteLocation.open(
+                path, private=True, trusted_root=os.path.dirname(path)
+            )
 
     @pytest.mark.parametrize("suffix", trusted_sqlite._SIDECAR_SUFFIXES)
     def test_a_self_owned_0600_sidecar_still_opens(self, tmp_path, suffix):
         """The other direction: refusing our own sidecars breaks every WAL DB."""
         path, _sidecar = self._hub_with_sidecar(tmp_path, suffix, 0o600)
 
-        TrustedSQLiteLocation.open(path, private=True).close()
+        TrustedSQLiteLocation.open(
+            path, private=True, trusted_root=os.path.dirname(path)
+        ).close()
 
     def test_sqlites_own_live_sidecars_still_open_end_to_end(self, tmp_path):
         """With a live WAL connection holding real ``-wal``/``-shm`` files, a
@@ -743,7 +762,9 @@ class TestHostileSidecarRefusal:
         try:
             assert os.path.exists(path + "-wal")
 
-            TrustedSQLiteLocation.open(path, private=True).close()
+            TrustedSQLiteLocation.open(
+                path, private=True, trusted_root=os.path.dirname(path)
+            ).close()
             HubDatabase(path).close()
         finally:
             first.close()

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -23,6 +23,7 @@ from pixlstash.hub.engine import HubEngine
 from pixlstash.trusted_sqlite import (
     TrustedSQLiteLocation,
     TrustedSQLiteLocationError,
+    _reject_symlinked_path,
 )
 
 
@@ -336,6 +337,61 @@ class TestHubFileSecurity:
         finally:
             os.chmod(directory, 0o700)
             guard.close()
+
+
+class TestTrustedPathSymlinkCheck:
+    """What "the caller's path goes through a symlink" is allowed to mean.
+
+    The check used to be ``os.path.abspath(p) != os.path.realpath(p)``. On
+    POSIX those differ only where a symlink was resolved, so it read correctly
+    here — and wrongly on Windows, where ``realpath`` also expands 8.3 short
+    names. ``C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\...`` was rejected as
+    "contains a symlink", taking down every Windows test that opens a hub.
+
+    Both directions, because the refusal is a security control: a genuinely
+    symlinked path must still be refused, and a path that merely canonicalises
+    to a different string must not be.
+    """
+
+    def test_a_symlinked_ancestor_is_still_refused(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir(mode=0o700)
+        link = tmp_path / "via-link"
+        link.symlink_to(real, target_is_directory=True)
+
+        with pytest.raises(TrustedSQLiteLocationError, match="symlink"):
+            TrustedSQLiteLocation.open(str(link / "hub.db"), private=True, create=True)
+
+    def test_a_symlinked_file_is_still_refused(self, tmp_path):
+        directory = tmp_path / "hub"
+        directory.mkdir(mode=0o700)
+        target = directory / "real.db"
+        target.touch(mode=0o600)
+        link = directory / "hub.db"
+        link.symlink_to(target)
+
+        with pytest.raises(TrustedSQLiteLocationError, match="symlink"):
+            TrustedSQLiteLocation.open(str(link), private=True)
+
+    def test_the_verdict_never_consults_realpath(self, tmp_path, monkeypatch):
+        """No 8.3 name exists on Linux, so assert the cause, not the symptom.
+
+        What made the old check wrong on Windows is that it asked ``realpath``
+        a question realpath does not answer: "did this path cross a symlink?"
+        Nothing on POSIX can produce a short name to reproduce that with, so
+        this pins the property instead — the decision does not depend on the
+        canonical spelling at all. ``realpath`` is made to explode; a path with
+        no symlink in it must still be accepted.
+        """
+        directory = tmp_path / "hub"
+        directory.mkdir(mode=0o700)
+
+        def explode(*_args, **_kwargs):
+            raise AssertionError("the symlink verdict must not consult realpath")
+
+        monkeypatch.setattr(os.path, "realpath", explode)
+
+        _reject_symlinked_path(str(directory / "hub.db"))
 
 
 class TestAuthServiceOnTheHub:

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -375,6 +375,28 @@ class TestTrustedPathSymlinkCheck:
         with pytest.raises(TrustedSQLiteLocationError, match="symlink"):
             TrustedSQLiteLocation.open(str(link), private=True)
 
+    def test_a_windows_vault_outside_the_config_directory_is_allowed(
+        self, tmp_path, monkeypatch
+    ):
+        """The vault's own call shape: not a credential store, so not gated.
+
+        ``vault.py`` opens with ``private=False`` and the default
+        ``allow_windows_app_config=False``. Under the old blanket refusal that
+        combination raised for *every* path on Windows — including inside the
+        config directory, since the flag alone decided — so no Windows install
+        could open its library. Both directions matter here more than usual:
+        the test below must keep failing closed for the credential store.
+        """
+        directory = tmp_path / "library"
+        directory.mkdir(mode=0o700)
+        monkeypatch.setattr(os, "name", "nt")
+        monkeypatch.setattr(
+            trusted_sqlite, "user_config_dir", lambda *_a, **_k: str(tmp_path / "conf")
+        )
+
+        guard = TrustedSQLiteLocation.open(str(directory / "vault.db"), create=True)
+        guard.close()
+
     def test_a_windows_location_outside_the_config_directory_is_refused(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -20,6 +20,7 @@ from pixlstash.db_models.user_token import UserToken
 from pixlstash.hub.db import HubDatabase
 from pixlstash.hub.db import HubPermissionError
 from pixlstash.hub.engine import HubEngine
+from pixlstash import trusted_sqlite
 from pixlstash.trusted_sqlite import (
     TrustedSQLiteLocation,
     TrustedSQLiteLocationError,
@@ -372,6 +373,55 @@ class TestTrustedPathSymlinkCheck:
 
         with pytest.raises(TrustedSQLiteLocationError, match="symlink"):
             TrustedSQLiteLocation.open(str(link), private=True)
+
+    def test_a_windows_location_outside_the_config_directory_is_refused(
+        self, tmp_path, monkeypatch
+    ):
+        """The Windows fail-closed policy had no test at all.
+
+        It matters more now: the session fixture in conftest points
+        ``user_config_dir`` at the system temp directory so Windows tests can
+        open a hub under ``tmp_path``. That is test scaffolding, and scaffolding
+        that widens a security boundary needs the boundary asserted somewhere or
+        it can be widened further by accident.
+
+        ``os.name`` is patched rather than skipping off Windows, the same way
+        the fchmod test simulates its platform: a policy asserted only on the
+        lane that already fails is a policy nobody sees.
+        """
+        directory = tmp_path / "hub"
+        directory.mkdir(mode=0o700)
+        monkeypatch.setattr(os, "name", "nt")
+        monkeypatch.setattr(
+            trusted_sqlite, "user_config_dir", lambda *_a, **_k: str(tmp_path / "conf")
+        )
+
+        with pytest.raises(TrustedSQLiteLocationError, match="DACL"):
+            TrustedSQLiteLocation.open(
+                str(directory / "hub.db"),
+                private=True,
+                create=True,
+                allow_windows_app_config=True,
+            )
+
+    def test_a_windows_location_inside_the_config_directory_is_allowed(
+        self, tmp_path, monkeypatch
+    ):
+        """The other direction: over-blocking would lock every Windows user out."""
+        config = tmp_path / "conf"
+        config.mkdir(mode=0o700)
+        monkeypatch.setattr(os, "name", "nt")
+        monkeypatch.setattr(
+            trusted_sqlite, "user_config_dir", lambda *_a, **_k: str(config)
+        )
+
+        guard = TrustedSQLiteLocation.open(
+            str(config / "hub.db"),
+            private=True,
+            create=True,
+            allow_windows_app_config=True,
+        )
+        guard.close()
 
     def test_the_verdict_never_consults_realpath(self, tmp_path, monkeypatch):
         """No 8.3 name exists on Linux, so assert the cause, not the symptom.

--- a/tests/test_hub_registry.py
+++ b/tests/test_hub_registry.py
@@ -26,6 +26,7 @@ from pixlstash.hub.registry import (
 )
 from pixlstash.hub.schema import CURRENT_SCHEMA_VERSION, read_schema_version
 from pixlstash.cli import main as cli_main
+from pixlstash.trusted_sqlite import TrustedSQLiteLocation
 
 
 def make_vault_folder(root, name="library", *, with_credentials=False):
@@ -293,6 +294,28 @@ class TestAttachAndList:
 
         vault_db = os.path.join(library.path, "vault.db")
         assert stat.S_IMODE(os.lstat(vault_db).st_mode) == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_create_makes_every_missing_component_private_under_a_group_umask(
+        self, registry, tmp_path
+    ):
+        """W21 at the registry's own makedirs: intermediates too, not the leaf.
+
+        ``pixlstash libraries create <deep new path>`` on stock Ubuntu (umask
+        002) left the intermediate at 0775 and yielded a library the guarded
+        open refused.
+        """
+        old_umask = os.umask(0o002)
+        try:
+            os.chmod(tmp_path, 0o700)
+            library = registry.create(str(tmp_path / "deep" / "brand-new"))
+        finally:
+            os.umask(old_umask)
+
+        for directory in (tmp_path / "deep", tmp_path / "deep" / "brand-new"):
+            mode = stat.S_IMODE(os.lstat(directory).st_mode)
+            assert mode == 0o700, f"{directory} is {oct(mode)}, expected 0o700"
+        TrustedSQLiteLocation.open(os.path.join(library.path, "vault.db")).close()
 
     def test_unreachable_library_is_listed_and_flagged(self, registry, tmp_path):
         folder = make_vault_folder(tmp_path, "removable")

--- a/tests/test_hub_registry.py
+++ b/tests/test_hub_registry.py
@@ -275,6 +275,25 @@ class TestAttachAndList:
         names = [library.name for library in registry.list_libraries()]
         assert names[0] == "alpha"
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_create_makes_the_vault_db_owner_only_under_a_group_umask(
+        self, registry, tmp_path
+    ):
+        """``registry.create`` is the second unguarded ``VaultDatabase`` site.
+
+        Left to SQLite, the fresh ``vault.db`` would be 0664 under the
+        Debian/Ubuntu umask 002; the pre-create inside ``VaultDatabase`` must
+        cover this call site too, not only ``Vault.__init__``.
+        """
+        old_umask = os.umask(0o002)
+        try:
+            library = registry.create(str(tmp_path / "brand-new"))
+        finally:
+            os.umask(old_umask)
+
+        vault_db = os.path.join(library.path, "vault.db")
+        assert stat.S_IMODE(os.lstat(vault_db).st_mode) == 0o600
+
     def test_unreachable_library_is_listed_and_flagged(self, registry, tmp_path):
         folder = make_vault_folder(tmp_path, "removable")
         library = registry.attach(folder)

--- a/tests/test_image_plugins_api.py
+++ b/tests/test_image_plugins_api.py
@@ -48,7 +48,7 @@ def test_list_plugins_returns_rotate():
         plugin_names = [p["name"] for p in data.get("plugins", [])]
         assert "rotate" in plugin_names
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -88,7 +88,7 @@ def test_rotate_plugin_swaps_dimensions():
             assert new_meta.get("width") == orig_height
             assert new_meta.get("height") == orig_width
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -103,7 +103,7 @@ def test_run_plugin_with_unknown_name_returns_404():
         )
         assert resp.status_code == 404
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -117,6 +117,6 @@ def test_run_plugin_without_picture_ids_returns_400():
         )
         assert resp.status_code == 400
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_impossible_clear_authz.py
+++ b/tests/test_impossible_clear_authz.py
@@ -148,7 +148,7 @@ def test_scoped_read_token_cannot_clear_or_restore():
         assert r.status_code == 403, r.text
         assert _FACE_TAG in _tags(server, pic_a)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -175,7 +175,7 @@ def test_owner_can_clear_and_restore():
         assert r.json()["restored"] == 1
         assert _FACE_TAG in _tags(server, pic_a)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -191,6 +191,6 @@ def test_clear_rejects_invalid_filter_set():
         assert r.status_code == 400, r.text
         assert _FACE_TAG in _tags(server, pic_a)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_keep_cover_only.py
+++ b/tests/test_keep_cover_only.py
@@ -218,7 +218,7 @@ def _scoped_token(client, server, picture_id: int) -> str:
 
 
 def _teardown(temp_dir, server):
-    server.vault.close()
+    server.close()
     temp_dir.cleanup()
     gc.collect()
 

--- a/tests/test_label_ledger.py
+++ b/tests/test_label_ledger.py
@@ -122,7 +122,7 @@ def test_confirm_records_pos_and_snapshots_prediction():
         assert lmv == "epoch-50"
         assert abs(lconf - 0.88) < 1e-6
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -143,7 +143,7 @@ def test_reject_records_neg_and_snapshots_prediction():
         assert lmv == "epoch-50"
         assert abs(lconf - 0.92) < 1e-6
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -171,7 +171,7 @@ def test_manual_remove_records_neg_that_survives_lost_tag():
         )
         assert _ledger(server, pic_id, "malformed hand")[:2] == ("NEG", "human")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -185,7 +185,7 @@ def test_manual_add_of_content_tag_is_not_recorded():
         assert resp.status_code == 200
         assert _ledger(server, pic_id, "beach sunset") is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -201,7 +201,7 @@ def test_accept_remove_suggestion_records_neg():
 
         assert _ledger(server, pic_id, "malformed hand")[:2] == ("NEG", "human")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -217,7 +217,7 @@ def test_dismiss_add_suggestion_records_neg():
 
         assert _ledger(server, pic_id, "bad anatomy")[:2] == ("NEG", "human")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -233,7 +233,7 @@ def test_dismiss_remove_suggestion_records_pos():
 
         assert _ledger(server, pic_id, "malformed hand")[:2] == ("POS", "human")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -251,7 +251,7 @@ def test_reopen_clears_dismiss_ledger():
         assert state == "UNKNOWN"
         assert source is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -271,7 +271,7 @@ def test_tagger_does_not_clobber_human_label():
         tag_prediction_service.delete_tag_predictions(server.vault, pic_id)
         assert _ledger(server, pic_id, "malformed hand")[:2] == ("NEG", "human")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -333,7 +333,7 @@ def test_retag_status_flip_preserves_accepted_human_label():
         # The durable human label is untouched.
         assert _ledger(server, pic_id, "malformed hand")[:2] == ("POS", "human")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -386,7 +386,7 @@ def test_retag_updates_live_confidence_on_confirmed_human_row():
         # The frozen human-label ledger is untouched.
         assert _ledger(server, pic_id, "malformed hand") == ledger_before
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -420,6 +420,6 @@ def test_retag_updates_live_confidence_on_rejected_human_row():
         )
         assert _ledger(server, pic_id, "malformed hand") == ledger_before
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -4,10 +4,13 @@ and on an upgrade from the pre-snapshots (v1.4.1) schema with real data."""
 import contextlib
 import hashlib
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
 import tempfile
+
+from sqlmodel import text
 
 
 _MIGRATIONS_DIR = os.path.join(os.path.dirname(__file__), "..", "pixlstash")
@@ -1090,3 +1093,59 @@ def test_alembic_0094_adds_telemetry_consent_columns_defaulting_off():
             )
         finally:
             conn.close()
+
+
+_E2E_FIXTURE = os.path.join(_PROJECT_ROOT, "test-data", "images", "vault.db")
+
+
+def test_a_populated_library_upgrades_through_the_picture_table_rebuild():
+    """A vault with rows must survive migration 0080's rebuild of ``picture``.
+
+    ``op.batch_alter_table`` is the only way SQLite can drop a column: it
+    copies the table, ``DROP``s the original and renames. The vault engine runs
+    with ``PRAGMA foreign_keys=ON`` (``database.init_database``), so that
+    ``DROP`` raises "FOREIGN KEY constraint failed" as soon as any row
+    references the table — which is every real library, and the committed e2e
+    fixture. It brought the whole `e2e` lane down: the server could not boot.
+
+    A fresh database has nothing referencing ``picture``, so `upgrade head` on
+    an empty file passes either way; only a populated upgrade catches this.
+    The fixture is used because it is the artefact that actually failed, and
+    the e2e job already treats its absence as a coverage failure.
+
+    Goes through ``VaultDatabase`` deliberately: the standalone
+    ``PIXLSTASH_DB_URL`` path builds its engine from ``alembic.ini`` with no
+    connect listener, so FK enforcement is off there and the defect is
+    invisible.
+    """
+    from pixlstash.database import VaultDatabase
+
+    assert os.path.isfile(_E2E_FIXTURE), (
+        f"committed e2e fixture missing at {_E2E_FIXTURE}"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "vault.db")
+        shutil.copyfile(_E2E_FIXTURE, db_path)
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
+            before = conn.execute("SELECT COUNT(*) FROM picture").fetchone()[0]
+        assert before > 0, "fixture must carry pictures for this to mean anything"
+
+        db = VaultDatabase(db_path)
+        try:
+            with contextlib.closing(sqlite3.connect(db_path)) as conn:
+                after = conn.execute("SELECT COUNT(*) FROM picture").fetchone()[0]
+                # The rebuild copies rows; losing them would be the other
+                # failure mode of suspending enforcement around it.
+                assert after == before
+                violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+                assert violations == []
+
+            # Enforcement must be back on for the connection the app then uses;
+            # a suspension that leaked would disable it for the whole session.
+            enabled = db.run_immediate_read_task(
+                lambda session: session.exec(text("PRAGMA foreign_keys")).one()[0]
+            )
+            assert enabled == 1
+        finally:
+            db.close()

--- a/tests/test_multi_project_membership_authz.py
+++ b/tests/test_multi_project_membership_authz.py
@@ -106,7 +106,13 @@ def env():
 
         files = [("file", (n, d, c)) for n, d, c in _good_picture_files()[:2]]
         assert len(files) >= 2, "need >=2 test pictures"
-        st = upload_pictures_and_wait(client, files, timeout_s=30)
+        # 120 s, not 30: this is the first import after a cold Server boot in
+        # this file, and on the shared Windows CI runner that start-up cost
+        # (ONNX session init, thumbnailing) blew a 30 s wall-clock bound while
+        # the import itself was healthy. Same reasoning as the recorded
+        # test_florence skip: a tight wall-clock bound on contended CI hardware
+        # is a flake generator, not a signal.
+        st = upload_pictures_and_wait(client, files, timeout_s=120)
         assert st["status"] == "completed", st
         pic_ids = [p["id"] for p in client.get(f"{API}/pictures").json()]
         assert len(pic_ids) >= 2

--- a/tests/test_openapi_response_schemas.py
+++ b/tests/test_openapi_response_schemas.py
@@ -34,7 +34,7 @@ def _build_schema():
     try:
         return server.api.openapi()
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 

--- a/tests/test_operation_log.py
+++ b/tests/test_operation_log.py
@@ -71,7 +71,7 @@ def _setup():
 
 
 def _teardown(temp_dir, server):
-    server.vault.close()
+    server.close()
     temp_dir.cleanup()
     gc.collect()
 

--- a/tests/test_picture_is_video.py
+++ b/tests/test_picture_is_video.py
@@ -422,7 +422,7 @@ class TestFetchBestPictureId:
                 "lower-scored still image outranks the higher-scored video"
             )
         finally:
-            server.vault.close()
+            server.close()
             temp_dir.cleanup()
             gc.collect()
 
@@ -456,6 +456,6 @@ class TestFetchBestPictureId:
                 "with is_video equal, score must decide"
             )
         finally:
-            server.vault.close()
+            server.close()
             temp_dir.cleanup()
             gc.collect()

--- a/tests/test_picture_set_locking.py
+++ b/tests/test_picture_set_locking.py
@@ -173,7 +173,7 @@ def test_large_lock_lookups_survive_sqlite_variable_ceiling():
         assert set(detail) == set(picture_ids[:3])
         assert {item["id"] for item in detail[picture_ids[1]]} == {set_id}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -196,7 +196,7 @@ def test_large_project_and_stack_routes_survive_sqlite_variable_ceiling():
         assert stack_response.status_code == 200, stack_response.text
         assert set(stack_response.json()["picture_ids"]) == set(picture_ids)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -268,7 +268,7 @@ def test_lock_flag_roundtrips_and_serializes():
         _set_locked(client, set_id, False)
         assert client.get(f"/picture_sets/{set_id}?info=true").json()["locked"] is False
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -320,7 +320,7 @@ def test_locked_set_rejects_field_edits_and_delete():
         delete_resp = client.delete(f"/picture_sets/{set_id}")
         assert delete_resp.status_code == 200, delete_resp.text
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -359,7 +359,7 @@ def test_locked_set_rejects_membership_mutations():
             client.post(f"/picture_sets/{set_id}/members/{pics[1]}").status_code == 200
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -426,7 +426,7 @@ def test_cross_set_picture_label_freeze_and_membership_allowed():
         delete_resp = client.delete(f"/pictures/{pic}")
         assert delete_resp.status_code == 200, delete_resp.text
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -458,7 +458,7 @@ def test_stack_sibling_in_locked_set_blocks_label_edit():
             resp = client.delete(f"/pictures/{target}")
             assert resp.status_code == 423, (target, resp.text)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -494,7 +494,7 @@ def test_bulk_delete_skips_locked_and_reports():
         meta = client.get(f"/pictures/{locked_pic}/metadata").json()
         assert meta["id"] == locked_pic
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -535,7 +535,7 @@ def test_locked_members_endpoint_and_metadata():
         assert free_meta["locked_by_sets"] == []
         assert free_meta["locked"] is False
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -605,7 +605,7 @@ def test_metadata_hides_locked_set_names_from_out_of_scope_token():
             "an in-scope locked set must still be named"
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -632,7 +632,7 @@ def test_review_creation_blocked_on_locked_set():
         )
         assert resp.status_code == 423, resp.text
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -695,7 +695,7 @@ def test_review_decisions_blocked_on_locked_suspect():
         _set_locked(client, set_id, False)
         assert client.post(f"/tag_suggestions/{sid}/accept").status_code == 200
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -766,7 +766,7 @@ def test_scan_excludes_locked_pictures_from_suspects_only():
         assert pic_free in suspect_ids
         assert pic_locked not in suspect_ids
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -798,7 +798,7 @@ def test_reset_tags_and_description_blocked_on_locked_pic():
         _set_locked(client, set_id, False)
         assert client.post(f"/pictures/{pic}/reset_tags").status_code == 200
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -823,7 +823,7 @@ def test_fix_twin_blocked_when_twin_locked():
         _set_locked(client, locked_set, False)
         assert client.post(f"/tag_suggestions/{sid}/fix-twin").status_code == 200
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -844,7 +844,7 @@ def test_swap_blocked_when_suspect_locked():
 
         assert client.post(f"/tag_suggestions/{sid}/swap").status_code == 423
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -865,7 +865,7 @@ def test_reopen_blocked_on_locked_suspect():
 
         assert client.post(f"/tag_suggestions/{sid}/reopen").status_code == 423
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -892,7 +892,7 @@ def test_bulk_accept_skips_locked_rows_and_reports():
         assert locked_pic in resp.json()["skipped_locked"]
         assert free_pic not in resp.json()["skipped_locked"]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -922,7 +922,7 @@ def test_bulk_reopen_skips_locked_rows_and_reports():
         assert locked_pic in body["skipped_locked"]
         assert body["count"] == 1  # only the free row reopened
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -973,7 +973,7 @@ def test_reference_folder_metadata_import_skips_locked():
         tags = {t["tag"] for t in client.get(f"/pictures/{pic}/tags").json()["tags"]}
         assert tags == {"frozen-keep"}, tags
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1020,7 +1020,7 @@ def test_tagger_preserves_locked_confirmed_tags():
         assert locked_tags == {"original"}, locked_tags
         assert free_tags == {"tagger-new"}, free_tags
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1065,7 +1065,7 @@ def test_character_reassignment_preserves_locked_pic_description():
         )
         assert desc == "keepme-frozen"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1130,7 +1130,7 @@ def test_description_regeneration_skips_locked_pic():
         assert descs[0] == "frozen-desc"  # locked: untouched
         assert descs[1] == "regenerated-caption"  # free: regenerated
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1168,7 +1168,7 @@ def test_legacy_suggestion_queue_withholds_locked_pending_rows():
         ).json()
         assert [r["id"] for r in decided] == [decided_id]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1260,7 +1260,7 @@ def test_finders_exclude_stack_sibling_of_locked_member():
             # The over-blocking case: an unrelated picture is still queued.
             assert free_pic in selected, name
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1313,7 +1313,7 @@ def test_stacking_refused_when_it_would_grow_a_locked_set():
         )
         assert stacks == [None, None]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1343,7 +1343,7 @@ def test_stacking_still_works_when_no_locked_set_would_grow():
         assert resp.status_code == 200, resp.text
         assert _set_member_ids(server, locked_id) == {both_a, both_b}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1368,7 +1368,7 @@ def test_comfyui_output_propagation_skips_locked_set():
         assert _set_member_ids(server, locked_id) == {source_pic}
         assert _set_member_ids(server, open_id) == {source_pic, output_pic}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1390,7 +1390,7 @@ def test_comfyui_view_context_assignment_skips_locked_set():
         _assign_pictures_to_view_context(server, [output_pic], open_id, None, None)
         assert _set_member_ids(server, open_id) == {output_pic}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1413,7 +1413,7 @@ def test_image_plugin_output_propagation_skips_locked_set():
         assert _set_member_ids(server, locked_id) == {source_pic}
         assert _set_member_ids(server, open_id) == {source_pic, output_pic}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1493,7 +1493,7 @@ def test_locked_set_refuses_every_route_that_detaches_a_stack_member():
         assert _stack_of(server, frozen) == stack_id
         assert _stack_of(server, sibling) == stack_id
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1526,7 +1526,7 @@ def test_unlocked_stacks_still_split_unstack_and_lose_members():
         assert _stack_of(server, pics[4]) is None
         assert _stack_of(server, pics[5]) is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1589,7 +1589,7 @@ def test_detaching_cannot_be_used_to_escape_a_locked_set():
         )
         assert _stack_of(server, sibling) is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1689,7 +1689,7 @@ def test_a_scrapheaped_locked_member_still_freezes_its_stack_against_detach():
         assert _stack_of(server, live_a) is None
         assert _stack_of(server, frozen) is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1718,6 +1718,6 @@ def test_a_scrapheaped_member_of_an_unlocked_set_never_freezes_the_stack():
         # The dissolve takes the scrapheaped row with it too.
         assert _stack_of(server, heaped) is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_picture_sets.py
+++ b/tests/test_picture_sets.py
@@ -63,7 +63,7 @@ def test_create_and_list_picture_set():
         sets = resp.json()
         assert any(s["id"] == set_id for s in sets)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -84,7 +84,7 @@ def test_get_picture_set_metadata_and_members():
         assert resp.status_code == 200
         assert resp.json()["picture_ids"] == []
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -156,7 +156,7 @@ def test_add_and_remove_picture_from_set():
         resp = client.get(f"/picture_sets/{set_id}/members")
         assert pic_id not in resp.json()["picture_ids"]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -182,7 +182,7 @@ def test_update_and_delete_picture_set():
         resp = client.get(f"/picture_sets/{set_id}?info=true")
         assert resp.status_code == 404
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -261,7 +261,7 @@ def test_reassigning_set_project_reconciles_member_picture_memberships():
         assert metadata_resp.status_code == 200
         assert metadata_resp.json().get("project_id") == project_id
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -321,7 +321,7 @@ def test_moving_set_to_new_project_disassociates_pictures_from_old():
         assert pic_id in _project_picture_ids(client, project_b)
         assert pic_id not in _project_picture_ids(client, project_a)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -360,7 +360,7 @@ def test_moving_set_keeps_pictures_anchored_by_another_set_in_old_project():
         assert pic_id in _project_picture_ids(client, project_b)
         assert pic_id in _project_picture_ids(client, project_a)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -388,7 +388,7 @@ def test_reference_picture_set_created_with_character():
             f"Expected 1 reference set for character, found {len(ref_sets)}"
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -416,7 +416,7 @@ def test_reference_picture_set_unique_per_character():
         assert len(ref_a) == 1, "Reference set for CharA missing or duplicated"
         assert len(ref_b) == 1, "Reference set for CharB missing or duplicated"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -449,7 +449,7 @@ def test_no_duplicate_reference_picture_sets():
         ]
         assert len(ref_sets) >= 1, "No reference picture set found for character name"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -524,7 +524,7 @@ def test_set_view_represents_a_stack_by_its_in_set_member():
         assert leader in all_ids
         assert member not in all_ids
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -590,6 +590,6 @@ def test_members_endpoint_expands_stack_siblings():
         expanded_ids = set(members_expanded_resp.json()["picture_ids"])
         assert pic_a in expanded_ids and pic_b in expanded_ids
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_picture_sets_query_cost.py
+++ b/tests/test_picture_sets_query_cost.py
@@ -153,7 +153,7 @@ def test_query_count_does_not_grow_with_the_number_of_sets():
             f"{large.count} for 10. The per-set loop is back."
         )
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -175,7 +175,7 @@ def test_counts_and_previews_are_unchanged():
             # first three members, in that order.
             assert row["top_picture_ids"] == member_ids[:3]
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -214,7 +214,7 @@ def test_hidden_tags_are_excluded_from_counts_and_previews():
             assert row["top_picture_ids"] == visible[:3]
             assert not set(row["top_picture_ids"]) & hidden
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -248,6 +248,6 @@ def test_set_thumbnail_applies_the_same_hidden_tag_rule():
             "condition is excluding too much"
         )
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()

--- a/tests/test_pictures_stream.py
+++ b/tests/test_pictures_stream.py
@@ -150,7 +150,7 @@ def test_stream_completes_for_small_batch_smaller_than_total():
         # 25 rows at batch_limit=10 -> 3 calls (10, 10, 5 with done=True on 3rd).
         assert calls == 3
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -167,7 +167,7 @@ def test_stream_done_when_total_below_batch_limit():
         assert body["next_offset"] == 5
         _ = ids
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -199,7 +199,7 @@ def test_small_character_stream_emits_its_partial_final_batch(total):
         assert body["next_offset"] == total
         assert sorted(picture["id"] for picture in body["pictures"]) == sorted(ids)
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -245,7 +245,7 @@ def test_small_character_grid_reads_bypass_a_long_writer_slice():
         release_writer.set()
         if writer_future is not None:
             writer_future.result(timeout=2)
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -289,7 +289,7 @@ def test_stream_continues_when_hidden_tag_post_filter_shrinks_batches():
             f"expected 4 stream calls (40 visible rows / batch_limit 10); got {calls}"
         )
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -305,7 +305,7 @@ def test_stream_done_includes_partial_final_batch_smaller_than_limit():
         # 12 rows / batch_limit 10 -> 2 calls (10 + 2 with done=True).
         assert calls == 2
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -319,7 +319,7 @@ def test_count_endpoint_returns_total():
         body = resp.json()
         assert body["count"] == len(ids)
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -342,7 +342,7 @@ def test_count_endpoint_excludes_hidden_tagged_pictures_when_filter_enabled():
         assert body["count"] >= filtered_count
         assert body["count"] <= len(ids)
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -377,6 +377,6 @@ def test_pictures_endpoint_paginates_correctly():
         # 55 pictures / limit 10 → 6 calls (pages of 10,10,10,10,10,5).
         assert calls == 6, f"Expected 6 pages for 55 pictures at limit=10; got {calls}"
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()

--- a/tests/test_project_membership_service.py
+++ b/tests/test_project_membership_service.py
@@ -60,7 +60,7 @@ def server():
     try:
         yield srv
     finally:
-        srv.vault.close()
+        srv.close()
         temp_dir.cleanup()
         gc.collect()
 

--- a/tests/test_projects_api.py
+++ b/tests/test_projects_api.py
@@ -57,7 +57,7 @@ def test_create_and_get_project():
         assert resp.json()["id"] == project_id
         assert resp.json()["name"] == "MyProject"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -73,7 +73,7 @@ def test_list_projects():
         assert isinstance(projects, list)
         assert any(p["name"] == "ListProject" for p in projects)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -92,7 +92,7 @@ def test_update_project():
         assert resp.status_code == 200
         assert resp.json()["name"] == "UpdatedName"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -119,7 +119,7 @@ def test_delete_project_pictures_survive():
         resp = client.get(f"/pictures/{pic_id}/metadata")
         assert resp.status_code == 200
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -142,7 +142,7 @@ def test_assign_pictures_to_project():
         assert resp.status_code == 200
         assert resp.json()["image_count"] >= 1
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -162,7 +162,7 @@ def test_project_export_is_valid_zip():
             names = zf.namelist()
         assert any("project.json" in n for n in names)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -193,7 +193,7 @@ def test_project_attachment_upload_list_delete():
         assert resp.status_code == 200
         assert not any(a["id"] == att_id for a in resp.json())
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -208,7 +208,7 @@ def test_project_get_by_name():
         assert resp.status_code == 200
         assert resp.json()["id"] == project_id
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -220,6 +220,6 @@ def test_project_duplicate_name_rejected():
         resp = client.post("/projects", json={"name": "DupProject"})
         assert resp.status_code == 409
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import sqlite3
+import stat
 import threading
 from datetime import datetime, timedelta, timezone
 import shutil
@@ -36,6 +37,7 @@ from pixlstash.db_models.picture_project import PictureProjectMember
 from pixlstash.db_models.tag import Tag
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.server import Server
+from pixlstash.trusted_sqlite import TrustedSQLiteLocation
 from pixlstash.db_models.user_token import UserToken
 from pixlstash.services import scrapheap_service
 from pixlstash.utils.snapshot_compression import (
@@ -231,6 +233,38 @@ def test_full_restore_reverts_mutation(server):
     assert restored_pic.description == "before", (
         f"Expected description 'before' after restore, got '{restored_pic.description}'"
     )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+def test_full_restore_leaves_live_db_owner_only_under_group_umask(server):
+    """A successful restore must not loosen the live database's mode.
+
+    ``VACUUM INTO`` creates the snapshot at 0644 & ~umask and ``copy2``
+    preserves that mode, so under the Debian/Ubuntu umask 002 the swapped-in
+    ``vault.db`` used to come out group-writable — and the trusted-location
+    check then refused it at the next startup, bricking the library.
+    """
+    _create_file(server, "perm.jpg")
+    pic = _add_picture(server, filename="perm.jpg")
+
+    old_umask = os.umask(0o002)
+    try:
+        cp = server.vault.snapshot_service.create_snapshot("MANUAL")
+        report = server.vault.restore_service.restore_full(cp.id)
+    finally:
+        os.umask(old_umask)
+
+    assert not report.errors, f"Restore errors: {report.errors}"
+    live_db = os.path.join(server.vault.image_root, "vault.db")
+    assert stat.S_IMODE(os.lstat(live_db).st_mode) == 0o600
+
+    # Reopens cleanly: this guard is the exact check that refuses a
+    # group-writable vault.db at the next startup.
+    guard = TrustedSQLiteLocation.open(live_db)
+    guard.close()
+
+    # And the re-created engine still serves reads.
+    assert _get_picture(server, pic.id) is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -235,6 +235,53 @@ def test_full_restore_reverts_mutation(server):
     )
 
 
+def test_the_location_guard_is_released_before_the_restore_swap(server, monkeypatch):
+    """No open guard fd may survive to the ``os.replace`` of ``vault.db``.
+
+    Windows refuses to replace a file the process holds an open handle on
+    (WinError 5), so the guard retained for POSIX lock-lifetime (the WAL
+    split-brain fix) must be released inside the swap's exclusive section,
+    strictly after ``engine.dispose()``. Linux performs that replace happily
+    with the fd open, which is exactly why this regression reached CI: no
+    Linux test could fail on it. This pins the invariant Linux CAN see —
+    at the moment of the replace, the guard is gone.
+    """
+    _create_file(server, "guarded.jpg")
+    _add_picture(server, filename="guarded.jpg", description="x")
+    cp = server.vault.snapshot_service.create_snapshot("MANUAL")
+
+    live_db = server.vault.db._db_path
+    # This fixture's vault takes the unregistered branch (vault.py, no
+    # hub-registered library), which carries NO guard — leaving the test
+    # vacuously green with or without the release (the revert-check caught
+    # that). Arm the guard exactly as a registered-library open does, so the
+    # invariant is exercised against the state the corruption fix created.
+    if server.vault.db._location_guard is None:
+        server.vault.db._location_guard = TrustedSQLiteLocation.open(live_db)
+    assert server.vault.db._location_guard is not None
+
+    guard_state_at_replace = []
+    real_replace = os.replace
+
+    def observing_replace(src, dst, *args, **kwargs):
+        if str(dst) == str(live_db):
+            guard_state_at_replace.append(
+                getattr(server.vault.db, "_location_guard", None)
+            )
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", observing_replace)
+
+    report = server.vault.restore_service.restore_full(cp.id)
+
+    assert not report.errors, f"Restore errors: {report.errors}"
+    assert guard_state_at_replace, "the swap never replaced the live database"
+    assert guard_state_at_replace == [None], (
+        "an open location-guard fd survived to os.replace; "
+        "that is WinError 5 on Windows"
+    )
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
 def test_full_restore_leaves_live_db_owner_only_under_group_umask(server):
     """A successful restore must not loosen the live database's mode.

--- a/tests/test_reviews_api.py
+++ b/tests/test_reviews_api.py
@@ -42,7 +42,7 @@ def _setup():
 
 
 def _teardown(temp_dir, server):
-    server.vault.close()
+    server.close()
     temp_dir.cleanup()
     gc.collect()
 

--- a/tests/test_score_agreement_stats.py
+++ b/tests/test_score_agreement_stats.py
@@ -225,7 +225,7 @@ def test_agreement_places_pictures_in_the_right_cells():
         assert agreement["rated"] == 2
         assert agreement["total"] == 2
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -242,7 +242,7 @@ def test_bucket_boundaries_match_the_smart_score_histogram():
         assert _cell(agreement, 3, "2-3") == 1
         assert _cell(agreement, 3, "1-2") == 0
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -266,7 +266,7 @@ def test_score_zero_and_null_are_both_unrated():
         assert agreement["pearson"] is None
         assert agreement["spearman"] is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -288,7 +288,7 @@ def test_rated_but_unscored_counts_as_rated_yet_is_not_plotted():
         assert agreement["pairs"] == 0
         assert all(cell["count"] == 0 for cell in agreement["cells"])
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -309,7 +309,7 @@ def test_tau_b_is_suppressed_below_the_minimum_pair_count():
         assert agreement["pearson"] is None
         assert agreement["spearman"] is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -346,7 +346,7 @@ def test_matrix_ignores_the_score_filter_it_sets_itself():
         assert score_dist["1"] == 0
         assert score_dist["5"] == 1
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -365,7 +365,7 @@ def test_matrix_ignores_the_smart_score_bucket_filter_it_sets_itself():
         assert _cell(filtered, 1, "1-2") == 1
         assert _cell(filtered, 5, "4-5") == 1
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -389,7 +389,7 @@ def test_matrix_still_honours_other_filters():
         assert _cell(agreement, 1, "1-2") == 0, "the untagged picture is out of scope"
         assert agreement["total"] == 1
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -404,6 +404,6 @@ def test_agreement_is_absent_without_the_picture_include():
         assert resp.status_code == 200
         assert resp.json()["score_agreement"] == {}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_sidebar_counts_query_cost.py
+++ b/tests/test_sidebar_counts_query_cost.py
@@ -243,7 +243,7 @@ def env():
             "picture_ids": picture_ids,
         }
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 

--- a/tests/test_smart_score_consistency.py
+++ b/tests/test_smart_score_consistency.py
@@ -157,7 +157,7 @@ def test_smart_score_consistency():
         assert score_all_p1 > score_all_p2
 
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 

--- a/tests/test_smart_score_invalidation.py
+++ b/tests/test_smart_score_invalidation.py
@@ -196,7 +196,7 @@ def test_adding_penalised_tag_invalidates_and_requeues():
         assert _get_smart_score(server, pic_id) is None
         assert pic_id in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -213,7 +213,7 @@ def test_adding_content_tag_does_not_invalidate():
         assert _get_smart_score(server, pic_id) == 0.5
         assert pic_id not in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -237,7 +237,7 @@ def test_removing_penalised_tag_invalidates():
 
         assert _get_smart_score(server, pic_id) is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -261,7 +261,7 @@ def test_removing_content_tag_does_not_invalidate():
 
         assert _get_smart_score(server, pic_id) == 0.5
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -281,7 +281,7 @@ def test_confirm_penalised_prediction_invalidates():
         assert _get_smart_score(server, pic_id) is None
         assert pic_id in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -336,7 +336,7 @@ def test_confirm_registers_origin_stamped_rescore_refresh():
         ]
         assert edited not in server.vault.interactive_rescore_registry.snapshot()
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -353,7 +353,7 @@ def test_reject_penalised_prediction_invalidates():
 
         assert _get_smart_score(server, pic_id) is None
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -370,7 +370,7 @@ def test_confirm_content_prediction_does_not_invalidate():
 
         assert _get_smart_score(server, pic_id) == 0.5
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -397,7 +397,7 @@ def test_delete_anomaly_prediction_invalidates():
         assert _get_smart_score(server, pic_id) is None
         assert pic_id in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -419,7 +419,7 @@ def test_delete_content_prediction_does_not_invalidate():
         assert _get_smart_score(server, pic_id) == 0.5
         assert pic_id not in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -493,7 +493,7 @@ def test_bulk_tagger_rewrite_invalidates_batch_in_one_statement():
         assert len(smart_score_updates) == 1, smart_score_updates
         assert "IN (" in smart_score_updates[0].replace("\n", " ")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -543,7 +543,7 @@ def test_sub_threshold_model_prediction_is_not_scored():
         )
         assert raw[pic_id]["watermark"] == pytest.approx(0.4)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -566,7 +566,7 @@ def test_above_threshold_model_prediction_is_scored():
             > 0.0
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -591,7 +591,7 @@ def test_human_positive_below_threshold_still_counts():
             > 0.0
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -619,7 +619,7 @@ def test_human_negative_suppresses_even_above_threshold():
             == 0.0
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -663,7 +663,7 @@ def test_unapplied_model_prediction_is_not_scored():
             > 0.0
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -691,7 +691,7 @@ def test_unapplied_prediction_is_dropped_from_the_ungated_signature_too():
         after = server.vault.db.run_task(lambda s: anomaly_state_signature(s, [pic_id]))
         assert before[pic_id] != after[pic_id]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -728,7 +728,7 @@ def test_tagger_rewrite_dropping_anomaly_tag_invalidates_cached_score():
         assert _get_smart_score(server, pic_id) is None
         assert pic_id in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -749,7 +749,7 @@ def test_tagger_rewrite_without_anomaly_change_keeps_cached_score():
         assert _get_smart_score(server, pic_id) == 0.5
         assert pic_id not in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -826,7 +826,7 @@ def test_penalised_tag_config_change_invalidates_only_matching_pictures():
         assert carrier_tag in missing and carrier_pred in missing
         assert bystander not in missing
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -844,7 +844,7 @@ def test_no_weight_change_invalidates_nothing():
         assert cleared == 0
         assert _get_smart_score(server, pic_id) == 0.5
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -871,7 +871,7 @@ def test_patch_config_invalidates_only_pictures_with_the_changed_tag():
         assert _get_smart_score(server, carrier) is None
         assert _get_smart_score(server, bystander) == 0.5
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -927,7 +927,7 @@ def test_invalidate_all_anomaly_scores_clears_only_anomaly_bearing_pictures():
         assert anomaly in missing
         assert content_only not in missing and clean not in missing
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -955,7 +955,7 @@ def test_threshold_offset_change_invalidates_anomaly_scores_via_patch():
         assert _get_smart_score(server, content_only) == 0.5
         assert anomaly in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -979,7 +979,7 @@ def test_identical_threshold_offset_save_is_a_noop():
         assert _get_smart_score(server, pic_id) == 0.5
         assert pic_id not in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1064,7 +1064,7 @@ def test_background_task_scores_and_honours_the_users_penalised_tags():
             "the hardcoded defaults"
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1108,7 +1108,7 @@ def test_persist_leaves_row_null_when_anomaly_state_changed_mid_scoring():
         assert _get_smart_score(server, pic_id) is None
         assert pic_id in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1131,7 +1131,7 @@ def test_persist_writes_score_when_anomaly_state_unchanged():
         assert _get_smart_score(server, pic_id) == 0.5
         assert pic_id not in _find_missing_ids(server)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1223,7 +1223,7 @@ def test_interactive_edit_refreshes_card_without_waiting_for_backfill_drain():
         # The registry self-evicts on consume.
         assert edited not in server.vault.interactive_rescore_registry.snapshot()
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1258,7 +1258,7 @@ def test_full_backfill_emits_once_at_drain_not_per_batch():
         )
         assert events == [{"picture_ids": batch2, "fields": ["smart_score"]}]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1324,7 +1324,7 @@ def test_own_origin_edit_does_not_also_pill_on_drain():
             if "origin_client_id" not in e and edited in e["picture_ids"]
         ]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1375,7 +1375,7 @@ def test_drain_still_fires_for_unregistered_ids_alongside_own_origin():
         bulk = [e for e in events if "origin_client_id" not in e]
         assert bulk == [{"picture_ids": [background], "fields": ["smart_score"]}]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1416,7 +1416,7 @@ def test_cas_skipped_id_is_not_announced_and_stays_registered():
             == "tab-x"
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1474,7 +1474,7 @@ def test_over_cap_demoted_id_falls_back_to_bulk_drain_emit():
         bulk = [e for e in events if "origin_client_id" not in e]
         assert bulk == [{"picture_ids": [demoted], "fields": ["smart_score"]}]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1538,7 +1538,7 @@ def test_persist_writes_batch_as_single_bulk_statement():
         ]
         assert len(score_updates) == 1, score_updates
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1569,7 +1569,7 @@ def test_persist_preserves_metadata_hash():
         h1 = server.vault.db.run_task(lambda s: s.get(Picture, pic_id).metadata_hash)
         assert h1 == h0
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1597,7 +1597,7 @@ def test_persist_excludes_picture_deleted_mid_flight():
         assert persisted == [pic_id]
         assert _get_smart_score(server, pic_id) == 0.5
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
 
 
@@ -1658,5 +1658,5 @@ def test_penalised_tag_change_invalidates_atomically_no_second_task():
         assert DBPriority.LOW not in route_tasks
         assert route_tasks.count(DBPriority.IMMEDIATE) == 1
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -105,7 +105,12 @@ def test_new_snapshot_contains_no_portable_identity_and_is_private(server):
     try:
         snapshot = server.vault.snapshot_service.create_snapshot("MANUAL")
         archive = os.path.join(server.vault.image_root, snapshot.relative_path)
-        assert os.stat(archive).st_mode & 0o777 == 0o600
+        if os.name != "nt":
+            # Windows synthesises st_mode from the read-only attribute (0o666
+            # for any writable file), so no chmod can ever make this hold
+            # there; access is the directory ACL's job. The identity
+            # assertions below are the test's point and run everywhere.
+            assert os.stat(archive).st_mode & 0o777 == 0o600
         with _open_snapshot(server, snapshot) as connection:
             for table in ("user", "usertoken", "guest_session", "guest_score"):
                 assert connection.execute(

--- a/tests/test_stack_state_filter.py
+++ b/tests/test_stack_state_filter.py
@@ -164,7 +164,7 @@ def test_stack_state_stacked_narrows_the_stream():
             ids["member"],
         }
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -179,7 +179,7 @@ def test_stack_state_unstacked_narrows_the_stream():
             ids["settled"],
         }
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -229,7 +229,7 @@ def test_a_stack_whose_only_sibling_is_scrapheaped_is_not_stacked():
         survivor = next(p for p in resp.json()["pictures"] if p["id"] == ids["leader"])
         assert (survivor.get("stack_count") or 0) < 2
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -249,7 +249,7 @@ def test_a_stack_with_two_live_members_is_still_stacked():
             client, "&stack_state=unstacked"
         )
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -265,7 +265,7 @@ def test_stack_state_unresolved_returns_only_undecided_group_members():
         # Nor is a picture the detector never grouped.
         assert ids["leader"] not in got
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -283,7 +283,7 @@ def test_stack_state_absent_returns_everything():
         assert _stream_ids(client) == collapsed
         assert _stream_ids_uncollapsed(client) == set(ids.values())
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -302,7 +302,7 @@ def test_stack_state_counts_match_the_stream():
             assert _count(client, params) == len(_stream_ids(client, params)), state
         assert _count(client) == len(_stream_ids(client))
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()
 
@@ -323,6 +323,6 @@ def test_unrecognised_stack_state_does_not_empty_the_grid():
         # must behave as the absence of the parameter if it ever is.
         assert _stream_ids(client, "&stack_state=all") == unfiltered
     finally:
-        server.vault.close()
+        server.close()
         tmp.cleanup()
         gc.collect()

--- a/tests/test_stacks_api.py
+++ b/tests/test_stacks_api.py
@@ -61,7 +61,7 @@ def test_create_stack_and_list_members():
         data = resp.json()
         assert set(data["picture_ids"]) == {pic_id1, pic_id2}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -82,7 +82,7 @@ def test_get_stack_pictures_in_order():
         assert isinstance(pics, list)
         assert len(pics) == 2
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -106,7 +106,7 @@ def test_stack_member_reorder():
         assert ordered_ids.index(pic_id1) == 1
         assert ordered_ids.index(pic_id2) == 0
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -132,7 +132,7 @@ def test_remove_last_member_auto_deletes_stack():
         resp = client.get(f"/stacks/{stack_id}")
         assert resp.status_code == 404
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -143,7 +143,7 @@ def test_stack_not_found_returns_404():
         resp = client.get("/stacks/99999")
         assert resp.status_code == 404
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -248,7 +248,7 @@ def test_removing_a_member_clears_its_stack_position():
         assert state[picture_ids[0]] == (stack_id, 0)
         assert state[picture_ids[1]] == (stack_id, 1)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -268,7 +268,7 @@ def test_scrapheaped_member_does_not_keep_a_one_live_member_stack_alive():
         )
         assert client.get(f"/stacks/{stack_id}").status_code == 404
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -310,6 +310,6 @@ def test_removing_a_member_records_the_scrapheaped_members_so_undo_restores_them
             "including the members that are in the Scrapheap"
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_stacks_membership.py
+++ b/tests/test_stacks_membership.py
@@ -101,7 +101,7 @@ def test_adding_collapsed_stack_to_project_adds_every_member():
         for pid in ids:
             assert pid in in_project, f"{pid} should be in project (atomic stack add)"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -135,7 +135,7 @@ def test_removing_collapsed_stack_from_project_removes_every_member():
                 f"{pid} should be removed (atomic stack remove)"
             )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -158,7 +158,7 @@ def test_adding_collapsed_stack_to_set_adds_every_member():
         members = _set_member_ids(server, set_id)
         assert members == set(ids), f"all members expected in set, got {members}"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -181,7 +181,7 @@ def test_removing_collapsed_stack_from_set_removes_every_member():
         assert resp.status_code == 200, resp.text
         assert _set_member_ids(server, set_id) == set()
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -255,7 +255,7 @@ def test_dragging_stack_to_character_moves_every_member():
             f"all members should move to new character, got {char_by_pic}"
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -282,6 +282,6 @@ def test_stacking_unions_project_membership():
         for pid in ids:
             assert pid in in_project, f"{pid} should be in project after union"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_stats_api.py
+++ b/tests/test_stats_api.py
@@ -76,7 +76,7 @@ def test_stats_basic_counts():
         assert data["smart_score_distribution"] == []
         assert data["resolution_distribution"] == []
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -102,7 +102,7 @@ def test_stats_tag_filter_reduces_total():
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -133,7 +133,7 @@ def test_stats_score_filter():
         assert resp.status_code == 200
         assert resp.json()["total"] == 2
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -163,7 +163,7 @@ def test_stats_include_picture():
         assert isinstance(data["resolution_distribution"], list)
         assert len(data["resolution_distribution"]) > 0
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -189,7 +189,7 @@ def test_stats_include_cooc():
         assert set(pair["tags"]) == {"cooc_a", "cooc_b"}
         assert pair["count"] == 1
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -211,7 +211,7 @@ def test_stats_include_conf():
         assert isinstance(data["regular_tags"], list)
         assert "conf_tag" in data["regular_tags"]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -242,6 +242,6 @@ def test_stats_cache_expires_after_ttl(monkeypatch):
             "Stats should be recomputed after TTL expires"
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_tag_health_api.py
+++ b/tests/test_tag_health_api.py
@@ -85,7 +85,7 @@ def _setup():
 
 
 def _teardown(temp_dir, server):
-    server.vault.close()
+    server.close()
     temp_dir.cleanup()
     gc.collect()
 

--- a/tests/test_tag_prediction_scope.py
+++ b/tests/test_tag_prediction_scope.py
@@ -98,7 +98,7 @@ def env():
 
         yield server, client, anon, picture_ids, scoped_token
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 

--- a/tests/test_tag_predictions_api.py
+++ b/tests/test_tag_predictions_api.py
@@ -66,7 +66,7 @@ def test_get_tag_predictions_empty():
         assert resp.status_code == 200
         assert resp.json() == []
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -93,7 +93,7 @@ def test_confirm_prediction_adds_tag():
             p["tag"] == "sunny" and p["status"] == "CONFIRMED" for p in confirmed
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -118,7 +118,7 @@ def test_reject_prediction_does_not_add_tag():
         rejected = resp.json()
         assert any(p["tag"] == "rainy" and p["status"] == "REJECTED" for p in rejected)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -136,7 +136,7 @@ def test_delete_tag_predictions():
         assert resp.status_code == 200
         assert resp.json() == []
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -149,7 +149,7 @@ def test_confirm_nonexistent_prediction_returns_404():
         resp = client.post(f"/pictures/{pic_id}/tag_predictions/nonexistenttag/confirm")
         assert resp.status_code == 404
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -175,7 +175,7 @@ def test_label_thresholds_uses_saved_offset_by_default(monkeypatch):
         assert rows["cat"]["effective_threshold"] == 0.5
         assert rows["dog"]["effective_threshold"] == 0.3
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -206,6 +206,6 @@ def test_label_thresholds_offset_query_overrides_saved(monkeypatch):
         resp = client.get("/tagger/label-thresholds", params={"offset": 5})
         assert resp.status_code == 422
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_tag_suggestions_api.py
+++ b/tests/test_tag_suggestions_api.py
@@ -111,7 +111,7 @@ def test_list_ranks_pending_by_score():
         # The file extension is returned so the client can render full-res images.
         assert filtered[0]["picture_ext"] == "png"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -136,7 +136,7 @@ def test_accept_remove_deletes_tag():
         accepted = client.get("/tag_suggestions", params={"status": "ACCEPTED"}).json()
         assert any(r["id"] == sid for r in accepted)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -154,7 +154,7 @@ def test_accept_add_creates_tag():
 
         assert _has_tag(client, pic_id, "bad anatomy")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -178,7 +178,7 @@ def test_reopen_undoes_accepted_remove():
         pending = client.get("/tag_suggestions").json()
         assert any(r["id"] == sid for r in pending)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -237,7 +237,7 @@ def test_fix_twin_tags_the_twin_and_undoes():
         assert not _has_tag(client, twin_id, "malformed hand")
         assert any(r["id"] == sid for r in client.get("/tag_suggestions").json())
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -287,7 +287,7 @@ def test_swap_flips_both_labels_and_undoes():
         assert _has_tag(client, suspect, "malformed hand")
         assert not _has_tag(client, twin, "malformed hand")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -311,7 +311,7 @@ def test_dismiss_leaves_tag_untouched():
         ).json()
         assert any(r["id"] == sid for r in dismissed)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -342,7 +342,7 @@ def test_list_includes_tagger_confidence():
         assert len(rows) == 1
         assert abs(rows[0]["tagger_confidence"] - 0.42) < 1e-6
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -427,7 +427,7 @@ def test_bulk_accept_resolves_when_signals_agree():
         assert reopened["count"] == 1
         assert _has_tag(client, suspect, "malformed hand")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -470,7 +470,7 @@ def test_bulk_accept_dry_run_counts_without_writing():
         assert applied["accepted_ids"] == [sid]
         assert not _has_tag(client, suspect, "malformed hand")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -499,7 +499,7 @@ def test_bulk_accept_skips_when_tagger_contradicts_neighbour():
         assert _has_tag(client, suspect, "malformed hand")
         assert not _has_tag(client, twin, "malformed hand")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -530,7 +530,7 @@ def test_bulk_accept_skips_when_neighbour_vote_is_weak():
         assert low["count"] == 1
         assert not _has_tag(client, suspect, "malformed hand")
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -552,7 +552,7 @@ def test_bulk_accept_adds_tag_when_signals_agree():
         assert _has_tag(client, suspect, "malformed hand")  # missing tag added
         assert _has_tag(client, twin, "malformed hand")  # twin keeps it
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -616,7 +616,7 @@ def test_scan_tag_builds_and_rebuilds_queue():
         rows2 = client.get("/tag_suggestions").json()
         assert len(rows2) == len(rows)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -663,7 +663,7 @@ def test_scan_tag_prefers_perceptual_near_duplicate_twin():
         assert c not in {row["picture_id"], row["twin_picture_id"]}
         assert "dhash hamming" in row["reason"]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -710,7 +710,7 @@ def test_scan_tag_rejects_low_similarity_perceptual_override():
         assert row["twin_sim"] >= tag_scan_service.MIN_DISPLAY_TWIN_SIM
         assert "dhash hamming" not in row["reason"]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -769,7 +769,7 @@ def test_scan_tag_confidence_fallback_for_new_tag():
         # B has no prediction at all, so it must not be surfaced.
         assert b not in {r["picture_id"] for r in rows}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -815,7 +815,7 @@ def test_scan_tag_confidence_fallback_ignores_stale_model_version():
         assert res["count"] == 0
         assert client.get("/tag_suggestions").json() == []
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -869,7 +869,7 @@ def test_scan_tag_confidence_fallback_excludes_human_rejected():
         assert a in picture_ids  # un-reviewed confident candidate still proposed
         assert b not in picture_ids  # human-rejected candidate excluded
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -991,7 +991,7 @@ def test_scan_tag_base_rate_default_thresholds_vs_explicit_override():
         assert rows_after[ids["u"]]["direction"] == "add"
         assert rows_after[ids["t1"]]["direction"] == "remove"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1113,7 +1113,7 @@ def test_scan_tag_base_rate_default_thresholds_majority_tag_regression():
         assert res_regressed["added"] == 0
         assert res_regressed["removed"] == 0
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1125,7 +1125,7 @@ def test_accept_missing_suggestion_returns_404():
         resp = client.post("/tag_suggestions/999999/accept")
         assert resp.status_code == 404
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1258,7 +1258,7 @@ def test_filter_by_project_returns_only_in_project_suspects():
             out_pic,
         }
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1278,7 +1278,7 @@ def test_filter_by_set_returns_only_in_set_suspects():
         rows = client.get("/tag_suggestions", params={"set_id": set_id}).json()
         assert {r["picture_id"] for r in rows} == {in_pic}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1316,7 +1316,7 @@ def test_filter_by_character_numeric_and_unassigned():
         ).json()
         assert {r["picture_id"] for r in rows} == {unassigned_pic}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1346,7 +1346,7 @@ def test_filters_and_together_intersection():
         # Only the picture in BOTH dimensions survives the intersection.
         assert {r["picture_id"] for r in rows} == {both}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1365,7 +1365,7 @@ def test_empty_scope_yields_no_rows_not_error():
         # An unknown id is likewise empty, not an error.
         assert client.get("/tag_suggestions", params={"set_id": 999999}).json() == []
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1435,7 +1435,7 @@ def test_bulk_accept_respects_filter_dry_run_and_apply():
             client, out_suspect, "malformed hand"
         )  # out of scope, untouched
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1507,7 +1507,7 @@ def test_scoped_token_list_only_sees_its_own_suspects():
         rows = bearer.get(f"{API}/tag_suggestions", headers=headers).json()
         assert {r["picture_id"] for r in rows} == {pic_a}
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1529,7 +1529,7 @@ def test_scoped_token_filter_cannot_widen_to_other_set():
         assert rows == []
         assert all(r["picture_id"] != pic_b for r in rows)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1614,7 +1614,7 @@ def test_scoped_token_list_redacts_out_of_scope_twin():
         assert owner_rows[0]["twin_sim"] == 0.97
         assert str(pic_b) in owner_rows[0]["reason"]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1638,7 +1638,7 @@ def test_owner_filter_does_not_redact_own_twin():
         assert rows[0]["twin_picture_id"] == pic_b
         assert str(pic_b) in rows[0]["reason"]
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1734,7 +1734,7 @@ def test_scan_tag_survives_large_picture_ids_scope():
         assert {r["picture_id"] for r in rows} == set(embedded)
         assert all(r["direction"] == "add" for r in rows)
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1810,7 +1810,7 @@ def test_legacy_scan_refreshes_stale_pending_in_place():
             == 1
         )
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -1858,6 +1858,6 @@ def test_accept_refuses_when_a_manual_fix_contradicts_the_suggestion():
         add_sid = _seed_suggestion(server, pic, "malformed hand", "add", source="model")
         assert accept_suggestion(server.vault, add_sid)["direction"] == "add"
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_tagger_runs_api.py
+++ b/tests/test_tagger_runs_api.py
@@ -66,7 +66,7 @@ def test_ingest_lists_and_upserts_runs():
         assert run140["verdict"] == "improved"
         assert abs(run140["anomaly_macro_f1"] - 0.705) < 1e-6
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -77,6 +77,6 @@ def test_ingest_requires_run():
         resp = client.post("/tagger-runs", json={"payload": {"verdict": "improved"}})
         assert resp.status_code == 400
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_thumbnail_cache_headers.py
+++ b/tests/test_thumbnail_cache_headers.py
@@ -193,7 +193,7 @@ def test_character_thumbnail_revalidates_instead_of_going_stale():
         assert conditional.status_code == 304
         assert conditional.content == b""
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -221,6 +221,6 @@ def test_picture_set_thumbnail_revalidates_instead_of_going_stale():
         assert conditional.status_code == 304
         assert conditional.content == b""
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()

--- a/tests/test_workers_api.py
+++ b/tests/test_workers_api.py
@@ -41,7 +41,7 @@ def test_workers_progress_has_expected_keys():
         assert "ram_used_gb" in process
         assert "ram_total_gb" in process
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -68,7 +68,7 @@ def test_an_active_dedup_scan_never_reports_terminal_task_progress(monkeypatch):
         assert snapshot["total"] == 6
         assert snapshot["remaining"] == 1
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()
 
@@ -81,6 +81,6 @@ def test_version_endpoint_returns_200():
         data = resp.json()
         assert "version" in data
     finally:
-        server.vault.close()
+        server.close()
         temp_dir.cleanup()
         gc.collect()


### PR DESCRIPTION
One PR because none of the three can be proved in isolation. `develop` has three unrelated failures at once, so a PR that fixes any one of them still shows red for the other two, and merging on a red check proves nothing. Combined, the run can actually go green.

Each commit stands alone and is separately reviewable. Previously opened as #772, #773 and #774, now closed in favour of this.

---

### 1. `e2e` — the backend cannot start (`5de4d7ae`)

```
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) FOREIGN KEY constraint failed
[SQL: DROP TABLE picture]
Error: Process from config.webServer was not able to start. Exit code: 1
```

`op.batch_alter_table` rebuilds a table by copy-drop-rename, and the vault engine runs `PRAGMA foreign_keys=ON`, so migration 0080 fails on any database holding pictures — the committed e2e fixture (`0049_snapshots`, 111 pictures) and every real library. A **fresh** database has nothing referencing `picture`, which is why `test_alembic_upgrade_head_fresh_db` stayed green throughout. 36 migrations use batch mode, so this is a class, not one migration.

Fixed in `migrations/env.py`, the chokepoint every caller routes through, per SQLite's documented table-rebuild procedure, with `PRAGMA foreign_key_check` afterwards so suspending enforcement cannot mask real damage.

*(This is the fix reviewed in #771. It never reached `develop`: #771 was stacked on #767's branch and merged into it after that branch had already gone to `develop`. Marked merged, never landed. My sequencing error.)*

### 2. `backend shard 1` — `DID NOT RAISE HubPermissionError` (`62316d80`)

The test builds its "loose" directory with `mkdir(mode=0o775)`. That mode is masked by the process umask; runners default to 022, so it lands at **0755**, isn't group-writable, and the code correctly declines to raise. The production code was never wrong — the fixture failed to create the condition it asserts on. It passes on an Ubuntu workstation because the default umask there is 002.

`chmod` isn't umask-masked. Verified: `tests/test_hub_bootstrap.py` is 46 passed under **both** `umask 022` and `umask 002`; before the change it is red under 022 and green under 002, which is exactly the CI-versus-local split.

### 3. `backend shard 3` — `assert [True, True, …] == []` (`948fa47a`)

The production behaviour is correct; the assertion was. The test claimed **nothing in the process** read the vault during the request. Instrumenting the observer with the callable and thread shows all 15 reads come from the WorkPlanner thread probing for work:

```
DURING REQUEST: []
IN THE NEXT 2s: [('WorkPlanner', 'QualityTask.count_missing_quality'),
                 ('WorkPlanner', 'MissingLikenessFinder._likeness_state'), …]
```

The runner's call took 0.63 s, long enough to catch probes; this machine finishes first. Timing-dependent from the day it was written.

Now it observes the guest lookup by name — the claim in the test's own name, and the same `_lookup_by_token` sentinel `test_writer_waits_for_request_paused_in_guest_lookup` waits on, so a rename cannot quietly defang it. Checked it is not vacuous: on the positive path (token matching the **active** library) the same request returns 200 and the observer does record `_lookup_by_token`.

---

## Verification

Each fix was reproduced first and each fails without its change. The full backend gate list is running locally under `umask 022` to match the runner; I will report the result on this PR. `#764` (the #757 sidebar work) is deliberately **not** in here — it is a behaviour change, and it should be validated against a green base rather than bundled into the repair.