### PR TITLE
Let a screen reader follow a long export (#758)

### DIFF
--- a/frontend/src/components/widgets/ProgressOverlay.test.js
+++ b/frontend/src/components/widgets/ProgressOverlay.test.js
@@ -1,0 +1,167 @@
+/**
+ * ProgressOverlay accessibility (issue #758).
+ *
+ * The shared progress surface for export, plugin progress and, in v1.10.0, the
+ * model shelf's cross-drive move. It shipped with no ARIA at all, a failure
+ * state encoded only as a red card, and an indeterminate animation that ran
+ * regardless of `prefers-reduced-motion`.
+ *
+ * The announcement tests are the ones with teeth. Getting ARIA *present* is
+ * easy; the failure mode that actually makes a screen reader unusable is a
+ * correct-looking `aria-live` region that re-reads on every tick of a
+ * multi-gigabyte copy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import ProgressOverlay from "./ProgressOverlay.vue";
+
+const stubs = {
+  "v-icon": { template: "<i class='v-icon'><slot /></i>" },
+};
+
+const mountOverlay = (props = {}) =>
+  mount(ProgressOverlay, {
+    props: { visible: true, message: "Exporting", ...props },
+    global: { stubs },
+  });
+
+const live = (w) => w.find("[aria-live]");
+const bar = (w) => w.find('[role="progressbar"]');
+
+describe("the progress bar exposes its value", () => {
+  it("reports a determinate value with the full range", () => {
+    const w = mountOverlay({ percent: 42, status: "running" });
+    expect(bar(w).attributes("aria-valuenow")).toBe("42");
+    expect(bar(w).attributes("aria-valuemin")).toBe("0");
+    expect(bar(w).attributes("aria-valuemax")).toBe("100");
+  });
+
+  it("omits aria-valuenow when indeterminate rather than claiming zero", () => {
+    // A progressbar reporting 0 forever is a worse lie than one reporting
+    // nothing: "no value" is the defined way to say the total is unknown.
+    const w = mountOverlay({ indeterminate: true, status: "running" });
+    expect(bar(w).attributes("aria-valuenow")).toBeUndefined();
+  });
+
+  it("labels itself from the message", () => {
+    const w = mountOverlay({ message: "Moving adapters" });
+    expect(bar(w).attributes("aria-label")).toBe("Moving adapters");
+  });
+
+  it("marks the overlay busy only while work is in flight", () => {
+    expect(mountOverlay({ status: "running" }).attributes("aria-busy")).toBe(
+      "true",
+    );
+    expect(
+      mountOverlay({ status: "completed" }).attributes("aria-busy"),
+    ).toBeUndefined();
+  });
+});
+
+describe("announcements stay coarse enough to be usable", () => {
+  it("does not re-announce on every percent", async () => {
+    // The regression this exists to stop. The region is aria-atomic, so any
+    // text change re-reads the whole thing. A long copy ticking 1% at a time
+    // would make the reader talk without pause.
+    const w = mountOverlay({ percent: 30, status: "running" });
+    const before = live(w).text();
+    await w.setProps({ percent: 31 });
+    expect(live(w).text()).toBe(before);
+    await w.setProps({ percent: 44 });
+    expect(live(w).text()).toBe(before);
+  });
+
+  it("does announce when a quartile is crossed", async () => {
+    const w = mountOverlay({ percent: 30, status: "running" });
+    const before = live(w).text();
+    await w.setProps({ percent: 51 });
+    expect(live(w).text()).not.toBe(before);
+    expect(live(w).text()).toContain("50 percent");
+  });
+
+  it("announces each terminal state by name", async () => {
+    const w = mountOverlay({ percent: 100, status: "running" });
+    for (const [status, word] of [
+      ["completed", "Done"],
+      ["failed", "Failed"],
+      ["cancelled", "Cancelled"],
+    ]) {
+      await w.setProps({ status });
+      expect(live(w).text()).toContain(word);
+    }
+  });
+
+  it("says it is working when there is no total to report", () => {
+    const w = mountOverlay({ indeterminate: true, status: "running" });
+    expect(live(w).text()).toContain("Working");
+  });
+
+  it("escalates to role=alert only on failure", async () => {
+    const w = mountOverlay({ status: "running" });
+    expect(live(w).attributes("role")).toBe("status");
+    await w.setProps({ status: "failed" });
+    expect(live(w).attributes("role")).toBe("alert");
+  });
+
+  it("keeps the tick-by-tick counter away from assistive tech", () => {
+    // Same numbers already reach a reader through aria-valuenow. Left exposed,
+    // this line is a second thing changing inside the atomic region.
+    const w = mountOverlay({ count: 3, total: 9, status: "running" });
+    const meta = w.find(".progress-overlay__meta");
+    expect(meta.text()).toContain("3 / 9");
+    expect(meta.attributes("aria-hidden")).toBe("true");
+  });
+});
+
+describe("failure is not carried by colour alone", () => {
+  it("adds a glyph and a word, not just the red card", () => {
+    const w = mountOverlay({ status: "failed" });
+    expect(w.classes()).toContain("progress-overlay--error");
+    expect(w.find(".progress-overlay__state-ico").exists()).toBe(true);
+    expect(w.find(".progress-overlay__state-word").text()).toContain("Failed");
+  });
+
+  it("shows no state word while merely running", () => {
+    const w = mountOverlay({ status: "running" });
+    expect(w.find(".progress-overlay__state-word").exists()).toBe(false);
+  });
+
+  it("names cancelled and completed too, so neither is colour or absence", () => {
+    for (const [status, word] of [
+      ["cancelled", "Cancelled"],
+      ["completed", "Done"],
+    ]) {
+      const w = mountOverlay({ status });
+      expect(w.find(".progress-overlay__state-word").text()).toContain(word);
+    }
+  });
+});
+
+describe("the indeterminate animation respects reduced motion", () => {
+  // Asserted against the component source: jsdom does not evaluate media
+  // queries, and this defect lives in the stylesheet, not the markup.
+  const source = readFileSync(
+    resolve("src/components/widgets/ProgressOverlay.vue"),
+    "utf8",
+  );
+  const reducedMotionBlock = source.slice(
+    source.indexOf("@media (prefers-reduced-motion: reduce)"),
+  );
+
+  it("has a reduced-motion block at all", () => {
+    expect(source).toContain("@media (prefers-reduced-motion: reduce)");
+  });
+
+  it("stops the slide rather than merely slowing it", () => {
+    expect(reducedMotionBlock).toContain("animation: none");
+  });
+
+  it("still shows the track as busy once the motion is gone", () => {
+    // Killing the animation without widening the fill would leave a 38% stub
+    // parked at the left, which reads as stalled rather than working.
+    expect(reducedMotionBlock).toMatch(/width:\s*100%/);
+  });
+});

--- a/frontend/src/components/widgets/ProgressOverlay.vue
+++ b/frontend/src/components/widgets/ProgressOverlay.vue
@@ -4,18 +4,41 @@
     class="progress-overlay"
     :class="[
       `progress-overlay--${anchor}`,
-      { 'progress-overlay--error': status === 'failed' },
+      { 'progress-overlay--error': hasFailed },
     ]"
+    :aria-busy="isRunning || undefined"
   >
-    <div class="progress-overlay__title">{{ message }}</div>
-    <div class="progress-overlay__bar">
+    <div class="progress-overlay__title">
+      <!-- A glyph and a word, so failure is not carried by the red card alone.
+           Same rule DedupWhyPills states: colour may reinforce a state, never
+           be the only thing encoding it. -->
+      <v-icon v-if="hasFailed" class="progress-overlay__state-ico" size="16"
+        >mdi-alert-circle</v-icon
+      >
+      <span>
+        <span v-if="stateWord" class="progress-overlay__state-word"
+          >{{ stateWord }}. </span
+        >{{ message }}
+      </span>
+    </div>
+    <div
+      class="progress-overlay__bar"
+      role="progressbar"
+      :aria-label="message || 'Progress'"
+      :aria-valuenow="indeterminate ? null : Math.round(percent)"
+      aria-valuemin="0"
+      aria-valuemax="100"
+    >
       <div
         class="progress-overlay__fill"
         :class="{ 'progress-overlay__fill--indeterminate': indeterminate }"
         :style="{ width: `${percent}%` }"
       ></div>
     </div>
-    <div v-if="total != null" class="progress-overlay__meta">
+    <!-- aria-hidden: the same numbers reach a screen reader through the
+         progressbar's aria-valuenow and the announcement below. Left visible
+         to assistive tech they would be read again on every tick. -->
+    <div v-if="total != null" class="progress-overlay__meta" aria-hidden="true">
       {{ count }} / {{ total }}
     </div>
     <button
@@ -26,6 +49,13 @@
     >
       {{ abortLabel }}
     </button>
+    <span
+      class="visually-hidden"
+      :role="hasFailed ? 'alert' : 'status'"
+      aria-live="polite"
+      aria-atomic="true"
+      >{{ announcement }}</span
+    >
   </div>
 </template>
 
@@ -67,6 +97,36 @@ const emit = defineEmits(["abort"]);
 
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
 const isTerminal = computed(() => TERMINAL_STATUSES.has(props.status));
+const hasFailed = computed(() => props.status === "failed");
+const isRunning = computed(() => props.visible && !isTerminal.value);
+
+/** The word shown beside the glyph for a state colour alone must not carry. */
+const STATE_WORDS = {
+  failed: "Failed",
+  cancelled: "Cancelled",
+  completed: "Done",
+};
+const stateWord = computed(() => STATE_WORDS[props.status] ?? "");
+
+/**
+ * What a screen reader hears. Deliberately coarse.
+ *
+ * The live region is `aria-atomic`, so it re-reads in full every time its text
+ * changes. Announcing each percent would make a multi-GB move unusable: the
+ * reader would talk continuously and drown out everything else on the page.
+ * Quartiles give the "periodic progress" the issue asks for while leaving the
+ * exact figure available on demand through the progressbar's `aria-valuenow`.
+ */
+const announcement = computed(() => {
+  if (!props.visible) return "";
+  const subject = props.message || "Progress";
+  if (isTerminal.value) {
+    return `${subject}. ${STATE_WORDS[props.status] ?? props.status}.`;
+  }
+  if (props.indeterminate) return `${subject}. Working.`;
+  const quartile = Math.floor((props.percent || 0) / 25) * 25;
+  return `${subject}. ${quartile} percent.`;
+});
 </script>
 
 <style scoped>
@@ -96,9 +156,21 @@ const isTerminal = computed(() => TERMINAL_STATUSES.has(props.status));
 }
 
 .progress-overlay__title {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
   font-size: var(--text-sm);
   margin-bottom: var(--space-2);
   white-space: pre-line;
+}
+
+.progress-overlay__state-ico {
+  flex: none;
+  margin-top: 1px;
+}
+
+.progress-overlay__state-word {
+  font-weight: var(--weight-semibold);
 }
 
 .progress-overlay__bar {
@@ -131,6 +203,22 @@ const isTerminal = computed(() => TERMINAL_STATUSES.has(props.status));
   }
   100% {
     transform: translateX(220%);
+  }
+}
+
+/* A sliding bar is exactly the kind of continuous motion that triggers
+   vestibular symptoms, and this one can run for the whole length of a
+   multi-GB move. Hold it still and let it fill the track instead, so "busy"
+   is still visible without animating. */
+@media (prefers-reduced-motion: reduce) {
+  .progress-overlay__fill {
+    transition: none;
+  }
+
+  .progress-overlay__fill--indeterminate {
+    width: 100% !important;
+    animation: none;
+    opacity: 0.55;
   }
 }
 


### PR DESCRIPTION
ProgressOverlay had no ARIA at all, encoded failure as a red card and nothing else, and ran its indeterminate slide regardless of `prefers-reduced-motion`. It takes a third caller in v1.10.0 (the model shelf's cross-drive move), which can run for minutes on multiple gigabytes.

Ported from the donor the issue names, `DedupScanBanner.vue`, rather than inventing a pattern.

## The part that needed a judgment call

Getting ARIA *present* is easy. The failure mode that actually makes a screen reader unusable is a correct-looking `aria-live` region that re-reads on every tick.

The region is `aria-atomic`, so any text change re-reads it in full. Announcing each percent would leave the reader talking continuously for the whole length of a multi-gigabyte copy, drowning out everything else on the page. So announcements are **coarse on purpose**:

- quartiles while running, which is the "periodic progress" the issue asks for
- terminal states announced by name
- the exact figure available on demand via `aria-valuenow`
- the tick-by-tick `count / total` line is `aria-hidden`, because those numbers already reach a reader through the bar and would otherwise be a second thing changing inside the atomic region

`aria-valuenow` is omitted entirely when indeterminate. A bar reporting 0 forever is a worse lie than one reporting nothing.

## Also

- Failure carries a glyph and a word. Cancelled and completed are named too, so no state is left to colour or to absence.
- Under reduced motion the slide stops and the track holds filled, rather than parking the 38% stub at the left edge where it would read as stalled.

## Verification
- 2617 frontend tests pass, `eslint .` clean, `npm run build` ok
- 16 new tests. **Every assertion was mutation-tested**: announcing per-percent, claiming 0 when indeterminate, reverting failure to colour only, removing the reduced-motion guard, and re-exposing the counter were each reintroduced and confirmed to fail.

## Not verified
Not exercised with a real screen reader. The tests assert the ARIA contract, not what NVDA or VoiceOver actually says.

Closes #758

https://claude.ai/code/session_01PPYSfMTVkJvyXUGhxJH4Vf