### PR TITLE
Refuse only the dangling foreign keys a migration caused

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1245,6 +1245,31 @@ Snapshot `.sqlite` files are opened through `services/restore/schema_upgrade.sna
 
 **Known edge, unreachable today.** `wal=False` means "do not *set* WAL", not "force a single file". `journal_mode` is a persistent header property, so against a database file whose header **already** says WAL, a `wal=False` engine reports `wal` and creates a `-wal` sidecar, which is exactly the outcome the flag exists to prevent. No path reaches it: every snapshot is produced by `VACUUM INTO` from the live WAL vault, and `VACUUM INTO` emits a `delete`-mode file. **Do not "fix" this by having the connect listener run `PRAGMA journal_mode=DELETE`.** SQLite refuses to leave WAL while another connection holds the file, so the second pooled connection raises "database is locked", and the pragma is a *write*: it would fail, or mutate the file, on read-only preview opens, which are eight of the nine snapshot engines. If a WAL-header snapshot ever becomes reachable, convert the **file** once at materialisation time (`wal_checkpoint(TRUNCATE)` + `journal_mode=DELETE` on a single exclusive connection, which is what `_upgrade_snapshot_schema` and `preview._fill_snapshot_hashes_at` already do), never per connection.
 
+#### Trusted SQLite locations, and the accepted Windows residue (W17)
+
+Every credential-bearing SQLite open goes through `trusted_sqlite.py`, whose
+module docstring is the design record: which actor each check is for, why the
+earlier DACL refusal was removed (it stopped the server starting on Windows,
+W6/W7/W18), and what a `private=True` open verifies instead.
+
+**Accepted risk W17.** Python exposes neither owner SID nor directory DACL
+portably, so the POSIX `mode & 0o022` test — "another principal cannot write
+this directory" — has no Windows implementation. On Windows a library on a
+network share, removable media, or a deliberately loosened folder is therefore
+not protected against another local principal substituting `vault.db` or
+pre-positioning a sidecar before startup. What still runs there: redirect
+rejection (symlink **and** junction), the regular-file requirement on the target
+and every sidecar, and the `(st_dev, st_ino)` identity match across the open.
+The vault is authorization-bearing (`authz/membership.py` answers scope
+questions out of it), so this is not reads-only; the blast radius is stated in
+full in the module docstring.
+
+Owner: lindkvis. Revisit 2026-11-08, together with the native ACL verifier
+(`win32security.GetNamedSecurityInfo`, or ctypes against advapi32) that is the
+route back to tightening this. Recorded here rather than in a review document
+because `docs/reviews/` is gitignored: an accepted risk nobody else can read is
+not a record.
+
 ### Vector storage
 
 - Embeddings (`image_embedding`, `text_embedding`, `Face.features`) are stored as `BLOB` columns.

--- a/pixlstash/migrations/env.py
+++ b/pixlstash/migrations/env.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections import Counter
 from contextlib import contextmanager
 from logging.config import fileConfig
 from pathlib import Path
@@ -31,12 +32,47 @@ if config.config_file_name is not None:
 # Target metadata for 'autogenerate'
 target_metadata = SQLModel.metadata
 
+logger = logging.getLogger("alembic.env")
+
 
 def _get_database_url() -> str:
     env_url = os.getenv("PIXLSTASH_DB_URL")
     if env_url:
         return env_url
     return config.get_main_option("sqlalchemy.url")
+
+
+def _database_is_at_script_head() -> bool:
+    """True when the database already holds every revision in the tree.
+
+    ``command.upgrade(config, "head")`` runs on every vault open, so the
+    integrity scans below would otherwise cost two whole-database
+    ``foreign_key_check`` passes on every start. Nothing can run, so nothing
+    can be broken: skip them.
+
+    A ``downgrade`` also starts from head and so skips the scans. That is
+    deliberate — downgrades only ever run through the standalone Alembic CLI
+    (``tests/test_migrations.py``), never against a live vault. The
+    suspension itself is not skipped, so the rebuild still works.
+
+    Must be called after ``context.configure()``.
+    """
+    from alembic.script import ScriptDirectory
+
+    script_heads = set(ScriptDirectory.from_config(config).get_heads())
+    return set(context.get_context().get_current_heads()) == script_heads
+
+
+def _foreign_key_violations(connection) -> Counter:
+    """Count dangling foreign keys per (child table, parent table, FK id).
+
+    ``PRAGMA foreign_key_check`` reports one row per violation as
+    ``(table, rowid, parent, fkid)``. The rowid is dropped: a batch rebuild
+    renumbers rowids of any table without an ``INTEGER PRIMARY KEY``, so the
+    same pre-existing orphan would otherwise look like a new one.
+    """
+    rows = connection.execute(text("PRAGMA foreign_key_check")).all()
+    return Counter((row[0], row[2], row[3]) for row in rows)
 
 
 @contextmanager
@@ -56,8 +92,24 @@ def _foreign_keys_suspended(connection):
     Suspending enforcement around the rebuild is SQLite's own documented
     procedure for altering a table (sqlite.org/lang_altertable.html, steps 1
     and 11), not a workaround. Because it is genuinely unsafe to leave a
-    migration's output unchecked, ``PRAGMA foreign_key_check`` runs afterwards
-    and refuses to let a run that broke referential integrity pass silently.
+    migration's output unchecked, ``PRAGMA foreign_key_check`` runs before and
+    after, and the run is refused if *it* broke referential integrity.
+
+    Refused, not merely reported, on the path that matters: a vault opens
+    Alembic on an already-open connection, so Alembic treats the transaction
+    as external and leaves the commit to ``database._run_migrations``. The
+    check therefore runs while the whole run is still uncommitted — SQLite's
+    procedure checks at step 10, before the commit at step 11 — and the
+    rollback below discards every migration in the run. The standalone engine
+    has no external transaction, so SQLite's non-transactional DDL commits
+    each migration as it goes and the guard can only refuse the result; its
+    caller is the snapshot upgrader, which throws its scratch file away when
+    the upgrade fails.
+
+    Only violations the run *introduced* are refused. A database that already
+    holds orphan rows (written before its FKs existed, or by any path with
+    enforcement off) is logged and left alone — failing on those would brick
+    an existing library on every open, with no way back.
 
     The PRAGMA has to be issued outside a transaction to take effect, hence the
     commit on the way in; pysqlite does not emit ``BEGIN`` for DDL or PRAGMA,
@@ -71,19 +123,40 @@ def _foreign_keys_suspended(connection):
     was_enabled = bool(connection.execute(text("PRAGMA foreign_keys")).scalar())
     connection.execute(text("PRAGMA foreign_keys=OFF"))
     connection.commit()
+
+    # Deliberately not gated on ``was_enabled``: the standalone engine leaves
+    # SQLite's default (off), and that is the snapshot-restore path — the one
+    # migration input that did not come from this process.
+    check = not _database_is_at_script_head()
+    pre_existing = _foreign_key_violations(connection) if check else Counter()
+    if pre_existing:
+        logger.warning(
+            "Database holds %d dangling foreign key(s) before migrating: %s. "
+            "These predate this run and are left untouched.",
+            sum(pre_existing.values()),
+            dict(pre_existing),
+        )
+    connection.commit()
+
+    completed = False
     try:
         yield
+        if check:
+            introduced = _foreign_key_violations(connection) - pre_existing
+            if introduced:
+                raise RuntimeError(
+                    "Migrations introduced dangling foreign keys "
+                    f"({sum(introduced.values())} rows): {dict(introduced)}"
+                )
+        completed = True
     finally:
-        connection.commit()
+        if completed:
+            connection.commit()
+        else:
+            connection.rollback()
         if was_enabled:
             connection.execute(text("PRAGMA foreign_keys=ON"))
             connection.commit()
-            violations = connection.execute(text("PRAGMA foreign_key_check")).all()
-            if violations:
-                raise RuntimeError(
-                    "Migrations left dangling foreign keys "
-                    f"({len(violations)} rows); first: {violations[0]}"
-                )
 
 
 def run_migrations_offline() -> None:

--- a/pixlstash/trusted_sqlite.py
+++ b/pixlstash/trusted_sqlite.py
@@ -101,9 +101,11 @@ an existence check rather than a trust check:
 Revisit when a native ACL verifier exists (``win32security.GetNamedSecurityInfo``
 or ctypes against advapi32), which is the route back to tightening this.
 
-Accepted-risk record (W17, docs/reviews/plan-windows-permissions.md): owner
-lindkvis, revisit 2026-11-08, together with the native ACL verifier (3c) that
-would close the Windows residue.
+Accepted-risk record (W17): owner lindkvis, revisit 2026-11-08, together with
+the native ACL verifier (3c) that would close the Windows residue. Recorded in
+``docs/backend_architecture.md`` §13 ("Trusted SQLite locations, and the
+accepted Windows residue") — not in ``docs/reviews/``, which is gitignored, so
+a record kept there would exist only on the machine that wrote it.
 """
 
 from __future__ import annotations

--- a/tests/test_authz_library_pin.py
+++ b/tests/test_authz_library_pin.py
@@ -163,7 +163,12 @@ class TestPinnedRoutes:
             # test_writer_waits_for_request_paused_in_guest_lookup keys on, and
             # that test waits for it, so a rename cannot quietly defang this.
             def observed_read(callback, *args, **kwargs):
-                vault_reads.append(getattr(callback, "__name__", repr(callback)))
+                vault_reads.append(
+                    (
+                        getattr(callback, "__module__", ""),
+                        getattr(callback, "__name__", repr(callback)),
+                    )
+                )
                 return real_read(callback, *args, **kwargs)
 
             monkeypatch.setattr(
@@ -175,8 +180,14 @@ class TestPinnedRoutes:
                 cookies={"guest_session": "plausible-cookie"},
             )
             assert response.status_code == 403
-            assert "_lookup_by_token" not in vault_reads, (
-                f"the guest vault lookup ran before the pin refused: {vault_reads}"
+            # Every read the authentication path makes, not just the guest
+            # lookup: naming one callable would still pass if the pin were
+            # moved behind some *other* vault read in the same module. The
+            # background probes stay excluded because they come from
+            # ``pixlstash.tasks``, so this cannot go timing-dependent again.
+            auth_reads = [read for read in vault_reads if read[0] == "pixlstash.auth"]
+            assert auth_reads == [], (
+                f"authentication read the vault before the pin refused: {vault_reads}"
             )
 
     def test_writer_waits_for_request_paused_in_guest_lookup(

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1149,3 +1149,183 @@ def test_a_populated_library_upgrades_through_the_picture_table_rebuild():
             assert enabled == 1
         finally:
             db.close()
+
+
+def test_a_library_carrying_dangling_rows_still_opens():
+    """Orphan rows that predate the run must not stop a library opening.
+
+    ``PRAGMA foreign_key_check`` reports the whole database, and
+    ``command.upgrade`` runs on every vault open, so a guard that refuses any
+    violation refuses one it did not cause — permanently, with no repair path.
+    Rows written before their FK existed, or by any path with enforcement off,
+    are exactly that. The committed fixture already ships some (``guest_score``
+    -> ``usertoken``); migration 0093 clears those, so this adds one that
+    survives to head.
+
+    Goes through ``VaultDatabase`` because that is where it bites: the vault
+    engine runs with enforcement on, so the guard is active there.
+    """
+    from pixlstash.database import VaultDatabase
+
+    assert os.path.isfile(_E2E_FIXTURE), (
+        f"committed e2e fixture missing at {_E2E_FIXTURE}"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "vault.db")
+        shutil.copyfile(_E2E_FIXTURE, db_path)
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
+            _insert_minimal_row(conn, "quality", id=999999, picture_id=999999)
+            conn.commit()
+            assert conn.execute("PRAGMA foreign_key_check").fetchall(), (
+                "the row must be an actual violation for this to test anything"
+            )
+
+        db = VaultDatabase(db_path)
+        try:
+            with contextlib.closing(sqlite3.connect(db_path)) as conn:
+                survived = conn.execute(
+                    "SELECT COUNT(*) FROM quality WHERE picture_id = 999999"
+                ).fetchone()[0]
+                # Left alone, not quietly repaired: deleting rows to satisfy a
+                # check the run did not fail is its own kind of data loss.
+                assert survived == 1
+        finally:
+            db.close()
+
+
+_BREAKING_MIGRATION = '''"""Orphan a character by deleting its project (test fixture only)."""
+
+from alembic import op
+
+revision = "9999_break_a_foreign_key"
+down_revision = "{head}"
+branch_labels = None
+depends_on = None
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    op.execute("DELETE FROM project WHERE id = 1")
+
+
+def downgrade() -> None:
+    op.execute("INSERT INTO project (id, name) VALUES (1, 'orphan-maker')")
+'''
+
+
+def _database_at_head_with_a_character_in_a_project(db_path):
+    """Upgrade *db_path* to head and give it one valid character -> project row."""
+    result = _run_alembic(["upgrade", "head"], f"sqlite:///{db_path}", _MIGRATIONS_DIR)
+    assert result.returncode == 0, (
+        f"alembic upgrade head failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        _insert_minimal_row(conn, "project", id=1, name="orphan-maker")
+        _insert_minimal_row(conn, "character", id=1, name="orphan", project_id=1)
+        conn.commit()
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == [], (
+            "the seed rows must be valid, or the guard has nothing new to catch"
+        )
+
+
+@contextlib.contextmanager
+def _migration_tree_that_breaks_a_foreign_key(db_path):
+    """A copy of the real migration tree with one FK-breaking migration on top."""
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        head = conn.execute("SELECT version_num FROM alembic_version").fetchone()[0]
+
+    with tempfile.TemporaryDirectory() as tree:
+        shutil.copytree(
+            os.path.join(_MIGRATIONS_DIR, "migrations"),
+            os.path.join(tree, "migrations"),
+        )
+        shutil.copyfile(
+            os.path.join(_MIGRATIONS_DIR, "alembic.ini"),
+            os.path.join(tree, "alembic.ini"),
+        )
+        with open(
+            os.path.join(tree, "migrations", "versions", "9999_break_a_foreign_key.py"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write(_BREAKING_MIGRATION.format(head=head))
+        yield tree
+
+
+def test_a_migration_that_orphans_a_row_is_refused_and_the_run_rolled_back():
+    """Suspending enforcement must not let a migration ship a broken database.
+
+    The vault path is the one that can be prevented rather than merely
+    reported: Alembic runs on the caller's open connection, so nothing is
+    committed until ``_run_migrations`` says so, and the guard rejects the run
+    before that happens.
+    """
+    from alembic import command
+    from alembic.config import Config
+
+    from pixlstash.database import create_configured_engine
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "vault.db")
+        _database_at_head_with_a_character_in_a_project(db_path)
+
+        with _migration_tree_that_breaks_a_foreign_key(db_path) as tree:
+            config = Config(os.path.join(tree, "alembic.ini"))
+            config.set_main_option("script_location", os.path.join(tree, "migrations"))
+            config.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+
+            engine = create_configured_engine(db_path)
+            try:
+                with engine.connect() as conn:
+                    # database._run_migrations inspects the schema first, which
+                    # leaves the transaction open and hands Alembic an external
+                    # one. Reproduce that, or the rollback under test is not
+                    # the one production gets.
+                    conn.exec_driver_sql("SELECT 1")
+                    assert conn.in_transaction()
+                    config.attributes["connection"] = conn
+
+                    raised = None
+                    try:
+                        command.upgrade(config, "head")
+                    except RuntimeError as exc:
+                        raised = exc
+                    assert raised is not None, "the broken migration was accepted"
+                    assert "introduced dangling foreign keys" in str(raised)
+            finally:
+                engine.dispose()
+
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
+            assert (
+                conn.execute("SELECT COUNT(*) FROM project WHERE id = 1").fetchone()[0]
+                == 1
+            ), "the rejected migration's delete was committed anyway"
+            assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+            assert (
+                conn.execute("SELECT version_num FROM alembic_version").fetchone()[0]
+                != "9999_break_a_foreign_key"
+            )
+
+
+def test_the_standalone_engine_refuses_a_broken_foreign_key_too():
+    """The guard must not be gated on enforcement having been on.
+
+    ``alembic.ini`` builds its own engine with no connect listener, so SQLite
+    leaves foreign keys off there — and that is the snapshot upgrade path
+    (``services/restore/schema_upgrade``), the one migration input that did not
+    come from this process. It cannot roll back (each migration commits as it
+    goes, with no external transaction), but it must still refuse: its caller
+    discards the scratch file it was upgrading.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "vault.db")
+        _database_at_head_with_a_character_in_a_project(db_path)
+
+        with _migration_tree_that_breaks_a_foreign_key(db_path) as tree:
+            result = _run_alembic(["upgrade", "head"], f"sqlite:///{db_path}", tree)
+
+        assert result.returncode != 0, (
+            f"the broken migration was accepted:\nstdout: {result.stdout}"
+        )
+        assert "introduced dangling foreign keys" in result.stderr, result.stderr


### PR DESCRIPTION
Follow-up to #775, addressing the blocker and the two code-level mediums from the CSO review of that PR. Base is `develop` (#775 is merged).

### 1. Blocker: a pre-existing orphan row bricked the library

`PRAGMA foreign_key_check` reports the **whole database**, and `command.upgrade(config, "head")` runs on **every** vault open, so any orphan row that predates the run refused the open, every time, with "Migrations left dangling foreign keys" and no repair path. Rows written before their FK existed, or by any path with enforcement off, are exactly that: the committed e2e fixture ships some today (`guest_score` -> `usertoken`, cleared later by 0093).

Now only violations the run *introduced* are refused: the check runs before and after, and compares. Pre-existing ones are logged and left alone. Deleting rows to satisfy a check the run did not fail would be its own data loss.

The two scans are skipped when the database is already at the script head, where nothing can run and so nothing can break: that is every normal open, which previously paid for one scan and would otherwise now pay for two.

### 2. Medium: the check ran after the commit

It detected damage it could not prevent. SQLite's own procedure checks at step 10, before the commit at step 11.

A vault hands Alembic an already-open connection, so Alembic treats the transaction as external and leaves the commit to `database._run_migrations`. Moving the check inside that window means a rejected run is rolled back in full. The standalone engine has no external transaction, so SQLite's non-transactional DDL still commits each migration as it goes and the guard can only refuse the result there; its caller is the snapshot upgrader, which discards the scratch file it was upgrading.

### 3. Medium: the check was gated on `was_enabled`

`was_enabled` is False on the standalone-engine branch (`alembic.ini`, no connect listener, SQLite defaults FK off), which is `services/restore/schema_upgrade` — the snapshot restore path, the one migration input that did not come from this process. The control was present where the data is trusted and absent where it is not. It is no longer gated; only restoring `PRAGMA foreign_keys=ON` is.

### 4. Process: the W17 accepted-risk record pointed into `docs/reviews/`

Which is gitignored, so the record existed only on the machine that wrote it. Summarised in `docs/backend_architecture.md` §13 (owner, revisit date, what still runs on Windows, blast radius) with the detail staying in the `trusted_sqlite.py` module docstring. No behaviour change.

### 5. Low: the library-pin test named one callable

`test_library_mismatch_is_refused_before_any_guest_vault_lookup` asserted `"_lookup_by_token" not in vault_reads`, which still passes if the pin moves behind some *other* vault read in the same path. It now asserts no read from `pixlstash.auth` ran at all. Background probes come from `pixlstash.tasks`, so this cannot go timing-dependent again.

Not touched: the `trusted_root` tautology and the vault's `private=False` acceptance. Both are recorded accepted risks; changing either removes functionality rather than fixing a defect.

## Verification

Three new tests in `tests/test_migrations.py`, one per fix. All three fail against `develop` and pass here:

- `test_a_library_carrying_dangling_rows_still_opens` — e2e fixture plus one orphan `quality` row, opened through `VaultDatabase` (enforcement on, where the guard bites). Fails on `develop` with the brick.
- `test_a_migration_that_orphans_a_row_is_refused_and_the_run_rolled_back` — a temporary copy of the migration tree with one migration that deletes a project out from under its character, run on a supplied connection with an open transaction, exactly as `_run_migrations` does. Refused, and the delete is gone afterwards.
- `test_the_standalone_engine_refuses_a_broken_foreign_key_too` — the same broken migration through the `alembic.ini` engine, where enforcement is off. Refused (it was silently accepted before).

`tests/test_migrations.py` (24), `tests/test_architecture_guardrails.py` (30), `tests/test_restore.py` + `tests/test_snapshots.py` (111), `tests/test_authz_library_pin.py` (15) all green locally. `ruff format` and `ruff check` clean. No new test files, so the CI shard gate is unaffected.