### PR TITLE
Describe an ai-toolkit run without touching it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,7 @@ jobs:
           CI_SHARD: ${{ matrix.shard }}
         run: >-
           python -m pytest $PYTEST_FLAGS --ci-shard "$CI_SHARD/4"
+          tests/test_aitoolkit_run.py
           tests/test_anomaly_region_scope.py
           tests/test_architecture_guardrails.py
           tests/test_async_import_staging.py

--- a/pixlstash/utils/aitoolkit_run.py
+++ b/pixlstash/utils/aitoolkit_run.py
@@ -1,0 +1,330 @@
+"""Read an ai-toolkit training run off disk and describe it, without touching it.
+
+The model shelf needs to show a user what a training run produced before they
+commit to importing any of it: which steps were saved, what each step looked
+like, and what the run was trained against. All of that is already on disk in
+ai-toolkit's output folder, so this module reads it and nothing else. It does
+not hash, copy, move, or write anything, which is what makes it safe to run
+against a folder the user has merely pointed at.
+
+Layout it understands::
+
+    output/
+      MyCharacter/
+        MyCharacter_000000250.safetensors
+        MyCharacter_000002750.safetensors
+        MyCharacter.safetensors          <- the bare final, no step in the name
+        config.yaml
+        samples/
+          1712345678901__000000250_0.jpg
+          1712345678901__000000250_1.jpg
+
+**Scoped to ai-toolkit deliberately.** Other trainers lay their output out
+differently, and a reader that tries to cover all of them ends up recognising
+none of them reliably. Other trainers get their own reader later, or not at all.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+
+from pixlstash.pixl_logging import get_logger
+
+logger = get_logger(__name__)
+
+CHECKPOINT_SUFFIX = ".safetensors"
+SAMPLE_SUFFIXES = (".jpg", ".jpeg", ".png", ".webp")
+CONFIG_NAMES = ("config.yaml", "config.yml")
+SAMPLES_DIRNAME = "samples"
+
+# `<run>_000002750.safetensors`. The step is zero-padded and always trails, so
+# anchoring on the end avoids tripping over a run whose own name ends in digits
+# (`sdxl_v2_000000500` is run "sdxl_v2" at step 500, not run "sdxl" at v2).
+_STEP_RE = re.compile(r"^(?P<name>.+)_(?P<step>\d{4,})$")
+
+# `1712345678901__000002750_3.jpg`, i.e. <timestamp>__<step>_<index>. The
+# separator between timestamp and step is a DOUBLE underscore, which is what
+# lets the timestamp itself be parsed unambiguously.
+_SAMPLE_RE = re.compile(r"^(?P<ts>\d+)__(?P<step>\d+)_(?P<index>\d+)$")
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    """One saved adapter file from a run."""
+
+    path: str
+    filename: str
+    step: int | None
+    """``None`` for the bare final checkpoint, which carries no step in its name."""
+
+    @property
+    def is_final(self) -> bool:
+        return self.step is None
+
+
+@dataclass(frozen=True)
+class Sample:
+    """One preview image ai-toolkit rendered at a given step."""
+
+    path: str
+    filename: str
+    step: int
+    index: int
+    timestamp: str
+
+
+@dataclass
+class TrainingRun:
+    """Everything a run says about itself, read from disk only."""
+
+    name: str
+    path: str
+    checkpoints: list[Checkpoint] = field(default_factory=list)
+    samples: list[Sample] = field(default_factory=list)
+    base_model: str | None = None
+    trigger_words: list[str] = field(default_factory=list)
+    rank: int | None = None
+    config_error: str | None = None
+    """Why the config could not be read, when it could not. The run is still
+    usable without it: steps and samples come from filenames."""
+
+    @property
+    def steps(self) -> list[int]:
+        """Every step that has a checkpoint, ascending. Excludes the final."""
+        return sorted(c.step for c in self.checkpoints if c.step is not None)
+
+    def samples_for_step(self, step: int) -> list[Sample]:
+        """Previews for one step, in the order ai-toolkit rendered them."""
+        return sorted(
+            (s for s in self.samples if s.step == step), key=lambda s: s.index
+        )
+
+
+def _split_step(stem: str) -> tuple[str, int | None]:
+    """Split a checkpoint stem into its run name and step.
+
+    A stem with no trailing step is the run's final save, so the step is
+    ``None`` rather than 0. Zero is a real step ai-toolkit can emit, and
+    conflating "final" with "step 0" would sort the finished adapter to the
+    front of the list.
+    """
+    match = _STEP_RE.match(stem)
+    if not match:
+        return stem, None
+    return match.group("name"), int(match.group("step"))
+
+
+def _read_checkpoints(run_dir: str) -> list[Checkpoint]:
+    found: list[Checkpoint] = []
+    for entry in os.scandir(run_dir):
+        if not entry.is_file() or not entry.name.endswith(CHECKPOINT_SUFFIX):
+            continue
+        stem = entry.name[: -len(CHECKPOINT_SUFFIX)]
+        _, step = _split_step(stem)
+        found.append(Checkpoint(path=entry.path, filename=entry.name, step=step))
+    # Ascending by step with the final last: that is the order a user reads a
+    # run in, and the final is the one they most often want.
+    return sorted(
+        found, key=lambda c: (c.step is None, c.step if c.step is not None else 0)
+    )
+
+
+def _read_samples(run_dir: str) -> list[Sample]:
+    samples_dir = os.path.join(run_dir, SAMPLES_DIRNAME)
+    if not os.path.isdir(samples_dir):
+        return []
+
+    found: list[Sample] = []
+    for entry in os.scandir(samples_dir):
+        if not entry.is_file():
+            continue
+        stem, ext = os.path.splitext(entry.name)
+        if ext.lower() not in SAMPLE_SUFFIXES:
+            continue
+        match = _SAMPLE_RE.match(stem)
+        if not match:
+            # Not a failure. A user may well have dropped their own images in
+            # here, and they simply are not step previews.
+            logger.debug(
+                "Ignoring unrecognised sample filename %r in %s",
+                entry.name,
+                samples_dir,
+            )
+            continue
+        found.append(
+            Sample(
+                path=entry.path,
+                filename=entry.name,
+                step=int(match.group("step")),
+                index=int(match.group("index")),
+                timestamp=match.group("ts"),
+            )
+        )
+    return sorted(found, key=lambda s: (s.step, s.index))
+
+
+def _find_key(node: object, key: str) -> object | None:
+    """First value for ``key`` anywhere in a nested mapping or list.
+
+    ai-toolkit nests these under ``config.process[0].model`` and friends, and
+    that path has moved between versions. Searching by key rather than by path
+    means a layout change costs nothing here.
+    """
+    if isinstance(node, dict):
+        if key in node:
+            return node[key]
+        for value in node.values():
+            found = _find_key(value, key)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for item in node:
+            found = _find_key(item, key)
+            if found is not None:
+                return found
+    return None
+
+
+def _config_path(run_dir: str) -> str | None:
+    for name in CONFIG_NAMES:
+        candidate = os.path.join(run_dir, name)
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _apply_config(run: TrainingRun) -> None:
+    """Fill in base model, triggers and rank from ``config.yaml``, best effort.
+
+    Every failure here is recorded on the run and logged, never raised: the
+    checkpoints and samples are the point, and they come from filenames. A run
+    whose config is missing or malformed is still worth showing, it just shows
+    less.
+    """
+    path = _config_path(run.path)
+    if path is None:
+        run.config_error = "no config.yaml in the run folder"
+        return
+
+    # Local import, and optional on purpose. PyYAML is present transitively but
+    # is not a declared dependency, and this is the only thing in the reader
+    # that wants it. Per the project's import rule, a clearly optional import
+    # may be local.
+    try:
+        import yaml
+    except ImportError as exc:
+        run.config_error = f"PyYAML unavailable, config not read ({exc})"
+        logger.warning(
+            "PyYAML is unavailable, so %s was not read. The run still lists its "
+            "checkpoints and samples; only base model, trigger words and rank "
+            "are missing.",
+            path,
+        )
+        return
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            parsed = yaml.safe_load(handle)
+    except (OSError, UnicodeDecodeError) as exc:
+        run.config_error = f"could not read {os.path.basename(path)}: {exc}"
+        logger.warning("Could not read ai-toolkit config %s: %s", path, exc)
+        return
+    except yaml.YAMLError as exc:
+        run.config_error = f"could not parse {os.path.basename(path)}: {exc}"
+        logger.warning("Could not parse ai-toolkit config %s: %s", path, exc)
+        return
+
+    base_model = _find_key(parsed, "name_or_path")
+    if isinstance(base_model, str) and base_model.strip():
+        run.base_model = base_model.strip()
+
+    trigger = _find_key(parsed, "trigger_word")
+    if isinstance(trigger, str) and trigger.strip():
+        run.trigger_words = [trigger.strip()]
+    elif isinstance(trigger, list):
+        run.trigger_words = [
+            item.strip() for item in trigger if isinstance(item, str) and item.strip()
+        ]
+
+    rank = _find_key(parsed, "linear")
+    if isinstance(rank, bool):
+        # `linear: true` is a different setting that happens to share the name.
+        # bool is a subclass of int, so this check has to come first or a rank
+        # of 1 appears out of nowhere.
+        logger.debug("Ignoring boolean `linear` in %s; it is not a rank.", path)
+    elif isinstance(rank, int):
+        run.rank = rank
+
+
+def read_run(run_dir: str) -> TrainingRun:
+    """Describe one ai-toolkit run folder.
+
+    Args:
+        run_dir: A single run's output folder, the one holding the
+            ``.safetensors`` files.
+
+    Returns:
+        The run. A folder with no checkpoints still returns a ``TrainingRun``;
+        callers decide whether an empty run is worth showing.
+
+    Raises:
+        NotADirectoryError: If ``run_dir`` is not a directory. Anything else on
+            disk is reported on the run rather than raised.
+    """
+    if not os.path.isdir(run_dir):
+        raise NotADirectoryError(f"Not an ai-toolkit run folder: {run_dir}")
+
+    run = TrainingRun(name=os.path.basename(os.path.normpath(run_dir)), path=run_dir)
+    try:
+        run.checkpoints = _read_checkpoints(run_dir)
+        run.samples = _read_samples(run_dir)
+    except OSError as exc:
+        # A run folder that becomes unreadable mid-scan is worth surfacing, but
+        # it must not take the whole output listing down with it.
+        run.config_error = f"could not list {run_dir}: {exc}"
+        logger.warning("Could not list ai-toolkit run folder %s: %s", run_dir, exc)
+        return run
+
+    _apply_config(run)
+    return run
+
+
+def read_output_root(root: str) -> list[TrainingRun]:
+    """Describe every run under an ai-toolkit ``output/`` folder.
+
+    Args:
+        root: The ``output/`` folder itself, whose children are run folders.
+
+    Returns:
+        Runs that hold at least one checkpoint, sorted by name. A child folder
+        with no ``.safetensors`` in it is not a training run, so it is skipped
+        rather than listed as an empty one.
+
+    Raises:
+        NotADirectoryError: If ``root`` is not a directory.
+    """
+    if not os.path.isdir(root):
+        raise NotADirectoryError(f"Not an ai-toolkit output folder: {root}")
+
+    runs: list[TrainingRun] = []
+    try:
+        children = sorted(os.scandir(root), key=lambda e: e.name)
+    except OSError as exc:
+        logger.warning("Could not list ai-toolkit output folder %s: %s", root, exc)
+        raise
+
+    for entry in children:
+        if not entry.is_dir():
+            continue
+        run = read_run(entry.path)
+        if run.checkpoints:
+            runs.append(run)
+        else:
+            logger.debug(
+                "Skipping %s: no %s files, so it is not a training run.",
+                entry.path,
+                CHECKPOINT_SUFFIX,
+            )
+    return runs

--- a/tests/test_aitoolkit_run.py
+++ b/tests/test_aitoolkit_run.py
@@ -1,0 +1,236 @@
+"""Reading an ai-toolkit run off disk.
+
+The rule under test throughout: **the reader only reads.** It must never hash,
+copy, move or write, because the shelf runs it against a folder the user has
+merely pointed at and has not yet agreed to import.
+
+The second rule: a run missing its config is still a run. Steps and previews
+come from filenames, so a broken or absent ``config.yaml`` costs the base model,
+triggers and rank, and nothing else.
+"""
+
+import os
+
+import pytest
+
+from pixlstash.utils.aitoolkit_run import (
+    Checkpoint,
+    TrainingRun,
+    read_output_root,
+    read_run,
+)
+
+CONFIG = """\
+job: extension
+config:
+  name: MyCharacter
+  process:
+    - type: sd_trainer
+      model:
+        name_or_path: black-forest-labs/FLUX.1-dev
+      network:
+        type: lora
+        linear: 16
+        linear_alpha: 16
+      trigger_word: ohwx
+"""
+
+
+def _run_folder(tmp_path, name="MyCharacter", steps=(250, 2750), final=True):
+    run = tmp_path / name
+    (run / "samples").mkdir(parents=True)
+    for step in steps:
+        (run / f"{name}_{step:09d}.safetensors").write_bytes(b"")
+        for index in range(2):
+            (run / "samples" / f"1712345678901__{step:09d}_{index}.jpg").write_bytes(
+                b""
+            )
+    if final:
+        (run / f"{name}.safetensors").write_bytes(b"")
+    return run
+
+
+class TestCheckpoints:
+    def test_finds_every_step_and_the_bare_final(self, tmp_path):
+        run = read_run(str(_run_folder(tmp_path)))
+        assert run.steps == [250, 2750]
+        assert [c.filename for c in run.checkpoints] == [
+            "MyCharacter_000000250.safetensors",
+            "MyCharacter_000002750.safetensors",
+            "MyCharacter.safetensors",
+        ]
+
+    def test_the_final_sorts_last_not_first(self, tmp_path):
+        # The final carries no step. Treating that as step 0 would sort the
+        # finished adapter to the front, which is the opposite of useful.
+        run = read_run(str(_run_folder(tmp_path)))
+        assert run.checkpoints[-1].is_final
+        assert run.checkpoints[-1].step is None
+
+    def test_step_zero_is_a_step_not_a_final(self, tmp_path):
+        # `_000000000` is a real save ai-toolkit can emit. It must not be
+        # confused with the bare final.
+        run_dir = _run_folder(tmp_path, steps=(0, 500), final=False)
+        run = read_run(str(run_dir))
+        assert run.steps == [0, 500]
+        assert not any(c.is_final for c in run.checkpoints)
+
+    def test_a_run_whose_name_ends_in_digits_is_not_mis_split(self, tmp_path):
+        # "sdxl_v2" at step 500, not "sdxl" at some version.
+        run_dir = tmp_path / "sdxl_v2"
+        run_dir.mkdir()
+        (run_dir / "sdxl_v2_000000500.safetensors").write_bytes(b"")
+        run = read_run(str(run_dir))
+        assert run.steps == [500]
+
+    def test_a_digit_run_inside_the_name_is_not_taken_as_the_step(self, tmp_path):
+        # The case the end-anchor actually protects: the name carries its own
+        # 4+ digit group. A non-greedy or unanchored pattern reads "flux_2024"
+        # as run "flux" at step 2024 and loses the real step entirely.
+        run_dir = tmp_path / "flux_2024"
+        run_dir.mkdir()
+        (run_dir / "flux_2024_000000500.safetensors").write_bytes(b"")
+        run = read_run(str(run_dir))
+        assert run.steps == [500]
+
+    def test_non_checkpoint_files_are_ignored(self, tmp_path):
+        run_dir = _run_folder(tmp_path)
+        (run_dir / "notes.txt").write_bytes(b"")
+        (run_dir / "optimizer.pt").write_bytes(b"")
+        run = read_run(str(run_dir))
+        assert all(c.filename.endswith(".safetensors") for c in run.checkpoints)
+
+
+class TestSamples:
+    def test_groups_previews_by_step(self, tmp_path):
+        run = read_run(str(_run_folder(tmp_path)))
+        assert [s.index for s in run.samples_for_step(2750)] == [0, 1]
+        assert all(s.step == 2750 for s in run.samples_for_step(2750))
+
+    def test_parses_the_double_underscore_layout(self, tmp_path):
+        run = read_run(str(_run_folder(tmp_path)))
+        first = run.samples_for_step(250)[0]
+        assert first.timestamp == "1712345678901"
+        assert (first.step, first.index) == (250, 0)
+
+    def test_a_users_own_images_are_skipped_not_fatal(self, tmp_path):
+        run_dir = _run_folder(tmp_path)
+        (run_dir / "samples" / "my-reference.jpg").write_bytes(b"")
+        run = read_run(str(run_dir))
+        assert "my-reference.jpg" not in [s.filename for s in run.samples]
+        assert len(run.samples) == 4
+
+    def test_a_run_with_no_samples_folder_still_reads(self, tmp_path):
+        run_dir = tmp_path / "Bare"
+        run_dir.mkdir()
+        (run_dir / "Bare_000000100.safetensors").write_bytes(b"")
+        run = read_run(str(run_dir))
+        assert run.samples == []
+        assert run.steps == [100]
+
+
+class TestConfig:
+    def test_reads_base_model_trigger_and_rank(self, tmp_path):
+        run_dir = _run_folder(tmp_path)
+        (run_dir / "config.yaml").write_text(CONFIG, encoding="utf-8")
+        run = read_run(str(run_dir))
+        assert run.base_model == "black-forest-labs/FLUX.1-dev"
+        assert run.trigger_words == ["ohwx"]
+        assert run.rank == 16
+        assert run.config_error is None
+
+    def test_finds_keys_wherever_ai_toolkit_nests_them(self, tmp_path):
+        # The nesting path has moved between ai-toolkit versions. Searching by
+        # key rather than by path means a layout change costs nothing.
+        run_dir = _run_folder(tmp_path)
+        (run_dir / "config.yaml").write_text(
+            "a:\n  b:\n    - c:\n        name_or_path: some/model\n", encoding="utf-8"
+        )
+        run = read_run(str(run_dir))
+        assert run.base_model == "some/model"
+
+    def test_a_missing_config_is_recorded_not_raised(self, tmp_path):
+        run = read_run(str(_run_folder(tmp_path)))
+        assert run.config_error is not None
+        assert run.base_model is None
+        # The part that matters: the run is still fully usable.
+        assert run.steps == [250, 2750]
+        assert len(run.samples) == 4
+
+    def test_malformed_yaml_is_recorded_not_raised(self, tmp_path):
+        run_dir = _run_folder(tmp_path)
+        (run_dir / "config.yaml").write_text("a: [unclosed\n", encoding="utf-8")
+        run = read_run(str(run_dir))
+        assert run.config_error is not None
+        assert run.steps == [250, 2750]
+
+    def test_linear_true_is_not_read_as_rank_one(self, tmp_path):
+        # bool is a subclass of int, so a naive isinstance check invents rank 1.
+        run_dir = _run_folder(tmp_path)
+        (run_dir / "config.yaml").write_text("network:\n  linear: true\n", "utf-8")
+        run = read_run(str(run_dir))
+        assert run.rank is None
+
+    def test_a_list_of_triggers_is_kept_whole(self, tmp_path):
+        run_dir = _run_folder(tmp_path)
+        (run_dir / "config.yaml").write_text(
+            "trigger_word:\n  - ohwx\n  - woman\n", encoding="utf-8"
+        )
+        run = read_run(str(run_dir))
+        assert run.trigger_words == ["ohwx", "woman"]
+
+
+class TestOutputRoot:
+    def test_lists_every_run_by_name(self, tmp_path):
+        _run_folder(tmp_path, name="Bravo")
+        _run_folder(tmp_path, name="Alpha")
+        runs = read_output_root(str(tmp_path))
+        assert [r.name for r in runs] == ["Alpha", "Bravo"]
+
+    def test_skips_a_folder_that_holds_no_checkpoints(self, tmp_path):
+        _run_folder(tmp_path, name="Real")
+        (tmp_path / "datasets").mkdir()
+        (tmp_path / "datasets" / "a.jpg").write_bytes(b"")
+        assert [r.name for r in read_output_root(str(tmp_path))] == ["Real"]
+
+    def test_a_missing_root_is_an_error_worth_raising(self, tmp_path):
+        with pytest.raises(NotADirectoryError):
+            read_output_root(str(tmp_path / "nope"))
+
+    def test_a_file_where_a_run_folder_belongs_is_an_error(self, tmp_path):
+        target = tmp_path / "afile"
+        target.write_bytes(b"")
+        with pytest.raises(NotADirectoryError):
+            read_run(str(target))
+
+
+class TestReadsOnly:
+    def test_nothing_on_disk_changes(self, tmp_path):
+        """The load-bearing guarantee: this runs against folders the user has
+        only pointed at, so it must not write, move or delete anything."""
+        _run_folder(tmp_path, name="Alpha")
+        run_dir = tmp_path / "Alpha"
+        (run_dir / "config.yaml").write_text(CONFIG, encoding="utf-8")
+
+        def snapshot():
+            seen = {}
+            for base, _dirs, files in os.walk(tmp_path):
+                for name in files:
+                    path = os.path.join(base, name)
+                    stat = os.stat(path)
+                    seen[path] = (stat.st_size, stat.st_mtime_ns)
+            return seen
+
+        before = snapshot()
+        runs = read_output_root(str(tmp_path))
+        assert runs and runs[0].checkpoints
+        assert snapshot() == before
+
+
+class TestDataclassSurface:
+    def test_a_checkpoint_knows_whether_it_is_final(self):
+        assert Checkpoint(path="p", filename="f", step=None).is_final
+        assert not Checkpoint(path="p", filename="f", step=10).is_final
+
+    def test_an_empty_run_reports_no_steps_rather_than_failing(self):
+        assert TrainingRun(name="x", path="/tmp/x").steps == []


### PR DESCRIPTION
B6 of the model shelf. The shelf has to show what a training run produced *before* the user commits to importing any of it: which steps were saved, what each looked like, and what it was trained against.

**It only reads.** No hashing, no copying, no writing. That is the load-bearing property, because the shelf runs this against a folder the user has merely pointed at. A test snapshots size and mtime of every file in the tree and asserts nothing moved.

**A run missing its config is still a run.** Steps and previews come from filenames, so an absent or malformed `config.yaml` costs the base model, trigger words and rank, and nothing else. The reason is recorded on the run rather than raised.

## Decisions worth a second opinion

**PyYAML is a local, optional import.** It is present transitively but is *not* declared in `pyproject.toml`. Declaring it would make this a dependency change, which per CLAUDE.md needs security review before push, and that seemed a poor trade for a field the reader works fine without. If you would rather declare it, say so and I will split that out for review.

**Config keys are found by searching the parsed tree, not by a fixed path.** ai-toolkit has moved that nesting between versions; searching by key means a layout change costs nothing here.

## Two traps the tests pin

- The bare final checkpoint carries no step. Treating that as step 0 sorts the finished adapter to the *front* of the run, and step 0 is itself a real save ai-toolkit emits, so the two cannot be conflated.
- `linear: true` is a different setting sharing a name with the rank. Since `bool` subclasses `int`, a naive `isinstance(rank, int)` invents a rank of 1.

Scoped to ai-toolkit deliberately. Other trainers lay output out differently, and a reader trying to cover all of them recognises none of them reliably.

## Verification
- 156 tests pass including the CI-shard gate; `ruff format` and `ruff check` clean
- `tests/test_aitoolkit_run.py` added to `ci.yml` in alphabetical position
- Mutation-tested. **One test was found to be decorative this way**: the "run name ending in digits" case did not actually exercise the step regex anchor, because `sdxl_v2` has no 4+ digit group. Added `flux_2024`, which does, and confirmed it fails against an unanchored pattern.

## Not verified
Not run against a real ai-toolkit output folder. Fixtures are built from the layout in the integration plan, so if real output differs, this is where it shows.

https://claude.ai/code/session_01PPYSfMTVkJvyXUGhxJH4Vf