### PR TITLE
Contain Picture.file_path at the resolver (#776)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,7 @@ jobs:
           tests/test_multi_project_membership_authz.py
           tests/test_openapi_response_schemas.py
           tests/test_operation_log.py
+          tests/test_path_containment.py
           tests/test_pending_score_invalidation.py
           tests/test_picture_is_video.py
           tests/test_picture_mutation_scope.py

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1128,6 +1128,36 @@ The fix is an additive column, `public_id`: 128 bits of randomness as lowercase 
 - File-based **SQLite** at `{image_root}/vault.db`
 - All writes are serialised through `VaultDatabase`'s task queue (single writer); reads run in parallel.
 
+### Stored path containment (#776)
+
+Paths stored in the database (`Picture.file_path`, sidecar columns,
+`Snapshot.relative_path`) are treated as untrusted — a substituted `vault.db`
+or a restored archive can carry arbitrary values — and are contained before
+they reach the filesystem:
+
+- **`ImageUtils.resolve_picture_path` is the chokepoint for picture paths.**
+  The legitimate root set is `image_root` **plus every configured reference
+  folder** (host-side and path-mapped forms). Each `Vault` registers a lazy
+  provider for its reference-folder roots via
+  `path_utils.register_reference_roots_provider` (cached; refreshed once on a
+  containment miss, so a just-added folder is honoured immediately). A path
+  outside the set resolves to `None` with a logged warning — the value callers
+  already handle for an empty path — so unattended tasks skip the row instead
+  of crashing. Containing against `image_root` alone would refuse real
+  reference-folder libraries; never do that.
+- **Snapshot file paths** (`relative_path` / manifest / hashes) go through
+  `resolve_path_within(vault_root, …)` at every read/delete site (retention
+  prune, snapshot delete, restore, identity scrub); `os.path.join` silently
+  discards the base for an absolute component and must not be used there.
+- **Sidecar write-backs** funnel through `caption_file_utils.writeback_path`,
+  which refuses an image path outside the root set and only honours a recorded
+  `tags_file`/`description_file` value that is exactly the image stem plus a
+  safe suffix.
+
+Both directions are asserted in `tests/test_path_containment.py`: escape is
+refused at each sink, and in-root plus reference-folder pictures keep working
+(over-blocking is its own regression).
+
 ### Hub and library identity
 
 `hub.db` sits beside `server-config.json`, outside every image library. It owns

--- a/pixlstash/routes/reference_folders.py
+++ b/pixlstash/routes/reference_folders.py
@@ -1356,6 +1356,7 @@ def create_router(server) -> APIRouter:
                             SIDECAR_TYPE_TAGS,
                             rf.tags_suffix,
                             pic.tags_file,
+                            image_root=server.vault.image_root,
                         )
                         mtime = (
                             write_sidecar(target, ", ".join(tags))
@@ -1375,6 +1376,7 @@ def create_router(server) -> APIRouter:
                             SIDECAR_TYPE_DESCRIPTION,
                             rf.description_suffix,
                             pic.description_file,
+                            image_root=server.vault.image_root,
                         )
                         mtime = (
                             write_sidecar(target, description)

--- a/pixlstash/services/restore/full_restore.py
+++ b/pixlstash/services/restore/full_restore.py
@@ -39,6 +39,7 @@ from pixlstash.db_models.picture_likeness import (
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.event_types import EventType
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.path_utils import resolve_path_within
 
 from ._models import (
     RestoreInProgressError,
@@ -160,7 +161,7 @@ class FullRestoreMixin:
             Populated RestoreReport.
         """
         cp = self._get_snapshot_or_raise(snapshot_id)
-        abs_snapshot = os.path.join(vault_root, cp.relative_path)
+        abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
         if not os.path.exists(abs_snapshot):
             raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 
@@ -647,7 +648,16 @@ class FullRestoreMixin:
             for snap in live_snapshots:
                 if snap["relative_path"] in existing_snapshot_paths:
                     continue
-                abs_snap = os.path.join(vault_root, snap["relative_path"])
+                try:
+                    abs_snap = resolve_path_within(vault_root, snap["relative_path"])
+                except ValueError as exc:
+                    logger.warning(
+                        "RestoreService: snapshot index row %s points outside "
+                        "the vault root; not re-inserting it after restore: %s",
+                        snap["relative_path"],
+                        exc,
+                    )
+                    continue
                 if not os.path.exists(abs_snap):
                     # File was pruned/deleted since capture — skip rather than
                     # leave a dangling index row pointing at nothing.

--- a/pixlstash/services/restore/preview.py
+++ b/pixlstash/services/restore/preview.py
@@ -32,6 +32,7 @@ from pixlstash.db_models import (
 )
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.path_utils import resolve_path_within
 from pixlstash.utils.snapshot_compression import is_compressed
 
 from ._models import (
@@ -73,7 +74,7 @@ class PreviewMixin:
         """
         vault_root = self._vault.image_root
         cp = self._get_snapshot_or_raise(snapshot_id)
-        abs_snapshot = os.path.join(vault_root, cp.relative_path)
+        abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
         if not os.path.exists(abs_snapshot):
             raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 
@@ -147,7 +148,7 @@ class PreviewMixin:
 
         vault_root = self._vault.image_root
         cp = self._get_snapshot_or_raise(snapshot_id)
-        abs_snapshot = os.path.join(vault_root, cp.relative_path)
+        abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
         if not os.path.exists(abs_snapshot):
             raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 
@@ -216,7 +217,7 @@ class PreviewMixin:
         """
         vault_root = self._vault.image_root
         cp = self._get_snapshot_or_raise(snapshot_id)
-        abs_snapshot = os.path.join(vault_root, cp.relative_path)
+        abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
         if not os.path.exists(abs_snapshot):
             raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 

--- a/pixlstash/services/restore/resource_restore.py
+++ b/pixlstash/services/restore/resource_restore.py
@@ -32,6 +32,7 @@ from pixlstash.db_models import (
 )
 from pixlstash.event_types import EventType
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.path_utils import resolve_path_within
 
 from ._models import (
     MissingDependenciesError,
@@ -108,7 +109,7 @@ class ResourceRestoreMixin:
         try:
             vault_root = self._vault.image_root
             cp = self._get_snapshot_or_raise(snapshot_id)
-            abs_snapshot = os.path.join(vault_root, cp.relative_path)
+            abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
             if not os.path.exists(abs_snapshot):
                 raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 
@@ -202,7 +203,7 @@ class ResourceRestoreMixin:
         try:
             vault_root = self._vault.image_root
             cp = self._get_snapshot_or_raise(snapshot_id)
-            abs_snapshot = os.path.join(vault_root, cp.relative_path)
+            abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
             if not os.path.exists(abs_snapshot):
                 raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 

--- a/pixlstash/services/snapshot_service.py
+++ b/pixlstash/services/snapshot_service.py
@@ -21,6 +21,7 @@ from pixlstash.db_models import Character, Picture, PictureSet, Project
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services.portable_identity import sanitize_vault_file
+from pixlstash.utils.path_utils import resolve_path_within
 from pixlstash.utils.snapshot_compression import (
     COMPRESSED_SUFFIX,
     compress_snapshot,
@@ -279,14 +280,25 @@ class SnapshotService:
             cp = session.get(Snapshot, snapshot_id)
             if cp is None:
                 return False
-            abs_snapshot = os.path.join(vault_root, cp.relative_path)
-            abs_manifest = os.path.join(vault_root, cp.manifest_relative_path)
-            abs_hashes = os.path.join(
-                vault_root, self._hashes_relative_path(cp.manifest_relative_path)
+            rel_paths = (
+                cp.relative_path,
+                cp.manifest_relative_path,
+                self._hashes_relative_path(cp.manifest_relative_path),
             )
             session.delete(cp)
             session.commit()
-            for path in (abs_snapshot, abs_manifest, abs_hashes):
+            for rel_path in rel_paths:
+                try:
+                    path = resolve_path_within(vault_root, rel_path)
+                except ValueError as exc:
+                    logger.warning(
+                        "SnapshotService: refusing to remove snapshot file "
+                        "outside the vault root (snapshot id=%d, rel_path=%s): %s",
+                        snapshot_id,
+                        rel_path,
+                        exc,
+                    )
+                    continue
                 try:
                     if os.path.exists(path):
                         os.remove(path)
@@ -686,7 +698,18 @@ class SnapshotService:
                         cp.manifest_relative_path,
                         self._hashes_relative_path(cp.manifest_relative_path),
                     ):
-                        abs_path = os.path.join(vault_root, rel_path)
+                        try:
+                            abs_path = resolve_path_within(vault_root, rel_path)
+                        except ValueError as exc:
+                            logger.warning(
+                                "SnapshotService: GFS prune refusing to remove "
+                                "a file outside the vault root (snapshot id=%d, "
+                                "rel_path=%s): %s",
+                                cp.id,
+                                rel_path,
+                                exc,
+                            )
+                            continue
                         try:
                             if os.path.exists(abs_path):
                                 os.remove(abs_path)

--- a/pixlstash/tasks/reference_folder_scan_task.py
+++ b/pixlstash/tasks/reference_folder_scan_task.py
@@ -498,7 +498,9 @@ class ReferenceFolderScanTask(BaseTask):
 
         # Export: create the file from the database when there is content to write.
         if sync and export_content:
-            target = writeback_path(file_path, sidecar_type, suffix, None)
+            target = writeback_path(
+                file_path, sidecar_type, suffix, None, image_root=self._db.image_root
+            )
             if target is None:
                 return
             new_mtime = write_sidecar(target, export_content)

--- a/pixlstash/tasks/snapshot_identity_scrub_task.py
+++ b/pixlstash/tasks/snapshot_identity_scrub_task.py
@@ -10,6 +10,7 @@ from pixlstash.services.portable_identity import (
     sanitize_snapshot_archive,
 )
 from pixlstash.tasks.base_task import BaseTask, TaskPriority
+from pixlstash.utils.path_utils import resolve_path_within
 
 logger = get_logger(__name__)
 
@@ -58,7 +59,23 @@ class SnapshotIdentityScrubTask(BaseTask):
 
     def _run_task(self):
         vault_root = self._db.image_root
-        archive = os.path.join(vault_root, self._relative_path)
+        try:
+            archive = resolve_path_within(vault_root, self._relative_path)
+        except ValueError as exc:
+            # A registered archive path outside the vault root is never a file
+            # this task may touch. There is nothing legitimate to scrub there;
+            # record it done so it stops being handed out, exactly like the
+            # missing-archive branch below.
+            logger.error(
+                "SnapshotIdentityScrubTask: snapshot %s is registered at %s, "
+                "which is outside the vault root — refusing to touch it and "
+                "recording it as done: %s",
+                self._snapshot_id,
+                self._relative_path,
+                exc,
+            )
+            self._db.run_task(self._record_scrubbed, None)
+            return
 
         if not os.path.exists(archive):
             # An orphaned row: the snapshot was registered but its archive is

--- a/pixlstash/utils/caption_file_utils.py
+++ b/pixlstash/utils/caption_file_utils.py
@@ -20,6 +20,7 @@ import tempfile
 from collections import Counter
 
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.path_utils import is_allowed_picture_path
 
 logger = get_logger(__name__)
 
@@ -183,19 +184,52 @@ def writeback_path(
     sidecar_type: str,
     configured_suffix: str | None,
     existing_path: str | None,
+    *,
+    image_root: str | None = None,
 ) -> str | None:
     """Return the path to write a sidecar of *sidecar_type* to.
 
     Prefers an already-resolved *existing_path*; otherwise builds one from the
     *configured_suffix* (or the module default for the type).
 
-    Returns ``None`` when the folder's configured suffix is not a usable
-    filename fragment, so a folder configured before the rule was enforced on
-    every write path skips its write-back (logged) instead of raising through
-    the caller and wedging a scan or returning a 500. Callers must handle it.
+    Both inputs that can carry a hostile database value are contained here,
+    at the single chokepoint every sidecar write-back goes through:
+
+    - When *image_root* is given and *image_path* is absolute, it must lie
+      under the library's legitimate roots (image root + reference folders,
+      see ``is_allowed_picture_path``) — a picture row with a fabricated
+      ``file_path`` must not direct a file write elsewhere.
+    - *existing_path* (typically the ``tags_file`` / ``description_file``
+      column, also a database value) is only honoured when it is exactly the
+      image stem plus a safe suffix; anything else is ignored (logged) and the
+      standard suffix-derived path is used instead.
+
+    Returns ``None`` when the write-back must be skipped entirely (contained
+    image path, unusable configured suffix), logged rather than raised so an
+    unattended scan is never wedged. Callers must handle it.
     """
+    if image_root and os.path.isabs(image_path):
+        if not is_allowed_picture_path(image_root, image_path):
+            logger.warning(
+                "Skipping %s sidecar write-back: image path %s is outside "
+                "the library roots (image_root=%s)",
+                sidecar_type,
+                image_path,
+                image_root,
+            )
+            return None
     if existing_path:
-        return existing_path
+        stem = os.path.splitext(image_path)[0]
+        tail = existing_path[len(stem) :] if existing_path.startswith(stem) else ""
+        if tail and is_safe_sidecar_suffix(tail):
+            return existing_path
+        logger.warning(
+            "Ignoring recorded %s sidecar path %r for %s: not the image "
+            "stem plus a safe suffix; using the configured suffix instead",
+            sidecar_type,
+            existing_path,
+            image_path,
+        )
     suffix = configured_suffix or (
         DEFAULT_TAGS_SUFFIX
         if sidecar_type == SIDECAR_TYPE_TAGS

--- a/pixlstash/utils/image_processing/image_utils.py
+++ b/pixlstash/utils/image_processing/image_utils.py
@@ -27,6 +27,7 @@ from pixlstash.pixl_logging import get_logger
 from pixlstash.db_models.picture import Picture
 from pixlstash.utils.comfyui_utilities import extract_comfy_workflow_info
 from pixlstash.utils.image_processing.video_utils import VideoUtils
+from pixlstash.utils.path_utils import is_allowed_picture_path, path_is_within
 
 logger = get_logger(__name__)
 
@@ -139,16 +140,39 @@ class ImageUtils:
         """
         Resolve a stored picture path to an absolute file path.
 
-        If file_path is already absolute it is returned unchanged.
-        If file_path is relative it is joined with image_root.
+        A relative ``file_path`` is joined with ``image_root``; an absolute one
+        is returned as-is.  Either way the result is contained: a stored path
+        that escapes the legitimate roots (the image root plus the configured
+        reference folders, see ``is_allowed_picture_path``) is refused with a
+        logged warning and ``None`` — the same value callers already handle for
+        an empty path — so a hostile database row is skipped, never followed to
+        the filesystem.  Without an ``image_root`` there is no root set to
+        contain against and the legacy passthrough behaviour is kept.
         """
         if not file_path:
             return None
         if os.path.isabs(file_path):
-            return file_path
+            if not image_root or is_allowed_picture_path(image_root, file_path):
+                return file_path
+            logger.warning(
+                "Refusing stored picture path outside the library roots: "
+                "%s (image_root=%s)",
+                file_path,
+                image_root,
+            )
+            return None
         if not image_root:
             return file_path
-        return os.path.join(image_root, file_path)
+        joined = os.path.join(image_root, file_path)
+        if not path_is_within(joined, image_root):
+            logger.warning(
+                "Refusing stored picture path that escapes the image root: "
+                "%s (image_root=%s)",
+                file_path,
+                image_root,
+            )
+            return None
+        return joined
 
     @staticmethod
     def get_thumbnail_path(

--- a/pixlstash/utils/path_utils.py
+++ b/pixlstash/utils/path_utils.py
@@ -1,6 +1,12 @@
 """Path safety utilities for server-side file I/O."""
 
 import os
+import threading
+from typing import Callable, Iterable
+
+from pixlstash.pixl_logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def resolve_path_within(base_dir: str, *segments: str) -> str:
@@ -45,3 +51,131 @@ def resolve_path_within(base_dir: str, *segments: str) -> str:
             f"Path would escape allowed directory: {segments!r} is not within {base_dir!r}"
         )
     return resolved
+
+
+def path_is_within(path: str, base: str) -> bool:
+    """Whether *path* lies within *base*, lexically or after symlink resolution.
+
+    The lexical check (``normpath``) neutralises ``..`` components without
+    resolving symlinks, so a library whose *content* is reached through a
+    symlink is not refused.  The ``realpath`` check then additionally accepts a
+    path spelled through a different alias of the same directory (e.g. a
+    symlinked root).  A symlink planted *inside* an allowed root that points
+    outside it is therefore accepted — planting one requires filesystem write
+    access, which is outside this containment's threat model (a substituted
+    database row).
+    """
+    if not path or not base:
+        return False
+    try:
+        norm_path = os.path.normcase(os.path.normpath(path))
+        norm_base = os.path.normcase(os.path.normpath(base))
+        if os.path.commonpath([norm_path, norm_base]) == norm_base:
+            return True
+        real_path = os.path.normcase(os.path.realpath(path))
+        real_base = os.path.normcase(os.path.realpath(base))
+        return os.path.commonpath([real_path, real_base]) == real_base
+    except ValueError:
+        # Mixed absolute/relative paths or different drives: not within.
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Allowed picture roots
+#
+# A stored ``Picture.file_path`` may legitimately live under the vault's
+# image_root (relative paths) or under any configured reference folder
+# (absolute paths; see the ``reference_folder`` table).  The reference-folder
+# list lives in the database, which ``resolve_picture_path`` cannot query
+# directly, so each Vault registers a provider here keyed by its image_root.
+# Roots are cached; a containment miss triggers one refresh before refusing,
+# so a freshly added reference folder is honoured immediately.
+# ---------------------------------------------------------------------------
+
+_roots_lock = threading.Lock()
+_reference_roots_providers: dict[str, Callable[[], Iterable[str]]] = {}
+_reference_roots_cache: dict[str, tuple[str, ...]] = {}
+
+
+def _roots_key(image_root: str) -> str:
+    return os.path.normcase(os.path.normpath(image_root))
+
+
+def register_reference_roots_provider(
+    image_root: str, provider: Callable[[], Iterable[str]]
+) -> None:
+    """Register *provider* as the source of reference-folder roots for a vault.
+
+    Args:
+        image_root: The vault's image root (the key callers of
+            ``is_allowed_picture_path`` pass).
+        provider: Zero-argument callable returning the current reference-folder
+            root directories.  Called lazily, only when a path is not already
+            under a known root.
+    """
+    key = _roots_key(image_root)
+    with _roots_lock:
+        _reference_roots_providers[key] = provider
+        _reference_roots_cache.pop(key, None)
+
+
+def unregister_reference_roots_provider(
+    image_root: str, provider: Callable[[], Iterable[str]] | None = None
+) -> None:
+    """Remove the provider (and cached roots) registered for *image_root*.
+
+    When *provider* is given, only that exact provider is removed — so a
+    closing vault cannot unhook a newer vault that has since registered for
+    the same image root.
+    """
+    key = _roots_key(image_root)
+    with _roots_lock:
+        # Equality, not identity: bound methods are recreated on each attribute
+        # access, but compare equal when they wrap the same function and object.
+        if provider is not None and _reference_roots_providers.get(key) != provider:
+            return
+        _reference_roots_providers.pop(key, None)
+        _reference_roots_cache.pop(key, None)
+
+
+def is_allowed_picture_path(image_root: str, abs_path: str) -> bool:
+    """Whether *abs_path* lies under the vault's legitimate picture roots.
+
+    The legitimate root set is ``image_root`` plus every configured
+    reference-folder root (both the stored host-side form and its path-mapped
+    container-side form, as supplied by the registered provider).
+
+    Args:
+        image_root: The vault's image root.
+        abs_path: An absolute stored picture path to check.
+
+    Returns:
+        True when the path is contained in a legitimate root.  False when it is
+        not — including when no provider is registered for *image_root*, in
+        which case only ``image_root`` itself is honoured.
+    """
+    if path_is_within(abs_path, image_root):
+        return True
+    key = _roots_key(image_root) if image_root else ""
+    with _roots_lock:
+        cached = _reference_roots_cache.get(key)
+        provider = _reference_roots_providers.get(key)
+    if cached is not None and any(path_is_within(abs_path, root) for root in cached):
+        return True
+    if provider is None:
+        return False
+    try:
+        fresh = tuple(root for root in provider() if root)
+    except Exception as exc:
+        logger.warning(
+            "Could not refresh reference-folder roots for image_root=%s "
+            "while checking %s: %s — the path is refused against the "
+            "last-known roots only",
+            image_root,
+            abs_path,
+            exc,
+        )
+        return False
+    with _roots_lock:
+        _reference_roots_cache[key] = fresh
+    return any(path_is_within(abs_path, root) for root in fresh)

--- a/pixlstash/utils/service/caption_utils.py
+++ b/pixlstash/utils/service/caption_utils.py
@@ -223,7 +223,11 @@ def sync_picture_sidecar(server, pic_id: int) -> list[dict]:
             # existing one (so clearing tags empties it).
             if existing or current_tags:
                 target = writeback_path(
-                    image_path, SIDECAR_TYPE_TAGS, rf.tags_suffix, existing
+                    image_path,
+                    SIDECAR_TYPE_TAGS,
+                    rf.tags_suffix,
+                    existing,
+                    image_root=server.vault.image_root,
                 )
                 new_mtime = (
                     write_sidecar(target, ", ".join(current_tags))
@@ -252,6 +256,7 @@ def sync_picture_sidecar(server, pic_id: int) -> list[dict]:
                     SIDECAR_TYPE_DESCRIPTION,
                     rf.description_suffix,
                     existing,
+                    image_root=server.vault.image_root,
                 )
                 new_mtime = (
                     write_sidecar(target, description) if target is not None else None

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -53,6 +53,10 @@ from pixlstash.services.scrapheap_service import DEFAULT_RETENTION_DAYS
 from pixlstash.services.snapshot_service import SnapshotService
 from pixlstash.services.restore import RestoreService
 from pixlstash.trusted_sqlite import TrustedSQLiteLocation
+from pixlstash.utils.path_utils import (
+    register_reference_roots_provider,
+    unregister_reference_roots_provider,
+)
 
 
 logger = get_logger(__name__)
@@ -145,6 +149,13 @@ class Vault:
         else:
             self.db = VaultDatabase(self._db_path)
         self.set_description(description or "")
+
+        # Containment root set for stored picture paths: resolve_picture_path
+        # refuses any absolute Picture.file_path that is not under image_root
+        # or a configured reference folder. The folder list lives in this
+        # vault's DB, so register a provider for it (queried lazily, cached,
+        # refreshed once on a containment miss). Unregistered in stop().
+        register_reference_roots_provider(self.image_root, self._reference_folder_roots)
 
         self.snapshot_service = SnapshotService(self)
         self.restore_service = RestoreService(self)
@@ -432,6 +443,34 @@ class Vault:
                     exc,
                 )
 
+    def _reference_folder_roots(self) -> list[str]:
+        """Return the reference-folder roots pictures may legitimately live under.
+
+        Each folder contributes its stored (host-side) path and, when a path
+        mapper is configured, its mapped (container-side) form — stored
+        ``Picture.file_path`` values are written under the mapped form in
+        Docker deployments, while the ``reference_folder`` row keeps the host
+        form.
+        """
+        from pixlstash.db_models.reference_folder import ReferenceFolder
+
+        def fetch(session: Session) -> list[str]:
+            return [
+                row.folder
+                for row in session.exec(select(ReferenceFolder)).all()
+                if row.folder
+            ]
+
+        folders = self.db.run_immediate_read_task(fetch)
+        roots: list[str] = []
+        for folder in folders:
+            roots.append(folder)
+            if self._path_mapper is not None:
+                mapped = self._path_mapper.resolve(folder)
+                if mapped != folder:
+                    roots.append(mapped)
+        return roots
+
     def watch_reference_folder(self, folder_id: int, folder_path: str) -> None:
         """Start watching *folder_path* for reference folder *folder_id*.
 
@@ -528,6 +567,9 @@ class Vault:
         Safe to call multiple times; subsequent calls after the first are no-ops.
         Called automatically by ``close()``.
         """
+        unregister_reference_roots_provider(
+            self.image_root, self._reference_folder_roots
+        )
         with self._changed_tags_notify_lock:
             timer = self._changed_tags_flush_timer
             self._changed_tags_flush_timer = None

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -1,0 +1,367 @@
+"""Containment of stored file paths before they reach the filesystem (#776).
+
+A ``Picture.file_path`` (or a snapshot's ``relative_path``) is a database value
+and must be treated as untrusted: a substituted vault DB or restored archive
+can put an arbitrary path in it.  These tests assert BOTH directions at every
+sink:
+
+- a stored path that escapes the legitimate roots (image_root + configured
+  reference folders) is refused at the resolver, the snapshot retention /
+  delete paths, the scrapheap purge delete, the caption sidecar write, and the
+  picture-serving route; and
+- an ordinary in-root path still resolves, is served, and is cleaned up — and,
+  most importantly, a picture under a reference folder OUTSIDE image_root
+  still works (over-blocking would break real libraries).
+"""
+
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+from sqlmodel import delete, select
+
+from pixlstash.db_models import Picture
+from pixlstash.db_models.reference_folder import ReferenceFolder, ReferenceFolderStatus
+from pixlstash.db_models.snapshot import Snapshot
+from pixlstash.server import Server
+from pixlstash.services.scrapheap_service import remove_picture_files
+from pixlstash.utils.caption_file_utils import SIDECAR_TYPE_TAGS, writeback_path
+from pixlstash.utils.image_processing.image_utils import ImageUtils
+from pixlstash.utils.path_utils import (
+    is_allowed_picture_path,
+    register_reference_roots_provider,
+    unregister_reference_roots_provider,
+)
+
+
+@pytest.fixture(scope="module")
+def server():
+    with tempfile.TemporaryDirectory() as tmp:
+        config_path = os.path.join(tmp, "server-config.json")
+        with open(config_path, "w") as fh:
+            json.dump({"disable_background_workers": True}, fh)
+        with Server(server_config_path=config_path) as srv:
+            yield srv
+
+
+@pytest.fixture(scope="module")
+def client(server):
+    client = TestClient(server.api)
+    resp = client.post(
+        "/login", json={"username": "testuser", "password": "testpassword"}
+    )
+    assert resp.status_code == 200
+    return client
+
+
+@pytest.fixture(autouse=True)
+def clean_db(server):
+    def _wipe(session):
+        session.exec(delete(Snapshot))
+        session.exec(delete(Picture))
+        session.exec(delete(ReferenceFolder))
+        session.commit()
+
+    server.vault.db.run_task(_wipe)
+    yield
+    server.vault.db.run_task(_wipe)
+
+
+def _add_picture(server, file_path: str, fmt: str = "png") -> int:
+    def _do(session):
+        pic = Picture(
+            file_path=file_path,
+            format=fmt,
+            original_file_name=os.path.basename(file_path),
+        )
+        session.add(pic)
+        session.commit()
+        return pic.id
+
+    return server.vault.db.run_task(_do)
+
+
+def _add_reference_folder(server, folder: str) -> int:
+    def _do(session):
+        rf = ReferenceFolder(
+            folder=folder, label="ext", status=ReferenceFolderStatus.ACTIVE
+        )
+        session.add(rf)
+        session.commit()
+        return rf.id
+
+    return server.vault.db.run_task(_do)
+
+
+def _write_png(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Image.new("RGB", (8, 8), (200, 30, 30)).save(path, format="PNG")
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_refuses_paths_outside_the_roots(tmp_path):
+    image_root = str(tmp_path / "library")
+    os.makedirs(image_root)
+    outside = tmp_path / "secret.png"
+    outside.write_bytes(b"x")
+    # Absolute path outside every root (no reference folders registered).
+    assert ImageUtils.resolve_picture_path(image_root, str(outside)) is None
+    # Relative traversal out of the image root.
+    assert ImageUtils.resolve_picture_path(image_root, "../secret.png") is None
+
+
+def test_resolver_still_resolves_ordinary_paths(tmp_path):
+    image_root = str(tmp_path / "library")
+    os.makedirs(image_root)
+    assert ImageUtils.resolve_picture_path(image_root, "a/b.png") == os.path.join(
+        image_root, "a/b.png"
+    )
+    in_root = os.path.join(image_root, "c.png")
+    assert ImageUtils.resolve_picture_path(image_root, in_root) == in_root
+
+
+def test_resolver_allows_registered_reference_folder_roots(tmp_path):
+    image_root = str(tmp_path / "library")
+    ref_root = str(tmp_path / "external-refs")
+    os.makedirs(image_root)
+    os.makedirs(ref_root)
+    provider = lambda: [ref_root]  # noqa: E731
+    register_reference_roots_provider(image_root, provider)
+    try:
+        ref_pic = os.path.join(ref_root, "sub", "pic.png")
+        assert ImageUtils.resolve_picture_path(image_root, ref_pic) == ref_pic
+        # Still refuses a sibling directory that is NOT a registered root.
+        assert (
+            ImageUtils.resolve_picture_path(image_root, str(tmp_path / "other.png"))
+            is None
+        )
+    finally:
+        unregister_reference_roots_provider(image_root, provider)
+    # With the provider gone, only image_root remains allowed.
+    assert not is_allowed_picture_path(image_root, os.path.join(ref_root, "p.png"))
+
+
+def test_vault_provider_allows_reference_folders_from_the_db(server, tmp_path):
+    """The Vault wires the reference_folder table into the resolver's root set."""
+    ref_root = str(tmp_path / "vault-refs")
+    os.makedirs(ref_root)
+    _add_reference_folder(server, ref_root)
+    ref_pic = os.path.join(ref_root, "pic.png")
+    assert ImageUtils.resolve_picture_path(server.vault.image_root, ref_pic) == ref_pic
+
+
+# ---------------------------------------------------------------------------
+# Picture serving route
+# ---------------------------------------------------------------------------
+
+
+def test_serving_refuses_out_of_root_file_path(server, client, tmp_path):
+    secret = tmp_path / "hostname-secret.png"
+    _write_png(str(secret))
+    pic_id = _add_picture(server, str(secret))
+    resp = client.get(f"/pictures/{pic_id}.png")
+    assert resp.status_code == 404
+    assert secret.read_bytes() not in (resp.content,)
+
+
+def test_serving_in_root_picture_still_works(server, client):
+    rel = "contain/in_root.png"
+    _write_png(os.path.join(server.vault.image_root, rel))
+    pic_id = _add_picture(server, rel)
+    resp = client.get(f"/pictures/{pic_id}.png")
+    assert resp.status_code == 200, resp.text
+
+
+def test_serving_reference_folder_picture_outside_image_root_still_works(
+    server, client, tmp_path
+):
+    """The over-blocking regression test: reference-folder pictures live under
+    roots that are NOT the image root and must keep working end to end."""
+    ref_root = str(tmp_path / "served-refs")
+    abs_path = os.path.join(ref_root, "ref_pic.png")
+    _write_png(abs_path)
+    _add_reference_folder(server, ref_root)
+    pic_id = _add_picture(server, abs_path)
+    resp = client.get(f"/pictures/{pic_id}.png")
+    assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Snapshot retention + delete
+# ---------------------------------------------------------------------------
+
+
+def _add_snapshot_row(server, kind, created_at, rel_path, manifest_rel):
+    def _do(session):
+        session.add(
+            Snapshot(
+                kind=kind,
+                created_at=created_at,
+                relative_path=rel_path,
+                manifest_relative_path=manifest_rel,
+                byte_size=1,
+                picture_count=0,
+                schema_version="test",
+            )
+        )
+        session.commit()
+
+    server.vault.db.run_task(_do)
+
+
+def test_gfs_retention_refuses_deletes_outside_the_vault_root(server, tmp_path):
+    vault_root = server.vault.image_root
+    now = datetime.now(timezone.utc)
+
+    victim = tmp_path / "victim-gfs.sqlite"
+    victim.write_bytes(b"keep me")
+    victim_manifest = tmp_path / "victim-gfs.manifest.json"
+    victim_manifest.write_bytes(b"keep me too")
+    hostile_rel = os.path.relpath(str(victim), vault_root)
+    hostile_manifest_rel = os.path.relpath(str(victim_manifest), vault_root)
+    assert hostile_rel.startswith("..")
+
+    # Oldest row is hostile; second-oldest is a legitimate in-root snapshot
+    # whose files retention MUST still clean up (the positive direction).
+    legit_rel = "snapshots/legit-old.sqlite.zst"
+    legit_manifest_rel = "snapshots/legit-old.manifest.json"
+    legit_abs = os.path.join(vault_root, legit_rel)
+    legit_manifest_abs = os.path.join(vault_root, legit_manifest_rel)
+    os.makedirs(os.path.dirname(legit_abs), exist_ok=True)
+    for p in (legit_abs, legit_manifest_abs):
+        with open(p, "wb") as fh:
+            fh.write(b"old snapshot bits")
+
+    _add_snapshot_row(
+        server, "DAILY", now - timedelta(days=30), hostile_rel, hostile_manifest_rel
+    )
+    _add_snapshot_row(
+        server, "DAILY", now - timedelta(days=20), legit_rel, legit_manifest_rel
+    )
+    for i in range(7):
+        _add_snapshot_row(
+            server,
+            "DAILY",
+            now - timedelta(days=i),
+            f"snapshots/recent-{i}.sqlite.zst",
+            f"snapshots/recent-{i}.manifest.json",
+        )
+
+    server.vault.snapshot_service._apply_gfs_retention(now)
+
+    # Hostile files survived; the legitimate pruned snapshot's files are gone.
+    assert victim.read_bytes() == b"keep me"
+    assert victim_manifest.read_bytes() == b"keep me too"
+    assert not os.path.exists(legit_abs)
+    assert not os.path.exists(legit_manifest_abs)
+    remaining = server.vault.db.run_immediate_read_task(
+        lambda s: s.exec(select(Snapshot)).all()
+    )
+    assert len(remaining) == 7
+
+
+def test_delete_snapshot_refuses_files_outside_the_vault_root(server, tmp_path):
+    vault_root = server.vault.image_root
+    victim = tmp_path / "victim-delete.sqlite"
+    victim.write_bytes(b"still here")
+    hostile_rel = os.path.relpath(str(victim), vault_root)
+    _add_snapshot_row(
+        server,
+        "MANUAL",
+        datetime.now(timezone.utc),
+        hostile_rel,
+        hostile_rel + ".manifest.json",
+    )
+    snap_id = server.vault.db.run_immediate_read_task(
+        lambda s: s.exec(select(Snapshot.id)).one()
+    )
+    assert server.vault.snapshot_service.delete_snapshot(snap_id) is True
+    assert victim.read_bytes() == b"still here"
+
+
+# ---------------------------------------------------------------------------
+# Scrapheap purge delete
+# ---------------------------------------------------------------------------
+
+
+def test_scrapheap_purge_refuses_out_of_root_targets(tmp_path):
+    image_root = str(tmp_path / "library")
+    os.makedirs(image_root)
+    victim = tmp_path / "victim-purge.png"
+    victim.write_bytes(b"precious")
+    remove_picture_files(image_root, [(1, str(victim), False)])
+    remove_picture_files(image_root, [(2, "../victim-purge.png", False)])
+    assert victim.read_bytes() == b"precious"
+
+
+def test_scrapheap_purge_still_removes_in_root_files(tmp_path):
+    image_root = str(tmp_path / "library")
+    doomed = os.path.join(image_root, "doomed.png")
+    _write_png(doomed)
+    unconfirmed = remove_picture_files(image_root, [(1, "doomed.png", False)])
+    assert not os.path.exists(doomed)
+    assert unconfirmed == []
+
+
+# ---------------------------------------------------------------------------
+# Caption sidecar write-back
+# ---------------------------------------------------------------------------
+
+
+def test_writeback_refuses_image_path_outside_the_roots(tmp_path):
+    image_root = str(tmp_path / "library")
+    os.makedirs(image_root)
+    outside_image = str(tmp_path / "loose" / "img.png")
+    assert (
+        writeback_path(
+            outside_image, SIDECAR_TYPE_TAGS, "_tags.txt", None, image_root=image_root
+        )
+        is None
+    )
+
+
+def test_writeback_ignores_fabricated_existing_path(tmp_path):
+    image_root = str(tmp_path / "library")
+    os.makedirs(image_root)
+    image = os.path.join(image_root, "img.png")
+    # A tags_file column pointing anywhere else must not become a write target;
+    # the suffix-derived sidecar path is used instead.
+    assert writeback_path(
+        image,
+        SIDECAR_TYPE_TAGS,
+        "_tags.txt",
+        str(tmp_path / "authorized_keys"),
+        image_root=image_root,
+    ) == os.path.join(image_root, "img_tags.txt")
+
+
+def test_writeback_still_works_for_reference_folder_pictures(tmp_path):
+    image_root = str(tmp_path / "library")
+    ref_root = str(tmp_path / "refs")
+    os.makedirs(image_root)
+    os.makedirs(ref_root)
+    provider = lambda: [ref_root]  # noqa: E731
+    register_reference_roots_provider(image_root, provider)
+    try:
+        image = os.path.join(ref_root, "img.png")
+        assert writeback_path(
+            image, SIDECAR_TYPE_TAGS, "_tags.txt", None, image_root=image_root
+        ) == os.path.join(ref_root, "img_tags.txt")
+        # A legitimately recorded stem+suffix existing path is honoured.
+        assert writeback_path(
+            image,
+            SIDECAR_TYPE_TAGS,
+            None,
+            os.path.join(ref_root, "img.txt"),
+            image_root=image_root,
+        ) == os.path.join(ref_root, "img.txt")
+    finally:
+        unregister_reference_roots_provider(image_root, provider)

--- a/tests/test_reference_folder_sidecars.py
+++ b/tests/test_reference_folder_sidecars.py
@@ -211,12 +211,25 @@ def test_writeback_path_returns_none_for_unusable_configured_suffix():
         writeback_path("/refs/f/photo.png", SIDECAR_TYPE_TAGS, "../escape.txt", None)
         is None
     )
-    # An already-resolved existing path is still honoured.
+    # An already-resolved existing path is still honoured when it is the image
+    # stem plus a safe suffix (the only shape a legitimately recorded sidecar
+    # path can have — see #776 for why anything else is refused).
+    assert (
+        writeback_path(
+            "/refs/f/photo.png",
+            SIDECAR_TYPE_TAGS,
+            "../escape.txt",
+            "/refs/f/photo_tags.txt",
+        )
+        == "/refs/f/photo_tags.txt"
+    )
+    # An existing path that is NOT stem+suffix (e.g. a fabricated tags_file
+    # column) is ignored; with no usable configured suffix either, no path.
     assert (
         writeback_path(
             "/refs/f/photo.png", SIDECAR_TYPE_TAGS, "../escape.txt", "/refs/f/ok.txt"
         )
-        == "/refs/f/ok.txt"
+        is None
     )
     # And a clean suffix is unaffected.
     assert (


### PR DESCRIPTION
Closes #776.

Stored paths (`Picture.file_path`, sidecar columns, `Snapshot.relative_path`) are now contained before they reach the filesystem. First and foremost this stops the accident class: a wrong absolute path written into `file_path` by an import or a bug no longer reaches an unattended retention delete, a sidecar write, or the serving route — it is logged and skipped. It also raises the bar against a tampered database row, without claiming to defend against whole-vault substitution (out of threat model per the accepted-risk record).

- Root set: `image_root` ∪ reference-folder roots (host and path-mapped forms), supplied by a vault-registered provider and refreshed on a containment miss, so a just-added folder works immediately.
- Over-blocking regression test: a picture under a reference folder outside `image_root` is still served 200 end-to-end.
- Revert-check done per sink: reverting only the resolver, only the snapshot service, or only the sidecar write-back each fails its corresponding new tests.
- Suites green: new `tests/test_path_containment.py` (14 tests, CI-gated) plus snapshots/restore/scrapheap/server/reference-folder/guardrail suites — 460+ tests, ruff clean.

https://claude.ai/code/session_01VGZQAuSvj8vSFH5NcXBywF