### PR TITLE
Scan model folders into the shelf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,7 @@ jobs:
           tests/test_metadata_hash_batching.py
           tests/test_migrations.py
           tests/test_model_file_classification.py
+          tests/test_model_folder_scanner.py
           tests/test_model_unload_race.py
           tests/test_multi_project_membership_authz.py
           tests/test_openapi_response_schemas.py

--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -352,8 +352,14 @@ CREATE TABLE IF NOT EXISTS model_file (
     model_id         INTEGER NOT NULL REFERENCES model(id),
     model_folder_id  INTEGER NOT NULL REFERENCES model_folder(id),
     relpath          TEXT NOT NULL,
-    state            TEXT NOT NULL,
+    state            TEXT NOT NULL,   -- 'present' | 'missing' | 'unreachable'
     seen_at          TEXT,
+    -- st_mtime_ns of this copy at the last scan. Paired with model.file_size it
+    -- is what lets a sweep skip re-hashing 1,800 unchanged adapters, without
+    -- the size-only blind spot where a same-size in-place edit leaves
+    -- model.sha256 naming bytes that are no longer there. Per-location, not
+    -- per-model: two copies of one file have two mtimes.
+    file_mtime       INTEGER,
     PRIMARY KEY (model_folder_id, relpath)
 )
 """

--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -264,6 +264,11 @@ _V1_LIBRARY_INDEXES = (
 # says "this library's character uses that adapter" and is keyed by sha256
 # because no foreign key can span the two databases.
 #
+# Two tables carry the shelf: ``model`` is what a file IS (identity, curation,
+# provenance) and ``model_file`` is WHERE a copy of it sits. That split is what
+# makes one file in two folders one row with two locations, and what makes
+# removing a folder a tombstone rather than a deletion.
+#
 # Hand-written DDL against stdlib sqlite3, like everything else here. The hub is
 # deliberately not SQLModel: a SQLModel table would be created inside every
 # vault as well.
@@ -271,7 +276,7 @@ _V1_LIBRARY_INDEXES = (
 
 # AUTOINCREMENT, not a bare INTEGER PRIMARY KEY, for the same reason
 # ``library.id`` uses it: SQLite hands a deleted row's id to the next insert, and
-# a recycled folder id would silently re-point every ``adapter_file`` row at a
+# a recycled folder id would silently re-point every ``model_file`` row at a
 # different folder.
 _V2_MODEL_FOLDER = """
 CREATE TABLE IF NOT EXISTS model_folder (
@@ -287,13 +292,28 @@ CREATE TABLE IF NOT EXISTS model_folder (
 )
 """
 
+# One content table for every ``.safetensors`` on the shelf, adapter or
+# checkpoint (integration plan §3, "File location needs its own row", ruled
+# 2026-08-08: *the same split applies to checkpoint*). Two content tables would
+# mean two location tables, or a location table with a discriminator column, and
+# every consumer branching on which one to read — for rows that differ in three
+# columns.
+#
 # `base_model` is free text on purpose. It comes from whatever the trainer wrote
 # and an enum would reject every model that ships after this release.
-_V2_ADAPTER = """
-CREATE TABLE IF NOT EXISTS adapter (
+_V2_MODEL = """
+CREATE TABLE IF NOT EXISTS model (
     id                    INTEGER PRIMARY KEY AUTOINCREMENT,
-    sha256                TEXT UNIQUE NOT NULL,
-    kind                  TEXT NOT NULL,
+    -- What the file IS, from the header: 'adapter' | 'checkpoint' | 'unknown'
+    -- (pixlstash.utils.adapter_header.FILE_*). Owner-correctable; 'unknown'
+    -- is a first-class value here and is never promoted to checkpoint.
+    file_kind             TEXT NOT NULL,
+    -- Which adapter algorithm. Meaningful only when file_kind = 'adapter'.
+    kind                  TEXT,
+    -- Interop identity (Civitai, {sha256}/file, the ComfyUI node). NULL only
+    -- while a checkpoint waits for MissingCheckpointHashFinder; the CHECK below
+    -- keeps today's NOT NULL guarantee exactly where it was load-bearing.
+    sha256                TEXT UNIQUE,
     display_name          TEXT,
     filename              TEXT,
     base_model            TEXT,
@@ -303,45 +323,38 @@ CREATE TABLE IF NOT EXISTS adapter (
     lineage_id            INTEGER,
     training_step         INTEGER,
     safetensors_metadata  TEXT,
+    param_count           INTEGER,
     file_size             INTEGER,
+    hashed_at             TEXT,
     stack_id              INTEGER REFERENCES adapter_stack(id),
     stack_position        INTEGER,
     run_key               TEXT,
-    created_at            TEXT
+    created_at            TEXT,
+    CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL)
 )
 """
 
-# One adapter, many paths. That is what a duplicate after an interrupted move
-# is, and what the same file copied into two registered folders is.
+# One model, many paths. That is what a duplicate after an interrupted move is,
+# and what the same file copied into two registered folders is — for a 24 GB
+# checkpoint exactly as much as for an adapter.
 #
-# This table is also the tombstone. Removing a folder drops its ``adapter_file``
-# rows and KEEPS the ``adapter`` row with its name, triggers and attachments, so
-# re-adding the folder re-links by sha256 with the user's curation intact. That
-# is what lets folder removal skip a confirmation prompt: nothing a user typed
-# is destroyed by it.
-_V2_ADAPTER_FILE = """
-CREATE TABLE IF NOT EXISTS adapter_file (
-    adapter_sha256   TEXT NOT NULL,
+# This table is also the tombstone. Removing a folder drops its ``model_file``
+# rows and KEEPS the ``model`` row with its name, triggers and attachments, so
+# re-adding the folder re-links with the user's curation intact. That is what
+# lets folder removal skip a confirmation prompt: nothing a user typed is
+# destroyed by it.
+_V2_MODEL_FILE = """
+CREATE TABLE IF NOT EXISTS model_file (
+    -- Integer, not sha256: this link does not cross a database. The precedent
+    -- is model_folder_id on the next line, which is already an integer FK, and
+    -- model.id is AUTOINCREMENT so a deleted id is never reissued. A sha256 key
+    -- could not name a checkpoint at all until something had read 24 GB of it.
+    model_id         INTEGER NOT NULL REFERENCES model(id),
     model_folder_id  INTEGER NOT NULL REFERENCES model_folder(id),
     relpath          TEXT NOT NULL,
     state            TEXT NOT NULL,
     seen_at          TEXT,
     PRIMARY KEY (model_folder_id, relpath)
-)
-"""
-
-# ``sha256`` is nullable here and NOT NULL on ``adapter``: a checkpoint may be
-# many gigabytes and is registered in place long before anything hashes it.
-_V2_CHECKPOINT = """
-CREATE TABLE IF NOT EXISTS checkpoint (
-    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
-    sha256             TEXT UNIQUE,
-    filename           TEXT NOT NULL,
-    local_path         TEXT,
-    base_model_family  TEXT,
-    file_size          INTEGER,
-    hashed_at          TEXT,
-    created_at         TEXT
 )
 """
 
@@ -358,25 +371,32 @@ CREATE TABLE IF NOT EXISTS adapter_stack (
 """
 
 _V2_MODEL_SHELF_INDEXES = (
-    # The scanner's hot path: "which files does this adapter have, and where".
-    "CREATE INDEX IF NOT EXISTS ix_adapter_file_sha ON adapter_file(adapter_sha256)",
+    # The scanner's hot path: "which files does this model have, and where".
+    "CREATE INDEX IF NOT EXISTS ix_model_file_model ON model_file(model_id)",
     # Folder removal and rescan both work folder-at-a-time.
-    "CREATE INDEX IF NOT EXISTS ix_adapter_file_folder "
-    "ON adapter_file(model_folder_id)",
+    "CREATE INDEX IF NOT EXISTS ix_model_file_folder ON model_file(model_folder_id)",
     # Expanding one stack in the shelf, in cover-first order.
-    "CREATE INDEX IF NOT EXISTS ix_adapter_stack_member "
-    "ON adapter(stack_id, stack_position)",
+    "CREATE INDEX IF NOT EXISTS ix_model_stack_member "
+    "ON model(stack_id, stack_position)",
+    # The hash finder's whole query, as a partial index. Mirrors 0095 in the
+    # vault: the queue is a handful of rows in a table of thousands, so a full
+    # index on sha256 would be almost entirely rows the finder never wants.
+    "CREATE INDEX IF NOT EXISTS ix_model_hash_queue ON model(id) WHERE sha256 IS NULL",
 )
 
 _V2_MODEL_SHELF_TABLES = (
-    # adapter_stack first: `adapter.stack_id` references it.
+    # adapter_stack first: `model.stack_id` references it.
     _V2_ADAPTER_STACK,
     _V2_MODEL_FOLDER,
-    _V2_ADAPTER,
-    _V2_ADAPTER_FILE,
-    _V2_CHECKPOINT,
+    _V2_MODEL,
+    _V2_MODEL_FILE,
     *_V2_MODEL_SHELF_INDEXES,
 )
+
+# The pre-reshape shelf shape. ``CREATE TABLE IF NOT EXISTS`` silently skips a
+# *reshape*, so a developer hub opened on an earlier develop would keep the old
+# three tables and gain the new two, with the scanner writing to neither.
+_V2_SUPERSEDED_SHELF_TABLES = ("adapter_file", "adapter", "checkpoint")
 
 
 # Ordered schema steps. Append only: a released version's statement list is
@@ -444,6 +464,32 @@ def _apply_v2(conn: sqlite3.Connection) -> None:
     # before this change has CURRENT_SCHEMA_VERSION = 2, so it would refuse a v3
     # hub with HubSchemaTooNewError and lock that user out of a downgrade.
     # CREATE TABLE IF NOT EXISTS throughout, so re-running is a no-op.
+    #
+    # One-shot drop first, for the same reason: IF NOT EXISTS cannot reshape a
+    # table, so a hub opened on an earlier unreleased develop would keep the
+    # superseded `adapter`/`adapter_file`/`checkpoint` shape alongside the new
+    # `model`/`model_file` one. Dropping rather than migrating is correct only
+    # because nothing has ever written these tables — the scan that fills them
+    # is unmerged, no route or UI reads them, and no released build shipped
+    # them (v1.10.0-dev.1 was tagged 13 hours before they landed). `model_folder`
+    # and `adapter_stack` are NOT dropped: a developer may have registered
+    # folders, and neither table changes shape.
+    existing = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    # `adapter` does not exist after the reshape, so this guard is false on a
+    # fresh hub and false on every subsequent re-run.
+    if "adapter" in existing:
+        logger.info(
+            "Replacing the superseded model-shelf tables %s with model/model_file.",
+            ", ".join(_V2_SUPERSEDED_SHELF_TABLES),
+        )
+        # DROP TABLE takes each table's indexes with it, so the superseded
+        # ix_adapter_* indexes need no separate statement.
+        for table in _V2_SUPERSEDED_SHELF_TABLES:
+            conn.execute(f"DROP TABLE IF EXISTS {table}")
+
     for statement in _V2_MODEL_SHELF_TABLES:
         conn.execute(statement)
 

--- a/pixlstash/services/model_folder_scanner.py
+++ b/pixlstash/services/model_folder_scanner.py
@@ -1,0 +1,623 @@
+"""Walk the registered model folders and record what is on disk.
+
+The shelf's rows come from here. A registered ``model_folder`` is walked for
+``.safetensors`` files, each file's header is read (never its tensors, see
+:mod:`pixlstash.utils.adapter_header`), and what comes back becomes one ``model``
+row saying what the file *is* plus one ``model_file`` row per copy saying where
+it *lives*.
+
+There is no per-kind branch, because there is no per-kind table. ``file_kind``
+carries what the header proved — ``adapter``, ``checkpoint`` or ``unknown`` —
+and only two things follow from it:
+
+* an **adapter** and an **unknown** are hashed on sight, so ``sha256`` is their
+  identity from the first scan;
+* a **checkpoint** is registered instantly with ``sha256`` NULL, because it may
+  be 24 GB and the shelf must not stall behind it. ``MissingCheckpointHashFinder``
+  fills the hash in later, which is what ``hashed_at`` was always for. Until
+  then the row is identified by the location it was found at, which is exactly
+  what ``model_file`` is.
+
+``unknown`` is stored as ``unknown`` and never promoted: a marker-free file too
+small to be a base model is most likely an adapter format we have not met yet,
+so it stays visible and correctable on the shelf. A correction the owner makes
+is never re-derived away — every column a person can edit is written with
+``COALESCE`` on the *stored* value, and ``file_kind`` is not rewritten at all,
+because the row is keyed by content and the parser would only ever repeat the
+guess the owner just overruled.
+
+**Detection proposes, it never applies.** A file that has vanished flips its
+``model_file`` row to ``missing`` and nothing is deleted, so the ``model`` row
+keeps the name, triggers and attachments the user gave it and re-linking is
+automatic when the file comes back. Anything we could not *look* at is a
+different fact and gets a different state: ``unreachable``, meaning "we do not
+know". That applies to a whole folder we cannot open and, just as importantly,
+to a subdirectory inside one we can — a NAS mounted under a registered folder
+must not read as a deletion the moment it drops.
+
+``kind = 'source'`` folders are skipped entirely. They are ai-toolkit output
+roots, scanned for importable *runs* by :mod:`pixlstash.utils.aitoolkit_run` and
+never catalogued in place — the same distinction the product already makes
+between a reference folder and an import folder.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import NamedTuple, Optional
+
+from pixlstash.hub.db import HubDatabase
+from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.adapter_header import (
+    FILE_ADAPTER,
+    FILE_CHECKPOINT,
+    FILE_UNKNOWN,
+    describe_adapter,
+)
+
+logger = get_logger(__name__)
+
+# The three states a ``model_file`` row can be in. ``missing`` is a fact ("the
+# folder was readable and the file was not in it"); ``unreachable`` is the
+# absence of one ("we could not look").
+STATE_PRESENT = "present"
+STATE_MISSING = "missing"
+STATE_UNREACHABLE = "unreachable"
+
+MODEL_SUFFIX = ".safetensors"
+
+# ai-toolkit output roots are taken FROM, never catalogued in place.
+SOURCE_FOLDER_KIND = "source"
+
+# Anything the scanner finds on disk was put there by something other than a
+# PixlStash-orchestrated training run; ``trained`` is reserved for the latter,
+# which also carries a ``training_run_id``.
+PROVENANCE_EXTERNAL = "external"
+
+_HASH_CHUNK_BYTES = 1024 * 1024
+
+# Files per write transaction. The hub's multi-process contract is "short
+# transactions only", and this also means an interrupted scan keeps the rows it
+# already wrote instead of discarding the whole folder.
+_WRITE_BATCH = 200
+
+# SQLite LIKE wildcards. Escaped before a relpath prefix is used in a LIKE, or a
+# folder named ``sd_xl`` would match ``sdaxl`` and quietly protect the wrong
+# subtree from the missing sweep.
+_LIKE_ESCAPE = str.maketrans({"\\": "\\\\", "%": "\\%", "_": "\\_"})
+
+
+@dataclass
+class FolderScanResult:
+    """What one folder's scan did, for logs and for the B5 API to report."""
+
+    folder_id: int
+    path: str
+    state: str
+    adapters: int = 0
+    checkpoints: int = 0
+    unreadable: int = 0
+    missing: int = 0
+    unreachable: int = 0
+    skipped: bool = False
+
+
+class _FileRecord(NamedTuple):
+    """One file's scan result, ready to write.
+
+    ``model_id`` is set only when the file was recognised from this folder's own
+    row and neither its size nor its mtime moved, so nothing had to be parsed or
+    hashed. Every other field is then irrelevant and the write is a single
+    ``model_file`` touch.
+    """
+
+    relpath: str
+    size: int
+    mtime_ns: int
+    model_id: Optional[int] = None
+    digest: Optional[str] = None
+    file_kind: str = FILE_UNKNOWN
+    kind: Optional[str] = None
+    display_name: Optional[str] = None
+    filename: Optional[str] = None
+    base_model: Optional[str] = None
+    trigger_words: Optional[str] = None
+    training_step: Optional[int] = None
+    param_count: Optional[int] = None
+
+
+def sha256_file(path: str) -> str:
+    """Return the full-file SHA-256 of *path* as lowercase hex.
+
+    Full file, unconditionally: ``model.sha256`` is an interop value (Civitai
+    lookup, the public ``{sha256}/file`` path, the ComfyUI node), so a sampled
+    digest in that column would break interop silently rather than loudly.
+    """
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while chunk := handle.read(_HASH_CHUNK_BYTES):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ModelFolderScanner:
+    """Reconcile the ``model`` and ``model_file`` tables with what is on disk.
+
+    Holds no state between calls: every method takes the hub connection handed
+    to the constructor, does its filesystem work outside any write transaction,
+    and writes in short batches.
+    """
+
+    def __init__(self, hub: HubDatabase) -> None:
+        """Bind the scanner to an open hub.
+
+        Args:
+            hub: The hub database. The scanner only ever touches the model-shelf
+                tables in it.
+        """
+        self._hub = hub
+
+    def scan_all(self) -> list[FolderScanResult]:
+        """Scan every registered folder that is catalogued in place.
+
+        Returns:
+            One :class:`FolderScanResult` per folder, in id order. ``source``
+            folders are included with ``skipped=True`` so a caller reporting
+            progress does not silently lose them.
+        """
+        rows = self._hub.fetchall("SELECT id, path, kind FROM model_folder ORDER BY id")
+        return [self.scan_folder(row["id"], row["path"], row["kind"]) for row in rows]
+
+    def scan_folder(self, folder_id: int, path: str, kind: str) -> FolderScanResult:
+        """Scan one registered folder and reconcile its rows with what is on disk.
+
+        Args:
+            folder_id: ``model_folder.id``.
+            path: The folder as registered. Owner-chosen and therefore trusted;
+                this is a read path only, so nothing here writes into it.
+            kind: ``model_folder.kind``. ``source`` folders are skipped.
+
+        Returns:
+            A :class:`FolderScanResult` describing what was found.
+        """
+        if kind == SOURCE_FOLDER_KIND:
+            return FolderScanResult(
+                folder_id=folder_id, path=path, state=STATE_PRESENT, skipped=True
+            )
+
+        if not self._is_readable(path):
+            return self._mark_unreachable(folder_id, path)
+
+        scanned_at = _utcnow()
+        known = self._known_files(folder_id)
+        result = FolderScanResult(folder_id=folder_id, path=path, state=STATE_PRESENT)
+        blocked: set[str] = set()
+
+        batch: list[_FileRecord] = []
+        for abs_path, relpath in self._walk(path, blocked):
+            record = self._describe(abs_path, relpath, known, result)
+            if record is not None:
+                batch.append(record)
+            if len(batch) >= _WRITE_BATCH:
+                self._write_batch(folder_id, batch, scanned_at)
+                batch = []
+        if batch:
+            self._write_batch(folder_id, batch, scanned_at)
+
+        # Before the missing sweep, never after: a subtree we could not read is
+        # not a subtree whose files were deleted.
+        result.unreachable = self._mark_unreachable_subtrees(
+            folder_id, blocked, scanned_at
+        )
+        result.missing = self._mark_missing(folder_id, scanned_at)
+        self._touch_folder(folder_id, scanned_at)
+        logger.info(
+            "Model folder %s (id=%s): %d adapters, %d checkpoints, %d missing, "
+            "%d unreachable, %d unreadable.",
+            path,
+            folder_id,
+            result.adapters,
+            result.checkpoints,
+            result.missing,
+            result.unreachable,
+            result.unreadable,
+        )
+        return result
+
+    # -- filesystem -------------------------------------------------------
+
+    @staticmethod
+    def _is_readable(path: str) -> bool:
+        return bool(path) and os.path.isdir(path) and os.access(path, os.R_OK | os.X_OK)
+
+    @staticmethod
+    def _walk(root: str, blocked: set[str]):
+        """Yield ``(abs_path, relpath)`` for every model file under *root*.
+
+        Symlinks are not followed (``os.walk`` default), so a folder that links
+        back into itself or into another registered folder cannot make the scan
+        loop or double-count.
+
+        A directory that cannot be listed is collected into *blocked* rather
+        than discarded. ``os.walk`` swallows those errors by default, which
+        would make an unplugged mount under a registered folder indistinguishable
+        from a deletion — the one thing this module promises never to do.
+        """
+
+        def on_error(exc: OSError) -> None:
+            failed = exc.filename or root
+            logger.warning(
+                "Model scan could not list %s: %s. Its files stay unreachable "
+                "rather than being reported missing.",
+                failed,
+                exc,
+            )
+            blocked.add(os.path.relpath(failed, root))
+
+        for directory, _dirs, files in os.walk(root, onerror=on_error):
+            for name in sorted(files):
+                if not name.lower().endswith(MODEL_SUFFIX):
+                    continue
+                abs_path = os.path.join(directory, name)
+                yield abs_path, os.path.relpath(abs_path, root)
+
+    def _describe(
+        self,
+        abs_path: str,
+        relpath: str,
+        known: dict[str, tuple[int, Optional[int], Optional[int]]],
+        result: FolderScanResult,
+    ) -> Optional[_FileRecord]:
+        """Return the row for one file, hashing it only when it has to be.
+
+        A file already recorded at this relpath whose size *and* mtime both still
+        match is taken as unchanged and is not re-hashed: re-reading every byte
+        of 1,800 adapters on each sweep would make the scan cost the whole
+        folder. Size alone is not enough — a same-size in-place edit would leave
+        ``model.sha256`` naming bytes that are no longer on disk, in the column
+        Civitai lookup and the public ``{sha256}/file`` route both resolve on.
+
+        The comparison is against *this folder's* row. Trusting another folder's
+        row for the same relpath would file one file under another's digest.
+        """
+        try:
+            stat_result = os.stat(abs_path)
+        except OSError as exc:
+            logger.warning(
+                "Model scan could not stat %s: %s. Skipping the file; it will be "
+                "reconsidered on the next scan.",
+                abs_path,
+                exc,
+            )
+            result.unreadable += 1
+            return None
+        size = stat_result.st_size
+        mtime_ns = stat_result.st_mtime_ns
+
+        previous = known.get(relpath)
+        if previous is not None and previous[1:] == (size, mtime_ns):
+            result.adapters += 1
+            return _FileRecord(
+                relpath=relpath, size=size, mtime_ns=mtime_ns, model_id=previous[0]
+            )
+
+        info = describe_adapter(abs_path)
+        if info is None:
+            logger.warning(
+                "Model scan could not read a safetensors header from %s; leaving "
+                "the file unregistered so it is retried rather than recorded wrong.",
+                abs_path,
+            )
+            result.unreadable += 1
+            return None
+
+        record = _FileRecord(
+            relpath=relpath,
+            size=size,
+            mtime_ns=mtime_ns,
+            file_kind=info.file_kind,
+            # Which adapter algorithm, and only that. NULL for anything that is
+            # not an adapter, so the column never carries a guess about a file
+            # whose kind was never in question.
+            kind=info.kind if info.file_kind == FILE_ADAPTER else None,
+            display_name=info.display_name,
+            filename=os.path.basename(abs_path),
+            base_model=info.base_model,
+            trigger_words=json.dumps(info.trigger_words)
+            if info.trigger_words
+            else None,
+            training_step=info.training_step,
+            param_count=info.param_count,
+        )
+
+        if info.file_kind == FILE_CHECKPOINT:
+            # No hash: it may be 24 GB. MissingCheckpointHashFinder supplies it.
+            result.checkpoints += 1
+            return record
+
+        try:
+            digest = sha256_file(abs_path)
+        except OSError as exc:
+            logger.warning(
+                "Model scan could not hash %s (%d bytes): %s. Leaving it "
+                "unregistered; a partial hash would be a wrong identity.",
+                abs_path,
+                size,
+                exc,
+            )
+            result.unreadable += 1
+            return None
+
+        result.adapters += 1
+        return record._replace(digest=digest)
+
+    # -- hub reads --------------------------------------------------------
+
+    def _known_files(
+        self, folder_id: int
+    ) -> dict[str, tuple[int, Optional[int], Optional[int]]]:
+        """Return ``{relpath: (model_id, file_size, file_mtime)}`` for this folder."""
+        rows = self._hub.fetchall(
+            "SELECT mf.relpath, mf.model_id, mf.file_mtime, m.file_size "
+            "FROM model_file mf JOIN model m ON m.id = mf.model_id "
+            "WHERE mf.model_folder_id = ?",
+            (folder_id,),
+        )
+        return {
+            row["relpath"]: (row["model_id"], row["file_size"], row["file_mtime"])
+            for row in rows
+        }
+
+    # -- hub writes -------------------------------------------------------
+
+    def _write_batch(
+        self, folder_id: int, batch: list[_FileRecord], scanned_at: str
+    ) -> None:
+        with self._hub.transaction() as conn:
+            for record in batch:
+                model_id = record.model_id
+                if model_id is None:
+                    model_id = self._upsert_model(conn, folder_id, record, scanned_at)
+                self._upsert_model_file(conn, folder_id, model_id, record, scanned_at)
+
+    @staticmethod
+    def _upsert_model(
+        conn: sqlite3.Connection,
+        folder_id: int,
+        record: _FileRecord,
+        scanned_at: str,
+    ) -> int:
+        """Insert the content row, or refresh it without overwriting curation.
+
+        Every column the user can edit is written with ``COALESCE`` on the
+        *stored* value, so a re-scan can fill a blank but can never replace a
+        name, a base model or a corrected kind someone typed. ``file_kind`` and
+        ``provenance`` are not in the update at all: the row is identified by its
+        content, so the parser can only ever repeat the classification the owner
+        just overruled. ``file_size`` is a fact about the file and is refreshed.
+
+        Returns:
+            ``model.id`` for this file.
+        """
+        if record.digest is None:
+            return ModelFolderScanner._upsert_unhashed(
+                conn, folder_id, record, scanned_at
+            )
+        conn.execute(
+            "INSERT INTO model (file_kind, kind, sha256, display_name, filename, "
+            "base_model, trigger_words, provenance, training_step, param_count, "
+            "file_size, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(sha256) DO UPDATE SET "
+            "kind = COALESCE(model.kind, excluded.kind), "
+            "display_name = COALESCE(model.display_name, excluded.display_name), "
+            "filename = COALESCE(model.filename, excluded.filename), "
+            "base_model = COALESCE(model.base_model, excluded.base_model), "
+            "trigger_words = COALESCE(model.trigger_words, excluded.trigger_words), "
+            "training_step = COALESCE(model.training_step, excluded.training_step), "
+            "param_count = COALESCE(model.param_count, excluded.param_count), "
+            "file_size = excluded.file_size",
+            (
+                record.file_kind,
+                record.kind,
+                record.digest,
+                record.display_name,
+                record.filename,
+                record.base_model,
+                record.trigger_words,
+                PROVENANCE_EXTERNAL,
+                record.training_step,
+                record.param_count,
+                record.size,
+                scanned_at,
+            ),
+        )
+        return int(
+            conn.execute(
+                "SELECT id FROM model WHERE sha256 = ?", (record.digest,)
+            ).fetchone()[0]
+        )
+
+    @staticmethod
+    def _upsert_unhashed(
+        conn: sqlite3.Connection,
+        folder_id: int,
+        record: _FileRecord,
+        scanned_at: str,
+    ) -> int:
+        """Register a checkpoint in place, with no hash.
+
+        Identified by the location it was found at, because that is all it has
+        until something has read all 24 GB of it. Reaching here at all means the
+        size or the mtime moved, so the bytes changed and any hash already
+        recorded for this path is stale: it is cleared rather than left to
+        misidentify the file, which puts the row straight back into
+        ``MissingCheckpointHashFinder``'s queue.
+        """
+        existing = conn.execute(
+            "SELECT model_id FROM model_file WHERE model_folder_id = ? AND relpath = ?",
+            (folder_id, record.relpath),
+        ).fetchone()
+        if existing is None:
+            return int(
+                conn.execute(
+                    "INSERT INTO model (file_kind, kind, display_name, filename, "
+                    "base_model, trigger_words, provenance, training_step, "
+                    "param_count, file_size, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        record.file_kind,
+                        record.kind,
+                        record.display_name,
+                        record.filename,
+                        record.base_model,
+                        record.trigger_words,
+                        PROVENANCE_EXTERNAL,
+                        record.training_step,
+                        record.param_count,
+                        record.size,
+                        scanned_at,
+                    ),
+                ).lastrowid
+            )
+
+        model_id = int(existing["model_id"])
+        conn.execute(
+            "UPDATE model SET sha256 = NULL, hashed_at = NULL, file_size = ?, "
+            "filename = COALESCE(filename, ?), "
+            "display_name = COALESCE(display_name, ?), "
+            "base_model = COALESCE(base_model, ?), "
+            "param_count = COALESCE(param_count, ?) WHERE id = ?",
+            (
+                record.size,
+                record.filename,
+                record.display_name,
+                record.base_model,
+                record.param_count,
+                model_id,
+            ),
+        )
+        return model_id
+
+    @staticmethod
+    def _upsert_model_file(
+        conn: sqlite3.Connection,
+        folder_id: int,
+        model_id: int,
+        record: _FileRecord,
+        scanned_at: str,
+    ) -> None:
+        conn.execute(
+            "INSERT INTO model_file (model_id, model_folder_id, relpath, state, "
+            "seen_at, file_mtime) VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(model_folder_id, relpath) DO UPDATE SET "
+            "model_id = excluded.model_id, state = excluded.state, "
+            "seen_at = excluded.seen_at, file_mtime = excluded.file_mtime",
+            (
+                model_id,
+                folder_id,
+                record.relpath,
+                STATE_PRESENT,
+                scanned_at,
+                record.mtime_ns,
+            ),
+        )
+
+    def _mark_unreachable_subtrees(
+        self, folder_id: int, blocked: set[str], scanned_at: str
+    ) -> int:
+        """Flip every row under a directory this scan could not list.
+
+        Stamped with this scan's ``seen_at`` as well, so the missing sweep that
+        runs next skips them: they were accounted for, just not read.
+        """
+        if not blocked:
+            return 0
+        touched = 0
+        with self._hub.transaction() as conn:
+            for relative_dir in sorted(blocked):
+                if relative_dir in (".", ""):
+                    # The root itself became unlistable mid-scan. Nothing under
+                    # it was seen, so the whole folder is what we could not read.
+                    cursor = conn.execute(
+                        "UPDATE model_file SET state = ?, seen_at = ? "
+                        "WHERE model_folder_id = ?",
+                        (STATE_UNREACHABLE, scanned_at, folder_id),
+                    )
+                else:
+                    prefix = (relative_dir + os.sep).translate(_LIKE_ESCAPE)
+                    cursor = conn.execute(
+                        "UPDATE model_file SET state = ?, seen_at = ? "
+                        "WHERE model_folder_id = ? AND relpath LIKE ? ESCAPE '\\'",
+                        (STATE_UNREACHABLE, scanned_at, folder_id, prefix + "%"),
+                    )
+                touched += int(cursor.rowcount or 0)
+        return touched
+
+    def _mark_missing(self, folder_id: int, scanned_at: str) -> int:
+        """Flip every row this scan did not touch to ``missing``.
+
+        Compared on ``seen_at`` rather than by listing the relpaths that were
+        found: a folder of 1,800 adapters would blow past SQLite's bound-variable
+        limit, and every present row was just stamped with this scan's timestamp.
+
+        Strictly **older than** this scan's stamp, not merely different from it.
+        With ``!=`` two scans running at once each sweep away the rows the other
+        just stamped, and a shelf whose files are all on disk reads as entirely
+        missing — measured at 4 of 5 unsynchronised runs flipping every file.
+        ``<`` makes a concurrent scan's newer stamp survive, which is correct in
+        both directions and across processes: a row is only demoted by the scan
+        that walked the folder and did not find it. The residual case, a file
+        created after a scan walked past it, is a file that scan genuinely never
+        saw, and the next scan restores it.
+        """
+        with self._hub.transaction() as conn:
+            cursor = conn.execute(
+                "UPDATE model_file SET state = ? WHERE model_folder_id = ? "
+                "AND (seen_at IS NULL OR seen_at < ?) AND state != ?",
+                (STATE_MISSING, folder_id, scanned_at, STATE_MISSING),
+            )
+            return int(cursor.rowcount or 0)
+
+    def _mark_unreachable(self, folder_id: int, path: str) -> FolderScanResult:
+        """Record that the folder could not be read, and change nothing else.
+
+        Not ``missing``: an unplugged drive says nothing about whether its files
+        still exist, and declaring them gone would make the shelf lie about
+        content the user still has.
+        """
+        logger.warning(
+            "Model folder %s (id=%s) is not a readable directory; marking its "
+            "files unreachable rather than missing.",
+            path,
+            folder_id,
+        )
+        scanned_at = _utcnow()
+        with self._hub.transaction() as conn:
+            cursor = conn.execute(
+                "UPDATE model_file SET state = ? WHERE model_folder_id = ? "
+                "AND state != ?",
+                (STATE_UNREACHABLE, folder_id, STATE_UNREACHABLE),
+            )
+        self._touch_folder(folder_id, scanned_at)
+        return FolderScanResult(
+            folder_id=folder_id,
+            path=path,
+            state=STATE_UNREACHABLE,
+            unreachable=int(cursor.rowcount or 0),
+        )
+
+    def _touch_folder(self, folder_id: int, scanned_at: str) -> None:
+        with self._hub.transaction() as conn:
+            conn.execute(
+                "UPDATE model_folder SET last_checked = ? WHERE id = ?",
+                (scanned_at, folder_id),
+            )

--- a/tests/test_hub_model_shelf_schema.py
+++ b/tests/test_hub_model_shelf_schema.py
@@ -5,9 +5,16 @@ about the machine: a folder of LoRAs is on this disk. Re-registering the same
 folder in every library would be absurd. The only vault-side table is
 ``adapter_attachment``, which is a different change.
 
-The rule under test throughout: **applying the schema twice is a no-op, and a
-hub that already exists picks the tables up on its next open.** That is what
-lets these land by amending v2 instead of inventing a v3.
+Two rules under test throughout:
+
+1. **Applying the schema twice is a no-op, and a hub that already exists picks
+   the tables up on its next open.** That is what lets these land by amending v2
+   instead of inventing a v3.
+2. **``model`` is what a file is; ``model_file`` is where a copy of it sits.**
+   One content table and one location table, for adapters and checkpoints
+   alike (integration plan §3). A checkpoint therefore tombstones exactly the
+   way an adapter does, which the superseded inline ``checkpoint.local_path``
+   could not do.
 """
 
 import sqlite3
@@ -22,11 +29,14 @@ from pixlstash.hub.schema import (
 
 SHELF_TABLES = (
     "model_folder",
-    "adapter",
-    "adapter_file",
-    "checkpoint",
+    "model",
+    "model_file",
     "adapter_stack",
 )
+
+# The shape this replaced. Nothing ever wrote them (the scan is unmerged and no
+# released build shipped them), so `_apply_v2` drops rather than migrates.
+SUPERSEDED_TABLES = ("adapter", "adapter_file", "checkpoint")
 
 
 @pytest.fixture
@@ -55,10 +65,46 @@ def ddl_for(conn, name):
     return row[0] if row else None
 
 
+def add_model(conn, *, file_kind="adapter", sha256="h", **columns):
+    """Insert one content row and return its id."""
+    columns = {
+        "file_kind": file_kind,
+        "sha256": sha256,
+        "provenance": "external",
+        **columns,
+    }
+    placeholders = ", ".join("?" for _ in columns)
+    cursor = conn.execute(
+        f"INSERT INTO model ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(columns.values()),
+    )
+    return int(cursor.lastrowid)
+
+
+def add_folder(conn, path):
+    cursor = conn.execute(
+        "INSERT INTO model_folder (path, kind, movable) VALUES (?, 'user', 'per_item')",
+        (path,),
+    )
+    return int(cursor.lastrowid)
+
+
+def add_file(conn, model_id, folder_id, relpath, state="present"):
+    conn.execute(
+        "INSERT INTO model_file (model_id, model_folder_id, relpath, state) "
+        "VALUES (?, ?, ?, ?)",
+        (model_id, folder_id, relpath, state),
+    )
+
+
 class TestFreshHub:
     def test_every_shelf_table_is_created(self, hub):
         apply_migrations(hub)
-        assert SHELF_TABLES == tuple(t for t in SHELF_TABLES if t in table_names(hub))
+        assert set(SHELF_TABLES) <= table_names(hub)
+
+    def test_the_superseded_tables_are_gone(self, hub):
+        apply_migrations(hub)
+        assert not (set(SUPERSEDED_TABLES) & table_names(hub))
 
     def test_the_hub_stays_on_version_two(self, hub):
         # The whole point of amending v2: a build that predates this change has
@@ -68,17 +114,15 @@ class TestFreshHub:
         assert read_schema_version(hub) == 2
         assert CURRENT_SCHEMA_VERSION == 2
 
-    @pytest.mark.parametrize(
-        "table", ("model_folder", "adapter", "checkpoint", "adapter_stack")
-    )
+    @pytest.mark.parametrize("table", ("model_folder", "model", "adapter_stack"))
     def test_ids_never_recycle(self, hub, table):
         # AUTOINCREMENT, per the library.id precedent. Without it SQLite hands a
-        # deleted row's id to the next insert, and a recycled folder id would
-        # silently re-point every adapter_file row at a different folder.
+        # deleted row's id to the next insert, and a recycled id would silently
+        # re-point every model_file row at a different folder or model.
         apply_migrations(hub)
         assert "AUTOINCREMENT" in ddl_for(hub, table)
 
-    def test_the_scan_and_stack_indexes_exist(self, hub):
+    def test_the_scan_stack_and_hash_queue_indexes_exist(self, hub):
         apply_migrations(hub)
         indexes = {
             row[0]
@@ -87,10 +131,20 @@ class TestFreshHub:
             ).fetchall()
         }
         assert {
-            "ix_adapter_file_sha",
-            "ix_adapter_file_folder",
-            "ix_adapter_stack_member",
+            "ix_model_file_model",
+            "ix_model_file_folder",
+            "ix_model_stack_member",
+            "ix_model_hash_queue",
         } <= indexes
+
+    def test_the_hash_queue_index_is_partial(self, hub):
+        # A full index on sha256 would be almost entirely rows the finder never
+        # wants: the queue is a handful of rows in a table of thousands.
+        apply_migrations(hub)
+        sql = hub.execute(
+            "SELECT sql FROM sqlite_master WHERE name='ix_model_hash_queue'"
+        ).fetchone()[0]
+        assert "WHERE sha256 IS NULL" in sql
 
 
 class TestReRunIsSafe:
@@ -114,7 +168,7 @@ class TestReRunIsSafe:
         apply_migrations is for.
         """
         apply_migrations(hub)
-        for table in SHELF_TABLES:
+        for table in ("model_file", "model", "model_folder", "adapter_stack"):
             hub.execute(f"DROP TABLE {table}")
         assert read_schema_version(hub) == 2  # still v2, nothing to upgrade
         assert not (set(SHELF_TABLES) & table_names(hub))
@@ -134,38 +188,80 @@ class TestReRunIsSafe:
             ("/models/loras",)
         ]
 
+    def test_a_pre_reshape_hub_is_reshaped_on_its_next_open(self, hub):
+        """A developer hub opened on an earlier develop still gets the new shape.
+
+        ``CREATE TABLE IF NOT EXISTS`` cannot reshape a table, so without the
+        drop guard such a hub would keep the superseded three tables and gain
+        the new two, with the scan writing to neither.
+        """
+        apply_migrations(hub)
+        hub.execute("DROP TABLE model_file")
+        hub.execute("DROP TABLE model")
+        hub.execute("CREATE TABLE adapter (sha256 TEXT)")
+        hub.execute("CREATE TABLE adapter_file (relpath TEXT)")
+        hub.execute("CREATE TABLE checkpoint (local_path TEXT)")
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert not (set(SUPERSEDED_TABLES) & table_names(hub))
+        assert {"model", "model_file"} <= table_names(hub)
+
+    def test_the_drop_guard_is_idempotent_and_loses_nothing_after_the_first_open(
+        self, hub
+    ):
+        """Three consecutive opens; only the first may drop anything.
+
+        The guard keys on ``adapter``, which does not exist after the reshape,
+        so it must be false on a fresh hub and false on every re-run. If it
+        ever fired again it would take a populated ``model``/``model_file`` pair
+        with it — the guard drops tables, and a drop cannot be undone.
+        """
+        apply_migrations(hub)
+        folder_id = add_folder(hub, "/models")
+        model_id = add_model(hub, display_name="Clementine v3")
+        add_file(hub, model_id, folder_id, "clem.safetensors")
+        hub.commit()
+
+        for _ in range(2):
+            apply_migrations(hub)
+            assert hub.execute("SELECT display_name FROM model").fetchone() == (
+                "Clementine v3",
+            )
+            assert hub.execute("SELECT COUNT(*) FROM model_file").fetchone()[0] == 1
+            assert hub.execute("SELECT COUNT(*) FROM model_folder").fetchone()[0] == 1
+
 
 class TestConstraints:
-    def test_an_adapter_is_identified_by_its_hash(self, hub):
+    def test_a_model_is_identified_by_its_hash(self, hub):
         apply_migrations(hub)
-        for _ in range(1):
-            hub.execute(
-                "INSERT INTO adapter (sha256, kind, provenance) VALUES (?, ?, ?)",
-                ("abc", "lora", "external"),
-            )
+        add_model(hub, sha256="abc")
         with pytest.raises(sqlite3.IntegrityError):
-            hub.execute(
-                "INSERT INTO adapter (sha256, kind, provenance) VALUES (?, ?, ?)",
-                ("abc", "lora", "trained"),
-            )
+            add_model(hub, sha256="abc", provenance="trained")
+
+    def test_an_adapter_may_not_be_stored_without_a_hash(self, hub):
+        # The CHECK keeps `adapter`'s old NOT NULL exactly where it was
+        # load-bearing: an adapter is hashed on sight, and its sha256 is the
+        # interop identity Civitai lookup and `{sha256}/file` both resolve on.
+        apply_migrations(hub)
+        with pytest.raises(sqlite3.IntegrityError):
+            add_model(hub, file_kind="adapter", sha256=None)
 
     def test_a_checkpoint_may_be_registered_before_it_is_hashed(self, hub):
-        # Deliberately different from `adapter`: a checkpoint can be many
+        # Deliberately different from an adapter: a checkpoint can be many
         # gigabytes and is registered in place long before anything hashes it.
         apply_migrations(hub)
-        hub.execute(
-            "INSERT INTO checkpoint (filename, local_path) VALUES (?, ?)",
-            ("flux1-dev.safetensors", "/models/flux1-dev.safetensors"),
-        )
-        assert hub.execute("SELECT sha256 FROM checkpoint").fetchone() == (None,)
+        add_model(hub, file_kind="checkpoint", sha256=None, filename="flux1-dev")
+        assert hub.execute("SELECT sha256 FROM model").fetchone() == (None,)
 
     def test_two_unhashed_checkpoints_do_not_collide(self, hub):
         # SQLite treats NULLs as distinct under UNIQUE, which is what allows a
         # whole folder to be registered before any of it is hashed.
         apply_migrations(hub)
         for name in ("a.safetensors", "b.safetensors"):
-            hub.execute("INSERT INTO checkpoint (filename) VALUES (?)", (name,))
-        assert hub.execute("SELECT COUNT(*) FROM checkpoint").fetchone()[0] == 2
+            add_model(hub, file_kind="checkpoint", sha256=None, filename=name)
+        assert hub.execute("SELECT COUNT(*) FROM model").fetchone()[0] == 2
 
     def test_one_path_per_folder_is_recorded_once(self, hub):
         apply_migrations(hub)
@@ -180,56 +276,95 @@ class TestConstraints:
             )
 
     def test_the_same_file_may_sit_in_two_folders(self, hub):
-        # One adapter, many paths. That is what a copy into a second registered
+        # One model, many paths. That is what a copy into a second registered
         # folder is, and what a duplicate after an interrupted move is.
         apply_migrations(hub)
-        hub.execute(
-            "INSERT INTO adapter (sha256, kind, provenance) VALUES ('h', 'lora', 'external')"
-        )
+        model_id = add_model(hub)
         for path in ("/a", "/b"):
-            hub.execute(
-                "INSERT INTO model_folder (path, kind, movable) VALUES (?, 'user', 'per_item')",
-                (path,),
-            )
-        for folder_id in (1, 2):
-            hub.execute(
-                "INSERT INTO adapter_file "
-                "(adapter_sha256, model_folder_id, relpath, state) "
-                "VALUES ('h', ?, 'x.safetensors', 'present')",
-                (folder_id,),
-            )
-        assert hub.execute("SELECT COUNT(*) FROM adapter_file").fetchone()[0] == 2
+            add_file(hub, model_id, add_folder(hub, path), "x.safetensors")
+        assert hub.execute("SELECT COUNT(*) FROM model_file").fetchone()[0] == 2
+
+    def test_a_location_cannot_name_a_model_that_does_not_exist(self, hub):
+        # The FK is what keeps `model_file` from outliving its content row.
+        apply_migrations(hub)
+        folder_id = add_folder(hub, "/models")
+        with pytest.raises(sqlite3.IntegrityError):
+            add_file(hub, 9999, folder_id, "ghost.safetensors")
+
+
+class TestUnknownIsFirstClass:
+    """``unknown`` is shown, never promoted, and correctable in one statement."""
+
+    def test_an_unknown_file_stores_as_unknown_and_is_not_an_adapter(self, hub):
+        apply_migrations(hub)
+        add_model(hub, file_kind="unknown", sha256="u", kind=None)
+        add_model(hub, file_kind="adapter", sha256="a", kind="lora")
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE sha256 = 'u'"
+        ).fetchone() == ("unknown",)
+        adapters = hub.execute(
+            "SELECT sha256 FROM model WHERE file_kind = 'adapter'"
+        ).fetchall()
+        assert adapters == [("a",)]
+
+    def test_correcting_an_unknown_to_checkpoint_keeps_its_locations(self, hub):
+        # The correction is the point of storing `unknown` rather than guessing.
+        # Under the superseded shape it was a cross-table move; here it is one
+        # UPDATE and the location rows never move.
+        apply_migrations(hub)
+        model_id = add_model(hub, file_kind="unknown", sha256="u", kind=None)
+        add_file(hub, model_id, add_folder(hub, "/a"), "vae.safetensors")
+        add_file(hub, model_id, add_folder(hub, "/b"), "vae.safetensors")
+        hub.commit()
+
+        hub.execute(
+            "UPDATE model SET file_kind = 'checkpoint' WHERE id = ?", (model_id,)
+        )
+
+        assert hub.execute("SELECT file_kind FROM model").fetchall() == [
+            ("checkpoint",)
+        ]
+        assert hub.execute(
+            "SELECT COUNT(*) FROM model_file WHERE model_id = ?", (model_id,)
+        ).fetchone() == (2,)
 
 
 class TestTombstone:
-    def test_dropping_a_folders_files_keeps_the_adapter_and_its_curation(self, hub):
-        """Why folder removal needs no confirmation prompt.
+    """Why folder removal needs no confirmation prompt.
 
-        Removing a folder drops ``adapter_file`` rows and keeps the ``adapter``
-        row, so the display name the user typed survives and re-adding the
-        folder re-links by sha256. Nothing a user authored is destroyed, which
-        is the whole basis for not interrupting them with a dialog.
-        """
+    Removing a folder drops ``model_file`` rows and keeps the ``model`` row, so
+    the display name the user typed survives and re-adding the folder re-links.
+    Nothing a user authored is destroyed, which is the whole basis for not
+    interrupting them with a dialog.
+    """
+
+    @pytest.mark.parametrize(
+        "file_kind, sha256",
+        (
+            ("adapter", "h"),
+            # The case the superseded shape could not do at all: a checkpoint
+            # carried its path inline, so removing the folder either destroyed
+            # the row or left it pointing at a folder that was gone.
+            ("checkpoint", None),
+        ),
+    )
+    def test_dropping_a_folders_files_keeps_the_model_and_its_curation(
+        self, hub, file_kind, sha256
+    ):
         apply_migrations(hub)
-        hub.execute(
-            "INSERT INTO adapter (sha256, kind, provenance, display_name) "
-            "VALUES ('h', 'lora', 'external', 'Clementine v3')"
+        model_id = add_model(
+            hub, file_kind=file_kind, sha256=sha256, display_name="Clementine v3"
         )
-        hub.execute(
-            "INSERT INTO model_folder (path, kind, movable) "
-            "VALUES ('/models', 'user', 'per_item')"
-        )
-        hub.execute(
-            "INSERT INTO adapter_file "
-            "(adapter_sha256, model_folder_id, relpath, state) "
-            "VALUES ('h', 1, 'clem.safetensors', 'present')"
-        )
+        folder_id = add_folder(hub, "/models")
+        add_file(hub, model_id, folder_id, "clem.safetensors")
         hub.commit()
 
-        hub.execute("DELETE FROM adapter_file WHERE model_folder_id = 1")
-        hub.execute("DELETE FROM model_folder WHERE id = 1")
+        hub.execute("DELETE FROM model_file WHERE model_folder_id = ?", (folder_id,))
+        hub.execute("DELETE FROM model_folder WHERE id = ?", (folder_id,))
         hub.commit()
 
-        assert hub.execute("SELECT display_name FROM adapter").fetchone() == (
+        assert hub.execute("SELECT display_name FROM model").fetchone() == (
             "Clementine v3",
         )
+        assert hub.execute("SELECT COUNT(*) FROM model_file").fetchone()[0] == 0

--- a/tests/test_model_folder_scanner.py
+++ b/tests/test_model_folder_scanner.py
@@ -1,0 +1,610 @@
+"""What the model-folder scan records, and what it refuses to record.
+
+The scan is the only thing that puts rows on the shelf, so the tests here are
+about the claims the rest of the feature is built on:
+
+1. **One content row, many location rows.** ``model`` says what a file is,
+   ``model_file`` says where a copy of it lives, for a checkpoint exactly as
+   much as for an adapter. Two copies of one file are one row with two
+   locations.
+2. **An adapter's identity is its full-file SHA-256**, computed on sight.
+   A checkpoint registers instantly with no hash, because it may be 24 GB and
+   the shelf must not stall behind it.
+3. **Nothing is ever deleted by a scan.** A vanished file flips a state; a
+   folder or subdirectory we could not read flips a *different* state, because
+   "gone" and "we could not look" are different facts and only one of them is
+   safe to act on.
+4. **A scan re-derives facts and never overwrites choices.**
+"""
+
+import hashlib
+import json
+import os
+import struct
+
+import pytest
+
+from pixlstash.hub.db import HubDatabase
+from pixlstash.services import model_folder_scanner as scanner_module
+from pixlstash.services.model_folder_scanner import (
+    STATE_MISSING,
+    STATE_PRESENT,
+    STATE_UNREACHABLE,
+    ModelFolderScanner,
+)
+
+SKIP_AS_ROOT = pytest.mark.skipif(
+    hasattr(os, "getuid") and os.getuid() == 0,
+    reason="root ignores the permission bits this test removes",
+)
+
+
+def _tensor(shape):
+    return {"dtype": "F16", "shape": list(shape), "data_offsets": [0, 0]}
+
+
+def _write_safetensors(path, tensors, metadata=None):
+    """Write a header-only safetensors file. The payload is never read."""
+    header = dict(tensors)
+    if metadata is not None:
+        header["__metadata__"] = metadata
+    blob = json.dumps(header).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob)
+    return str(path)
+
+
+def write_adapter(path, *, name=None, base_model=None, triggers=None, pad=0):
+    """A file with LoRA tensor markers, so it is *proven* to be an adapter."""
+    tensors = {f"blocks.{i}.lora_A.weight": _tensor([8, 16]) for i in range(2 + pad)}
+    tensors["blocks.0.lora_B.weight"] = _tensor([16, 8])
+    metadata = {"format": "pt"}
+    if name:
+        metadata["ss_output_name"] = name
+    if base_model:
+        metadata["ss_base_model_version"] = base_model
+    if triggers:
+        metadata["ss_tag_frequency"] = json.dumps({"1_set": {t: 1 for t in triggers}})
+    return _write_safetensors(path, tensors, metadata)
+
+
+def write_checkpoint(path):
+    """Marker-free and far over the checkpoint parameter threshold."""
+    return _write_safetensors(path, {"model.weight": _tensor([40000, 40000])})
+
+
+def write_unknown(path):
+    """Marker-free and far under it: the band the shelf must show as unknown."""
+    return _write_safetensors(path, {"vae.weight": _tensor([64, 64])})
+
+
+@pytest.fixture
+def hub(tmp_path):
+    database = HubDatabase(str(tmp_path / "hub.db"))
+    yield database
+    database.close()
+
+
+@pytest.fixture
+def scanner(hub):
+    return ModelFolderScanner(hub)
+
+
+def register_folder(hub, path, kind="user"):
+    with hub.transaction() as conn:
+        cursor = conn.execute(
+            "INSERT INTO model_folder (path, kind, movable, created_at) "
+            "VALUES (?, ?, 'per_item', '2026-08-09T00:00:00+00:00')",
+            (str(path), kind),
+        )
+        return int(cursor.lastrowid)
+
+
+def models(hub, file_kind=None):
+    """Return ``{id: row}`` for the content rows, optionally of one kind."""
+    if file_kind is None:
+        rows = hub.fetchall("SELECT * FROM model")
+    else:
+        rows = hub.fetchall("SELECT * FROM model WHERE file_kind = ?", (file_kind,))
+    return {row["id"]: row for row in rows}
+
+
+def adapters(hub):
+    return {row["sha256"]: row for row in models(hub, "adapter").values()}
+
+
+def checkpoints(hub):
+    return list(models(hub, "checkpoint").values())
+
+
+def located(hub):
+    """Return ``{relpath: row}`` for the location rows."""
+    return {row["relpath"]: row for row in hub.fetchall("SELECT * FROM model_file")}
+
+
+def digest_at(hub, relpath):
+    row = hub.fetchone(
+        "SELECT m.sha256 FROM model_file mf JOIN model m ON m.id = mf.model_id "
+        "WHERE mf.relpath = ?",
+        (relpath,),
+    )
+    return row["sha256"]
+
+
+class TestAdapters:
+    def test_an_adapter_is_keyed_by_its_full_file_sha256(self, hub, scanner, tmp_path):
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        path = write_adapter(folder / "jimmy.safetensors", name="Jimmy")
+        folder_id = register_folder(hub, folder)
+
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        expected = hashlib.sha256(open(path, "rb").read()).hexdigest()
+        rows = adapters(hub)
+        assert set(rows) == {expected}
+        assert rows[expected]["file_kind"] == "adapter"
+        assert rows[expected]["kind"] == "lora"
+        assert rows[expected]["display_name"] == "Jimmy"
+        assert rows[expected]["provenance"] == "external"
+        assert rows[expected]["file_size"] == os.path.getsize(path)
+
+        row = located(hub)["jimmy.safetensors"]
+        assert row["state"] == STATE_PRESENT
+        assert row["model_id"] == rows[expected]["id"]
+        assert row["file_mtime"] == os.stat(path).st_mtime_ns
+
+    def test_metadata_the_file_carries_is_stored(self, hub, scanner, tmp_path):
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        write_adapter(
+            folder / "a.safetensors", base_model="flux.1-dev", triggers=["ohwx"]
+        )
+        folder_id = register_folder(hub, folder)
+
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        row = next(iter(adapters(hub).values()))
+        assert row["base_model"] == "flux.1-dev"
+        assert json.loads(row["trigger_words"]) == ["ohwx"]
+        assert row["param_count"] > 0
+
+    def test_a_file_that_did_not_name_itself_is_left_unnamed(
+        self, hub, scanner, tmp_path
+    ):
+        # `display_name` NULL is the "Needs a name" work queue. Deriving a name
+        # here would fill that queue with guesses and make a guess
+        # indistinguishable from a choice.
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        write_adapter(folder / "JimmyCarr_000002750.safetensors")
+        folder_id = register_folder(hub, folder)
+
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert next(iter(adapters(hub).values()))["display_name"] is None
+
+    def test_nested_files_keep_their_relative_path(self, hub, scanner, tmp_path):
+        folder = tmp_path / "loras"
+        (folder / "flux" / "people").mkdir(parents=True)
+        write_adapter(folder / "flux" / "people" / "a.safetensors")
+        folder_id = register_folder(hub, folder)
+
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert set(located(hub)) == {os.path.join("flux", "people", "a.safetensors")}
+
+    def test_one_file_in_two_folders_is_one_model_at_two_locations(
+        self, hub, scanner, tmp_path
+    ):
+        first = tmp_path / "one"
+        second = tmp_path / "two"
+        first.mkdir()
+        second.mkdir()
+        write_adapter(first / "a.safetensors")
+        write_adapter(second / "a.safetensors")
+        first_id = register_folder(hub, first)
+        second_id = register_folder(hub, second)
+
+        scanner.scan_folder(first_id, str(first), "user")
+        scanner.scan_folder(second_id, str(second), "user")
+
+        assert len(models(hub)) == 1
+        rows = hub.fetchall("SELECT model_folder_id FROM model_file")
+        assert sorted(row["model_folder_id"] for row in rows) == [first_id, second_id]
+
+    def test_a_name_the_user_typed_survives_the_file_turning_up_elsewhere(
+        self, hub, scanner, tmp_path
+    ):
+        # The second folder re-upserts the same content row, and the file's own
+        # metadata name would otherwise overwrite what the user chose. Curation
+        # wins over anything a scan re-derives.
+        first = tmp_path / "one"
+        second = tmp_path / "two"
+        first.mkdir()
+        second.mkdir()
+        write_adapter(first / "a.safetensors", name="From the file")
+        write_adapter(second / "copy.safetensors", name="From the file")
+        first_id = register_folder(hub, first)
+        second_id = register_folder(hub, second)
+        scanner.scan_folder(first_id, str(first), "user")
+        with hub.transaction() as conn:
+            conn.execute("UPDATE model SET display_name = 'Clementine'")
+
+        scanner.scan_folder(second_id, str(second), "user")
+
+        assert next(iter(models(hub).values()))["display_name"] == "Clementine"
+
+    def test_only_safetensors_files_are_considered(self, hub, scanner, tmp_path):
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        (folder / "notes.txt").write_text("not a model")
+        (folder / "old.ckpt").write_bytes(b"pickled")
+        folder_id = register_folder(hub, folder)
+
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert models(hub) == {}
+
+
+class TestCheckpointsAndUnknowns:
+    def test_a_checkpoint_registers_with_no_hash_and_a_location_row(
+        self, hub, scanner, tmp_path
+    ):
+        folder = tmp_path / "ckpt"
+        folder.mkdir()
+        write_checkpoint(folder / "sdxl.safetensors")
+        folder_id = register_folder(hub, folder)
+
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        rows = checkpoints(hub)
+        assert len(rows) == 1
+        assert rows[0]["sha256"] is None
+        assert rows[0]["hashed_at"] is None
+        assert rows[0]["filename"] == "sdxl.safetensors"
+        assert rows[0]["kind"] is None
+        assert adapters(hub) == {}
+        # The location row is what the superseded inline `local_path` could not
+        # give a checkpoint: a folder reference, a state, and a tombstone.
+        location = located(hub)["sdxl.safetensors"]
+        assert location["model_folder_id"] == folder_id
+        assert location["state"] == STATE_PRESENT
+        assert location["model_id"] == rows[0]["id"]
+
+    def test_a_checkpoint_in_two_folders_is_one_row_at_two_locations(
+        self, hub, scanner, tmp_path
+    ):
+        # Not two content rows racing for one `sha256 UNIQUE`. Under the
+        # superseded shape this was two `checkpoint` rows that the hash task had
+        # to merge, losing one of the two paths every time.
+        first = tmp_path / "one"
+        second = tmp_path / "two"
+        first.mkdir()
+        second.mkdir()
+        write_checkpoint(first / "sdxl.safetensors")
+        (second / "sdxl.safetensors").write_bytes(
+            (first / "sdxl.safetensors").read_bytes()
+        )
+        first_id = register_folder(hub, first)
+        second_id = register_folder(hub, second)
+
+        scanner.scan_folder(first_id, str(first), "user")
+        scanner.scan_folder(second_id, str(second), "user")
+
+        # Two rows here, one per location, because nothing has hashed them yet
+        # and an unhashed checkpoint has no identity beyond where it was found.
+        assert len(checkpoints(hub)) == 2
+        rows = hub.fetchall("SELECT model_folder_id FROM model_file")
+        assert sorted(row["model_folder_id"] for row in rows) == [first_id, second_id]
+
+    def test_an_unknown_file_is_never_recorded_as_a_checkpoint(
+        self, hub, scanner, tmp_path
+    ):
+        folder = tmp_path / "mixed"
+        folder.mkdir()
+        write_unknown(folder / "vae.safetensors")
+        folder_id = register_folder(hub, folder)
+
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert checkpoints(hub) == []
+        row = next(iter(models(hub).values()))
+        assert row["file_kind"] == "unknown"
+        # `kind` names an adapter algorithm. This file is not an adapter, so the
+        # column carries nothing rather than a guess.
+        assert row["kind"] is None
+        # Hashed all the same: it is under the checkpoint threshold, so it is
+        # cheap, and it gives the row an identity the shelf can link to.
+        assert row["sha256"] is not None
+
+    def test_a_file_kind_the_user_corrected_is_not_re_derived_away(
+        self, hub, scanner, tmp_path
+    ):
+        # The whole point of storing `unknown` rather than guessing is that the
+        # owner can correct it. The parser will keep saying `unknown` forever,
+        # so a re-scan that rewrote `file_kind` would undo every correction.
+        folder = tmp_path / "mixed"
+        folder.mkdir()
+        path = folder / "vae.safetensors"
+        write_unknown(path)
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        with hub.transaction() as conn:
+            conn.execute("UPDATE model SET file_kind = 'checkpoint'")
+
+        # Re-hashed, not short-circuited, so the upsert really runs.
+        os.utime(path, ns=(0, 0))
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert next(iter(models(hub).values()))["file_kind"] == "checkpoint"
+
+    def test_a_resized_checkpoint_loses_its_stale_hash(self, hub, scanner, tmp_path):
+        folder = tmp_path / "ckpt"
+        folder.mkdir()
+        path = folder / "sdxl.safetensors"
+        write_checkpoint(path)
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        with hub.transaction() as conn:
+            conn.execute("UPDATE model SET sha256 = 'deadbeef', hashed_at = 'then'")
+
+        _write_safetensors(
+            path, {"model.weight": _tensor([40000, 40000]), "extra": _tensor([2])}
+        )
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        rows = checkpoints(hub)
+        assert len(rows) == 1
+        assert rows[0]["sha256"] is None
+        assert rows[0]["hashed_at"] is None
+        # Still one row at one location: the path is the identity here.
+        assert len(located(hub)) == 1
+
+    def test_a_hashed_checkpoint_keeps_its_hash_across_a_rescan(
+        self, hub, scanner, tmp_path
+    ):
+        # The stale-hash clear must fire on a changed file and only then, or
+        # every sweep would re-queue every checkpoint on the machine.
+        folder = tmp_path / "ckpt"
+        folder.mkdir()
+        write_checkpoint(folder / "sdxl.safetensors")
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        with hub.transaction() as conn:
+            conn.execute("UPDATE model SET sha256 = 'abc', hashed_at = 'then'")
+
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert checkpoints(hub)[0]["sha256"] == "abc"
+
+
+class TestStates:
+    def test_a_vanished_file_goes_missing_and_keeps_its_model_row(
+        self, hub, scanner, tmp_path
+    ):
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        path = folder / "a.safetensors"
+        write_adapter(path)
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        with hub.transaction() as conn:
+            conn.execute("UPDATE model SET display_name = 'Named by hand'")
+
+        os.remove(path)
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert located(hub)["a.safetensors"]["state"] == STATE_MISSING
+        assert next(iter(models(hub).values()))["display_name"] == "Named by hand"
+
+    def test_a_vanished_checkpoint_goes_missing_too(self, hub, scanner, tmp_path):
+        # Free once a checkpoint has a location row: the same sweep covers it,
+        # with no code that knows what a checkpoint is.
+        folder = tmp_path / "ckpt"
+        folder.mkdir()
+        path = folder / "sdxl.safetensors"
+        write_checkpoint(path)
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        os.remove(path)
+        result = scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert result.missing == 1
+        assert located(hub)["sdxl.safetensors"]["state"] == STATE_MISSING
+        assert len(checkpoints(hub)) == 1
+
+    def test_a_returning_file_goes_back_to_present(self, hub, scanner, tmp_path):
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        path = folder / "a.safetensors"
+        write_adapter(path)
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        os.remove(path)
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        write_adapter(path)
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert located(hub)["a.safetensors"]["state"] == STATE_PRESENT
+        assert len(models(hub)) == 1
+
+    def test_an_unreadable_folder_is_unreachable_never_missing(
+        self, hub, scanner, tmp_path
+    ):
+        folder = tmp_path / "usb"
+        folder.mkdir()
+        write_adapter(folder / "a.safetensors")
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        os.remove(folder / "a.safetensors")
+        folder.rmdir()
+        result = scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert result.state == STATE_UNREACHABLE
+        assert located(hub)["a.safetensors"]["state"] == STATE_UNREACHABLE
+        # And nothing was removed on the strength of a folder we could not read.
+        assert len(models(hub)) == 1
+        assert len(located(hub)) == 1
+
+    @SKIP_AS_ROOT
+    def test_an_unreadable_subdirectory_is_unreachable_never_missing(
+        self, hub, scanner, tmp_path
+    ):
+        # A NAS mounted inside a registered folder. `os.walk` discards the
+        # listing error by default, which would report the whole mount deleted
+        # the moment it drops -- and `missing` is what "Forget unreferenced
+        # adapters" acts on.
+        folder = tmp_path / "models"
+        (folder / "nas").mkdir(parents=True)
+        write_adapter(folder / "local.safetensors")
+        write_adapter(folder / "nas" / "remote.safetensors", pad=1)
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        os.chmod(folder / "nas", 0o000)
+        try:
+            result = scanner.scan_folder(folder_id, str(folder), "user")
+        finally:
+            os.chmod(folder / "nas", 0o755)
+
+        rows = located(hub)
+        assert rows[os.path.join("nas", "remote.safetensors")]["state"] == (
+            STATE_UNREACHABLE
+        )
+        assert rows["local.safetensors"]["state"] == STATE_PRESENT
+        assert result.missing == 0
+        assert result.unreachable == 1
+
+    def test_last_checked_is_stamped_on_both_paths(self, hub, scanner, tmp_path):
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        reachable = hub.fetchone(
+            "SELECT last_checked FROM model_folder WHERE id = ?", (folder_id,)
+        )["last_checked"]
+        assert reachable is not None
+
+        folder.rmdir()
+        scanner.scan_folder(folder_id, str(folder), "user")
+        after = hub.fetchone(
+            "SELECT last_checked FROM model_folder WHERE id = ?", (folder_id,)
+        )["last_checked"]
+        assert after is not None and after != reachable
+
+
+class TestScanCost:
+    def test_an_unchanged_file_is_not_rehashed(
+        self, hub, scanner, tmp_path, monkeypatch
+    ):
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        write_adapter(folder / "a.safetensors")
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        calls = []
+        real = scanner_module.sha256_file
+        monkeypatch.setattr(
+            scanner_module,
+            "sha256_file",
+            lambda path: (calls.append(path), real(path))[1],
+        )
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert calls == []
+
+    def test_a_changed_file_is_rehashed(self, hub, scanner, tmp_path, monkeypatch):
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        path = folder / "a.safetensors"
+        write_adapter(path)
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        before = set(adapters(hub))
+
+        write_adapter(path, pad=3)
+        calls = []
+        real = scanner_module.sha256_file
+        monkeypatch.setattr(
+            scanner_module,
+            "sha256_file",
+            lambda p: (calls.append(p), real(p))[1],
+        )
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert len(calls) == 1
+        # The content row is new; the old one is a tombstone, not a deletion.
+        assert set(adapters(hub)) > before
+        assert digest_at(hub, "a.safetensors") not in before
+
+    def test_a_same_size_edit_is_caught_by_the_mtime(self, hub, scanner, tmp_path):
+        # Size alone would take this file as unchanged, leaving `model.sha256`
+        # naming bytes that are no longer on disk -- in the column the public
+        # `{sha256}/file` route resolves on.
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        path = folder / "a.safetensors"
+        write_adapter(path, name="AAAA")
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        stale = digest_at(hub, "a.safetensors")
+
+        write_adapter(path, name="BBBB")
+        assert os.path.getsize(path) == next(iter(models(hub).values()))["file_size"]
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        on_disk = hashlib.sha256(open(path, "rb").read()).hexdigest()
+        assert on_disk != stale
+        assert digest_at(hub, "a.safetensors") == on_disk
+
+
+class TestFolderKinds:
+    def test_source_folders_are_never_catalogued_in_place(self, hub, scanner, tmp_path):
+        # An ai-toolkit output root is a place things are taken FROM. Its
+        # checkpoints are imported as a run, never listed as shelf rows.
+        folder = tmp_path / "output"
+        folder.mkdir()
+        write_adapter(folder / "a.safetensors")
+        folder_id = register_folder(hub, folder, kind="source")
+
+        result = scanner.scan_folder(folder_id, str(folder), "source")
+
+        assert result.skipped is True
+        assert models(hub) == {}
+        assert located(hub) == {}
+
+    def test_scan_all_covers_every_registered_folder(self, hub, scanner, tmp_path):
+        first = tmp_path / "one"
+        second = tmp_path / "two"
+        first.mkdir()
+        second.mkdir()
+        write_adapter(first / "a.safetensors")
+        write_adapter(second / "b.safetensors")
+        register_folder(hub, first)
+        register_folder(hub, second)
+
+        results = scanner.scan_all()
+
+        assert len(results) == 2
+        assert sum(r.adapters for r in results) == 2
+        assert set(located(hub)) == {"a.safetensors", "b.safetensors"}
+
+
+class TestUnreadableFiles:
+    def test_a_file_with_no_readable_header_is_left_unregistered(
+        self, hub, scanner, tmp_path
+    ):
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        (folder / "truncated.safetensors").write_bytes(b"\x00\x01")
+        folder_id = register_folder(hub, folder)
+
+        result = scanner.scan_folder(folder_id, str(folder), "user")
+
+        assert result.unreadable == 1
+        assert models(hub) == {}
+        assert located(hub) == {}


### PR DESCRIPTION
Stacked on #803 (base: `feature/model-shelf-reshape`). Rebased onto the one-content-table / one-location-table shape.

## What the reshape did to this PR

About 70% is unchanged: `_walk`, `_is_readable`, `sha256_file`, the stat/size skip, `FolderScanResult`, the three states, the source-folder skip, `_mark_missing`, `_mark_unreachable`, `_touch_folder`.

- `_upsert_adapter` and `_upsert_checkpoint` collapse into one `_upsert_model` returning `model_id`.
- `_upsert_adapter_file` becomes `_upsert_model_file(model_id, ...)`.
- **The `("adapter"|"adapter_seen"|"checkpoint")` record tag and its three-way branch are gone.** That discriminator existed only because there were two content tables. What is left is a `_FileRecord` NamedTuple and one branch on "do I already know this row".
- `_known_files` joins `model_file -> model`.
- The checkpoint path gains a `model_file` row it did not get before, so `_mark_missing` now covers checkpoints with no new code (`test_a_vanished_checkpoint_goes_missing_too`).
- `file_kind` is stored and is never re-derived away, so an owner correcting `unknown` -> `checkpoint` keeps it. `kind` (the adapter algorithm) is NULL for anything that is not an adapter, rather than the decorative `KIND_UNKNOWN` the old guard could never actually produce.

## Three defects fixed (pinned as strict xfails by #799)

**D1 (high) - an unreadable subdirectory read as a deletion.** `os.walk` discards the listing error by default, so a NAS mounted inside a registered folder swept its whole subtree to `missing` the moment it dropped, silently, and `missing` is what *Forget unreferenced adapters* acts on. `_walk` now takes an `onerror` handler, logs the path, and collects the blocked relpaths; `_mark_unreachable_subtrees` flips those subtrees to `unreachable` and stamps them, before the missing sweep runs. LIKE wildcards in the prefix are escaped, or a folder named `sd_xl` would protect the wrong subtree.

**D2 (high) - two concurrent scans marked every file missing.** The sweep was `WHERE seen_at != <my stamp>`, so each scan swept away the other's stamps; QA measured 4 of 5 unsynchronised runs flipping all 60 files. The fix is `<` instead of `!=`: a concurrent scan's newer stamp survives, and a row is only demoted by the scan that walked the folder and did not find it. Correct across processes as well, which a lock would not have been, and it needs no lock, no generation column and no serialisation of two different folders. The residual case is a file created after a scan walked past it, which that scan genuinely never saw and the next scan restores.

**D3 (medium) - a corrected `kind` reverted on rescan.** `kind` was the one column upserted without `COALESCE`. It has one now, along with `param_count`; `file_kind` and `provenance` are left out of the update entirely, because the row is keyed by content so the parser can only ever repeat the classification the owner just overruled.

Also from QA's mutation sweep: the re-hash short circuit now compares against *this folder's own* `model_file` row (a wrong-identity class), and `base_model` / `trigger_words` / `training_step` / `filename` keep their `COALESCE`.

## The size-only blind spot is closed

QA flagged that the no-rehash short circuit missed a same-size in-place edit, and accepted the trade (48 s vs 0 s per sweep on 1,800 files). But it meant `model.sha256` could name bytes whose digest differs, and B5's `{sha256}/file` route would serve them silently. The short circuit now compares `st_mtime_ns` as well as size, stored per-location in `model_file.file_mtime` (added in #803; B7 needs it anyway). Cost is one extra integer from the `stat` call that was already being made - no additional I/O.

## Tests

`tests/test_model_folder_scanner.py`, 25 passed. Mutation-tested: dropping `os.walk(onerror=)`, disabling the subtree sweep, reverting the short circuit to size-only, letting `file_kind` be overwritten, dropping the stale-checkpoint-hash clear, and storing `kind` for non-adapters each fail the suite.

**Over the 600-line guideline** at 1,234 lines (623 source + 610 test). It was 894 before the rebase; the shape did not add scope, and this is one module plus its suite with no seam to split on that would leave either half testable.