### PR TITLE
Tell an adapter from a checkpoint, and derive a name worth showing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,7 @@ jobs:
           tests/test_metadata_hash.py
           tests/test_metadata_hash_batching.py
           tests/test_migrations.py
+          tests/test_model_file_classification.py
           tests/test_model_unload_race.py
           tests/test_multi_project_membership_authz.py
           tests/test_openapi_response_schemas.py

--- a/pixlstash/utils/adapter_header.py
+++ b/pixlstash/utils/adapter_header.py
@@ -70,6 +70,27 @@ _MARKER_RE = re.compile(
 
 KIND_UNKNOWN = "unknown"
 
+# What the file is, as opposed to which algorithm an adapter uses.
+FILE_ADAPTER = "adapter"
+FILE_CHECKPOINT = "checkpoint"
+FILE_UNKNOWN = "unknown"
+
+# Parameter count above which a marker-free file is a base checkpoint rather
+# than an adapter we failed to recognise.
+#
+# Adapters are low-rank deltas and checkpoints are whole models, so the two
+# separate by about an order of magnitude: a rank-32 adapter runs to tens of
+# millions of parameters, while SDXL is ~2.6 B and Flux ~12 B. The threshold
+# sits well above the largest plausible adapter (a high-rank adapter on a large
+# base can reach the low hundreds of millions) and well below the smallest
+# plausible checkpoint, so the band between them returns FILE_UNKNOWN rather
+# than guessing. The caller resolves that band with the folder's declared kind,
+# which is a user-visible and user-correctable prior rather than a heuristic.
+#
+# Parameter count, not file size: size is confounded in both directions, since
+# quantisation shrinks a checkpoint and a high rank inflates an adapter.
+_CHECKPOINT_MIN_PARAMS = 1_000_000_000
+
 
 @dataclass(frozen=True)
 class AdapterInfo:
@@ -81,7 +102,18 @@ class AdapterInfo:
     differently, since the first is a prompt to fill something in.
 
     Attributes:
-        kind: Adapter algorithm from tensor names, or ``"unknown"``.
+        kind: Adapter algorithm from tensor names, or ``"unknown"``. Only
+            meaningful when ``is_adapter`` is true.
+        is_adapter: Whether adapter tensor markers were found. This is *proven*
+            from names the file cannot strip without breaking, so an
+            unrecognised LyCORIS variant reads as "an adapter whose kind we do
+            not know" rather than being mistaken for a checkpoint.
+        file_kind: What the file is: ``"adapter"``, ``"checkpoint"`` or
+            ``"unknown"``. Never guesses checkpoint from the absence of
+            markers alone; see :func:`classify_model_file`.
+        param_count: Total parameters, summed from the tensor shapes already in
+            the header. Exact and free, unlike file size which quantisation and
+            rank both confound.
         tensor_count: Number of tensors, excluding the metadata entry.
         base_model: Trainer-reported base model. **Free text** (``zimage``,
             ``krea2``, ``minimax_h3`` seen in the wild), not a closed set.
@@ -96,6 +128,9 @@ class AdapterInfo:
 
     kind: str
     tensor_count: int
+    is_adapter: bool = False
+    file_kind: str = FILE_UNKNOWN
+    param_count: int = 0
     base_model: Optional[str] = None
     trigger_words: list[str] = field(default_factory=list)
     display_name: Optional[str] = None
@@ -199,6 +234,86 @@ def detect_adapter_kind(tensor_names) -> str:
         if found.intersection(markers):
             return kind
     return KIND_UNKNOWN
+
+
+def has_adapter_markers(tensor_names) -> bool:
+    """Return whether *tensor_names* contain any known adapter marker.
+
+    Separate from :func:`detect_adapter_kind` on purpose. That function answers
+    "which algorithm", and returns ``"unknown"`` both for a file with no markers
+    at all and for one whose markers we do not recognise. Those are different
+    facts and the shelf needs them apart: the first may be a checkpoint, the
+    second is definitely an adapter.
+
+    Args:
+        tensor_names: Iterable of tensor keys from the header.
+
+    Returns:
+        True when at least one tensor name carries an adapter marker.
+    """
+    for name in tensor_names:
+        if isinstance(name, str) and _MARKER_RE.search(name):
+            return True
+    return False
+
+
+def count_parameters(header: dict) -> int:
+    """Return the total parameter count implied by a safetensors *header*.
+
+    Each tensor entry carries its ``shape``, so the count is exact and costs no
+    extra I/O: the header has already been read. Entries whose shape is missing
+    or malformed contribute nothing rather than raising, because this runs in
+    the import path and a file we cannot measure is still a file the user wants.
+
+    Args:
+        header: Parsed safetensors header.
+
+    Returns:
+        Sum over tensors of the product of each shape, or 0 when nothing is
+        measurable. A scalar tensor (empty shape) counts as one parameter.
+    """
+    total = 0
+    for key, entry in header.items():
+        if key == "__metadata__" or not isinstance(entry, dict):
+            continue
+        shape = entry.get("shape")
+        if not isinstance(shape, list):
+            continue
+        count = 1
+        for dim in shape:
+            if not isinstance(dim, int) or isinstance(dim, bool) or dim < 0:
+                count = 0
+                break
+            count *= dim
+        total += count
+    return total
+
+
+def classify_model_file(tensor_names, param_count: int) -> str:
+    """Return what a file *is*, given its tensor names and parameter count.
+
+    The rule is deliberately asymmetric. Adapter is asserted on **positive**
+    evidence (markers the file cannot strip). Checkpoint is also asserted on
+    positive evidence (a parameter count no adapter reaches). Everything else
+    is ``"unknown"``, which the shelf shows as unknown and lets the user
+    correct.
+
+    ``unknown`` must never be rendered or stored as checkpoint. A marker-free
+    file is only a checkpoint when it is big enough to be one; otherwise it is
+    most likely an adapter format we have not met yet.
+
+    Args:
+        tensor_names: Iterable of tensor keys from the header.
+        param_count: Total parameters, from :func:`count_parameters`.
+
+    Returns:
+        ``"adapter"``, ``"checkpoint"`` or ``"unknown"``.
+    """
+    if has_adapter_markers(tensor_names):
+        return FILE_ADAPTER
+    if param_count >= _CHECKPOINT_MIN_PARAMS:
+        return FILE_CHECKPOINT
+    return FILE_UNKNOWN
 
 
 def _trigger_words_from_tag_frequency(raw) -> list[str]:
@@ -309,9 +424,14 @@ def describe_adapter(path: str) -> Optional[AdapterInfo]:
     # carrying only that is "no metadata" as far as the shelf is concerned.
     informative = {key for key in metadata if key != "format"}
 
+    param_count = count_parameters(header)
+
     return AdapterInfo(
         kind=detect_adapter_kind(tensor_names),
         tensor_count=len(tensor_names),
+        is_adapter=has_adapter_markers(tensor_names),
+        file_kind=classify_model_file(tensor_names, param_count),
+        param_count=param_count,
         base_model=str(base_model) if base_model else None,
         trigger_words=_trigger_words_from_tag_frequency(
             metadata.get("ss_tag_frequency")

--- a/pixlstash/utils/model_utils.py
+++ b/pixlstash/utils/model_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import platform
+import re
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -115,11 +116,65 @@ def clean_asset_name(filename: str) -> str:
 
     Used to produce human-readable model and LoRA names for text embedding.
     Example: 'z_image_turbo_bf16.safetensors' -> 'z image turbo bf16'
+
+    Note:
+        This feeds sentence embeddings (``inference/workflows/text_embedding``),
+        so its output is baked into stored vectors. Changing it would silently
+        invalidate every embedding built from ComfyUI metadata. The shelf's
+        display name therefore layers on top in :func:`derive_model_name`
+        instead of altering this.
     """
     name = os.path.basename(filename or "")
     name = os.path.splitext(name)[0]
     name = name.replace("_", " ").replace("-", " ")
     return name.strip()
+
+
+# Trailing tokens that record where in a training run a checkpoint was saved.
+# `JimmyCarr_000002750` and `ohwx_woman-step00004500` are one subject each, not
+# a subject called "JimmyCarr 000002750".
+#
+# The bare-digit rule needs five digits or more on purpose: ai-toolkit
+# zero-pads its step counts, while a genuine version suffix is short. So
+# `000002750` goes and the `2` in `portrait mix v2` stays.
+_TRAINING_SUFFIX_RE = re.compile(
+    r"^(?:step\d+|epoch\d+|\d+ep|\d{5,})$",
+    re.IGNORECASE,
+)
+
+
+def derive_model_name(filename: str) -> str:
+    """Return a display name for a model file that never said what it is called.
+
+    Builds on :func:`clean_asset_name` and additionally drops trailing training
+    bookkeeping, because the step and epoch are parsed into their own fields and
+    repeating them in the name turns six checkpoints of one run into six
+    unrelated-looking rows.
+
+    This is a *derived* name and the caller must treat it as one: the shelf
+    stores ``display_name`` as NULL and computes this at render, so
+    ``WHERE display_name IS NULL`` stays an exact "nobody has named this" queue
+    and a guess is never mistaken for a choice.
+
+    Args:
+        filename: File name or path.
+
+    Returns:
+        A human-readable name, or ``""`` when nothing survives. Callers decide
+        what an empty result looks like; the shelf shows "no name in file".
+
+    Examples:
+        >>> derive_model_name("JimmyCarr_000002750.safetensors")
+        'JimmyCarr'
+        >>> derive_model_name("ohwx_woman-step00004500.safetensors")
+        'ohwx woman'
+        >>> derive_model_name("portrait_mix_v2.safetensors")
+        'portrait mix v2'
+    """
+    tokens = clean_asset_name(filename).split()
+    while tokens and _TRAINING_SUFFIX_RE.match(tokens[-1]):
+        tokens.pop()
+    return " ".join(tokens)
 
 
 def trim_process_memory() -> None:

--- a/tests/test_model_file_classification.py
+++ b/tests/test_model_file_classification.py
@@ -1,0 +1,195 @@
+"""Adapter versus checkpoint, and the display name derived from a filename.
+
+Split from ``test_adapter_header.py`` because these cover a different question.
+That file asks "what does this adapter say about itself"; this one asks "what
+*is* this file, and what do we call it when it will not say".
+
+The rule under test throughout: **``unknown`` is never upgraded to
+``checkpoint``.** A marker-free file is a checkpoint only when it is large
+enough to be one. Anything smaller is most likely an adapter format we have not
+met yet, and calling it a checkpoint would put it in the wrong list with no way
+for the user to see why.
+"""
+
+import json
+import struct
+
+import pytest
+
+from pixlstash.utils.adapter_header import (
+    FILE_ADAPTER,
+    FILE_CHECKPOINT,
+    FILE_UNKNOWN,
+    KIND_UNKNOWN,
+    classify_model_file,
+    count_parameters,
+    describe_adapter,
+    has_adapter_markers,
+)
+from pixlstash.utils.model_utils import clean_asset_name, derive_model_name
+
+
+def _write_safetensors(path, tensors, metadata=None):
+    """Write a syntactically valid safetensors file with no tensor payload.
+
+    Only the header is ever read, so the payload is omitted deliberately: it
+    keeps the fixtures small and proves the reader never reaches past the
+    header.
+    """
+    header = dict(tensors)
+    if metadata is not None:
+        header["__metadata__"] = metadata
+    blob = json.dumps(header).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob)
+    return str(path)
+
+
+def _tensor(shape):
+    return {"dtype": "F16", "shape": list(shape), "data_offsets": [0, 0]}
+
+
+class TestParameterCount:
+    def test_sums_the_product_of_every_shape(self):
+        header = {"a": _tensor([2, 3]), "b": _tensor([10])}
+        assert count_parameters(header) == 16
+
+    def test_ignores_the_metadata_entry(self):
+        header = {"a": _tensor([4]), "__metadata__": {"format": "pt"}}
+        assert count_parameters(header) == 4
+
+    def test_a_scalar_tensor_counts_as_one(self):
+        assert count_parameters({"s": _tensor([])}) == 1
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            {"dtype": "F16"},  # no shape at all
+            {"dtype": "F16", "shape": "3"},  # shape not a list
+            {"dtype": "F16", "shape": [2, "x"]},  # non-integer dim
+            {"dtype": "F16", "shape": [2, -1]},  # negative dim
+        ],
+    )
+    def test_a_malformed_entry_contributes_nothing_rather_than_raising(self, bad):
+        # This runs in the import path. A file we cannot measure is still a file
+        # the user wants on the shelf.
+        assert count_parameters({"good": _tensor([5]), "bad": bad}) == 5
+
+
+class TestAdapterMarkers:
+    def test_markers_are_found_by_name(self):
+        assert has_adapter_markers(["blocks.0.lora_A.weight"])
+
+    def test_a_marker_free_file_reports_no_markers(self):
+        assert not has_adapter_markers(["model.diffusion_model.input_blocks.0.weight"])
+
+    def test_non_string_keys_are_skipped(self):
+        assert not has_adapter_markers([None, 42, ("tuple",)])
+
+
+class TestFileClassification:
+    def test_markers_make_it_an_adapter_at_any_size(self):
+        # Positive evidence beats size: a tiny adapter is still an adapter.
+        assert classify_model_file(["x.lora_A.weight"], param_count=1) == FILE_ADAPTER
+
+    def test_markers_win_even_at_checkpoint_scale(self):
+        assert (
+            classify_model_file(["x.lora_A.weight"], param_count=12_000_000_000)
+            == FILE_ADAPTER
+        )
+
+    def test_marker_free_and_large_is_a_checkpoint(self):
+        assert (
+            classify_model_file(["model.weight"], param_count=2_600_000_000)
+            == FILE_CHECKPOINT
+        )
+
+    def test_marker_free_and_small_stays_unknown(self):
+        # The regression that matters: this must NOT become a checkpoint. It is
+        # far more likely an adapter format the marker table has not learned.
+        assert (
+            classify_model_file(["some.unrecognised.weight"], param_count=40_000_000)
+            == FILE_UNKNOWN
+        )
+
+    def test_an_empty_file_is_unknown(self):
+        assert classify_model_file([], param_count=0) == FILE_UNKNOWN
+
+
+class TestDescribeAdapterCarriesTheNewFields:
+    def test_an_adapter_reports_is_adapter_and_its_kind(self, tmp_path):
+        path = _write_safetensors(
+            tmp_path / "a.safetensors",
+            {"blocks.0.lora_A.weight": _tensor([32, 768])},
+        )
+        info = describe_adapter(path)
+        assert info.is_adapter is True
+        assert info.kind == "lora"
+        assert info.file_kind == FILE_ADAPTER
+        assert info.param_count == 32 * 768
+
+    def test_an_unrecognised_adapter_is_still_an_adapter(self, tmp_path):
+        # kind is unknown, is_adapter is false, and the file is small: exactly
+        # the case that used to be indistinguishable from a checkpoint.
+        path = _write_safetensors(
+            tmp_path / "b.safetensors",
+            {"blocks.0.some_future_format.weight": _tensor([8, 8])},
+        )
+        info = describe_adapter(path)
+        assert info.kind == KIND_UNKNOWN
+        assert info.is_adapter is False
+        assert info.file_kind == FILE_UNKNOWN
+
+    def test_a_large_marker_free_file_reports_checkpoint(self, tmp_path):
+        path = _write_safetensors(
+            tmp_path / "c.safetensors",
+            {"model.diffusion_model.weight": _tensor([100_000, 20_000])},
+        )
+        info = describe_adapter(path)
+        assert info.is_adapter is False
+        assert info.file_kind == FILE_CHECKPOINT
+        assert info.param_count == 2_000_000_000
+
+
+class TestDerivedName:
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("JimmyCarr_000002750.safetensors", "JimmyCarr"),
+            ("ohwx_woman-step00004500.safetensors", "ohwx woman"),
+            ("hmmotion_minimax-h3_epoch12.safetensors", "hmmotion minimax h3"),
+            ("k3nk-13ep.safetensors", "k3nk"),
+            ("ClementineDetailed.safetensors", "ClementineDetailed"),
+        ],
+    )
+    def test_training_bookkeeping_is_dropped(self, filename, expected):
+        assert derive_model_name(filename) == expected
+
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("portrait_mix_v2.safetensors", "portrait mix v2"),
+            ("JimmyCarr2.safetensors", "JimmyCarr2"),
+            ("sdxl_1.safetensors", "sdxl 1"),
+        ],
+    )
+    def test_version_suffixes_survive(self, filename, expected):
+        # A short trailing number is a version, not a step count. Stripping it
+        # would merge JimmyCarr and JimmyCarr2, which are two different runs.
+        assert derive_model_name(filename) == expected
+
+    def test_repeated_suffixes_are_all_dropped(self):
+        assert derive_model_name("subject_epoch3_000001500.safetensors") == "subject"
+
+    def test_a_name_that_is_only_bookkeeping_derives_to_empty(self):
+        # The caller decides what to show; the shelf renders "no name in file".
+        assert derive_model_name("step00001500.safetensors") == ""
+
+    def test_clean_asset_name_is_unchanged(self):
+        # Guards the embedding path: this output is baked into stored vectors,
+        # so derive_model_name layers on top rather than altering it.
+        assert clean_asset_name("z_image_turbo_bf16.safetensors") == (
+            "z image turbo bf16"
+        )
+        assert clean_asset_name("JimmyCarr_000002750.safetensors") == (
+            "JimmyCarr 000002750"
+        )


### PR DESCRIPTION
Stacks on #783. Adds the two things the shelf needs beyond "what does this adapter say about itself".

**Classification.** `is_adapter` is true when tensor markers are present, `param_count` is `sum(prod(shape))` over the shapes the header already carries (exact, no extra I/O, and not file size, which quantisation and rank confound in both directions). The rule that matters: **`unknown` is never upgraded to `checkpoint`.** A marker-free file is a checkpoint only when it is large enough to be one; anything smaller is most likely an adapter format the marker table has not met yet, and calling it a checkpoint would file it in the wrong list with no way for the user to see why.

**Derived name.** `derive_model_name()` drops trailing training bookkeeping, so six checkpoints of one run stop looking like six unrelated models. The bare-digit rule needs five digits, because ai-toolkit zero-pads step counts while a genuine version suffix is short: `000002750` goes, the `2` in `portrait mix v2` stays.

## Deviation from the plan worth flagging

The step said extend `clean_asset_name()`. **I did not.** It feeds `inference/workflows/text_embedding`, so its output is baked into stored vectors, and changing it would silently invalidate every embedding built from ComfyUI metadata. `derive_model_name()` layers on top instead, and a test pins the old behaviour so this cannot be undone by accident.

## Verification
- 187 tests pass (206 including `test_migrations.py`, since this now sits on the #780 migration changes)
- `ruff format --check` and `ruff check` clean
- `tests/test_model_file_classification.py` added to `ci.yml` in alphabetical position

https://claude.ai/code/session_01PPYSfMTVkJvyXUGhxJH4Vf