### PR TITLE
Make the compare zoom reachable from the keyboard (#762)

### DIFF
--- a/frontend/src/components/views/DuplicateQueue.vue
+++ b/frontend/src/components/views/DuplicateQueue.vue
@@ -543,7 +543,9 @@
       role="alert"
     >
       <v-icon size="48">mdi-alert-circle-outline</v-icon>
-      <h3>{{ store.scan.status === "failed" ? "Scan failed" : "Scan incomplete" }}</h3>
+      <h3>
+        {{ store.scan.status === "failed" ? "Scan failed" : "Scan incomplete" }}
+      </h3>
       <p>
         Some duplicate comparisons were not completed, so this queue cannot be
         marked clear. Review any available groups and run the scan again.
@@ -1051,7 +1053,8 @@ function onToggleExpansion(group, stackId) {
  */
 function onExpansionKey(group) {
   if (store.showingDecided) {
-    announcement.value = "Every picture in this decided group is already shown.";
+    announcement.value =
+      "Every picture in this decided group is already shown.";
     return;
   }
   const result = toggleExpansionForGroup(group);
@@ -1217,7 +1220,7 @@ function onMixedRowFocus(index, event) {
 /** Open Compare on a mixed row, focusing it first so the two cannot disagree. */
 function onCompareMixed(index) {
   setMixedFocus(index);
-  compareOpen.value = true;
+  openCompare();
 }
 
 /**
@@ -1647,12 +1650,35 @@ watch(
 /** Open Compare on a row, focusing it first so the two can never disagree. */
 function onCompare(index) {
   store.setFocus(index);
+  openCompare();
+}
+
+/**
+ * The control that opened Compare, so focus can go back to it.
+ *
+ * WCAG 2.4.3 expects focus to return to the invoking control, not to the
+ * container. Returning it to `rootEl` dumped a keyboard user at the top of the
+ * queue and made them walk back to the row they were judging.
+ */
+const compareInvoker = ref(null);
+
+function openCompare() {
+  compareInvoker.value =
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
   compareOpen.value = true;
 }
 
 function closeCompare() {
   compareOpen.value = false;
-  rootEl.value?.focus?.();
+  const invoker = compareInvoker.value;
+  compareInvoker.value = null;
+  // The invoker can be gone: deciding from inside the dialog removes its row.
+  // Falling back to the container beats dropping focus onto <body>, which
+  // strands the keyboard entirely.
+  if (invoker?.isConnected) invoker.focus();
+  else rootEl.value?.focus?.();
 }
 
 /**
@@ -2523,7 +2549,7 @@ const handleKeydown = createDedupKeyHandler({
   store,
   isCompareOpen: () => compareOpen.value,
   openCompare: () => {
-    if (store.focusedGroup) compareOpen.value = true;
+    if (store.focusedGroup) openCompare();
   },
   closeCompare,
   undo: () => operationStore.undo(),
@@ -2559,6 +2585,8 @@ const handleKeydown = createDedupKeyHandler({
     flip: (delta) => compareRef.value?.flipZoom?.(delta),
     to: (index) => compareRef.value?.zoomTo?.(index),
     togglePixels: () => compareRef.value?.toggleZoomPixels?.(),
+    step: (direction) => compareRef.value?.stepZoom?.(direction),
+    pan: (dx, dy) => Boolean(compareRef.value?.panZoom?.(dx, dy)),
   },
 });
 
@@ -2626,7 +2654,7 @@ const handleMixedKeydown = createDedupKeyHandler({
   store: mixedKeyStore,
   isCompareOpen: () => compareOpen.value,
   openCompare: () => {
-    if (mixedFocusedRow.value) compareOpen.value = true;
+    if (mixedFocusedRow.value) openCompare();
   },
   closeCompare,
   undo: () => operationStore.undo(),
@@ -2650,6 +2678,8 @@ const handleMixedKeydown = createDedupKeyHandler({
     flip: (delta) => compareRef.value?.flipZoom?.(delta),
     to: (index) => compareRef.value?.zoomTo?.(index),
     togglePixels: () => compareRef.value?.toggleZoomPixels?.(),
+    step: (direction) => compareRef.value?.stepZoom?.(direction),
+    pan: (dx, dy) => Boolean(compareRef.value?.panZoom?.(dx, dy)),
   },
   unitsOf: mixedUnitsFor,
   signatureOf: (row) => row?.stack_id,

--- a/frontend/src/components/widgets/DedupCompareDialog.vue
+++ b/frontend/src/components/widgets/DedupCompareDialog.vue
@@ -1133,6 +1133,15 @@ let panState = null;
 
 /** The current scale, 1 = actual pixels; null until the image has measured
  * (the un-measured state renders the classic fit look via CSS). */
+// One key press moves the zoom about 27%, which is `exp(120 * ZOOM_INTENSITY)`.
+// Expressed as a wheel delta rather than a scale factor so the keyboard and the
+// wheel share one curve instead of two that drift.
+const ZOOM_KEY_STEP_DELTA = 120;
+// A pan step is a fifth of the viewport: far enough to make progress across a
+// 1024px crop, small enough to keep the eye's place.
+const ZOOM_PAN_FRACTION = 0.2;
+const ZOOM_PAN_MIN_STEP = 48;
+
 const zoomScale = ref(null);
 /** The floor of the continuum: the scale at which this image exactly fits. */
 const zoomFitScale = ref(1);
@@ -1418,6 +1427,56 @@ function applyZoomScale(next, cursor) {
 }
 
 /**
+ * Step the zoom from the keyboard, anchored on the VIEWPORT CENTRE.
+ *
+ * Routed through `zoomStepScale`, the same function the wheel uses, so the two
+ * inputs cannot drift into different zoom curves. The wheel anchors on the
+ * cursor because there is one; a key press has no pointer, so the centre of
+ * what the user is looking at is the honest anchor.
+ *
+ * @param {number} direction - +1 to zoom in, -1 to zoom out.
+ */
+function stepZoomByKey(direction) {
+  if (!zoomOpen.value || zoomScale.value === null) return;
+  const el = zoomScrollEl.value;
+  // Negative deltaY is "zoom in" in the wheel's own convention.
+  const next = zoomStepScale(
+    zoomScale.value,
+    -direction * ZOOM_KEY_STEP_DELTA,
+    zoomFitScale.value,
+  );
+  if (next === zoomScale.value) return;
+  applyZoomScale(
+    next,
+    el ? { x: el.clientWidth / 2, y: el.clientHeight / 2 } : { x: 0, y: 0 },
+  );
+}
+
+/**
+ * Pan the zoomed image from the keyboard.
+ *
+ * Only meaningful while the image overflows its viewport, which is exactly when
+ * a mouse user would drag. At Fit there is nothing to pan and the key should
+ * fall through rather than silently doing nothing.
+ *
+ * @param {number} dx - columns to move, in step units.
+ * @param {number} dy - rows to move, in step units.
+ * @returns {boolean} whether the pan was applied.
+ */
+function panZoomByKey(dx, dy) {
+  const el = zoomScrollEl.value;
+  if (!zoomOpen.value || !el || !zoomOverflowing.value) return false;
+  const stepX = Math.max(ZOOM_PAN_MIN_STEP, el.clientWidth * ZOOM_PAN_FRACTION);
+  const stepY = Math.max(
+    ZOOM_PAN_MIN_STEP,
+    el.clientHeight * ZOOM_PAN_FRACTION,
+  );
+  el.scrollLeft += dx * stepX;
+  el.scrollTop += dy * stepY;
+  return true;
+}
+
+/**
  * Escape peels ONE layer: with the zoom up, a close request (AppDialog's own
  * Escape handling on its subtree, Vuetify's ESC/scrim, the header X) closes
  * the ZOOM and keeps the dialog; the next one closes the dialog. The queue's
@@ -1519,6 +1578,9 @@ defineExpose({
   flipZoom,
   zoomTo,
   toggleZoomPixels,
+  stepZoom: stepZoomByKey,
+  panZoom: panZoomByKey,
+  canPanZoom: () => zoomOpen.value && zoomOverflowing.value,
   zoomLevel: () => zoomScale.value,
 });
 

--- a/frontend/src/composables/useDedupQueueKeyboard.js
+++ b/frontend/src/composables/useDedupQueueKeyboard.js
@@ -190,6 +190,14 @@ const NO_ZOOM = {
   togglePixels: () => {},
 };
 
+/** Which way each arrow pans, as [dx, dy] in step units. */
+const ZOOM_PAN_VECTORS = {
+  arrowleft: [-1, 0],
+  arrowright: [1, 0],
+  arrowup: [0, -1],
+  arrowdown: [0, 1],
+};
+
 export function createDedupKeyHandler({
   store,
   isCompareOpen,
@@ -308,6 +316,20 @@ export function createDedupKeyHandler({
           zoom.close();
           return;
         }
+        // Shift turns the arrows into a PAN. Unmodified they still flip, which
+        // is the gesture the comparison is built on. Only Shift can express
+        // this: the guard above returns on ctrl/meta/alt before reaching here,
+        // so those modifiers never arrive.
+        //
+        // The pan is refused at Fit, where there is nothing to move, and the
+        // key then falls through to the flip rather than eating the press.
+        if (event.shiftKey) {
+          const pan = ZOOM_PAN_VECTORS[key];
+          if (pan && zoom.pan?.(pan[0], pan[1])) {
+            claim(event);
+            return;
+          }
+        }
         if (key === "arrowright" || key === "arrowdown") {
           claim(event);
           zoom.flip(1);
@@ -316,6 +338,18 @@ export function createDedupKeyHandler({
         if (key === "arrowleft" || key === "arrowup") {
           claim(event);
           zoom.flip(-1);
+          return;
+        }
+        // `=` is the unshifted key on the same cap as `+` on most layouts, so
+        // accepting it means zooming in does not require Shift.
+        if (key === "+" || key === "=") {
+          claim(event);
+          zoom.step?.(1);
+          return;
+        }
+        if (key === "-" || key === "_") {
+          claim(event);
+          zoom.step?.(-1);
           return;
         }
         if (/^[1-9]$/.test(key)) {

--- a/frontend/src/composables/useDedupQueueKeyboard.test.js
+++ b/frontend/src/composables/useDedupQueueKeyboard.test.js
@@ -424,6 +424,10 @@ describe("dedup keyboard — the blink compare (zoom)", () => {
       flip: vi.fn(),
       to: vi.fn(),
       togglePixels: vi.fn(),
+      step: vi.fn(),
+      // Reports whether the pan applied. False means "nothing to pan", which
+      // is what lets the key fall through to the flip.
+      pan: vi.fn(() => true),
     };
     compareOpen = true;
     handle = createDedupKeyHandler({ ...deps, zoom });
@@ -451,6 +455,67 @@ describe("dedup keyboard — the blink compare (zoom)", () => {
     zoomOpen = true;
     handle(keyEvent("p"));
     expect(zoom.togglePixels).toHaveBeenCalled();
+  });
+
+  it("plus and minus step the zoom", () => {
+    zoomOpen = true;
+    handle(keyEvent("+"));
+    handle(keyEvent("-"));
+    expect(zoom.step).toHaveBeenCalledWith(1);
+    expect(zoom.step).toHaveBeenCalledWith(-1);
+  });
+
+  it("accepts = for zoom in, so it needs no Shift", () => {
+    // `=` is the unshifted key on the same cap as `+` on most layouts.
+    zoomOpen = true;
+    handle(keyEvent("="));
+    expect(zoom.step).toHaveBeenCalledWith(1);
+  });
+
+  it("Shift plus an arrow pans instead of flipping", () => {
+    zoomOpen = true;
+    handle(keyEvent("ArrowRight", { shiftKey: true }));
+    expect(zoom.pan).toHaveBeenCalledWith(1, 0);
+    // The whole point: the flip must NOT also fire, or the image the user is
+    // panning changes under them.
+    expect(zoom.flip).not.toHaveBeenCalled();
+  });
+
+  it("pans in all four directions", () => {
+    zoomOpen = true;
+    for (const [key, vector] of [
+      ["ArrowLeft", [-1, 0]],
+      ["ArrowRight", [1, 0]],
+      ["ArrowUp", [0, -1]],
+      ["ArrowDown", [0, 1]],
+    ]) {
+      handle(keyEvent(key, { shiftKey: true }));
+      expect(zoom.pan).toHaveBeenCalledWith(vector[0], vector[1]);
+    }
+  });
+
+  it("an unmodified arrow still flips, which is the core gesture", () => {
+    zoomOpen = true;
+    handle(keyEvent("ArrowRight"));
+    expect(zoom.flip).toHaveBeenCalledWith(1);
+    expect(zoom.pan).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the flip when there is nothing to pan", () => {
+    // At Fit the image does not overflow, so a pan is meaningless. Eating the
+    // key there would make Shift+Arrow feel broken rather than unavailable.
+    zoomOpen = true;
+    zoom.pan = vi.fn(() => false);
+    handle(keyEvent("ArrowRight", { shiftKey: true }));
+    expect(zoom.flip).toHaveBeenCalledWith(1);
+  });
+
+  it("leaves the zoom keys alone when the zoom is shut", () => {
+    zoomOpen = false;
+    handle(keyEvent("+"));
+    handle(keyEvent("ArrowRight", { shiftKey: true }));
+    expect(zoom.step).not.toHaveBeenCalled();
+    expect(zoom.pan).not.toHaveBeenCalled();
   });
 
   it("Escape peels one layer: zoom first, Compare second", () => {


### PR DESCRIPTION
At 100% on a 1024px image the keyboard could not move the viewport, which is the entire comparison for a face crop or a texture detail. Wheel zoomed, drag panned, and `P` was the only key.

Relevant to v1.10.0 because the model shelf proposes reusing this comparator for training checkpoints.

## Zoom

`+` and `-` step it, and `=` is accepted so zooming in needs no Shift. Both route through **`zoomStepScale`, the function the wheel already uses**, so the two inputs cannot drift into different zoom curves. A key press has no pointer, so the step anchors on the viewport centre rather than a cursor.

## Pan

**Shift with an arrow.** Only Shift can express this: `useDedupQueueKeyboard.js` returns on ctrl/meta/alt *before* the compare block is reached, so those modifiers never arrive. Unmodified arrows still flip, which is the gesture the whole comparison is built on.

At Fit there is nothing to pan, so `panZoom` reports failure and the key **falls through to the flip** rather than being eaten. A key that silently does nothing feels broken; one that does the other thing reads as unavailable.

## Focus return

All four sites that open Compare now route through one helper that records the invoking element, and close restores it. It falls back to the container when that element is gone, which happens whenever a verdict given from inside the dialog removes its own row. Dropping to `<body>` instead would strand the keyboard entirely.

## Verification
- 2642 frontend tests pass (151 files), `eslint .` clean, `npm run build` ok
- **All 71 pre-existing keyboard tests still pass**, which is the check that matters most here: this edits a factory shared by the main queue and the mixed-stack queue
- 7 new tests, mutation-tested: making the pan eat the key when it cannot pan, dropping the Shift guard so plain arrows pan, and wiring the step backwards each fail

## Not verified
Not driven by hand in a browser. The pan step (a fifth of the viewport, floor 48px) and the zoom step (~27% per press) are numbers chosen to feel right and I have not felt them. **Worth a minute with the keyboard before merge** to check they are not too coarse or too fine.

Closes #762

https://claude.ai/code/session_01PPYSfMTVkJvyXUGhxJH4Vf