### PR TITLE
Attach shelf adapters to a library's characters and sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,7 @@ jobs:
           CI_SHARD: ${{ matrix.shard }}
         run: >-
           python -m pytest $PYTEST_FLAGS --ci-shard "$CI_SHARD/4"
+          tests/test_adapter_attachment.py
           tests/test_adapter_header.py
           tests/test_aitoolkit_run.py
           tests/test_anomaly_region_scope.py

--- a/pixlstash/db_models/__init__.py
+++ b/pixlstash/db_models/__init__.py
@@ -1,3 +1,8 @@
+from .adapter_attachment import (  # noqa: F401
+    ENTITY_CHARACTER,
+    ENTITY_SET,
+    AdapterAttachment,
+)
 from .character import Character  # noqa: F401
 from .dedup import (  # noqa: F401
     DedupGroup,

--- a/pixlstash/db_models/adapter_attachment.py
+++ b/pixlstash/db_models/adapter_attachment.py
@@ -1,0 +1,54 @@
+"""Which adapters this library's characters and sets use.
+
+The only model-shelf table that lives in a **vault**. The adapters themselves,
+the folders they sit in and the checkpoints beside them are all hub tables,
+because those are facts about the machine. Which character a LoRA belongs to is
+a fact about *this library*, so it lives here and travels with the library.
+
+**The link is the sha256, never an integer adapter id.** Two reasons, and both
+have bitten this codebase before:
+
+* No foreign key can span the hub and a vault. They are separate SQLite files,
+  so an integer id here would be an unenforceable reference that nothing checks.
+* SQLite hands a deleted row's id to the next insert. An integer link would
+  silently re-point at a *different* adapter after a delete plus an insert, and
+  the row would look perfectly valid while being wrong. This is the same
+  recycled-identifier hazard `library.uuid` and the hub's `AUTOINCREMENT` ids
+  exist to eliminate.
+
+The sha256 is already the adapter's identity, already the API path component,
+and stable across a hub rebuild or a re-import, which is exactly what an
+attachment needs to survive.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+ENTITY_CHARACTER = "character"
+ENTITY_SET = "set"
+
+
+class AdapterAttachment(SQLModel, table=True):
+    """One adapter attached to one character or one picture set.
+
+    Characters and sets are peers here, addressed through ``entity_type`` rather
+    than through two nullable scalar columns. A scalar ``character_id`` plus a
+    scalar ``set_id`` would make "attached to both" and "attached to neither"
+    representable states that mean nothing, and every reader would have to
+    decide what to do about them.
+
+    The composite primary key makes attaching the same adapter to the same
+    entity twice a no-op at the database level rather than a duplicate row the
+    UI has to de-duplicate.
+    """
+
+    __tablename__ = "adapter_attachment"
+
+    adapter_sha256: str = Field(primary_key=True, index=True)
+    entity_type: str = Field(primary_key=True)
+    """``character`` or ``set``. See ENTITY_CHARACTER / ENTITY_SET."""
+
+    entity_id: int = Field(primary_key=True, index=True)
+    created_at: Optional[datetime] = Field(default=None)

--- a/pixlstash/db_models/character.py
+++ b/pixlstash/db_models/character.py
@@ -14,6 +14,10 @@ class Character(SQLModel, table=True):
     name: str = Field(index=True, nullable=False)
     description: Optional[str] = Field(default=None)
     extra_metadata: Optional[str] = Field(default=None)
+    # Mirrors PictureSet.set_color: a hex string seeded by POSITION in the
+    # shared 48-colour list, never by value. The list is therefore never
+    # reordered or trimmed. See #761.
+    character_color: Optional[str] = Field(default=None)
 
     reference_picture_set_id: Optional[int] = Field(
         default=None, foreign_key="pictureset.id"

--- a/pixlstash/migrations/versions/0103_add_adapter_attachment.py
+++ b/pixlstash/migrations/versions/0103_add_adapter_attachment.py
@@ -1,0 +1,84 @@
+"""Attach model-shelf adapters to this library's characters and sets.
+
+``adapter_attachment`` is the only model-shelf table that lives in a vault. The
+adapters, the folders holding them and the checkpoints beside them are hub
+tables, because those describe the machine. Which character a LoRA belongs to
+describes *this library*, so it belongs here and travels with the library.
+
+The link is ``adapter_sha256``, a TEXT column, and deliberately not an integer
+adapter id. No foreign key can span the hub and a vault, so an integer would be
+an unenforceable reference; worse, SQLite hands a deleted row's id to the next
+insert, so an integer link would silently re-point at a different adapter after
+a delete plus insert while still looking valid.
+
+``character_color`` rides along because it is a one-column addition to an
+existing table and splitting it into its own revision buys nothing. It mirrors
+``PictureSet.set_color``: a hex seeded by position in the shared 48-colour list.
+Only the column lands here; the assignment logic is #761.
+
+Revision ID: 0103_add_adapter_attachment
+Revises: 0102_add_snapshot_identity_scrubbed_at
+Create Date: 2026-08-08
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0103_add_adapter_attachment"
+down_revision: Union[str, None] = "0102_add_snapshot_identity_scrubbed_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Conditional because the baseline runs SQLModel.metadata.create_all(),
+    # which already builds this table on a fresh database from the model added
+    # alongside this revision. An unconditional CREATE would fail there.
+    if "adapter_attachment" not in inspector.get_table_names():
+        op.create_table(
+            "adapter_attachment",
+            sa.Column("adapter_sha256", sa.String(), nullable=False),
+            sa.Column("entity_type", sa.String(), nullable=False),
+            sa.Column("entity_id", sa.Integer(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint("adapter_sha256", "entity_type", "entity_id"),
+        )
+        op.create_index(
+            "ix_adapter_attachment_adapter_sha256",
+            "adapter_attachment",
+            ["adapter_sha256"],
+        )
+        # The shelf's other direction: "what does this character use".
+        op.create_index(
+            "ix_adapter_attachment_entity",
+            "adapter_attachment",
+            ["entity_type", "entity_id"],
+        )
+
+    if "character" in inspector.get_table_names():
+        existing_cols = {col["name"] for col in inspector.get_columns("character")}
+        if "character_color" not in existing_cols:
+            op.add_column(
+                "character",
+                sa.Column("character_color", sa.String(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "character" in inspector.get_table_names():
+        existing_cols = {col["name"] for col in inspector.get_columns("character")}
+        if "character_color" in existing_cols:
+            op.drop_column("character", "character_color")
+
+    if "adapter_attachment" in inspector.get_table_names():
+        op.drop_table("adapter_attachment")

--- a/tests/test_adapter_attachment.py
+++ b/tests/test_adapter_attachment.py
@@ -1,0 +1,124 @@
+"""Attaching a model-shelf adapter to a character or a set.
+
+The load-bearing decision under test: **the link is the adapter's sha256, not an
+integer id.** No foreign key can span the hub and a vault, and SQLite hands a
+deleted row's id to the next insert, so an integer link would silently re-point
+at a different adapter after a delete plus insert while still looking valid.
+That is the same recycled-identifier hazard ``library.uuid`` exists to kill.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import inspect
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from pixlstash.db_models import (
+    ENTITY_CHARACTER,
+    ENTITY_SET,
+    AdapterAttachment,
+    Character,
+)
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def attach(session, sha, entity_type, entity_id):
+    row = AdapterAttachment(
+        adapter_sha256=sha,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(row)
+    session.commit()
+    return row
+
+
+class TestTheLinkIsAHash:
+    def test_the_adapter_is_addressed_by_content_not_by_id(self, session):
+        columns = {c.name for c in AdapterAttachment.__table__.columns}
+        assert "adapter_sha256" in columns
+        # An `adapter_id` here would be an unenforceable cross-database
+        # reference AND would survive a delete plus insert pointing at the
+        # wrong adapter. Neither is acceptable, so the column must not exist.
+        assert "adapter_id" not in columns
+
+    def test_the_hash_column_is_text(self, session):
+        column = AdapterAttachment.__table__.columns["adapter_sha256"]
+        assert isinstance(column.type, type(Character.__table__.columns["name"].type))
+
+
+class TestPeers:
+    def test_a_character_and_a_set_are_addressed_the_same_way(self, session):
+        attach(session, SHA_A, ENTITY_CHARACTER, 1)
+        attach(session, SHA_A, ENTITY_SET, 1)
+        rows = session.exec(select(AdapterAttachment)).all()
+        assert {r.entity_type for r in rows} == {ENTITY_CHARACTER, ENTITY_SET}
+
+    def test_the_same_id_in_different_namespaces_does_not_collide(self, session):
+        # Character 1 and set 1 are different things. A scalar character_id /
+        # set_id pair would make this representable in two ways.
+        attach(session, SHA_A, ENTITY_CHARACTER, 1)
+        attach(session, SHA_A, ENTITY_SET, 1)
+        assert len(session.exec(select(AdapterAttachment)).all()) == 2
+
+    def test_one_adapter_serves_many_entities(self, session):
+        for entity_id in (1, 2, 3):
+            attach(session, SHA_A, ENTITY_CHARACTER, entity_id)
+        assert len(session.exec(select(AdapterAttachment)).all()) == 3
+
+    def test_one_entity_holds_many_adapters(self, session):
+        for sha in (SHA_A, SHA_B):
+            attach(session, sha, ENTITY_CHARACTER, 1)
+        assert len(session.exec(select(AdapterAttachment)).all()) == 2
+
+
+class TestIdempotence:
+    def test_attaching_twice_is_refused_by_the_database(self, session):
+        # The composite key makes a double attach a no-op at the storage layer
+        # rather than a duplicate row the UI has to de-duplicate.
+        attach(session, SHA_A, ENTITY_CHARACTER, 1)
+        with pytest.raises(Exception):
+            attach(session, SHA_A, ENTITY_CHARACTER, 1)
+
+    def test_the_primary_key_is_all_three_columns(self, session):
+        key = {c.name for c in AdapterAttachment.__table__.primary_key.columns}
+        assert key == {"adapter_sha256", "entity_type", "entity_id"}
+
+
+class TestCharacterColor:
+    def test_a_character_carries_a_colour_like_a_set_does(self, session):
+        character = Character(name="Clementine", character_color="#8E24AA")
+        session.add(character)
+        session.commit()
+        assert session.exec(select(Character)).one().character_color == "#8E24AA"
+
+    def test_the_colour_is_optional(self, session):
+        session.add(Character(name="Unpainted"))
+        session.commit()
+        assert session.exec(select(Character)).one().character_color is None
+
+
+class TestSchemaShape:
+    def test_both_lookup_directions_are_indexed(self, session):
+        # The shelf asks "who uses this adapter" and "what does this character
+        # use". Both are hot paths in the same view.
+        engine = create_engine("sqlite://")
+        SQLModel.metadata.create_all(engine)
+        indexed = {
+            tuple(ix["column_names"])
+            for ix in inspect(engine).get_indexes("adapter_attachment")
+        }
+        flattened = {col for cols in indexed for col in cols}
+        assert "adapter_sha256" in flattened
+        assert "entity_id" in flattened


### PR DESCRIPTION
B3 of the model shelf. `adapter_attachment` is the **only** model-shelf table that lives in a vault. The adapters, their folders and the checkpoints beside them are hub tables (#788), because those describe the machine. Which character a LoRA belongs to describes *this library*, so it travels with the library.

## The link is a hash, and that is load-bearing

`adapter_sha256 TEXT`, never an integer adapter id. Two reasons, both of which have bitten this codebase before:

- **No foreign key can span the hub and a vault.** They are separate SQLite files, so an integer id would be an unenforceable reference that nothing checks.
- **SQLite hands a deleted row id to the next insert.** An integer link would silently re-point at a *different* adapter after a delete plus insert, and the row would look perfectly valid while being wrong. Same recycled-identifier hazard `library.uuid` and the hub AUTOINCREMENT ids exist to eliminate.

A mutation test confirms this: swapping the column for `adapter_id` fails 9 of 11 tests.

## Characters and sets are peers

Addressed through `entity_type`, not two nullable scalar columns. A scalar `character_id` plus `set_id` makes "attached to both" and "attached to neither" representable states that mean nothing, and every reader would then have to decide what to do about them.

## Rider worth calling out

`character_color` ships in the same migration, per the plan. It is a one-column addition mirroring `PictureSet.set_color`. **Only the column is here.** The first-unused assignment logic and the 48-hex list are #761 and are not touched, so nothing yet writes this column.

## Verification
- 163 tests pass including `test_migrations.py`, plus 42 more across `test_architecture_guardrails.py`, `test_openapi_response_schemas.py` and `test_identity_storage_guardrail.py`, since this adds a SQLModel field
- `ruff format` and `ruff check` clean
- `tests/test_adapter_attachment.py` added to `ci.yml` in alphabetical position
- Migration is conditional in both directions, because the baseline `create_all()` already builds the table on a fresh database from the model added here

## Not verified
No route reads or writes this yet, so there is no AuthzGate surface in this PR. That arrives with the attachment endpoints and will need `ROUTE_POLICIES` entries and coverage-matrix rows.

https://claude.ai/code/session_01PPYSfMTVkJvyXUGhxJH4Vf