### PR TITLE
Give the hub the model shelf's tables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,7 @@ jobs:
           tests/test_generic_field_reader_allowlist.py
           tests/test_hub_bootstrap.py
           tests/test_hub_engine.py
+          tests/test_hub_model_shelf_schema.py
           tests/test_hub_registry.py
           tests/test_identity_storage_guardrail.py
           tests/test_image_embedding_worker.py

--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -256,6 +256,129 @@ _V1_LIBRARY_INDEXES = (
 )
 
 
+# ---------------------------------------------------------------------------
+# Model shelf (v1.10.0). These live in the HUB, not in a vault, because what
+# they record is a fact about this machine rather than about a library: a folder
+# of LoRAs is on this disk, and re-registering the same folder in every library
+# would be absurd. The only vault-side table is ``adapter_attachment``, which
+# says "this library's character uses that adapter" and is keyed by sha256
+# because no foreign key can span the two databases.
+#
+# Hand-written DDL against stdlib sqlite3, like everything else here. The hub is
+# deliberately not SQLModel: a SQLModel table would be created inside every
+# vault as well.
+# ---------------------------------------------------------------------------
+
+# AUTOINCREMENT, not a bare INTEGER PRIMARY KEY, for the same reason
+# ``library.id`` uses it: SQLite hands a deleted row's id to the next insert, and
+# a recycled folder id would silently re-point every ``adapter_file`` row at a
+# different folder.
+_V2_MODEL_FOLDER = """
+CREATE TABLE IF NOT EXISTS model_folder (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    path                 TEXT NOT NULL UNIQUE,
+    kind                 TEXT NOT NULL,
+    owner                TEXT,
+    movable              TEXT NOT NULL,
+    host_path            TEXT,
+    delete_after_import  INTEGER,
+    last_checked         TEXT,
+    created_at           TEXT
+)
+"""
+
+# `base_model` is free text on purpose. It comes from whatever the trainer wrote
+# and an enum would reject every model that ships after this release.
+_V2_ADAPTER = """
+CREATE TABLE IF NOT EXISTS adapter (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    sha256                TEXT UNIQUE NOT NULL,
+    kind                  TEXT NOT NULL,
+    display_name          TEXT,
+    filename              TEXT,
+    base_model            TEXT,
+    trigger_words         TEXT,
+    provenance            TEXT NOT NULL,
+    training_run_id       INTEGER,
+    lineage_id            INTEGER,
+    training_step         INTEGER,
+    safetensors_metadata  TEXT,
+    file_size             INTEGER,
+    stack_id              INTEGER REFERENCES adapter_stack(id),
+    stack_position        INTEGER,
+    run_key               TEXT,
+    created_at            TEXT
+)
+"""
+
+# One adapter, many paths. That is what a duplicate after an interrupted move
+# is, and what the same file copied into two registered folders is.
+#
+# This table is also the tombstone. Removing a folder drops its ``adapter_file``
+# rows and KEEPS the ``adapter`` row with its name, triggers and attachments, so
+# re-adding the folder re-links by sha256 with the user's curation intact. That
+# is what lets folder removal skip a confirmation prompt: nothing a user typed
+# is destroyed by it.
+_V2_ADAPTER_FILE = """
+CREATE TABLE IF NOT EXISTS adapter_file (
+    adapter_sha256   TEXT NOT NULL,
+    model_folder_id  INTEGER NOT NULL REFERENCES model_folder(id),
+    relpath          TEXT NOT NULL,
+    state            TEXT NOT NULL,
+    seen_at          TEXT,
+    PRIMARY KEY (model_folder_id, relpath)
+)
+"""
+
+# ``sha256`` is nullable here and NOT NULL on ``adapter``: a checkpoint may be
+# many gigabytes and is registered in place long before anything hashes it.
+_V2_CHECKPOINT = """
+CREATE TABLE IF NOT EXISTS checkpoint (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    sha256             TEXT UNIQUE,
+    filename           TEXT NOT NULL,
+    local_path         TEXT,
+    base_model_family  TEXT,
+    file_size          INTEGER,
+    hashed_at          TEXT,
+    created_at         TEXT
+)
+"""
+
+# One subject, many runs, many steps per run. Mirrors PictureStack exactly
+# (id, name, created_at, updated_at) so the shelf can reuse the picture-stack
+# presentation rather than invent a second stacking idiom.
+_V2_ADAPTER_STACK = """
+CREATE TABLE IF NOT EXISTS adapter_stack (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT,
+    created_at  TEXT,
+    updated_at  TEXT
+)
+"""
+
+_V2_MODEL_SHELF_INDEXES = (
+    # The scanner's hot path: "which files does this adapter have, and where".
+    "CREATE INDEX IF NOT EXISTS ix_adapter_file_sha ON adapter_file(adapter_sha256)",
+    # Folder removal and rescan both work folder-at-a-time.
+    "CREATE INDEX IF NOT EXISTS ix_adapter_file_folder "
+    "ON adapter_file(model_folder_id)",
+    # Expanding one stack in the shelf, in cover-first order.
+    "CREATE INDEX IF NOT EXISTS ix_adapter_stack_member "
+    "ON adapter(stack_id, stack_position)",
+)
+
+_V2_MODEL_SHELF_TABLES = (
+    # adapter_stack first: `adapter.stack_id` references it.
+    _V2_ADAPTER_STACK,
+    _V2_MODEL_FOLDER,
+    _V2_ADAPTER,
+    _V2_ADAPTER_FILE,
+    _V2_CHECKPOINT,
+    *_V2_MODEL_SHELF_INDEXES,
+)
+
+
 # Ordered schema steps. Append only: a released version's statement list is
 # never edited, exactly as for an applied Alembic migration. ``library`` is
 # created before ``user_token`` because the latter references it.
@@ -314,6 +437,16 @@ def _apply_v2(conn: sqlite3.Connection) -> None:
         "source_path TEXT NOT NULL, payload_digest TEXT NOT NULL, "
         "state TEXT NOT NULL CHECK(state IN ('pending','copied','complete')))"
     )
+    # Model shelf (v1.10.0). Amending v2 rather than adding a v3 is deliberate.
+    # apply_migrations re-runs this function for any hub already at v2 (see the
+    # tail of that function), so an existing developer or dev-build hub picks
+    # these up on its next open. A v3 would be actively worse: a build shipped
+    # before this change has CURRENT_SCHEMA_VERSION = 2, so it would refuse a v3
+    # hub with HubSchemaTooNewError and lock that user out of a downgrade.
+    # CREATE TABLE IF NOT EXISTS throughout, so re-running is a no-op.
+    for statement in _V2_MODEL_SHELF_TABLES:
+        conn.execute(statement)
+
     # Rows from the earliest feature-lane v1 may predate the column entirely.
     # Backfill in Python so every library gets a distinct cryptographic value;
     # SQLite has no suitable random-hex default for ALTER TABLE.

--- a/tests/test_hub_model_shelf_schema.py
+++ b/tests/test_hub_model_shelf_schema.py
@@ -1,0 +1,235 @@
+"""The model shelf's hub tables (v1.10.0).
+
+These live in the hub rather than in a vault because what they record is a fact
+about the machine: a folder of LoRAs is on this disk. Re-registering the same
+folder in every library would be absurd. The only vault-side table is
+``adapter_attachment``, which is a different change.
+
+The rule under test throughout: **applying the schema twice is a no-op, and a
+hub that already exists picks the tables up on its next open.** That is what
+lets these land by amending v2 instead of inventing a v3.
+"""
+
+import sqlite3
+
+import pytest
+
+from pixlstash.hub.schema import (
+    CURRENT_SCHEMA_VERSION,
+    apply_migrations,
+    read_schema_version,
+)
+
+SHELF_TABLES = (
+    "model_folder",
+    "adapter",
+    "adapter_file",
+    "checkpoint",
+    "adapter_stack",
+)
+
+
+@pytest.fixture
+def hub(tmp_path):
+    conn = sqlite3.connect(tmp_path / "hub.db")
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def table_names(conn):
+    return {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+
+
+def ddl_for(conn, name):
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row[0] if row else None
+
+
+class TestFreshHub:
+    def test_every_shelf_table_is_created(self, hub):
+        apply_migrations(hub)
+        assert SHELF_TABLES == tuple(t for t in SHELF_TABLES if t in table_names(hub))
+
+    def test_the_hub_stays_on_version_two(self, hub):
+        # The whole point of amending v2: a build that predates this change has
+        # CURRENT_SCHEMA_VERSION = 2 and would refuse a v3 hub outright, locking
+        # a user out of downgrading.
+        apply_migrations(hub)
+        assert read_schema_version(hub) == 2
+        assert CURRENT_SCHEMA_VERSION == 2
+
+    @pytest.mark.parametrize(
+        "table", ("model_folder", "adapter", "checkpoint", "adapter_stack")
+    )
+    def test_ids_never_recycle(self, hub, table):
+        # AUTOINCREMENT, per the library.id precedent. Without it SQLite hands a
+        # deleted row's id to the next insert, and a recycled folder id would
+        # silently re-point every adapter_file row at a different folder.
+        apply_migrations(hub)
+        assert "AUTOINCREMENT" in ddl_for(hub, table)
+
+    def test_the_scan_and_stack_indexes_exist(self, hub):
+        apply_migrations(hub)
+        indexes = {
+            row[0]
+            for row in hub.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
+        assert {
+            "ix_adapter_file_sha",
+            "ix_adapter_file_folder",
+            "ix_adapter_stack_member",
+        } <= indexes
+
+
+class TestReRunIsSafe:
+    def test_applying_twice_changes_nothing(self, hub):
+        apply_migrations(hub)
+        before = sorted(
+            hub.execute("SELECT type, name, sql FROM sqlite_master").fetchall()
+        )
+        apply_migrations(hub)
+        after = sorted(
+            hub.execute("SELECT type, name, sql FROM sqlite_master").fetchall()
+        )
+        assert before == after
+
+    def test_an_existing_v2_hub_gains_the_tables_on_next_open(self, hub):
+        """The case that makes amending v2 legitimate.
+
+        A hub created by an earlier build is already at version 2, so the
+        migration loop skips every step. It must still end up with the shelf
+        tables, which is what the unconditional re-run at the tail of
+        apply_migrations is for.
+        """
+        apply_migrations(hub)
+        for table in SHELF_TABLES:
+            hub.execute(f"DROP TABLE {table}")
+        assert read_schema_version(hub) == 2  # still v2, nothing to upgrade
+        assert not (set(SHELF_TABLES) & table_names(hub))
+
+        apply_migrations(hub)
+        assert set(SHELF_TABLES) <= table_names(hub)
+
+    def test_existing_rows_survive_a_re_run(self, hub):
+        apply_migrations(hub)
+        hub.execute(
+            "INSERT INTO model_folder (path, kind, movable) VALUES (?, ?, ?)",
+            ("/models/loras", "user", "per_item"),
+        )
+        hub.commit()
+        apply_migrations(hub)
+        assert hub.execute("SELECT path FROM model_folder").fetchall() == [
+            ("/models/loras",)
+        ]
+
+
+class TestConstraints:
+    def test_an_adapter_is_identified_by_its_hash(self, hub):
+        apply_migrations(hub)
+        for _ in range(1):
+            hub.execute(
+                "INSERT INTO adapter (sha256, kind, provenance) VALUES (?, ?, ?)",
+                ("abc", "lora", "external"),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            hub.execute(
+                "INSERT INTO adapter (sha256, kind, provenance) VALUES (?, ?, ?)",
+                ("abc", "lora", "trained"),
+            )
+
+    def test_a_checkpoint_may_be_registered_before_it_is_hashed(self, hub):
+        # Deliberately different from `adapter`: a checkpoint can be many
+        # gigabytes and is registered in place long before anything hashes it.
+        apply_migrations(hub)
+        hub.execute(
+            "INSERT INTO checkpoint (filename, local_path) VALUES (?, ?)",
+            ("flux1-dev.safetensors", "/models/flux1-dev.safetensors"),
+        )
+        assert hub.execute("SELECT sha256 FROM checkpoint").fetchone() == (None,)
+
+    def test_two_unhashed_checkpoints_do_not_collide(self, hub):
+        # SQLite treats NULLs as distinct under UNIQUE, which is what allows a
+        # whole folder to be registered before any of it is hashed.
+        apply_migrations(hub)
+        for name in ("a.safetensors", "b.safetensors"):
+            hub.execute("INSERT INTO checkpoint (filename) VALUES (?)", (name,))
+        assert hub.execute("SELECT COUNT(*) FROM checkpoint").fetchone()[0] == 2
+
+    def test_one_path_per_folder_is_recorded_once(self, hub):
+        apply_migrations(hub)
+        hub.execute(
+            "INSERT INTO model_folder (path, kind, movable) VALUES (?, ?, ?)",
+            ("/models", "user", "per_item"),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            hub.execute(
+                "INSERT INTO model_folder (path, kind, movable) VALUES (?, ?, ?)",
+                ("/models", "managed", "root_only"),
+            )
+
+    def test_the_same_file_may_sit_in_two_folders(self, hub):
+        # One adapter, many paths. That is what a copy into a second registered
+        # folder is, and what a duplicate after an interrupted move is.
+        apply_migrations(hub)
+        hub.execute(
+            "INSERT INTO adapter (sha256, kind, provenance) VALUES ('h', 'lora', 'external')"
+        )
+        for path in ("/a", "/b"):
+            hub.execute(
+                "INSERT INTO model_folder (path, kind, movable) VALUES (?, 'user', 'per_item')",
+                (path,),
+            )
+        for folder_id in (1, 2):
+            hub.execute(
+                "INSERT INTO adapter_file "
+                "(adapter_sha256, model_folder_id, relpath, state) "
+                "VALUES ('h', ?, 'x.safetensors', 'present')",
+                (folder_id,),
+            )
+        assert hub.execute("SELECT COUNT(*) FROM adapter_file").fetchone()[0] == 2
+
+
+class TestTombstone:
+    def test_dropping_a_folders_files_keeps_the_adapter_and_its_curation(self, hub):
+        """Why folder removal needs no confirmation prompt.
+
+        Removing a folder drops ``adapter_file`` rows and keeps the ``adapter``
+        row, so the display name the user typed survives and re-adding the
+        folder re-links by sha256. Nothing a user authored is destroyed, which
+        is the whole basis for not interrupting them with a dialog.
+        """
+        apply_migrations(hub)
+        hub.execute(
+            "INSERT INTO adapter (sha256, kind, provenance, display_name) "
+            "VALUES ('h', 'lora', 'external', 'Clementine v3')"
+        )
+        hub.execute(
+            "INSERT INTO model_folder (path, kind, movable) "
+            "VALUES ('/models', 'user', 'per_item')"
+        )
+        hub.execute(
+            "INSERT INTO adapter_file "
+            "(adapter_sha256, model_folder_id, relpath, state) "
+            "VALUES ('h', 1, 'clem.safetensors', 'present')"
+        )
+        hub.commit()
+
+        hub.execute("DELETE FROM adapter_file WHERE model_folder_id = 1")
+        hub.execute("DELETE FROM model_folder WHERE id = 1")
+        hub.commit()
+
+        assert hub.execute("SELECT display_name FROM adapter").fetchone() == (
+            "Clementine v3",
+        )


### PR DESCRIPTION
B2 of the model shelf. `model_folder`, `adapter`, `adapter_file`, `checkpoint`, `adapter_stack`, per integration plan §3.

These belong to the **machine**, not to a library: a folder of LoRAs is on this disk, and re-registering the same folder in every library would be absurd. The only vault-side table is `adapter_attachment`, which is a separate change and links by sha256 because no foreign key can span the two databases.

## The decision that needs your eye

The plan said: amend `_apply_v2`, do not add a v3, **unless a v1.10 release candidate has already put a hub on a users disk**, in which case add a v3 instead.

**That condition has arguably been met**: `v1.10.0-dev.1` was published as a pre-release today. But having read the machinery, adding a v3 would be the wrong response, and worse than doing nothing:

- `apply_migrations` **already re-runs `_apply_v2` unconditionally** for any hub at v2 (`schema.py`, tail of the function), precisely so hubs from earlier builds pick up newly added v2 tables. So amending v2 does reach a dev.1 hub on its next open.
- A v3 would **lock dev.1 users out of downgrading**. That build has `CURRENT_SCHEMA_VERSION = 2`, so opening a v3 hub raises `HubSchemaTooNewError` and refuses.

So the escape hatch protects against a problem the existing code already solves, and the cure is worse. I went with amending v2. **If you disagree, this is the one thing here worth reverting before merge.**

## Other decisions

- **`AUTOINCREMENT` on every id**, per the `library.id` precedent. A recycled `model_folder` id would silently re-point every `adapter_file` row at a different folder.
- **`adapter.sha256` is `UNIQUE NOT NULL`; `checkpoint.sha256` is nullable.** Deliberately different. A checkpoint can be many gigabytes and is registered in place long before anything hashes it, and SQLite treats NULLs as distinct under UNIQUE, so a whole folder can be registered before any of it is hashed.
- **`adapter_file` is the tombstone.** Removing a folder drops its rows and keeps the `adapter` row with its name and attachments, so re-adding relinks by sha256 with curation intact. That is the entire basis for folder removal needing no confirmation prompt, so it is load-bearing for the UI decision, not just storage detail. A test pins it.

## Verification
- 256 tests pass, including the existing `test_hub_engine.py` and `test_hub_bootstrap.py`; `ruff format` and `ruff check` clean
- `tests/test_hub_model_shelf_schema.py` added to `ci.yml` in alphabetical position
- Mutation-tested: dropping AUTOINCREMENT, moving the DDL out of the re-run path, removing `adapter.sha256` UNIQUE, and making `checkpoint.sha256` NOT NULL each fail the suite.

## Not verified
No route touches these tables yet, so there is no AuthzGate surface in this PR. That arrives with B4/B5 and will need `ROUTE_POLICIES` entries and coverage-matrix rows.

https://claude.ai/code/session_01PPYSfMTVkJvyXUGhxJH4Vf