### PR TITLE
Contain stored paths before a destructive operation (#776)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,7 @@ jobs:
           tests/test_multi_project_membership_authz.py
           tests/test_openapi_response_schemas.py
           tests/test_operation_log.py
+          tests/test_path_containment.py
           tests/test_pending_score_invalidation.py
           tests/test_picture_is_video.py
           tests/test_picture_mutation_scope.py

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1128,6 +1128,41 @@ The fix is an additive column, `public_id`: 128 bits of randomness as lowercase 
 - File-based **SQLite** at `{image_root}/vault.db`
 - All writes are serialised through `VaultDatabase`'s task queue (single writer); reads run in parallel.
 
+### Stored path containment (#776)
+
+`Snapshot.relative_path` and `Picture.file_path` are database values, so a
+faulty import, a bug, or a restored archive can put a path in them that points
+outside the library. They are contained **before a destructive operation**,
+never on the read path:
+
+- **Snapshot file paths** (`relative_path` / manifest / hashes) go through
+  `resolve_path_within(vault_root, …)` at every read/delete site (retention
+  prune, snapshot delete, restore, identity scrub). `os.path.join` silently
+  discards the base when a component is absolute and must not be used there.
+- **The scrapheap purge delete** (`remove_picture_files`) is the one unattended
+  `os.remove` that follows `Picture.file_path` wherever it points, so it checks
+  the resolved path against `image_root` **plus the configured reference-folder
+  roots** (`Vault.reference_folder_roots()`, host-side and path-mapped forms).
+  Containing against `image_root` alone would strand every reference-folder
+  library's files; never do that. A refused path is reported as unconfirmed, so
+  the deletion ledger is corrected to `file_removed=False` and restore can
+  still resurrect the row.
+- **Sidecar write-backs** funnel through `caption_file_utils.writeback_path`,
+  which only honours a recorded `tags_file`/`description_file` value that is
+  exactly the image stem plus a safe suffix, so a fabricated column cannot
+  redirect a write.
+
+**Reads are deliberately not contained.** `resolve_picture_path` does not
+police where a picture lives. Whoever can write the vault DB can read those
+files directly, so refusing to serve them buys little, while a false refusal
+(an orphaned reference-folder row, a moved mount, a path-mapper form) presents
+to a desktop user as their pictures failing to load. Over-blocking a delete
+strands a file and is recoverable; over-blocking a read breaks the library.
+
+Both directions are asserted in `tests/test_path_containment.py`: escape is
+refused at each sink, and in-root plus reference-folder files are still deleted
+(over-blocking is its own regression).
+
 ### Hub and library identity
 
 `hub.db` sits beside `server-config.json`, outside every image library. It owns

--- a/pixlstash/services/restore/full_restore.py
+++ b/pixlstash/services/restore/full_restore.py
@@ -39,6 +39,7 @@ from pixlstash.db_models.picture_likeness import (
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.event_types import EventType
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.path_utils import resolve_path_within
 
 from ._models import (
     RestoreInProgressError,
@@ -160,7 +161,7 @@ class FullRestoreMixin:
             Populated RestoreReport.
         """
         cp = self._get_snapshot_or_raise(snapshot_id)
-        abs_snapshot = os.path.join(vault_root, cp.relative_path)
+        abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
         if not os.path.exists(abs_snapshot):
             raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 
@@ -647,7 +648,16 @@ class FullRestoreMixin:
             for snap in live_snapshots:
                 if snap["relative_path"] in existing_snapshot_paths:
                     continue
-                abs_snap = os.path.join(vault_root, snap["relative_path"])
+                try:
+                    abs_snap = resolve_path_within(vault_root, snap["relative_path"])
+                except ValueError as exc:
+                    logger.warning(
+                        "RestoreService: snapshot index row %s points outside "
+                        "the vault root; not re-inserting it after restore: %s",
+                        snap["relative_path"],
+                        exc,
+                    )
+                    continue
                 if not os.path.exists(abs_snap):
                     # File was pruned/deleted since capture — skip rather than
                     # leave a dangling index row pointing at nothing.

--- a/pixlstash/services/restore/preview.py
+++ b/pixlstash/services/restore/preview.py
@@ -32,6 +32,7 @@ from pixlstash.db_models import (
 )
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.path_utils import resolve_path_within
 from pixlstash.utils.snapshot_compression import is_compressed
 
 from ._models import (
@@ -73,7 +74,7 @@ class PreviewMixin:
         """
         vault_root = self._vault.image_root
         cp = self._get_snapshot_or_raise(snapshot_id)
-        abs_snapshot = os.path.join(vault_root, cp.relative_path)
+        abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
         if not os.path.exists(abs_snapshot):
             raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 
@@ -147,7 +148,7 @@ class PreviewMixin:
 
         vault_root = self._vault.image_root
         cp = self._get_snapshot_or_raise(snapshot_id)
-        abs_snapshot = os.path.join(vault_root, cp.relative_path)
+        abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
         if not os.path.exists(abs_snapshot):
             raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 
@@ -216,7 +217,7 @@ class PreviewMixin:
         """
         vault_root = self._vault.image_root
         cp = self._get_snapshot_or_raise(snapshot_id)
-        abs_snapshot = os.path.join(vault_root, cp.relative_path)
+        abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
         if not os.path.exists(abs_snapshot):
             raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 

--- a/pixlstash/services/restore/resource_restore.py
+++ b/pixlstash/services/restore/resource_restore.py
@@ -32,6 +32,7 @@ from pixlstash.db_models import (
 )
 from pixlstash.event_types import EventType
 from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.path_utils import resolve_path_within
 
 from ._models import (
     MissingDependenciesError,
@@ -108,7 +109,7 @@ class ResourceRestoreMixin:
         try:
             vault_root = self._vault.image_root
             cp = self._get_snapshot_or_raise(snapshot_id)
-            abs_snapshot = os.path.join(vault_root, cp.relative_path)
+            abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
             if not os.path.exists(abs_snapshot):
                 raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 
@@ -202,7 +203,7 @@ class ResourceRestoreMixin:
         try:
             vault_root = self._vault.image_root
             cp = self._get_snapshot_or_raise(snapshot_id)
-            abs_snapshot = os.path.join(vault_root, cp.relative_path)
+            abs_snapshot = resolve_path_within(vault_root, cp.relative_path)
             if not os.path.exists(abs_snapshot):
                 raise ValueError(f"Snapshot file not found on disk: {abs_snapshot}")
 

--- a/pixlstash/services/scrapheap_service.py
+++ b/pixlstash/services/scrapheap_service.py
@@ -106,6 +106,7 @@ from pixlstash.db_models import DeletedFileLog, Picture, ReferenceFolder
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services.set_lock_service import locked_picture_ids
 from pixlstash.utils.image_processing.image_utils import ImageUtils
+from pixlstash.utils.path_utils import path_is_within
 from pixlstash.utils.service.scope_table import scope_id_subquery
 
 logger = get_logger(__name__)
@@ -1316,22 +1317,56 @@ def file_location_is_unreachable(file_path: str) -> bool:
 def remove_picture_files(
     image_root: str,
     targets: list[tuple[Optional[int], str, bool]],
+    reference_roots: tuple[str, ...] = (),
 ) -> list[str]:
     """Delete the on-disk originals (and thumbnails) for a purged selection.
 
+    ``Picture.file_path`` is a database value, and this is the one unattended
+    ``os.remove`` that follows it wherever it points. A path outside the
+    library's legitimate roots is therefore skipped rather than deleted
+    (#776): a wrong absolute path written by an import or a bug cannot reach
+    a delete. Skipping is the safe direction, because an undeleted file is
+    reported as unconfirmed and the ledger is corrected so restore can still
+    resurrect the row.
+
+    Args:
+        image_root: The vault's image root. Relative paths resolve under it.
+        targets: ``(picture id, stored path, was_reference_protected)``.
+        reference_roots: Configured reference-folder roots, which pictures may
+            legitimately live under even though they are outside *image_root*.
+            Pass :meth:`Vault.reference_folder_roots`. Defaulting to empty
+            means only *image_root* is honoured.
+
     Returns:
         ``path_sha`` of every target whose file is NOT confirmed gone — the
-        removal raised, or the location is unreachable so we cannot tell. The
-        caller must correct those ledger rows to ``file_removed=False``; see
-        :func:`mark_files_kept_in_session`.
+        removal raised, the path was refused, or the location is unreachable
+        so we cannot tell. The caller must correct those ledger rows to
+        ``file_removed=False``; see :func:`mark_files_kept_in_session`.
     """
     unconfirmed: list[str] = []
+    allowed_roots = (image_root, *reference_roots)
 
     def _unconfirmed(rel_path: str) -> None:
         unconfirmed.append(DeletedFileLog.hash_path(rel_path))
 
     for pic_id, rel_path, was_reference_protected in targets:
         file_path = ImageUtils.resolve_picture_path(image_root, rel_path)
+        if file_path and not any(
+            path_is_within(file_path, root) for root in allowed_roots if root
+        ):
+            logger.error(
+                "Delete-forever: refusing to remove the file for picture "
+                "id=%s because its stored path %s resolves to %s, which is "
+                "outside the library roots %s; neither it nor its thumbnail "
+                "is touched and the ledger will be corrected to "
+                "file_removed=False",
+                pic_id,
+                rel_path,
+                file_path,
+                allowed_roots,
+            )
+            _unconfirmed(rel_path)
+            continue
         if file_path and os.path.isfile(file_path):
             logger.info(
                 "Delete-forever: destroying file for picture id=%s "
@@ -1481,7 +1516,9 @@ def remove_picture_files_and_reconcile_ledger(
     ``owned_path_shas`` comes from the :func:`purge_rows_in_session` call that
     wrote those rows, and bounds the correction to them.
     """
-    unconfirmed = remove_picture_files(vault.image_root, targets)
+    unconfirmed = remove_picture_files(
+        vault.image_root, targets, vault.reference_folder_roots()
+    )
     if unconfirmed:
         vault.db.run_task(
             mark_files_kept_in_session,

--- a/pixlstash/services/snapshot_service.py
+++ b/pixlstash/services/snapshot_service.py
@@ -21,6 +21,7 @@ from pixlstash.db_models import Character, Picture, PictureSet, Project
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services.portable_identity import sanitize_vault_file
+from pixlstash.utils.path_utils import resolve_path_within
 from pixlstash.utils.snapshot_compression import (
     COMPRESSED_SUFFIX,
     compress_snapshot,
@@ -279,14 +280,25 @@ class SnapshotService:
             cp = session.get(Snapshot, snapshot_id)
             if cp is None:
                 return False
-            abs_snapshot = os.path.join(vault_root, cp.relative_path)
-            abs_manifest = os.path.join(vault_root, cp.manifest_relative_path)
-            abs_hashes = os.path.join(
-                vault_root, self._hashes_relative_path(cp.manifest_relative_path)
+            rel_paths = (
+                cp.relative_path,
+                cp.manifest_relative_path,
+                self._hashes_relative_path(cp.manifest_relative_path),
             )
             session.delete(cp)
             session.commit()
-            for path in (abs_snapshot, abs_manifest, abs_hashes):
+            for rel_path in rel_paths:
+                try:
+                    path = resolve_path_within(vault_root, rel_path)
+                except ValueError as exc:
+                    logger.warning(
+                        "SnapshotService: refusing to remove snapshot file "
+                        "outside the vault root (snapshot id=%d, rel_path=%s): %s",
+                        snapshot_id,
+                        rel_path,
+                        exc,
+                    )
+                    continue
                 try:
                     if os.path.exists(path):
                         os.remove(path)
@@ -686,7 +698,18 @@ class SnapshotService:
                         cp.manifest_relative_path,
                         self._hashes_relative_path(cp.manifest_relative_path),
                     ):
-                        abs_path = os.path.join(vault_root, rel_path)
+                        try:
+                            abs_path = resolve_path_within(vault_root, rel_path)
+                        except ValueError as exc:
+                            logger.warning(
+                                "SnapshotService: GFS prune refusing to remove "
+                                "a file outside the vault root (snapshot id=%d, "
+                                "rel_path=%s): %s",
+                                cp.id,
+                                rel_path,
+                                exc,
+                            )
+                            continue
                         try:
                             if os.path.exists(abs_path):
                                 os.remove(abs_path)

--- a/pixlstash/tasks/snapshot_identity_scrub_task.py
+++ b/pixlstash/tasks/snapshot_identity_scrub_task.py
@@ -10,6 +10,7 @@ from pixlstash.services.portable_identity import (
     sanitize_snapshot_archive,
 )
 from pixlstash.tasks.base_task import BaseTask, TaskPriority
+from pixlstash.utils.path_utils import resolve_path_within
 
 logger = get_logger(__name__)
 
@@ -58,7 +59,23 @@ class SnapshotIdentityScrubTask(BaseTask):
 
     def _run_task(self):
         vault_root = self._db.image_root
-        archive = os.path.join(vault_root, self._relative_path)
+        try:
+            archive = resolve_path_within(vault_root, self._relative_path)
+        except ValueError as exc:
+            # A registered archive path outside the vault root is never a file
+            # this task may touch. There is nothing legitimate to scrub there;
+            # record it done so it stops being handed out, exactly like the
+            # missing-archive branch below.
+            logger.error(
+                "SnapshotIdentityScrubTask: snapshot %s is registered at %s, "
+                "which is outside the vault root — refusing to touch it and "
+                "recording it as done: %s",
+                self._snapshot_id,
+                self._relative_path,
+                exc,
+            )
+            self._db.run_task(self._record_scrubbed, None)
+            return
 
         if not os.path.exists(archive):
             # An orphaned row: the snapshot was registered but its archive is

--- a/pixlstash/utils/caption_file_utils.py
+++ b/pixlstash/utils/caption_file_utils.py
@@ -189,13 +189,30 @@ def writeback_path(
     Prefers an already-resolved *existing_path*; otherwise builds one from the
     *configured_suffix* (or the module default for the type).
 
+    *existing_path* is typically the ``tags_file`` / ``description_file``
+    column, so it is a database value and is only honoured when it is exactly
+    the image stem plus a safe suffix, the one shape a legitimately recorded
+    sidecar path can have. Anything else is ignored (logged) and the standard
+    suffix-derived path is used instead, so a fabricated column cannot direct
+    a file write somewhere else (#776).
+
     Returns ``None`` when the folder's configured suffix is not a usable
     filename fragment, so a folder configured before the rule was enforced on
     every write path skips its write-back (logged) instead of raising through
     the caller and wedging a scan or returning a 500. Callers must handle it.
     """
     if existing_path:
-        return existing_path
+        stem = os.path.splitext(image_path)[0]
+        tail = existing_path[len(stem) :] if existing_path.startswith(stem) else ""
+        if tail and is_safe_sidecar_suffix(tail):
+            return existing_path
+        logger.warning(
+            "Ignoring recorded %s sidecar path %r for %s: not the image "
+            "stem plus a safe suffix; using the configured suffix instead",
+            sidecar_type,
+            existing_path,
+            image_path,
+        )
     suffix = configured_suffix or (
         DEFAULT_TAGS_SUFFIX
         if sidecar_type == SIDECAR_TYPE_TAGS

--- a/pixlstash/utils/path_utils.py
+++ b/pixlstash/utils/path_utils.py
@@ -45,3 +45,40 @@ def resolve_path_within(base_dir: str, *segments: str) -> str:
             f"Path would escape allowed directory: {segments!r} is not within {base_dir!r}"
         )
     return resolved
+
+
+def path_is_within(path: str, base: str) -> bool:
+    """Whether *path* lies within *base*, lexically or after symlink resolution.
+
+    Unlike :func:`resolve_path_within` this answers a question instead of
+    raising, and it does not rewrite the path. Use it where a caller holds an
+    already-absolute path and must decide whether to act on it.
+
+    The lexical check (``normpath``) neutralises ``..`` components without
+    resolving symlinks, so a library whose *content* is reached through a
+    symlink is not refused. The ``realpath`` check then additionally accepts a
+    path spelled through a different alias of the same directory (e.g. a
+    symlinked root). A symlink planted *inside* an allowed root that points
+    outside it is therefore accepted: planting one requires filesystem write
+    access, which is a bigger problem than this check is for.
+
+    Args:
+        path: The path to test. An empty value is never within anything.
+        base: The directory *path* must be under.
+
+    Returns:
+        True when *path* is contained in *base*.
+    """
+    if not path or not base:
+        return False
+    try:
+        norm_path = os.path.normcase(os.path.normpath(path))
+        norm_base = os.path.normcase(os.path.normpath(base))
+        if os.path.commonpath([norm_path, norm_base]) == norm_base:
+            return True
+        real_path = os.path.normcase(os.path.realpath(path))
+        real_base = os.path.normcase(os.path.realpath(base))
+        return os.path.commonpath([real_path, real_base]) == real_base
+    except ValueError:
+        # Mixed absolute/relative paths or different drives: not within.
+        return False

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -432,6 +432,49 @@ class Vault:
                     exc,
                 )
 
+    def reference_folder_roots(self) -> tuple[str, ...]:
+        """Return the roots pictures may legitimately live under besides image_root.
+
+        Each configured reference folder contributes its stored (host-side)
+        path and, when a path mapper is configured, its mapped
+        (container-side) form: stored ``Picture.file_path`` values are written
+        under the mapped form in Docker deployments, while the
+        ``reference_folder`` row keeps the host form.
+
+        Returns:
+            The root directories, empty when the folder list cannot be read
+            (logged) so a caller containing a destructive operation refuses
+            rather than guesses.
+        """
+        from pixlstash.db_models.reference_folder import ReferenceFolder
+
+        def fetch(session: Session) -> list[str]:
+            return [
+                row.folder
+                for row in session.exec(select(ReferenceFolder)).all()
+                if row.folder
+            ]
+
+        try:
+            folders = self.db.run_immediate_read_task(fetch)
+        except Exception as exc:
+            logger.warning(
+                "Could not read the reference folders of %s; treating the set "
+                "as empty, so paths outside the image root will be refused: %s",
+                self.image_root,
+                exc,
+            )
+            return ()
+
+        roots: list[str] = []
+        for folder in folders:
+            roots.append(folder)
+            if self._path_mapper is not None:
+                mapped = self._path_mapper.resolve(folder)
+                if mapped != folder:
+                    roots.append(mapped)
+        return tuple(roots)
+
     def watch_reference_folder(self, folder_id: int, folder_path: str) -> None:
         """Start watching *folder_path* for reference folder *folder_id*.
 

--- a/tests/test_path_containment.py
+++ b/tests/test_path_containment.py
@@ -1,0 +1,288 @@
+"""Containment of stored paths before they reach a destructive operation (#776).
+
+A snapshot's ``relative_path`` and a ``Picture.file_path`` are database values.
+A wrong one, written by a faulty import or a bug, previously reached an
+unattended ``os.remove``. These tests assert BOTH directions at every sink that
+deletes or overwrites:
+
+- a stored path that escapes the vault root is refused at snapshot delete, GFS
+  retention and the scrapheap purge, and a fabricated sidecar column cannot
+  redirect a write; and
+- ordinary in-root paths are still deleted and written, and a picture under a
+  reference folder OUTSIDE the image root is still purged, because
+  over-blocking a delete strands files and is its own regression.
+
+Reads are deliberately not contained. Whoever can write the vault DB can read
+those files directly, so refusing to serve them buys little, while a false
+refusal presents to a desktop user as their pictures failing to load.
+"""
+
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from PIL import Image
+from sqlmodel import delete, select
+
+from pixlstash.db_models import Picture
+from pixlstash.db_models.reference_folder import ReferenceFolder, ReferenceFolderStatus
+from pixlstash.db_models.snapshot import Snapshot
+from pixlstash.server import Server
+from pixlstash.services.scrapheap_service import remove_picture_files
+from pixlstash.utils.caption_file_utils import SIDECAR_TYPE_TAGS, writeback_path
+from pixlstash.utils.path_utils import path_is_within
+
+
+@pytest.fixture(scope="module")
+def server():
+    with tempfile.TemporaryDirectory() as tmp:
+        config_path = os.path.join(tmp, "server-config.json")
+        with open(config_path, "w") as fh:
+            json.dump({"disable_background_workers": True}, fh)
+        with Server(server_config_path=config_path) as srv:
+            yield srv
+
+
+@pytest.fixture(autouse=True)
+def clean_db(server):
+    def _wipe(session):
+        session.exec(delete(Snapshot))
+        session.exec(delete(Picture))
+        session.exec(delete(ReferenceFolder))
+        session.commit()
+
+    server.vault.db.run_task(_wipe)
+    yield
+    server.vault.db.run_task(_wipe)
+
+
+def _add_reference_folder(server, folder: str) -> int:
+    def _do(session):
+        rf = ReferenceFolder(
+            folder=folder, label="ext", status=ReferenceFolderStatus.ACTIVE
+        )
+        session.add(rf)
+        session.commit()
+        return rf.id
+
+    return server.vault.db.run_task(_do)
+
+
+def _write_png(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    Image.new("RGB", (8, 8), (200, 30, 30)).save(path, format="PNG")
+
+
+# ---------------------------------------------------------------------------
+# path_is_within
+# ---------------------------------------------------------------------------
+
+
+def test_path_is_within_accepts_containment_and_refuses_escape(tmp_path):
+    base = str(tmp_path / "root")
+    os.makedirs(base)
+    assert path_is_within(os.path.join(base, "a", "b.png"), base)
+    assert path_is_within(base, base)
+    assert not path_is_within(str(tmp_path / "elsewhere.png"), base)
+    assert not path_is_within(os.path.join(base, "..", "escape.png"), base)
+    # An empty side is never contained, rather than matching everything.
+    assert not path_is_within("", base)
+    assert not path_is_within(str(tmp_path / "x.png"), "")
+
+
+def test_path_is_within_follows_a_symlinked_root(tmp_path):
+    real = tmp_path / "real-root"
+    real.mkdir()
+    link = tmp_path / "linked-root"
+    try:
+        link.symlink_to(real, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available here")
+    # The same directory spelled through its alias is still contained.
+    assert path_is_within(str(real / "pic.png"), str(link))
+
+
+# ---------------------------------------------------------------------------
+# Snapshot retention + delete
+# ---------------------------------------------------------------------------
+
+
+def _add_snapshot_row(server, kind, created_at, rel_path, manifest_rel):
+    def _do(session):
+        session.add(
+            Snapshot(
+                kind=kind,
+                created_at=created_at,
+                relative_path=rel_path,
+                manifest_relative_path=manifest_rel,
+                byte_size=1,
+                picture_count=0,
+                schema_version="test",
+            )
+        )
+        session.commit()
+
+    server.vault.db.run_task(_do)
+
+
+def test_gfs_retention_refuses_deletes_outside_the_vault_root(server, tmp_path):
+    vault_root = server.vault.image_root
+    now = datetime.now(timezone.utc)
+
+    victim = tmp_path / "victim-gfs.sqlite"
+    victim.write_bytes(b"keep me")
+    victim_manifest = tmp_path / "victim-gfs.manifest.json"
+    victim_manifest.write_bytes(b"keep me too")
+    hostile_rel = os.path.relpath(str(victim), vault_root)
+    hostile_manifest_rel = os.path.relpath(str(victim_manifest), vault_root)
+    assert hostile_rel.startswith("..")
+
+    # Oldest row is hostile; second-oldest is a legitimate in-root snapshot
+    # whose files retention MUST still clean up (the positive direction).
+    legit_rel = "snapshots/legit-old.sqlite.zst"
+    legit_manifest_rel = "snapshots/legit-old.manifest.json"
+    legit_abs = os.path.join(vault_root, legit_rel)
+    legit_manifest_abs = os.path.join(vault_root, legit_manifest_rel)
+    os.makedirs(os.path.dirname(legit_abs), exist_ok=True)
+    for p in (legit_abs, legit_manifest_abs):
+        with open(p, "wb") as fh:
+            fh.write(b"old snapshot bits")
+
+    _add_snapshot_row(
+        server, "DAILY", now - timedelta(days=30), hostile_rel, hostile_manifest_rel
+    )
+    _add_snapshot_row(
+        server, "DAILY", now - timedelta(days=20), legit_rel, legit_manifest_rel
+    )
+    for i in range(7):
+        _add_snapshot_row(
+            server,
+            "DAILY",
+            now - timedelta(days=i),
+            f"snapshots/recent-{i}.sqlite.zst",
+            f"snapshots/recent-{i}.manifest.json",
+        )
+
+    server.vault.snapshot_service._apply_gfs_retention(now)
+
+    # Hostile files survived; the legitimate pruned snapshot's files are gone.
+    assert victim.read_bytes() == b"keep me"
+    assert victim_manifest.read_bytes() == b"keep me too"
+    assert not os.path.exists(legit_abs)
+    assert not os.path.exists(legit_manifest_abs)
+    remaining = server.vault.db.run_immediate_read_task(
+        lambda s: s.exec(select(Snapshot)).all()
+    )
+    assert len(remaining) == 7
+
+
+def test_delete_snapshot_refuses_files_outside_the_vault_root(server, tmp_path):
+    vault_root = server.vault.image_root
+    victim = tmp_path / "victim-delete.sqlite"
+    victim.write_bytes(b"still here")
+    hostile_rel = os.path.relpath(str(victim), vault_root)
+    _add_snapshot_row(
+        server,
+        "MANUAL",
+        datetime.now(timezone.utc),
+        hostile_rel,
+        hostile_rel + ".manifest.json",
+    )
+    snap_id = server.vault.db.run_immediate_read_task(
+        lambda s: s.exec(select(Snapshot.id)).one()
+    )
+    assert server.vault.snapshot_service.delete_snapshot(snap_id) is True
+    assert victim.read_bytes() == b"still here"
+
+
+def test_delete_snapshot_still_removes_in_root_files(server):
+    vault_root = server.vault.image_root
+    rel = "snapshots/deletable.sqlite.zst"
+    manifest_rel = "snapshots/deletable.manifest.json"
+    abs_path = os.path.join(vault_root, rel)
+    abs_manifest = os.path.join(vault_root, manifest_rel)
+    os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+    for p in (abs_path, abs_manifest):
+        with open(p, "wb") as fh:
+            fh.write(b"snapshot bits")
+    _add_snapshot_row(server, "MANUAL", datetime.now(timezone.utc), rel, manifest_rel)
+    snap_id = server.vault.db.run_immediate_read_task(
+        lambda s: s.exec(select(Snapshot.id)).one()
+    )
+    assert server.vault.snapshot_service.delete_snapshot(snap_id) is True
+    assert not os.path.exists(abs_path)
+    assert not os.path.exists(abs_manifest)
+
+
+# ---------------------------------------------------------------------------
+# Scrapheap purge delete
+# ---------------------------------------------------------------------------
+
+
+def test_scrapheap_purge_refuses_out_of_root_targets(tmp_path):
+    image_root = str(tmp_path / "library")
+    os.makedirs(image_root)
+    victim = tmp_path / "victim-purge.png"
+    victim.write_bytes(b"precious")
+    unconfirmed = remove_picture_files(image_root, [(1, str(victim), False)])
+    unconfirmed += remove_picture_files(image_root, [(2, "../victim-purge.png", False)])
+    assert victim.read_bytes() == b"precious"
+    # Refused is reported as not-confirmed-gone, so the ledger is corrected and
+    # restore can still resurrect the row.
+    assert len(unconfirmed) == 2
+
+
+def test_scrapheap_purge_still_removes_in_root_files(tmp_path):
+    image_root = str(tmp_path / "library")
+    doomed = os.path.join(image_root, "doomed.png")
+    _write_png(doomed)
+    unconfirmed = remove_picture_files(image_root, [(1, "doomed.png", False)])
+    assert not os.path.exists(doomed)
+    assert unconfirmed == []
+
+
+def test_scrapheap_purge_still_removes_reference_folder_files(tmp_path):
+    """Over-blocking regression: reference-folder pictures live outside the
+    image root and must still be deleted by delete-forever."""
+    image_root = str(tmp_path / "library")
+    ref_root = str(tmp_path / "external-refs")
+    os.makedirs(image_root)
+    doomed = os.path.join(ref_root, "sub", "ref.png")
+    _write_png(doomed)
+    unconfirmed = remove_picture_files(image_root, [(1, doomed, True)], (ref_root,))
+    assert not os.path.exists(doomed)
+    assert unconfirmed == []
+
+
+def test_vault_supplies_the_reference_roots_the_purge_needs(server, tmp_path):
+    """The wiring: the roots the purge is handed come from the folder table."""
+    ref_root = str(tmp_path / "vault-refs")
+    os.makedirs(ref_root)
+    _add_reference_folder(server, ref_root)
+    assert ref_root in server.vault.reference_folder_roots()
+
+
+# ---------------------------------------------------------------------------
+# Caption sidecar write-back
+# ---------------------------------------------------------------------------
+
+
+def test_writeback_ignores_fabricated_existing_path(tmp_path):
+    image_root = str(tmp_path / "library")
+    os.makedirs(image_root)
+    image = os.path.join(image_root, "img.png")
+    # A tags_file column pointing anywhere else must not become a write target;
+    # the suffix-derived sidecar path is used instead.
+    assert writeback_path(
+        image, SIDECAR_TYPE_TAGS, "_tags.txt", str(tmp_path / "authorized_keys")
+    ) == os.path.join(image_root, "img_tags.txt")
+
+
+def test_writeback_honours_a_legitimate_existing_path(tmp_path):
+    image_root = str(tmp_path / "library")
+    os.makedirs(image_root)
+    image = os.path.join(image_root, "img.png")
+    recorded = os.path.join(image_root, "img_tags.txt")
+    assert writeback_path(image, SIDECAR_TYPE_TAGS, None, recorded) == recorded

--- a/tests/test_reference_folder_sidecars.py
+++ b/tests/test_reference_folder_sidecars.py
@@ -211,12 +211,25 @@ def test_writeback_path_returns_none_for_unusable_configured_suffix():
         writeback_path("/refs/f/photo.png", SIDECAR_TYPE_TAGS, "../escape.txt", None)
         is None
     )
-    # An already-resolved existing path is still honoured.
+    # An already-resolved existing path is still honoured when it is the image
+    # stem plus a safe suffix (the only shape a legitimately recorded sidecar
+    # path can have — see #776 for why anything else is refused).
+    assert (
+        writeback_path(
+            "/refs/f/photo.png",
+            SIDECAR_TYPE_TAGS,
+            "../escape.txt",
+            "/refs/f/photo_tags.txt",
+        )
+        == "/refs/f/photo_tags.txt"
+    )
+    # An existing path that is NOT stem+suffix (e.g. a fabricated tags_file
+    # column) is ignored; with no usable configured suffix either, no path.
     assert (
         writeback_path(
             "/refs/f/photo.png", SIDECAR_TYPE_TAGS, "../escape.txt", "/refs/f/ok.txt"
         )
-        == "/refs/f/ok.txt"
+        is None
     )
     # And a clean suffix is unaffected.
     assert (


### PR DESCRIPTION
Part of #776. This is the half of #777 that has no policy tension: contain the paths that reach a **delete or a write**, and leave the read path alone.

## What is contained

- **Snapshot file paths** (`relative_path` / manifest / hashes) go through `resolve_path_within(vault_root, …)` at every read/delete site: retention prune, snapshot delete, restore, identity scrub. `os.path.join` silently discards the base when a component is absolute, so a bad row previously reached `os.remove`. `resolve_path_within` already exists on develop and is already exercised on the Windows lane; no new path predicates are introduced for these sinks.
- **The scrapheap purge delete** (`remove_picture_files`) is the one unattended `os.remove` that follows `Picture.file_path` wherever it points. It now checks the resolved path against `image_root` plus the configured reference-folder roots, passed in by the caller from the new `Vault.reference_folder_roots()`. A refused path is reported as unconfirmed, so the ledger is corrected to `file_removed=False` and restore can still resurrect the row.
- **Sidecar write-backs** (`caption_file_utils.writeback_path`) only honour a recorded `tags_file` / `description_file` when it is exactly the image stem plus a safe suffix, the one shape a legitimate sidecar path can have. A fabricated column can no longer redirect a write.

## What is deliberately not contained

`resolve_picture_path` does not police where a picture lives, and `#777`'s reference-roots provider, cache and registration are not here.

Whoever can write the vault DB can read those files directly, so refusing to *serve* an out-of-root picture buys little. Against that, the false-refusal surface is real: an orphaned reference-folder row, a moved mount, a path-mapper form, or a Windows path spelling all produce a refusal, and a refusal at the resolver returns `None`, which a desktop user experiences as their pictures failing to load with only a server-side warning.

The asymmetry is the whole argument for this split: **over-blocking a delete strands a file and is recoverable; over-blocking a read breaks the library.** Same reasoning is recorded in `docs/backend_architecture.md`.

## Verification

- New `tests/test_path_containment.py`, 11 tests, added to the `backend` gate list in alphabetical position. Both directions at every sink: escape refused, and in-root plus reference-folder files still deleted.
- Revert-check: dropping only the `remove_picture_files` guard fails `test_scrapheap_purge_refuses_out_of_root_targets` and `test_scrapheap_purge_still_removes_reference_folder_files`.
- 433 passed across `test_path_containment`, `test_reference_folder_sidecars`, `test_scrapheap_retention`, `test_snapshots`, `test_restore`, `test_gfs_snapshot_schedule`, `test_architecture_guardrails`, `test_ci_shards`. `ruff format` + `ruff check` clean, `render_backend_architecture.py --check` OK.

Supersedes #777, which is closed with the reasoning.