### PR TITLE
Give the sidebar one left edge and one indent step (#760)

### DIFF
--- a/docs/design/visual-language.md
+++ b/docs/design/visual-language.md
@@ -472,19 +472,41 @@ Never add the border on select, and never "compensate" for it with padding. Addi
 3px of border and 8px of padding on `.active` moves the label 3px right; that is a
 bug that has shipped here twice, once under a comment asserting it does not happen.
 
-**Why these three widths.** `--gutter-glyph` is 16px because the sidebar already
-forced every chevron and row icon to 16px with `!important`. `--indent-step` is
-`--gutter-glyph + --space-3` = 24px, and equals `--space-6`, so it is on-grid by
-construction. `--entity-thumb` is 24px, promoted from the sidebar's own
-`--sidebar-thumb-size`. Nothing here was invented.
+**Rank is carried by type; depth is carried by indent.** Two rows at different
+ranks must differ in *type* even when they also differ in indent, so neither
+signal is load-bearing on its own. This is not decoration. When a project row and
+the section captions nested under it were set identically (both `--text-2xs`,
+semibold, uppercase), indentation had to signal both containment *and* rank, and
+the only way to make rank legible was a bigger step. Three levels of that pushed
+entity names to 91px in a 240px rail. One ramp step of contrast between project
+and caption is what makes a 16px indent enough.
 
-**One glyph advances the row by exactly one step.** This is the part that is easy
-to get subtly wrong: a 16px glyph in a row that gaps at 4px advances the label by
-20px, not 24, so glyph columns drift 4px per level and the tree reads as
-hand-placed. The glyph slot therefore carries its own `margin-right: --space-2` on
-top of the row gap, making the advance 16 + 4 + 4 = 24. With that, a child's
-chevron lands under its parent's icon and the child's icon under its parent's
-label. If you change a row's `gap`, re-check this sum.
+**The indent step is set by legibility, not by glyph arithmetic.** `--indent-step`
+is 16px because that is the smallest on-grid step that still reads as nesting at
+this density. It is deliberately *not* derived from the glyph column. An earlier
+version set it to `--gutter-glyph + --space-3` = 24px so that one chevron would
+advance exactly one level, and tuned a margin onto the glyph slot to make the sum
+come out. That bought a child's chevron landing precisely under its parent's
+label, which nobody notices, and charged 24px per level for it. Do not tune the
+step and the glyph advance to each other; they answer different questions.
+
+**Why the other two widths.** `--gutter-glyph` is 16px because the sidebar already
+forced every chevron and row icon to 16px with `!important`. `--entity-thumb` is
+24px, promoted from the sidebar's own `--sidebar-thumb-size`.
+
+**Children indent past their parent's glyph, not past its row.** A disclosure
+group's children step in once from the group's own glyph column, so a child's mark
+lands under its parent's label. That is what every file tree does. Do not flatten
+it to save width; take the width out of the step size instead.
+
+**A caption with nothing under it is not a disclosure.** Rendering a disclosure
+affordance for an empty group is wrong whether the chevron is visible or hidden,
+and reserved-but-blank is the worst of the three because the empty box reads as a
+missing glyph. Make the row inert instead: `aria-disabled`, no hover response,
+label at `--opacity-disabled`. The dimmed label is what explains the blank slot.
+Keep the slot reserved so the caption does not shift when the first child
+arrives, and **keep the group's own add action at full strength and operable**,
+because it is the only way out of the empty state.
 
 **Scoped CSS does not cross a component boundary.** A row rendered by a child
 component gets none of the parent's scoped rules, so a recursive tree component must

--- a/docs/design/visual-language.md
+++ b/docs/design/visual-language.md
@@ -478,8 +478,21 @@ signal is load-bearing on its own. This is not decoration. When a project row an
 the section captions nested under it were set identically (both `--text-2xs`,
 semibold, uppercase), indentation had to signal both containment *and* rank, and
 the only way to make rank legible was a bigger step. Three levels of that pushed
-entity names to 91px in a 240px rail. One ramp step of contrast between project
-and caption is what makes a 16px indent enough.
+entity names to 91px in a 240px rail. Two ramp steps of size between project and
+caption is what makes a 16px indent enough.
+
+**Rank is size, weight and tracking. It is never opacity.** A structural label
+must not be dimmer than the content it heads. Dimming the section captions to 0.7
+made them the quietest thing in the column, sitting between a full-strength
+project above and full-strength entity names below, which reads as a hole rather
+than a hierarchy. Chrome recedes by being *smaller*, not by fading.
+
+**A row's caret takes its row's colour and never its own opacity.** When only the
+caption was dimmed, its caret was not, so the caret outshone the label it
+belonged to while the project's caret sat far below its own. Tying a caret to a
+fraction of its label does not fix it either: 0.7 of a 0.7 label is 0.49, which
+measures 2.95:1 against the light sidebar and misses the 3:1 that a disclosure
+glyph owes as a meaningful graphical object (WCAG 1.4.11). Leave both alone.
 
 **The indent step is set by legibility, not by glyph arithmetic.** `--indent-step`
 is 16px because that is the smallest on-grid step that still reads as nesting at

--- a/docs/design/visual-language.md
+++ b/docs/design/visual-language.md
@@ -434,6 +434,63 @@ header 36px) so the custom title bar and controls fit — see the overrides in
 onto `--bar-height` is an open reconciliation item; it moves pixels, so it needs
 UI/UX sign-off — see §13.)
 
+### 5.1 The row grid (how a list row shares a left edge)
+
+The claim above — *columns of controls share a left edge* — is the one §5 made and
+never enforced. A list row is **four columns**, and the first two are reserved:
+
+```
+[disclosure gutter] [identity mark] [label 1fr] [actions auto]
+   --gutter-glyph      --entity-thumb
+```
+
+**Columns 1 and 2 are never conditional.** A row with no chevron reserves the
+gutter anyway; a row with no thumbnail reserves the identity column anyway. That is
+the whole mechanism: a character with a face photo and one without share a left edge
+because neither column ever collapses. Optional glyphs go `visibility: hidden`, never
+`display: none`, and never `v-if`.
+
+**Depth is a number, not a class.** A row carries `--depth: 0 | 1 | 2` and the grid
+multiplies it:
+
+```css
+padding-inline-start: calc(var(--space-3) + var(--depth, 0) * var(--indent-step));
+```
+
+No per-level classes, no `!important` override, no nested wrapper adding padding and
+a margin and a border that sum to an off-grid step.
+
+**The selection rail is always present and always transparent.** Only its colour
+changes on `.active`:
+
+```css
+border-left: 3px solid transparent;   /* base — always */
+.active { border-left-color: var(--active-bar); }
+```
+
+Never add the border on select, and never "compensate" for it with padding. Adding
+3px of border and 8px of padding on `.active` moves the label 3px right; that is a
+bug that has shipped here twice, once under a comment asserting it does not happen.
+
+**Why these three widths.** `--gutter-glyph` is 16px because the sidebar already
+forced every chevron and row icon to 16px with `!important`. `--indent-step` is
+`--gutter-glyph + --space-3` = 24px, and equals `--space-6`, so it is on-grid by
+construction. `--entity-thumb` is 24px, promoted from the sidebar's own
+`--sidebar-thumb-size`. Nothing here was invented.
+
+**One glyph advances the row by exactly one step.** This is the part that is easy
+to get subtly wrong: a 16px glyph in a row that gaps at 4px advances the label by
+20px, not 24, so glyph columns drift 4px per level and the tree reads as
+hand-placed. The glyph slot therefore carries its own `margin-right: --space-2` on
+top of the row gap, making the advance 16 + 4 + 4 = 24. With that, a child's
+chevron lands under its parent's icon and the child's icon under its parent's
+label. If you change a row's `gap`, re-check this sum.
+
+**Scoped CSS does not cross a component boundary.** A row rendered by a child
+component gets none of the parent's scoped rules, so a recursive tree component must
+consume these tokens itself rather than keep a private copy. Two copies of a row
+style drift, and the copy is where the rail bug survives.
+
 ---
 
 ## 6. Radius

--- a/frontend/src/components/editors/FolderTreeNode.vue
+++ b/frontend/src/components/editors/FolderTreeNode.vue
@@ -9,9 +9,6 @@ const props = defineProps({
   folderBrowseCache: { type: Object, required: true },
   expandedFolderIds: { type: Object, required: true }, // Set
   dropTargetKey: { type: String, default: null },
-  // True when the hovered row is the drop target but will not take the payload
-  // being dragged (a face drag over a reference folder, say).
-  dropRejected: { type: Boolean, default: false },
 });
 
 const emit = defineEmits([
@@ -55,12 +52,17 @@ function childImageCount() {
       class="sidebar-folder-row sidebar-folder-child-row"
       :class="{
         active: selectedFolderKey === 'path-' + entry.path,
-        droppable: dropTargetKey === 'path-' + entry.path && !dropRejected,
-        'not-droppable': dropTargetKey === 'path-' + entry.path && dropRejected,
+        droppable: dropTargetKey === 'path-' + entry.path,
       }"
+      :style="{ '--depth': depth }"
       :title="`${entry.path} - drop dragged reference images here to move them`"
       @contextmenu.prevent="
-        emit('context', { rfId, path: entry.path, label: entry.name, event: $event })
+        emit('context', {
+          rfId,
+          path: entry.path,
+          label: entry.name,
+          event: $event,
+        })
       "
       @dragover="emit('drag-over', { rfId, path: entry.path, event: $event })"
       @dragleave="emit('drag-leave', { rfId, path: entry.path, event: $event })"
@@ -75,13 +77,15 @@ function childImageCount() {
     >
       <v-icon
         size="12"
-        class="sidebar-folder-chevron"
-        :style="{ visibility: hasChildren() ? 'visible' : 'hidden' }"
+        class="sidebar-row-glyph sidebar-folder-chevron"
+        :class="{ 'sidebar-row-glyph--empty': !hasChildren() }"
         @click.stop="emit('toggle', entry.path)"
       >
         {{ isExpanded() ? "mdi-chevron-down" : "mdi-chevron-right" }}
       </v-icon>
-      <v-icon size="16" class="sidebar-folder-icon">mdi-folder-outline</v-icon>
+      <v-icon size="16" class="sidebar-row-glyph sidebar-folder-icon"
+        >mdi-folder-outline</v-icon
+      >
       <span class="sidebar-folder-label">{{ entry.name }}</span>
       <span
         v-if="folderBrowseCache[entry.path]?.loading || childImageCount() > 0"
@@ -110,7 +114,6 @@ function childImageCount() {
           :folder-browse-cache="folderBrowseCache"
           :expanded-folder-ids="expandedFolderIds"
           :drop-target-key="dropTargetKey"
-          :drop-rejected="dropRejected"
           @select="(key, payload) => emit('select', key, payload)"
           @toggle="(path) => emit('toggle', path)"
           @drag-over="(payload) => emit('drag-over', payload)"
@@ -129,111 +132,13 @@ function childImageCount() {
   </div>
 </template>
 
+<!-- The row itself is styled by the unscoped row system in SideBar.global.css.
+     This component used to carry its own copy of .sidebar-folder-row and
+     friends, which had drifted to an 8px inset instead of the sidebar's and
+     was missing the base selection rail, so selecting a nested folder shifted
+     its label 3px right. Do not re-add a local copy; see visual-language.md
+     §5.1. Only rules with no counterpart in the shared system stay here. -->
 <style scoped>
-.sidebar-folder-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  cursor: pointer;
-  font-size: var(--text-sm);
-  color: rgb(var(--v-theme-sidebar-text));
-  user-select: none;
-}
-
-.sidebar-folder-row:hover {
-  background: rgba(var(--v-theme-accent), 0.1);
-}
-
-.sidebar-folder-row.active {
-  background: rgba(var(--v-theme-primary), 0.18);
-  color: rgb(var(--v-theme-on-primary));
-  border-left: 3px solid rgb(var(--v-theme-primary));
-}
-
-.sidebar-folder-row.active:hover {
-  background: linear-gradient(rgba(var(--v-theme-accent), 0.08), rgba(var(--v-theme-accent), 0.08)), rgba(var(--v-theme-primary), 0.18);
-  color: rgb(var(--v-theme-on-primary));
-}
-
-.sidebar-folder-children {
-  padding-left: var(--space-2);
-  border-left: 1px dashed rgba(var(--v-theme-border), 0.35);
-  margin-left: var(--space-1);
-}
-
-.sidebar-folder-label {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
-
-.sidebar-folder-chevron,
-.sidebar-folder-icon {
-  flex-shrink: 0;
-  opacity: 0.7;
-}
-
-.sidebar-folder-status-badge {
-  flex-shrink: 0;
-  margin-left: var(--space-1);
-  opacity: 0.75;
-}
-
-.sidebar-folder-count-badge {
-  flex-shrink: 0;
-  margin-left: var(--space-2);
-  min-width: 22px;
-  text-align: right;
-  font-size: var(--text-2xs);
-  font-variant-numeric: tabular-nums;
-  color: rgb(var(--v-theme-sidebar-text));
-}
-
-.sidebar-folder-row.active .sidebar-folder-count-badge {
-  color: rgba(var(--v-theme-on-primary), 0.9);
-}
-
-.sidebar-folder-row.droppable {
-  filter: brightness(1.2);
-  background: rgb(var(--v-theme-primary));
-  color: rgb(var(--v-theme-on-primary));
-}
-
-/* Rejected drop target — same state as SideBar.css `.not-droppable`, repeated
-   here because this component's styles are scoped. */
-.sidebar-folder-row.not-droppable {
-  position: relative;
-  background: repeating-linear-gradient(
-    45deg,
-    transparent 0 var(--space-2),
-    rgba(var(--v-theme-border), 0.45) var(--space-2) var(--space-3)
-  );
-  outline: 1px dashed rgba(var(--v-theme-border), 0.7);
-  outline-offset: -1px;
-  border-radius: var(--radius-sm);
-  cursor: no-drop;
-}
-
-.sidebar-folder-row.not-droppable > * {
-  opacity: var(--opacity-disabled);
-}
-
-.sidebar-folder-row.not-droppable::after {
-  content: "\F073A"; /* mdi-cancel */
-  font-family: "Material Design Icons";
-  font-size: var(--text-sm);
-  line-height: 1;
-  position: absolute;
-  top: 50%;
-  right: var(--space-3);
-  transform: translateY(-50%);
-  color: rgb(var(--v-theme-sidebar-text));
-  pointer-events: none;
-}
-
 .sidebar-folder-status--active {
   color: rgb(var(--v-theme-sidebar-text));
   cursor: pointer;

--- a/frontend/src/components/panels/SideBar.css
+++ b/frontend/src/components/panels/SideBar.css
@@ -325,35 +325,21 @@
 }
 
 /* ---------------------------------------------------------------------------
-   ROW EMPHASIS. A row's disclosure caret carries the SAME emphasis as that
-   row's label. One number per row type, and both the label and the caret read
-   it, so a caret can never end up brighter or dimmer than the text it belongs
-   to. That drifted twice: the project caret sat at 0.5 against a full-strength
-   label, and the caption caret inherited full strength against a 0.7 label.
+   NOTHING IN THIS COLUMN IS DIMMED. Rank comes from size, weight, tracking and
+   indent; every structural label and every caret sits at the row's own colour.
 
-   Same, not a fraction of it. Caret at 0.7 x a 0.7 label is 0.49, which
-   measures 2.95:1 in the light theme and fails the 3:1 floor a disclosure
-   glyph owes as a meaningful graphical object (WCAG 1.4.11). At parity both
-   land clear: 13.45:1 / 9.73:1 at 1.0 and 5.41:1 / 5.55:1 at 0.7,
-   light / dark.
+   Two failed attempts are why this is spelled out. Dimming the caption to 0.7
+   made it the quietest thing in the column, between a full-strength project
+   above and full-strength names below: a header must never be quieter than the
+   rows it heads, or the hierarchy inverts. And when only the caption was
+   dimmed, its caret was not, so the caret read brighter than its own label
+   while the project's read much dimmer than its own.
 
-   `opacity`, not `color`, on purpose: an explicit colour here would stop the
-   label following `--active-text` when its row is selected.
+   The rule that survives both: a caret takes its row's colour and never carries
+   its own opacity. `SideBarRowSystem.test.js` enforces it. This also keeps a
+   selected project following `--active-text`, which an explicit colour here
+   would break.
    --------------------------------------------------------------------------- */
-.sidebar-project-tree-row {
-  --row-emphasis: 1;
-}
-
-.sidebar-project-tree-subheader {
-  --row-emphasis: 0.7;
-}
-
-.sidebar-project-tree-label,
-.sidebar-project-tree-chevron,
-.sidebar-project-tree-subheader-label,
-.sidebar-project-tree-sub-chevron {
-  opacity: var(--row-emphasis, 1);
-}
 
 .sidebar-project-tree-name-group {
   flex: 1;
@@ -364,16 +350,18 @@
   overflow: hidden;
 }
 
-/* One ramp step above the section captions nested under it, at full strength.
-   Rank is carried by TYPE, depth by indent. When a project and a section caption
-   are set identically, indentation has to signal both, which is what forced the
-   step up to 24px and pushed names off the end of the rail. */
+/* Two ramp steps above the section captions nested under it. Rank is carried by
+   TYPE, depth by indent. When a project and a section caption were set
+   identically, indentation had to signal both, which is what forced the step up
+   to 24px and pushed names off the end of the rail. The separation is size and
+   tracking rather than emphasis, because the only thing below a caption is
+   content, and dimming a header under its own content inverts the hierarchy. */
 .sidebar-project-tree-label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   font-weight: var(--weight-semibold);
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -436,8 +424,8 @@
   color: inherit;
 }
 
-/* A caption for the list beneath it, one rank below the project. Its emphasis
-   comes from --row-emphasis above, shared with its caret. */
+/* A caption for the list beneath it, one rank below the project. Subordinate by
+   size and tracking, never by being dimmer than the rows it heads. */
 .sidebar-project-tree-subheader-label {
   font-size: var(--text-2xs);
   font-weight: var(--weight-semibold);

--- a/frontend/src/components/panels/SideBar.css
+++ b/frontend/src/components/panels/SideBar.css
@@ -57,7 +57,6 @@
   container: sidebartabs / inline-size;
 }
 
-
 .sidebar-view-tabs {
   display: flex;
   align-items: stretch;
@@ -322,15 +321,39 @@
    collapsible row here. It swaps glyph rather than rotating one, so a single
    mechanism expresses disclosure across the sidebar. */
 .sidebar-project-tree-chevron {
-  opacity: 0.5;
   color: inherit;
-  transition: opacity 0.12s;
 }
 
-.sidebar-project-tree-row:hover .sidebar-project-tree-chevron {
-  opacity: 0.9;
+/* ---------------------------------------------------------------------------
+   ROW EMPHASIS. A row's disclosure caret carries the SAME emphasis as that
+   row's label. One number per row type, and both the label and the caret read
+   it, so a caret can never end up brighter or dimmer than the text it belongs
+   to. That drifted twice: the project caret sat at 0.5 against a full-strength
+   label, and the caption caret inherited full strength against a 0.7 label.
+
+   Same, not a fraction of it. Caret at 0.7 x a 0.7 label is 0.49, which
+   measures 2.95:1 in the light theme and fails the 3:1 floor a disclosure
+   glyph owes as a meaningful graphical object (WCAG 1.4.11). At parity both
+   land clear: 13.45:1 / 9.73:1 at 1.0 and 5.41:1 / 5.55:1 at 0.7,
+   light / dark.
+
+   `opacity`, not `color`, on purpose: an explicit colour here would stop the
+   label following `--active-text` when its row is selected.
+   --------------------------------------------------------------------------- */
+.sidebar-project-tree-row {
+  --row-emphasis: 1;
 }
 
+.sidebar-project-tree-subheader {
+  --row-emphasis: 0.7;
+}
+
+.sidebar-project-tree-label,
+.sidebar-project-tree-chevron,
+.sidebar-project-tree-subheader-label,
+.sidebar-project-tree-sub-chevron {
+  opacity: var(--row-emphasis, 1);
+}
 
 .sidebar-project-tree-name-group {
   flex: 1;
@@ -354,7 +377,6 @@
   font-weight: var(--weight-semibold);
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: rgb(var(--v-theme-sidebar-text));
 }
 
 .sidebar-project-tree-actions {
@@ -414,14 +436,14 @@
   color: inherit;
 }
 
-/* A caption for the list beneath it, one rank below the project. Held at 0.7 so
-   the rank difference survives even where the indent is only one 16px step. */
+/* A caption for the list beneath it, one rank below the project. Its emphasis
+   comes from --row-emphasis above, shared with its caret. */
 .sidebar-project-tree-subheader-label {
   font-size: var(--text-2xs);
   font-weight: var(--weight-semibold);
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: rgba(var(--v-theme-sidebar-text), 0.7);
+  color: inherit;
   flex: 1;
 }
 
@@ -438,8 +460,7 @@
   background: transparent;
 }
 
-.sidebar-project-tree-subheader--empty
-  .sidebar-project-tree-subheader-label {
+.sidebar-project-tree-subheader--empty .sidebar-project-tree-subheader-label {
   opacity: var(--opacity-disabled, 0.38);
 }
 
@@ -448,7 +469,6 @@
 .sidebar-project-tree-child {
   --depth: 2;
 }
-
 
 .sidebar-project-tree-files {
   padding-left: 0;
@@ -663,7 +683,6 @@
   color: rgb(var(--v-theme-sidebar-text));
 }
 
-
 /* The project menu's background is a 38% `tertiary` TINT over `sidebar`, not a
    solid `tertiary` fill, so `on-tertiary` is the wrong foreground here: an
    `on-<x>` token is authored against a solid, full-opacity `<x>` fill and is
@@ -704,7 +723,6 @@
   white-space: nowrap;
 }
 
-
 .sidebar-project-menu-add {
   display: flex;
   align-items: center;
@@ -725,7 +743,6 @@
   background: rgba(var(--v-theme-accent), 0.08);
   color: rgb(var(--v-theme-on-surface));
 }
-
 
 /* Sidebar right edge for counts */
 .sidebar {
@@ -946,7 +963,6 @@
   color: #c62828;
 }
 
-
 .sidebar-collapsed-list {
   display: flex;
   flex-direction: column;
@@ -1097,7 +1113,6 @@
   position: relative;
 }
 
-
 .sidebar-collapsed-divider {
   width: 70%;
   height: 1px;
@@ -1143,7 +1158,6 @@
   transition: transform 0.15s;
 }
 
-
 .sidebar-list-item {
   display: flex;
   align-items: center;
@@ -1163,7 +1177,6 @@
     color 0.12s,
     border-color 0.12s;
 }
-
 
 .sidebar-scroll {
   flex: 1 1 auto;
@@ -1264,7 +1277,6 @@
   object-fit: contain;
   display: block;
 }
-
 
 .sidebar-list-item.active {
   background: var(--active-wash);
@@ -1429,13 +1441,11 @@
   overflow: visible;
 }
 
-
 /* Top-level nav rows (All Pictures, Scrapheap) — slightly larger than --fixed */
 .sidebar-list-icon--toplevel {
   width: min(var(--sidebar-thumb-size), 26px) !important;
   height: min(var(--sidebar-thumb-size), 26px) !important;
 }
-
 
 .sidebar-list-icon .v-icon,
 .sidebar-collapsed-item .v-icon {
@@ -1693,7 +1703,6 @@
   z-index: 2;
 }
 
-
 .add-character-inline {
   color: rgb(var(--v-theme-sidebar-text)) !important;
   font-size: var(--text-md);
@@ -1760,7 +1769,6 @@
   color: rgb(var(--v-theme-primary)) !important;
 }
 
-
 .delete-character-inline {
   color: rgb(var(--v-theme-sidebar-text)) !important;
   font-size: var(--text-md);
@@ -1782,7 +1790,6 @@
   background: rgba(var(--v-theme-error), 0.15);
   color: rgb(var(--v-theme-error)) !important;
 }
-
 
 /* Items within People/Sets sit one step under their section header, which puts
    the thumbnail directly below the header's label. */
@@ -1813,7 +1820,6 @@
   letter-spacing: 0.02em;
   color: rgb(var(--v-theme-sidebar-text));
 }
-
 
 .sidebar-all-pictures-row .sidebar-list-item {
   flex: 1 1 0;
@@ -1928,7 +1934,6 @@
     rgba(var(--v-theme-sidebar-text), 0.05);
   color: rgb(var(--v-theme-sidebar-text));
 }
-
 
 .sidebar-folder-section-title {
   flex: 1 1 auto;
@@ -2143,7 +2148,6 @@ button.sidebar-ctx-item:disabled:hover {
   max-height: calc(100vh - 16px);
   overflow-y: auto;
 }
-
 
 .sidebar-ctx-icon-section-wrap {
   display: flex;

--- a/frontend/src/components/panels/SideBar.css
+++ b/frontend/src/components/panels/SideBar.css
@@ -297,6 +297,9 @@
   border-radius: var(--radius-sm);
 }
 
+/* Still used by the two Folders-tab section bands, whose caret sits at the far
+   right AFTER the actions. That is a self-consistent band pattern, unlike the
+   project row's old mid-row caret, so it is left alone. */
 .sidebar-project-tree-expand-indicator {
   flex-shrink: 0;
   opacity: 0.5;
@@ -315,6 +318,19 @@
   opacity: 0.9;
 }
 
+/* The project's disclosure, in the leading glyph column like every other
+   collapsible row here. It swaps glyph rather than rotating one, so a single
+   mechanism expresses disclosure across the sidebar. */
+.sidebar-project-tree-chevron {
+  opacity: 0.5;
+  color: inherit;
+  transition: opacity 0.12s;
+}
+
+.sidebar-project-tree-row:hover .sidebar-project-tree-chevron {
+  opacity: 0.9;
+}
+
 
 .sidebar-project-tree-name-group {
   flex: 1;
@@ -325,15 +341,20 @@
   overflow: hidden;
 }
 
+/* One ramp step above the section captions nested under it, at full strength.
+   Rank is carried by TYPE, depth by indent. When a project and a section caption
+   are set identically, indentation has to signal both, which is what forced the
+   step up to 24px and pushed names off the end of the rail. */
 .sidebar-project-tree-label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: var(--text-2xs);
+  font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  color: rgb(var(--v-theme-sidebar-text));
 }
 
 .sidebar-project-tree-actions {
@@ -393,13 +414,33 @@
   color: inherit;
 }
 
+/* A caption for the list beneath it, one rank below the project. Held at 0.7 so
+   the rank difference survives even where the indent is only one 16px step. */
 .sidebar-project-tree-subheader-label {
   font-size: var(--text-2xs);
   font-weight: var(--weight-semibold);
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: inherit;
+  color: rgba(var(--v-theme-sidebar-text), 0.7);
   flex: 1;
+}
+
+/* A caption with nothing under it is not a disclosure. The row goes inert and
+   dims, which is what explains the empty chevron slot; the slot itself stays
+   reserved so the caption does not shift when the first entity arrives. The
+   `+` action deliberately does NOT inherit the fade and stays operable: it is
+   the only way out of the empty state. */
+.sidebar-project-tree-subheader--empty {
+  cursor: default;
+}
+
+.sidebar-project-tree-subheader--empty:hover {
+  background: transparent;
+}
+
+.sidebar-project-tree-subheader--empty
+  .sidebar-project-tree-subheader-label {
+  opacity: var(--opacity-disabled, 0.38);
 }
 
 /* Child items sit one step under their sub-section header, which is itself one

--- a/frontend/src/components/panels/SideBar.css
+++ b/frontend/src/components/panels/SideBar.css
@@ -1,3 +1,6 @@
+/* The row system lives in SideBar.global.css, NOT here. Scoped rules cannot
+   reach a child component's internals, and FolderTreeNode renders rows of the
+   same family. See docs/design/visual-language.md §5.1. */
 
 .sidebar-section-divider {
   height: 1px;
@@ -244,10 +247,8 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: 0 var(--sidebar-right-edge, 8px) 0 var(--space-3);
   min-height: 28px;
   cursor: pointer;
-  border-left: 3px solid transparent;
   border-bottom: 1px solid rgba(var(--v-theme-border), 0.2);
   border-radius: 0;
   background: transparent;
@@ -269,7 +270,7 @@
 .sidebar-project-tree-row.active {
   background: var(--active-wash);
   color: var(--active-text);
-  border-left: 3px solid var(--active-bar);
+  border-left-color: var(--active-bar);
   border-radius: 0;
 }
 
@@ -371,7 +372,9 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-1) 0 var(--space-1) var(--space-3);
+  --depth: 1;
+  padding-top: var(--space-1);
+  padding-bottom: var(--space-1);
   padding-right: var(--sidebar-header-action-right-edge) !important;
   min-height: 24px;
   cursor: pointer;
@@ -390,14 +393,6 @@
   color: inherit;
 }
 
-/* v-show sets display:none — override to visibility:hidden so the space is preserved */
-.sidebar-project-tree-sub-chevron[style*="display: none"],
-.sidebar-project-tree-sub-chevron[style*="display:none"] {
-  display: inline-flex !important;
-  visibility: hidden;
-}
-
-
 .sidebar-project-tree-subheader-label {
   font-size: var(--text-2xs);
   font-weight: var(--weight-semibold);
@@ -407,9 +402,10 @@
   flex: 1;
 }
 
-/* Child items indented under a project sub-section */
+/* Child items sit one step under their sub-section header, which is itself one
+   step under the project row. Depth, not a hardcoded inset. */
 .sidebar-project-tree-child {
-  padding-left: var(--space-5) !important;
+  --depth: 2;
 }
 
 
@@ -449,15 +445,15 @@
   color: rgb(var(--v-theme-on-surface));
 }
 
+/* The rail is reserved on the base (see .sidebar-project-menu-item) so `.active`
+   only recolours it. The previous rule added the border here and tried to cancel
+   it with padding the base already carried, moving the label 3px on select. */
 .sidebar-collapsed-project-menu .sidebar-project-menu-item.active,
 .sidebar-collapsed-project-submenu .sidebar-project-menu-item.active {
   background: rgba(var(--v-theme-primary), 0.18);
   color: rgb(var(--v-theme-on-primary));
   font-weight: 600;
-  border-left: 3px solid rgb(var(--v-theme-primary));
-  padding-left: var(
-    --space-3
-  ); /* compensate for the 3px border so text stays aligned */
+  border-left-color: rgb(var(--v-theme-primary));
 }
 
 .sidebar-collapsed-project-submenu {
@@ -635,7 +631,10 @@
 .sidebar-project-menu-item {
   display: flex;
   align-items: center;
+  box-sizing: border-box;
   padding: var(--space-2) var(--space-3);
+  /* Reserved rail: `.active` recolours it, never adds it. */
+  border-left: 3px solid transparent;
   cursor: pointer;
   font-size: var(--text-sm);
   color: rgb(var(--v-theme-on-surface));
@@ -1078,8 +1077,8 @@
   letter-spacing: 0.07em;
   text-transform: uppercase;
   min-height: clamp(18px, calc(var(--sidebar-thumb-size) * 0.65), 24px);
-  padding: clamp(2px, calc(var(--sidebar-thumb-size) * 0.1), 8px) var(--space-3)
-    var(--space-1) var(--space-3);
+  padding-top: clamp(2px, calc(var(--sidebar-thumb-size) * 0.1), 8px);
+  padding-bottom: var(--space-1);
   padding-right: var(--sidebar-header-action-right-edge) !important;
   display: flex;
   align-items: center;
@@ -1104,12 +1103,12 @@
 }
 
 
-.sidebar-list-item,
-.sidebar-list-item.active {
+.sidebar-list-item {
   display: flex;
   align-items: center;
   min-height: calc(var(--sidebar-thumb-size) + 6px);
-  padding: var(--space-2) var(--space-3);
+  padding-top: var(--space-2);
+  padding-bottom: var(--space-2);
   padding-right: var(--sidebar-right-edge) !important;
   cursor: pointer;
   border-radius: 0;
@@ -1122,7 +1121,6 @@
     background 0.12s,
     color 0.12s,
     border-color 0.12s;
-  border-left: 3px solid transparent;
 }
 
 
@@ -1230,7 +1228,7 @@
 .sidebar-list-item.active {
   background: var(--active-wash);
   color: var(--active-text);
-  border-left: 3px solid var(--active-bar);
+  border-left-color: var(--active-bar);
   position: relative;
   border-radius: 0;
 }
@@ -1279,41 +1277,7 @@
    texture carries the state, the mdi-cancel glyph names it, and the disabled
    fade (the one legal fade, visual-language.md §11) drops the row's own
    content back. Shared by character/set rows, project rows and folder rows. */
-.sidebar-list-item.not-droppable,
-.sidebar-project-tree-row.not-droppable,
-.sidebar-folder-row.not-droppable {
-  position: relative;
-  background: repeating-linear-gradient(
-    45deg,
-    transparent 0 var(--space-2),
-    rgba(var(--v-theme-border), 0.45) var(--space-2) var(--space-3)
-  );
-  outline: 1px dashed rgba(var(--v-theme-border), 0.7);
-  outline-offset: -1px;
-  border-radius: var(--radius-sm);
-  cursor: no-drop;
-}
 
-.sidebar-list-item.not-droppable > *,
-.sidebar-project-tree-row.not-droppable > *,
-.sidebar-folder-row.not-droppable > * {
-  opacity: var(--opacity-disabled);
-}
-
-.sidebar-list-item.not-droppable::after,
-.sidebar-project-tree-row.not-droppable::after,
-.sidebar-folder-row.not-droppable::after {
-  content: "\F073A"; /* mdi-cancel */
-  font-family: "Material Design Icons";
-  font-size: var(--text-sm);
-  line-height: 1;
-  position: absolute;
-  top: 50%;
-  right: var(--space-3);
-  transform: translateY(-50%);
-  color: rgb(var(--v-theme-sidebar-text));
-  pointer-events: none;
-}
 
 .sidebar-header-spacer {
   flex: 1 1 auto;
@@ -1779,9 +1743,10 @@
 }
 
 
-/* Items within People/Sets sections get a tree indent */
+/* Items within People/Sets sit one step under their section header, which puts
+   the thumbnail directly below the header's label. */
 .sidebar-section-scroll .sidebar-list-item {
-  padding-left: var(--space-5);
+  --depth: 1;
 }
 
 .sidebar-section-block .sidebar-section-header {
@@ -1830,20 +1795,22 @@
 }
 
 @media (hover: none) and (pointer: coarse) {
-  .sidebar-list-item,
-  .sidebar-list-item.active {
+  /* Touch targets grow VERTICALLY only. A `padding` shorthand here would reset
+     padding-left and flatten every row back to depth 0. */
+  .sidebar-list-item {
     min-height: 56px;
-    padding: var(--space-3) var(--space-3);
+    padding-top: var(--space-3);
+    padding-bottom: var(--space-3);
   }
 
   .sidebar-section-header {
     min-height: 48px;
   }
 
-  .sidebar-all-pictures-row .sidebar-list-item,
-  .sidebar-all-pictures-row .sidebar-list-item.active {
+  .sidebar-all-pictures-row .sidebar-list-item {
     min-height: 48px;
-    padding: var(--space-3) var(--space-3);
+    padding-top: var(--space-3);
+    padding-bottom: var(--space-3);
   }
 
   .sidebar-list-icon {
@@ -1895,14 +1862,12 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: 0 var(--sidebar-right-edge, 8px) 0 var(--space-1);
   min-height: 28px;
   cursor: pointer;
   color: rgb(var(--v-theme-sidebar-text));
   background: transparent;
   border-top: 1px solid rgba(var(--v-theme-border), 0.22);
   border-bottom: 1px solid rgba(var(--v-theme-border), 0.2);
-  border-left: 3px solid transparent;
   user-select: none;
   transition:
     background 0.12s,
@@ -1958,65 +1923,13 @@
   flex-direction: column;
 }
 
-.sidebar-folder-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-  padding: var(--space-2) var(--space-3) var(--space-2) var(--space-1);
-  cursor: pointer;
-  color: rgb(var(--v-theme-sidebar-text));
-  user-select: none;
-  min-height: 28px;
-  border-left: 3px solid transparent;
-  transition:
-    background 0.12s,
-    color 0.12s;
-}
-
 .sidebar-folder-root-row {
   font-size: var(--text-sm);
 }
 
-.sidebar-folder-row:hover {
-  background: rgba(var(--v-theme-accent), 0.08);
-  color: rgb(var(--v-theme-sidebar-text));
-}
-
-.sidebar-folder-row.active {
-  background: rgba(var(--v-theme-primary), 0.18);
-  color: rgb(var(--v-theme-on-primary));
-  border-left: 3px solid rgb(var(--v-theme-primary));
-}
-
-.sidebar-folder-row.active:hover {
-  background:
-    linear-gradient(
-      rgba(var(--v-theme-accent), 0.08),
-      rgba(var(--v-theme-accent), 0.08)
-    ),
-    rgba(var(--v-theme-primary), 0.18);
-  color: rgb(var(--v-theme-on-primary));
-}
-
-.sidebar-folder-row.droppable {
-  filter: brightness(1.2);
-  background: rgb(var(--v-theme-primary));
-  color: rgb(var(--v-theme-on-primary));
-}
-
-.sidebar-folder-children {
-  padding-left: var(--space-2);
-  border-left: 1px dashed rgba(var(--v-theme-border), 0.35);
-  margin-left: var(--space-1);
-}
-
-.sidebar-folder-label {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
+/* .sidebar-folder-row and its states, .sidebar-folder-children and
+   .sidebar-folder-label live in SideBar.global.css: FolderTreeNode renders them
+   too, and a scoped rule cannot reach into a child component. */
 
 .sidebar-folder-actions {
   display: inline-flex;
@@ -2051,43 +1964,8 @@
   opacity: 1;
 }
 
-.sidebar-folder-chevron,
-.sidebar-folder-icon {
-  flex-shrink: 0;
-  opacity: 0.7;
-}
-
-/* All folder icons fixed at 16px regardless of thumbnail size */
-.sidebar-folders-list :deep(.sidebar-folder-icon) {
-  font-size: var(--text-md) !important;
-  width: 16px !important;
-  height: 16px !important;
-}
-.sidebar-folders-list :deep(.sidebar-folder-chevron) {
-  font-size: var(--text-md) !important;
-  width: 16px !important;
-  height: 16px !important;
-}
-
-.sidebar-folder-status-badge {
-  flex-shrink: 0;
-  margin-left: var(--space-1);
-  opacity: 0.75;
-}
-
-.sidebar-folder-count-badge {
-  flex-shrink: 0;
-  margin-left: var(--space-2);
-  min-width: 22px;
-  text-align: right;
-  font-size: var(--text-xs);
-  font-variant-numeric: tabular-nums;
-  color: rgb(var(--v-theme-sidebar-text));
-}
-
-.sidebar-folder-row.active .sidebar-folder-count-badge {
-  color: rgba(var(--v-theme-on-primary), 0.65);
-}
+/* The folder glyph and badge rules also live in SideBar.global.css, for the
+   same reason. */
 
 .sidebar-folder-status--active {
   color: rgb(var(--v-theme-sidebar-text));

--- a/frontend/src/components/panels/SideBar.css
+++ b/frontend/src/components/panels/SideBar.css
@@ -1319,7 +1319,6 @@
    fade (the one legal fade, visual-language.md §11) drops the row's own
    content back. Shared by character/set rows, project rows and folder rows. */
 
-
 .sidebar-header-spacer {
   flex: 1 1 auto;
 }

--- a/frontend/src/components/panels/SideBar.global.css
+++ b/frontend/src/components/panels/SideBar.global.css
@@ -51,11 +51,9 @@
   justify-content: center;
   width: var(--gutter-glyph);
   height: var(--gutter-glyph);
-  /* The advance a glyph adds must equal exactly one --indent-step, or glyph
-     columns miss by a few px per level and the tree looks hand-placed. The
-     rows carrying glyphs gap at --space-2, so 16 + 4 + 4 = 24 = --indent-step.
-     That is what makes a child's chevron land under its parent's icon, and the
-     child's icon under its parent's label. */
+  /* Plain separation between the glyph and what follows it. This does NOT have
+     to equal --indent-step: tuning the two to each other is what produced a
+     24px step and names starting at 91px. See visual-language.md §5.1. */
   margin-right: var(--space-2);
 }
 

--- a/frontend/src/components/panels/SideBar.global.css
+++ b/frontend/src/components/panels/SideBar.global.css
@@ -1,3 +1,205 @@
+/* ---------------------------------------------------------------------------
+   THE ROW SYSTEM — see docs/design/visual-language.md §5.1
+
+   Every list row in the sidebar starts at ONE left edge and moves only by whole
+   indent steps. Before this rule there were six left edges (2, 5, 8, 11, 19px)
+   and three depth steps (7, 8, 16px), so scrolling from Folders to People
+   shifted the column under the eye.
+
+   THIS BLOCK IS DELIBERATELY UNSCOPED. FolderTreeNode.vue renders rows of the
+   same family, and a scoped rule in SideBar.css cannot cross a component
+   boundary. It used to keep its own copy, which had drifted to a different
+   padding and a missing base rail; that is the drift this placement prevents.
+   Every selector here is `sidebar-`-prefixed, so global scope is contained.
+
+   Two invariants do the work:
+
+   1. The horizontal box is owned HERE and nowhere else. Row types still set
+      their own vertical padding (they are different heights on purpose), but a
+      per-type `padding-left` is now a bug. Depth is the only thing that moves
+      the edge, and it moves it by `--indent-step`, never by a hand-summed
+      composite of padding + margin + border.
+
+   2. The selection rail is ALWAYS present and ALWAYS transparent on the base;
+      only its colour changes on `.active`. Adding the border on select and
+      "compensating" with padding shifts the label 3px on click. That shipped
+      twice here, once under a comment asserting it did not happen.
+   --------------------------------------------------------------------------- */
+.sidebar-list-item,
+.sidebar-project-tree-row,
+.sidebar-project-tree-subheader,
+.sidebar-folder-row,
+.sidebar-folder-section-header,
+.sidebar-section-header {
+  box-sizing: border-box;
+  padding-left: calc(var(--space-3) + var(--depth, 0) * var(--indent-step));
+  padding-right: var(--sidebar-right-edge, 8px);
+  border-left: 3px solid transparent;
+}
+
+/* A leading glyph slot: a disclosure chevron, a folder icon, anything optional
+   in front of the label. It keeps its width whether or not it holds a glyph, so
+   a folder with no children shares an edge with one that has them. Hide the
+   glyph with `visibility`, never `display: none` and never `v-if`, because both
+   remove the box and the row jumps. This replaces an inline `:style` ternary in
+   SideBar.vue and an `[style*="display: none"]` attribute-selector hack, which
+   were two different local patches for this one missing rule. */
+.sidebar-row-glyph {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--gutter-glyph);
+  height: var(--gutter-glyph);
+  /* The advance a glyph adds must equal exactly one --indent-step, or glyph
+     columns miss by a few px per level and the tree looks hand-placed. The
+     rows carrying glyphs gap at --space-2, so 16 + 4 + 4 = 24 = --indent-step.
+     That is what makes a child's chevron land under its parent's icon, and the
+     child's icon under its parent's label. */
+  margin-right: var(--space-2);
+}
+
+.sidebar-row-glyph--empty {
+  visibility: hidden;
+}
+
+/* The folder-row family. Nested rows come from FolderTreeNode, so ONE copy of
+   these lives here rather than one per component. */
+.sidebar-folder-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+  padding-bottom: var(--space-2);
+  cursor: pointer;
+  color: rgb(var(--v-theme-sidebar-text));
+  user-select: none;
+  min-height: 28px;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+.sidebar-folder-row:hover {
+  background: rgba(var(--v-theme-accent), 0.08);
+  color: rgb(var(--v-theme-sidebar-text));
+}
+
+.sidebar-folder-row.active {
+  background: rgba(var(--v-theme-primary), 0.18);
+  color: rgb(var(--v-theme-on-primary));
+  border-left-color: rgb(var(--v-theme-primary));
+}
+
+.sidebar-folder-row.active:hover {
+  background:
+    linear-gradient(
+      rgba(var(--v-theme-accent), 0.08),
+      rgba(var(--v-theme-accent), 0.08)
+    ),
+    rgba(var(--v-theme-primary), 0.18);
+  color: rgb(var(--v-theme-on-primary));
+}
+
+.sidebar-folder-row.droppable {
+  filter: brightness(1.2);
+  background: rgb(var(--v-theme-primary));
+  color: rgb(var(--v-theme-on-primary));
+}
+
+/* No inset here. The old rule summed padding 4 + margin 2 + a 1px border into a
+   7px step that was both off-grid and invisible to anything measuring depth.
+   Each row carries its own `--depth` instead, so the wrapper is layout-only. */
+.sidebar-folder-children {
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-folder-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.sidebar-folder-chevron,
+.sidebar-folder-icon {
+  opacity: 0.7;
+}
+
+/* Folder glyphs stay at the glyph box regardless of thumbnail size. Width and
+   height come from `.sidebar-row-glyph`; only font-size needs forcing, because
+   Vuetify sets it inline from the `size` prop. */
+.sidebar-folder-icon,
+.sidebar-folder-chevron {
+  font-size: var(--text-md) !important;
+}
+
+.sidebar-folder-status-badge {
+  flex-shrink: 0;
+  margin-left: var(--space-1);
+  opacity: 0.75;
+}
+
+.sidebar-folder-count-badge {
+  flex-shrink: 0;
+  margin-left: var(--space-2);
+  min-width: 22px;
+  text-align: right;
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: rgb(var(--v-theme-sidebar-text));
+}
+
+.sidebar-folder-row.active .sidebar-folder-count-badge {
+  color: rgba(var(--v-theme-on-primary), 0.65);
+}
+
+/* The refused-drop state (#757). Unscoped for the same reason as the rest of
+   this block: FolderTreeNode renders folder rows, and a scoped rule cannot
+   reach it. It previously existed twice, once in SideBar.css and once copied
+   into that component under a comment explaining the copy was necessary. It is
+   not, once the family lives here.
+
+   A glyph plus a texture, not colour alone: the row must read as refused in
+   forced-colors and to a colour-blind user. */
+.sidebar-list-item.not-droppable,
+.sidebar-project-tree-row.not-droppable,
+.sidebar-folder-row.not-droppable {
+  position: relative;
+  background: repeating-linear-gradient(
+    45deg,
+    transparent 0 var(--space-2),
+    rgba(var(--v-theme-border), 0.45) var(--space-2) var(--space-3)
+  );
+  outline: 1px dashed rgba(var(--v-theme-border), 0.7);
+  outline-offset: -1px;
+  border-radius: var(--radius-sm);
+  cursor: no-drop;
+}
+
+.sidebar-list-item.not-droppable > *,
+.sidebar-project-tree-row.not-droppable > *,
+.sidebar-folder-row.not-droppable > * {
+  opacity: var(--opacity-disabled);
+}
+
+.sidebar-list-item.not-droppable::after,
+.sidebar-project-tree-row.not-droppable::after,
+.sidebar-folder-row.not-droppable::after {
+  content: "\F073A"; /* mdi-cancel */
+  font-family: "Material Design Icons";
+  font-size: var(--text-sm);
+  line-height: 1;
+  position: absolute;
+  top: 50%;
+  right: var(--space-3);
+  transform: translateY(-50%);
+  color: rgb(var(--v-theme-sidebar-text));
+  pointer-events: none;
+}
+
 /* Non-scoped: webkit scrollbar pseudo-elements are suppressed by scoped data-v selectors */
 /* Shared subtle scrollbar treatment — keep in sync with .grid-scroll-wrapper in ImageGrid.vue */
 .sidebar-scroll::-webkit-scrollbar {
@@ -20,10 +222,12 @@
   background: transparent !important;
 }
 
-/* Override ProjectFiles header inside the project tree to match subheader style */
+/* Override ProjectFiles header inside the project tree to match subheader style.
+   It sits alongside the People/Sets subheaders, so it takes their depth too. */
 .sidebar-project-tree-files .pf-header {
   min-height: 24px !important;
-  padding: var(--space-1) 0 var(--space-1) var(--space-3) !important;
+  padding: var(--space-1) 0 var(--space-1)
+    calc(var(--space-3) + 1 * var(--indent-step)) !important;
   padding-right: var(--sidebar-header-action-right-edge) !important;
   font-size: var(--text-2xs) !important;
   font-weight: var(--weight-semibold) !important;

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -845,6 +845,18 @@ async function browseFolderPath(path, prefetchChildren = false) {
   }
 }
 
+/* Whether a reference-folder row can disclose children, i.e. whether its
+   chevron is drawn. The slot is reserved either way (`.sidebar-row-glyph`), so
+   this only decides visibility and never the row's left edge. Not browsable in
+   Docker, and not-yet-browsed counts as "can", so the affordance is there
+   before the first browse returns. */
+function referenceFolderCanDisclose(rf) {
+  if (inDocker.value) return false;
+  const cached = folderBrowseCache.value[rf.folder];
+  if (!cached || cached.loading) return true;
+  return (cached.entries?.length ?? 0) > 0;
+}
+
 function handleFolderNodeSelect(key, payload) {
   selectedFolderKey.value = key;
   const payloadId = Number(payload?.referenceFolderId);
@@ -5079,16 +5091,9 @@ defineExpose({
               >
                 <v-icon
                   size="12"
-                  class="sidebar-folder-chevron"
-                  :style="{
-                    visibility:
-                      !inDocker &&
-                      (!folderBrowseCache[rf.folder] ||
-                        folderBrowseCache[rf.folder].loading ||
-                        (folderBrowseCache[rf.folder]?.entries?.length ?? 0) >
-                          0)
-                        ? 'visible'
-                        : 'hidden',
+                  class="sidebar-row-glyph sidebar-folder-chevron"
+                  :class="{
+                    'sidebar-row-glyph--empty': !referenceFolderCanDisclose(rf),
                   }"
                   @click.stop="
                     if (!inDocker) {
@@ -5103,7 +5108,7 @@ defineExpose({
                       : "mdi-chevron-right"
                   }}
                 </v-icon>
-                <v-icon size="16" class="sidebar-folder-icon"
+                <v-icon size="16" class="sidebar-row-glyph sidebar-folder-icon"
                   >mdi-folder-network-outline</v-icon
                 >
                 <span class="sidebar-folder-label">{{
@@ -5279,12 +5284,11 @@ defineExpose({
               >
                 <v-icon
                   size="12"
-                  class="sidebar-folder-chevron"
-                  style="visibility: hidden"
+                  class="sidebar-row-glyph sidebar-row-glyph--empty sidebar-folder-chevron"
                 >
                   mdi-chevron-right
                 </v-icon>
-                <v-icon size="16" class="sidebar-folder-icon"
+                <v-icon size="16" class="sidebar-row-glyph sidebar-folder-icon"
                   >mdi-folder-download-outline</v-icon
                 >
                 <span class="sidebar-folder-label">
@@ -5884,13 +5888,13 @@ defineExpose({
                       @click.stop="toggleProjectTreePeople(p.id)"
                     >
                       <v-icon
-                        v-show="
-                          sortedCharacters.filter((c) =>
-                            entityBelongsToProject(c, p.id),
-                          ).length > 0
-                        "
                         size="14"
-                        class="sidebar-project-tree-sub-chevron"
+                        class="sidebar-row-glyph sidebar-project-tree-sub-chevron"
+                        :class="{
+                          'sidebar-row-glyph--empty': !sortedCharacters.some(
+                            (c) => entityBelongsToProject(c, p.id),
+                          ),
+                        }"
                         >{{
                           projectTreePeopleCollapsed.has(p.id)
                             ? "mdi-chevron-right"
@@ -6104,13 +6108,13 @@ defineExpose({
                       @click.stop="toggleProjectTreeSets(p.id)"
                     >
                       <v-icon
-                        v-show="
-                          nonReferenceSets.filter((s) =>
-                            entityBelongsToProject(s, p.id),
-                          ).length > 0
-                        "
                         size="14"
-                        class="sidebar-project-tree-sub-chevron"
+                        class="sidebar-row-glyph sidebar-project-tree-sub-chevron"
+                        :class="{
+                          'sidebar-row-glyph--empty': !nonReferenceSets.some(
+                            (s) => entityBelongsToProject(s, p.id),
+                          ),
+                        }"
                         >{{
                           projectTreeSetsCollapsed.has(p.id)
                             ? "mdi-chevron-right"

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -845,6 +845,19 @@ async function browseFolderPath(path, prefetchChildren = false) {
   }
 }
 
+/* Whether a project's People / Sets caption has anything under it.
+   One helper per caption rather than the test inlined twice, because the
+   chevron's visibility and the row's inert state must never disagree: a live
+   caption with no chevron, or a dimmed caption you can still collapse, are both
+   worse than either state on its own. */
+function projectHasPeople(projectId) {
+  return sortedCharacters.value.some((c) => entityBelongsToProject(c, projectId));
+}
+
+function projectHasSets(projectId) {
+  return nonReferenceSets.value.some((s) => entityBelongsToProject(s, projectId));
+}
+
 /* Whether a reference-folder row can disclose children, i.e. whether its
    chevron is drawn. The slot is reserved either way (`.sidebar-row-glyph`), so
    this only decides visibility and never the row's left edge. Not browsable in
@@ -5824,15 +5837,18 @@ defineExpose({
                     onProjectDrop(p.id, $event);
                   "
                 >
+                  <v-icon
+                    class="sidebar-row-glyph sidebar-project-tree-chevron"
+                    size="14"
+                    @click.stop="toggleProjectExpanded(p.id)"
+                    >{{
+                      expandedProjectIds.has(p.id)
+                        ? "mdi-chevron-down"
+                        : "mdi-chevron-right"
+                    }}</v-icon
+                  >
                   <span class="sidebar-project-tree-name-group">
                     <span class="sidebar-project-tree-label">{{ p.name }}</span>
-                    <v-icon
-                      class="sidebar-project-tree-expand-indicator"
-                      :class="{ expanded: expandedProjectIds.has(p.id) }"
-                      size="14"
-                      @click.stop="toggleProjectExpanded(p.id)"
-                      >mdi-chevron-down</v-icon
-                    >
                   </span>
                   <v-icon
                     v-if="sharedProjectIds.has(p.id)"
@@ -5885,15 +5901,20 @@ defineExpose({
                   >
                     <div
                       class="sidebar-project-tree-subheader"
-                      @click.stop="toggleProjectTreePeople(p.id)"
+                      :class="{
+                        'sidebar-project-tree-subheader--empty':
+                          !projectHasPeople(p.id),
+                      }"
+                      :aria-disabled="!projectHasPeople(p.id) || undefined"
+                      @click.stop="
+                        projectHasPeople(p.id) && toggleProjectTreePeople(p.id)
+                      "
                     >
                       <v-icon
                         size="14"
                         class="sidebar-row-glyph sidebar-project-tree-sub-chevron"
                         :class="{
-                          'sidebar-row-glyph--empty': !sortedCharacters.some(
-                            (c) => entityBelongsToProject(c, p.id),
-                          ),
+                          'sidebar-row-glyph--empty': !projectHasPeople(p.id),
                         }"
                         >{{
                           projectTreePeopleCollapsed.has(p.id)
@@ -6105,15 +6126,20 @@ defineExpose({
                   >
                     <div
                       class="sidebar-project-tree-subheader"
-                      @click.stop="toggleProjectTreeSets(p.id)"
+                      :class="{
+                        'sidebar-project-tree-subheader--empty':
+                          !projectHasSets(p.id),
+                      }"
+                      :aria-disabled="!projectHasSets(p.id) || undefined"
+                      @click.stop="
+                        projectHasSets(p.id) && toggleProjectTreeSets(p.id)
+                      "
                     >
                       <v-icon
                         size="14"
                         class="sidebar-row-glyph sidebar-project-tree-sub-chevron"
                         :class="{
-                          'sidebar-row-glyph--empty': !nonReferenceSets.some(
-                            (s) => entityBelongsToProject(s, p.id),
-                          ),
+                          'sidebar-row-glyph--empty': !projectHasSets(p.id),
                         }"
                         >{{
                           projectTreeSetsCollapsed.has(p.id)

--- a/frontend/src/components/panels/SideBarRowSystem.test.js
+++ b/frontend/src/components/panels/SideBarRowSystem.test.js
@@ -61,6 +61,18 @@ describe("the row system is defined once, unscoped", () => {
     expect(globalCss).toContain("--indent-step");
   });
 
+  it("the refused-drop state is unscoped too", () => {
+    // #757 shipped `.not-droppable` twice: once in SideBar.css and once copied
+    // into FolderTreeNode under a comment explaining that the copy was needed
+    // because the styles are scoped. It is not needed once the folder-row
+    // family lives in the unscoped sheet, and a second copy is how the two
+    // drift apart again.
+    expect(globalCss).toContain(".sidebar-folder-row.not-droppable");
+    expect(scopedCss).not.toContain("not-droppable");
+    const style = folderTreeNode.split("<style")[1] ?? "";
+    expect(style).not.toContain("not-droppable");
+  });
+
   it("FolderTreeNode keeps no private copy of the row styles", () => {
     // It used to, and the copy had drifted to a different inset with no base
     // rail, so selecting a nested folder shifted its label 3px right.

--- a/frontend/src/components/panels/SideBarRowSystem.test.js
+++ b/frontend/src/components/panels/SideBarRowSystem.test.js
@@ -194,7 +194,60 @@ describe("optional glyphs keep their box", () => {
     );
     expect(project).toContain("font-size: var(--text-xs)");
     expect(caption).toContain("font-size: var(--text-2xs)");
-    expect(caption).toContain("0.7");
+    // Across every rule for the selector, not just the last: these row types
+    // are each declared in several places.
+    const declares = (sel, decl) =>
+      ruleBodies(scopedCss, sel).some((b) => b.includes(decl));
+    expect(
+      declares(".sidebar-project-tree-row", "--row-emphasis: 1"),
+      "the project row must declare full emphasis",
+    ).toBe(true);
+    expect(
+      declares(".sidebar-project-tree-subheader", "--row-emphasis: 0.7"),
+      "the caption row must declare reduced emphasis",
+    ).toBe(true);
+  });
+
+  it("a caret carries the same emphasis as its own label", () => {
+    // Both halves of this drifted: the project caret sat at 0.5 under a
+    // full-strength label, the caption caret at full strength over a 0.7 label.
+    // One rule feeds both, so they cannot diverge again. Parity rather than a
+    // fraction, because 0.7 x 0.7 = 0.49 measures 2.95:1 in light and fails the
+    // 3:1 floor a disclosure glyph owes under WCAG 1.4.11.
+    const shared = code(scopedCss)
+      .split("}")
+      .find(
+        (r) =>
+          r.includes("opacity: var(--row-emphasis") &&
+          r.split("{")[0].includes("chevron"),
+      );
+    expect(shared, "label and caret must share one emphasis rule").toBeTruthy();
+    const selectors = shared
+      .split("{")[0]
+      .split(",")
+      .map((s) => s.trim());
+    for (const part of [
+      ".sidebar-project-tree-label",
+      ".sidebar-project-tree-chevron",
+      ".sidebar-project-tree-subheader-label",
+      ".sidebar-project-tree-sub-chevron",
+    ]) {
+      expect(selectors).toContain(part);
+    }
+  });
+
+  it("no caret sets a standalone opacity that could diverge", () => {
+    for (const sel of [
+      ".sidebar-project-tree-chevron",
+      ".sidebar-project-tree-sub-chevron",
+    ]) {
+      for (const body of ruleBodies(scopedCss, sel)) {
+        if (body.includes("--row-emphasis")) continue;
+        expect(body, `${sel} must not carry its own opacity`).not.toMatch(
+          /opacity\s*:/,
+        );
+      }
+    }
   });
 
   it("leaves no v-show or display:none on a reserved glyph", () => {

--- a/frontend/src/components/panels/SideBarRowSystem.test.js
+++ b/frontend/src/components/panels/SideBarRowSystem.test.js
@@ -1,0 +1,173 @@
+/**
+ * The sidebar row system (issue #760, docs/design/visual-language.md §5.1).
+ *
+ * These assert the STYLESHEET, not a rendered component, because the bugs being
+ * pinned are cascade bugs: a row type quietly reintroducing its own
+ * `padding-left`, or an `.active` rule that adds the selection rail instead of
+ * recolouring it. Both shipped here before, and both are invisible to a test
+ * that only mounts a component and checks classes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const read = (name) =>
+  readFileSync(fileURLToPath(new URL(name, import.meta.url)), "utf8");
+
+const globalCss = read("./SideBar.global.css");
+const scopedCss = read("./SideBar.css");
+const folderTreeNode = read("../editors/FolderTreeNode.vue");
+
+/** Strip comments so prose about a bug is never mistaken for the bug. */
+const code = (css) => css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+/**
+ * Declaration blocks of EVERY rule whose selector list contains `selector`.
+ *
+ * Every, not the first: a row type is matched both by the shared row rule and
+ * by its own rule, and it is the second one that reintroduces a private inset.
+ * Returning only the first hit silently passed that exact regression.
+ */
+function ruleBodies(css, selector) {
+  return code(css)
+    .split("}")
+    .filter((r) => {
+      const [sel] = r.split("{");
+      return sel
+        .split(",")
+        .map((s) => s.trim())
+        .includes(selector);
+    })
+    .map((r) => r.split("{")[1])
+    .filter(Boolean);
+}
+
+/** The single rule that defines `selector`, asserted to be unambiguous. */
+function ruleBody(css, selector) {
+  const bodies = ruleBodies(css, selector);
+  return bodies.length ? bodies[bodies.length - 1] : null;
+}
+
+describe("the row system is defined once, unscoped", () => {
+  it("lives in the unscoped sheet so it reaches FolderTreeNode", () => {
+    // SideBar.css is `<style scoped>`, so a rule there cannot style a row
+    // rendered by a child component. This placement is the fix.
+    expect(globalCss).toContain(".sidebar-row-glyph");
+    expect(globalCss).toContain("--indent-step");
+  });
+
+  it("FolderTreeNode keeps no private copy of the row styles", () => {
+    // It used to, and the copy had drifted to a different inset with no base
+    // rail, so selecting a nested folder shifted its label 3px right.
+    const style = folderTreeNode.split("<style")[1] ?? "";
+    for (const dup of [
+      ".sidebar-folder-row {",
+      ".sidebar-folder-children {",
+      ".sidebar-folder-label {",
+    ]) {
+      expect(style).not.toContain(dup);
+    }
+  });
+});
+
+describe("every row starts at one left edge", () => {
+  const ROW_TYPES = [
+    ".sidebar-list-item",
+    ".sidebar-project-tree-row",
+    ".sidebar-project-tree-subheader",
+    ".sidebar-folder-row",
+    ".sidebar-folder-section-header",
+    ".sidebar-section-header",
+  ];
+
+  it("derives padding-left from depth in one shared rule", () => {
+    const body = ruleBody(globalCss, ROW_TYPES[0]);
+    expect(body).toBeTruthy();
+    expect(body).toContain("var(--depth, 0) * var(--indent-step)");
+  });
+
+  it("covers all six row types in that rule", () => {
+    const shared = code(globalCss)
+      .split("}")
+      .find((r) => r.includes("var(--depth, 0) * var(--indent-step)"));
+    const selectors = shared
+      .split("{")[0]
+      .split(",")
+      .map((s) => s.trim());
+    for (const type of ROW_TYPES) expect(selectors).toContain(type);
+  });
+
+  it("no row type sets its own padding-left or padding shorthand", () => {
+    // The regression that produced six left edges: each row type owning its own
+    // horizontal inset. Vertical padding stays per-type on purpose.
+    for (const css of [globalCss, scopedCss]) {
+      for (const type of ROW_TYPES) {
+        for (const body of ruleBodies(css, type)) {
+          if (body.includes("var(--depth, 0)")) continue; // the shared rule
+          expect(
+            body,
+            `${type} must not set its own horizontal inset`,
+          ).not.toMatch(/(^|\s|;)padding-left\s*:/);
+          expect(
+            body,
+            `${type} must not use the padding shorthand, it resets the inset`,
+          ).not.toMatch(/(^|\s|;)padding\s*:/);
+        }
+      }
+    }
+  });
+});
+
+describe("the selection rail is reserved, never added on select", () => {
+  it("the shared row rule reserves a transparent rail", () => {
+    const shared = code(globalCss)
+      .split("}")
+      .find((r) => r.includes("var(--depth, 0) * var(--indent-step)"));
+    expect(shared).toContain("border-left: 3px solid transparent");
+  });
+
+  it("no .active rule sets border-left width, only its colour", () => {
+    // `border-left: 3px solid <colour>` on `.active` widens the box by 3px and
+    // moves the label. Recolouring an already-reserved rail does not.
+    for (const css of [globalCss, scopedCss]) {
+      for (const rule of code(css).split("}")) {
+        const [selector, body = ""] = rule.split("{");
+        if (!selector.includes(".active") && !selector.includes(".droppable")) {
+          continue;
+        }
+        expect(
+          body,
+          `${selector.trim()} must recolour the rail, not re-declare it`,
+        ).not.toMatch(/border-left\s*:\s*\d/);
+      }
+    }
+  });
+});
+
+describe("optional glyphs keep their box", () => {
+  it("hides an absent glyph with visibility, not display", () => {
+    const body = ruleBody(globalCss, ".sidebar-row-glyph--empty");
+    expect(body).toContain("visibility: hidden");
+    expect(body).not.toContain("display");
+  });
+
+  it("advances the row by exactly one indent step", () => {
+    // 16px glyph + 4px own margin + 4px row gap = 24px = --indent-step. Drop the
+    // margin and glyph columns drift 4px per level.
+    const body = ruleBody(globalCss, ".sidebar-row-glyph");
+    expect(body).toContain("width: var(--gutter-glyph)");
+    expect(body).toContain("margin-right: var(--space-2)");
+  });
+
+  it("leaves no v-show or display:none on a reserved glyph", () => {
+    // Both remove the box and the row jumps. Two separate local hacks existed
+    // to patch this after the fact; neither should come back.
+    expect(scopedCss).not.toContain('[style*="display: none"]');
+    const sideBar = read("./SideBar.vue");
+    expect(sideBar).not.toContain('style="visibility: hidden"');
+    for (const m of sideBar.matchAll(/<v-icon[^>]*sidebar-row-glyph[^>]*>/g)) {
+      expect(m[0]).not.toContain("v-show");
+    }
+  });
+});

--- a/frontend/src/components/panels/SideBarRowSystem.test.js
+++ b/frontend/src/components/panels/SideBarRowSystem.test.js
@@ -192,57 +192,26 @@ describe("optional glyphs keep their box", () => {
       scopedCss,
       ".sidebar-project-tree-subheader-label",
     );
-    expect(project).toContain("font-size: var(--text-xs)");
+    expect(project).toContain("font-size: var(--text-sm)");
     expect(caption).toContain("font-size: var(--text-2xs)");
-    // Across every rule for the selector, not just the last: these row types
-    // are each declared in several places.
-    const declares = (sel, decl) =>
-      ruleBodies(scopedCss, sel).some((b) => b.includes(decl));
-    expect(
-      declares(".sidebar-project-tree-row", "--row-emphasis: 1"),
-      "the project row must declare full emphasis",
-    ).toBe(true);
-    expect(
-      declares(".sidebar-project-tree-subheader", "--row-emphasis: 0.7"),
-      "the caption row must declare reduced emphasis",
-    ).toBe(true);
   });
 
-  it("a caret carries the same emphasis as its own label", () => {
-    // Both halves of this drifted: the project caret sat at 0.5 under a
-    // full-strength label, the caption caret at full strength over a 0.7 label.
-    // One rule feeds both, so they cannot diverge again. Parity rather than a
-    // fraction, because 0.7 x 0.7 = 0.49 measures 2.95:1 in light and fails the
-    // 3:1 floor a disclosure glyph owes under WCAG 1.4.11.
-    const shared = code(scopedCss)
-      .split("}")
-      .find(
-        (r) =>
-          r.includes("opacity: var(--row-emphasis") &&
-          r.split("{")[0].includes("chevron"),
-      );
-    expect(shared, "label and caret must share one emphasis rule").toBeTruthy();
-    const selectors = shared
-      .split("{")[0]
-      .split(",")
-      .map((s) => s.trim());
-    for (const part of [
+  it("no structural label or caret in the project tree is dimmed", () => {
+    // Three separate defects came out of dimming things in this column:
+    //   - caption at 0.7 became quieter than the names it heads, inverting the
+    //     hierarchy;
+    //   - its caret was not dimmed with it, so the caret outshone its label,
+    //     while the project's caret at 0.5 was far dimmer than its own;
+    //   - a caret at 0.7 of a 0.7 label measures 2.95:1 in light, under the
+    //     3:1 a disclosure glyph owes as a graphical object (WCAG 1.4.11).
+    // Rank is size, weight, tracking and indent. Not opacity.
+    for (const sel of [
       ".sidebar-project-tree-label",
       ".sidebar-project-tree-chevron",
       ".sidebar-project-tree-subheader-label",
       ".sidebar-project-tree-sub-chevron",
     ]) {
-      expect(selectors).toContain(part);
-    }
-  });
-
-  it("no caret sets a standalone opacity that could diverge", () => {
-    for (const sel of [
-      ".sidebar-project-tree-chevron",
-      ".sidebar-project-tree-sub-chevron",
-    ]) {
       for (const body of ruleBodies(scopedCss, sel)) {
-        if (body.includes("--row-emphasis")) continue;
         expect(body, `${sel} must not carry its own opacity`).not.toMatch(
           /opacity\s*:/,
         );

--- a/frontend/src/components/panels/SideBarRowSystem.test.js
+++ b/frontend/src/components/panels/SideBarRowSystem.test.js
@@ -34,10 +34,14 @@ function ruleBodies(css, selector) {
     .split("}")
     .filter((r) => {
       const [sel] = r.split("{");
+      // Collapse whitespace: prettier wraps long descendant selectors across
+      // lines, and a matcher that depends on where it wrapped is a test that
+      // breaks on reformatting rather than on a defect.
+      const want = selector.replace(/\s+/g, " ").trim();
       return sel
         .split(",")
-        .map((s) => s.trim())
-        .includes(selector);
+        .map((s) => s.replace(/\s+/g, " ").trim())
+        .includes(want);
     })
     .map((r) => r.split("{")[1])
     .filter(Boolean);
@@ -152,12 +156,45 @@ describe("optional glyphs keep their box", () => {
     expect(body).not.toContain("display");
   });
 
-  it("advances the row by exactly one indent step", () => {
-    // 16px glyph + 4px own margin + 4px row gap = 24px = --indent-step. Drop the
-    // margin and glyph columns drift 4px per level.
+  it("keeps a fixed width so an absent glyph still holds its column", () => {
     const body = ruleBody(globalCss, ".sidebar-row-glyph");
     expect(body).toContain("width: var(--gutter-glyph)");
-    expect(body).toContain("margin-right: var(--space-2)");
+  });
+
+  it("an empty caption goes inert but keeps its add action operable", () => {
+    // The way out of an empty group is its `+`. Fading or disabling the whole
+    // row would take that with it and strand the user.
+    const body = ruleBody(
+      scopedCss,
+      ".sidebar-project-tree-subheader--empty .sidebar-project-tree-subheader-label",
+    );
+    expect(body, "the label, not the row, carries the fade").toContain(
+      "opacity: var(--opacity-disabled",
+    );
+
+    const sideBar = read("./SideBar.vue");
+    // The chevron's visibility and the row's inert state read the SAME helper,
+    // so they cannot disagree.
+    for (const group of ["projectHasPeople", "projectHasSets"]) {
+      expect(sideBar).toContain(`'sidebar-row-glyph--empty': !${group}(p.id)`);
+      expect(sideBar).toContain(
+        `:aria-disabled="!${group}(p.id) || undefined"`,
+      );
+    }
+  });
+
+  it("rank is carried by type, not indent alone", () => {
+    // A project and the captions nested under it must differ in type. When they
+    // did not, indent had to signal rank as well as depth, which is what forced
+    // a 24px step and pushed names to 91px in a 240px rail.
+    const project = ruleBody(scopedCss, ".sidebar-project-tree-label");
+    const caption = ruleBody(
+      scopedCss,
+      ".sidebar-project-tree-subheader-label",
+    );
+    expect(project).toContain("font-size: var(--text-xs)");
+    expect(caption).toContain("font-size: var(--text-2xs)");
+    expect(caption).toContain("0.7");
   });
 
   it("leaves no v-show or display:none on a reserved glyph", () => {

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -48,9 +48,12 @@
      value: each is measured off a size the sidebar already forced.
      --------------------------------------------------------------------------- */
   --gutter-glyph: 16px; /* the de-facto glyph box: chevrons and row icons */
-  --indent-step: 24px;  /* --gutter-glyph + --space-3, so a child's glyph lands
-                           under its parent's label. Equals --space-6, so
-                           on-grid by construction. */
+  --indent-step: 16px;  /* the smallest on-grid step that still reads as nesting
+                           at sidebar density. Set by legibility, NOT by glyph
+                           arithmetic: a step tuned to make a chevron advance
+                           exactly one level cost 24px per level and pushed
+                           names off the end of a 240px rail. Rank is carried
+                           by type, depth by this. */
   --entity-thumb: 24px; /* identity slot for a row carrying a picture; the
                            sidebar overrides it from its thumbnail slider. */
 

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -42,6 +42,19 @@
   --space-9: 64px;  /* hero / empty-state breathing room */
 
   /* ---------------------------------------------------------------------------
+     ROW WIDTHS — the three sizes that make list rows share a left edge. A row
+     reserves its leading glyph slot whether or not it has a glyph, and moves by
+     whole indent steps. See visual-language.md §5.1. None of these is a new
+     value: each is measured off a size the sidebar already forced.
+     --------------------------------------------------------------------------- */
+  --gutter-glyph: 16px; /* the de-facto glyph box: chevrons and row icons */
+  --indent-step: 24px;  /* --gutter-glyph + --space-3, so a child's glyph lands
+                           under its parent's label. Equals --space-6, so
+                           on-grid by construction. */
+  --entity-thumb: 24px; /* identity slot for a row carrying a picture; the
+                           sidebar overrides it from its thumbnail slider. */
+
+  /* ---------------------------------------------------------------------------
      RADIUS — four steps and a pill. The audit found 14 distinct radii
      (2/3/4/5/6/8/9/10/12/14/16/18/999/9999). Collapse to these. 9999 was a typo
      for the pill; use `--radius-pill`.


### PR DESCRIPTION
Six left edges (2, 5, 8, 11, 19px) and three depth steps (7, 8, 16px) become one edge and one 16px step. Depth is a `--depth` integer times `--indent-step`, never a hand-summed padding + margin + border composite.

Lands before any model-shelf UI so the shelf is not a fourth dialect.

## Beyond what #760 records

**`FolderTreeNode.vue` carried a divergent duplicate of the folder-row styles and the issue never mentions the file.** `SideBar.css` is `<style scoped>`, so it cannot reach a child component; the copy had drifted to an 8px inset with no base selection rail, so **selecting a nested folder shifted its label 3px right**. That is a second instance of the uncompensated-rail bug #760 caught once at `SideBar.css:458`. The row system now lives in the unscoped `SideBar.global.css` and the copy is deleted.

## Two corrections to the issue

**Not the four-column grid it proposes.** The project row puts its caret after the label and row templates carry three to six children with varying meaning, so a positional grid would assign the wrong element to each column and force a visual redesign. A flex row with a fixed-width, never-collapsing glyph slot gives the same guarantee.

**Its token arithmetic pushed names off the rail.** `--indent-step` was specified as `--gutter-glyph + --space-3` = 24px so one chevron would advance exactly one level. Over three real levels that put character names at 91px in a 240px sidebar. The step is now 16px and set by legibility, not glyph arithmetic; rank is carried by type instead. Names start at 75px in the deepest path and 59px in the shallow one.

## Also

- Empty People/Sets captions go inert and dim, with the chevron slot still reserved and the `+` fully operable, since it is the only way out of the empty state.
- The project caret moves to the leading glyph column so every collapsible row discloses from the same place.
- Nothing in the project tree is dimmed. A header must not be quieter than the rows it heads.

## Verification
- 2614 frontend tests pass, `eslint .` clean, `npm run build` ok
- `SideBarRowSystem.test.js` asserts the stylesheet rather than a mount, because these are cascade bugs a component test cannot see. **Every assertion was mutation-tested**: each invariant was deliberately broken and confirmed to fail. One early version passed against a deliberately broken file and was fixed.
- Reviewed on screen by the owner across several rounds.

## Known gap, not introduced here
The section captions and their `+` are `<div>`/`<v-icon>` with click handlers and no `tabindex` or `role`, so **collapsing a section or adding a person is not possible from the keyboard.** Pre-existing; belongs with #755.

Closes #760

https://claude.ai/code/session_01PPYSfMTVkJvyXUGhxJH4Vf