### PR TITLE
Give the shelf one content table and one location table

### DIFF
--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -352,8 +352,14 @@ CREATE TABLE IF NOT EXISTS model_file (
     model_id         INTEGER NOT NULL REFERENCES model(id),
     model_folder_id  INTEGER NOT NULL REFERENCES model_folder(id),
     relpath          TEXT NOT NULL,
-    state            TEXT NOT NULL,
+    state            TEXT NOT NULL,   -- 'present' | 'missing' | 'unreachable'
     seen_at          TEXT,
+    -- st_mtime_ns of this copy at the last scan. Paired with model.file_size it
+    -- is what lets a sweep skip re-hashing 1,800 unchanged adapters, without
+    -- the size-only blind spot where a same-size in-place edit leaves
+    -- model.sha256 naming bytes that are no longer there. Per-location, not
+    -- per-model: two copies of one file have two mtimes.
+    file_mtime       INTEGER,
     PRIMARY KEY (model_folder_id, relpath)
 )
 """

--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -264,6 +264,11 @@ _V1_LIBRARY_INDEXES = (
 # says "this library's character uses that adapter" and is keyed by sha256
 # because no foreign key can span the two databases.
 #
+# Two tables carry the shelf: ``model`` is what a file IS (identity, curation,
+# provenance) and ``model_file`` is WHERE a copy of it sits. That split is what
+# makes one file in two folders one row with two locations, and what makes
+# removing a folder a tombstone rather than a deletion.
+#
 # Hand-written DDL against stdlib sqlite3, like everything else here. The hub is
 # deliberately not SQLModel: a SQLModel table would be created inside every
 # vault as well.
@@ -271,7 +276,7 @@ _V1_LIBRARY_INDEXES = (
 
 # AUTOINCREMENT, not a bare INTEGER PRIMARY KEY, for the same reason
 # ``library.id`` uses it: SQLite hands a deleted row's id to the next insert, and
-# a recycled folder id would silently re-point every ``adapter_file`` row at a
+# a recycled folder id would silently re-point every ``model_file`` row at a
 # different folder.
 _V2_MODEL_FOLDER = """
 CREATE TABLE IF NOT EXISTS model_folder (
@@ -287,13 +292,28 @@ CREATE TABLE IF NOT EXISTS model_folder (
 )
 """
 
+# One content table for every ``.safetensors`` on the shelf, adapter or
+# checkpoint (integration plan §3, "File location needs its own row", ruled
+# 2026-08-08: *the same split applies to checkpoint*). Two content tables would
+# mean two location tables, or a location table with a discriminator column, and
+# every consumer branching on which one to read — for rows that differ in three
+# columns.
+#
 # `base_model` is free text on purpose. It comes from whatever the trainer wrote
 # and an enum would reject every model that ships after this release.
-_V2_ADAPTER = """
-CREATE TABLE IF NOT EXISTS adapter (
+_V2_MODEL = """
+CREATE TABLE IF NOT EXISTS model (
     id                    INTEGER PRIMARY KEY AUTOINCREMENT,
-    sha256                TEXT UNIQUE NOT NULL,
-    kind                  TEXT NOT NULL,
+    -- What the file IS, from the header: 'adapter' | 'checkpoint' | 'unknown'
+    -- (pixlstash.utils.adapter_header.FILE_*). Owner-correctable; 'unknown'
+    -- is a first-class value here and is never promoted to checkpoint.
+    file_kind             TEXT NOT NULL,
+    -- Which adapter algorithm. Meaningful only when file_kind = 'adapter'.
+    kind                  TEXT,
+    -- Interop identity (Civitai, {sha256}/file, the ComfyUI node). NULL only
+    -- while a checkpoint waits for MissingCheckpointHashFinder; the CHECK below
+    -- keeps today's NOT NULL guarantee exactly where it was load-bearing.
+    sha256                TEXT UNIQUE,
     display_name          TEXT,
     filename              TEXT,
     base_model            TEXT,
@@ -303,45 +323,38 @@ CREATE TABLE IF NOT EXISTS adapter (
     lineage_id            INTEGER,
     training_step         INTEGER,
     safetensors_metadata  TEXT,
+    param_count           INTEGER,
     file_size             INTEGER,
+    hashed_at             TEXT,
     stack_id              INTEGER REFERENCES adapter_stack(id),
     stack_position        INTEGER,
     run_key               TEXT,
-    created_at            TEXT
+    created_at            TEXT,
+    CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL)
 )
 """
 
-# One adapter, many paths. That is what a duplicate after an interrupted move
-# is, and what the same file copied into two registered folders is.
+# One model, many paths. That is what a duplicate after an interrupted move is,
+# and what the same file copied into two registered folders is — for a 24 GB
+# checkpoint exactly as much as for an adapter.
 #
-# This table is also the tombstone. Removing a folder drops its ``adapter_file``
-# rows and KEEPS the ``adapter`` row with its name, triggers and attachments, so
-# re-adding the folder re-links by sha256 with the user's curation intact. That
-# is what lets folder removal skip a confirmation prompt: nothing a user typed
-# is destroyed by it.
-_V2_ADAPTER_FILE = """
-CREATE TABLE IF NOT EXISTS adapter_file (
-    adapter_sha256   TEXT NOT NULL,
+# This table is also the tombstone. Removing a folder drops its ``model_file``
+# rows and KEEPS the ``model`` row with its name, triggers and attachments, so
+# re-adding the folder re-links with the user's curation intact. That is what
+# lets folder removal skip a confirmation prompt: nothing a user typed is
+# destroyed by it.
+_V2_MODEL_FILE = """
+CREATE TABLE IF NOT EXISTS model_file (
+    -- Integer, not sha256: this link does not cross a database. The precedent
+    -- is model_folder_id on the next line, which is already an integer FK, and
+    -- model.id is AUTOINCREMENT so a deleted id is never reissued. A sha256 key
+    -- could not name a checkpoint at all until something had read 24 GB of it.
+    model_id         INTEGER NOT NULL REFERENCES model(id),
     model_folder_id  INTEGER NOT NULL REFERENCES model_folder(id),
     relpath          TEXT NOT NULL,
     state            TEXT NOT NULL,
     seen_at          TEXT,
     PRIMARY KEY (model_folder_id, relpath)
-)
-"""
-
-# ``sha256`` is nullable here and NOT NULL on ``adapter``: a checkpoint may be
-# many gigabytes and is registered in place long before anything hashes it.
-_V2_CHECKPOINT = """
-CREATE TABLE IF NOT EXISTS checkpoint (
-    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
-    sha256             TEXT UNIQUE,
-    filename           TEXT NOT NULL,
-    local_path         TEXT,
-    base_model_family  TEXT,
-    file_size          INTEGER,
-    hashed_at          TEXT,
-    created_at         TEXT
 )
 """
 
@@ -358,25 +371,32 @@ CREATE TABLE IF NOT EXISTS adapter_stack (
 """
 
 _V2_MODEL_SHELF_INDEXES = (
-    # The scanner's hot path: "which files does this adapter have, and where".
-    "CREATE INDEX IF NOT EXISTS ix_adapter_file_sha ON adapter_file(adapter_sha256)",
+    # The scanner's hot path: "which files does this model have, and where".
+    "CREATE INDEX IF NOT EXISTS ix_model_file_model ON model_file(model_id)",
     # Folder removal and rescan both work folder-at-a-time.
-    "CREATE INDEX IF NOT EXISTS ix_adapter_file_folder "
-    "ON adapter_file(model_folder_id)",
+    "CREATE INDEX IF NOT EXISTS ix_model_file_folder ON model_file(model_folder_id)",
     # Expanding one stack in the shelf, in cover-first order.
-    "CREATE INDEX IF NOT EXISTS ix_adapter_stack_member "
-    "ON adapter(stack_id, stack_position)",
+    "CREATE INDEX IF NOT EXISTS ix_model_stack_member "
+    "ON model(stack_id, stack_position)",
+    # The hash finder's whole query, as a partial index. Mirrors 0095 in the
+    # vault: the queue is a handful of rows in a table of thousands, so a full
+    # index on sha256 would be almost entirely rows the finder never wants.
+    "CREATE INDEX IF NOT EXISTS ix_model_hash_queue ON model(id) WHERE sha256 IS NULL",
 )
 
 _V2_MODEL_SHELF_TABLES = (
-    # adapter_stack first: `adapter.stack_id` references it.
+    # adapter_stack first: `model.stack_id` references it.
     _V2_ADAPTER_STACK,
     _V2_MODEL_FOLDER,
-    _V2_ADAPTER,
-    _V2_ADAPTER_FILE,
-    _V2_CHECKPOINT,
+    _V2_MODEL,
+    _V2_MODEL_FILE,
     *_V2_MODEL_SHELF_INDEXES,
 )
+
+# The pre-reshape shelf shape. ``CREATE TABLE IF NOT EXISTS`` silently skips a
+# *reshape*, so a developer hub opened on an earlier develop would keep the old
+# three tables and gain the new two, with the scanner writing to neither.
+_V2_SUPERSEDED_SHELF_TABLES = ("adapter_file", "adapter", "checkpoint")
 
 
 # Ordered schema steps. Append only: a released version's statement list is
@@ -444,6 +464,32 @@ def _apply_v2(conn: sqlite3.Connection) -> None:
     # before this change has CURRENT_SCHEMA_VERSION = 2, so it would refuse a v3
     # hub with HubSchemaTooNewError and lock that user out of a downgrade.
     # CREATE TABLE IF NOT EXISTS throughout, so re-running is a no-op.
+    #
+    # One-shot drop first, for the same reason: IF NOT EXISTS cannot reshape a
+    # table, so a hub opened on an earlier unreleased develop would keep the
+    # superseded `adapter`/`adapter_file`/`checkpoint` shape alongside the new
+    # `model`/`model_file` one. Dropping rather than migrating is correct only
+    # because nothing has ever written these tables — the scan that fills them
+    # is unmerged, no route or UI reads them, and no released build shipped
+    # them (v1.10.0-dev.1 was tagged 13 hours before they landed). `model_folder`
+    # and `adapter_stack` are NOT dropped: a developer may have registered
+    # folders, and neither table changes shape.
+    existing = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    # `adapter` does not exist after the reshape, so this guard is false on a
+    # fresh hub and false on every subsequent re-run.
+    if "adapter" in existing:
+        logger.info(
+            "Replacing the superseded model-shelf tables %s with model/model_file.",
+            ", ".join(_V2_SUPERSEDED_SHELF_TABLES),
+        )
+        # DROP TABLE takes each table's indexes with it, so the superseded
+        # ix_adapter_* indexes need no separate statement.
+        for table in _V2_SUPERSEDED_SHELF_TABLES:
+            conn.execute(f"DROP TABLE IF EXISTS {table}")
+
     for statement in _V2_MODEL_SHELF_TABLES:
         conn.execute(statement)
 

--- a/tests/test_hub_model_shelf_schema.py
+++ b/tests/test_hub_model_shelf_schema.py
@@ -5,9 +5,16 @@ about the machine: a folder of LoRAs is on this disk. Re-registering the same
 folder in every library would be absurd. The only vault-side table is
 ``adapter_attachment``, which is a different change.
 
-The rule under test throughout: **applying the schema twice is a no-op, and a
-hub that already exists picks the tables up on its next open.** That is what
-lets these land by amending v2 instead of inventing a v3.
+Two rules under test throughout:
+
+1. **Applying the schema twice is a no-op, and a hub that already exists picks
+   the tables up on its next open.** That is what lets these land by amending v2
+   instead of inventing a v3.
+2. **``model`` is what a file is; ``model_file`` is where a copy of it sits.**
+   One content table and one location table, for adapters and checkpoints
+   alike (integration plan §3). A checkpoint therefore tombstones exactly the
+   way an adapter does, which the superseded inline ``checkpoint.local_path``
+   could not do.
 """
 
 import sqlite3
@@ -22,11 +29,14 @@ from pixlstash.hub.schema import (
 
 SHELF_TABLES = (
     "model_folder",
-    "adapter",
-    "adapter_file",
-    "checkpoint",
+    "model",
+    "model_file",
     "adapter_stack",
 )
+
+# The shape this replaced. Nothing ever wrote them (the scan is unmerged and no
+# released build shipped them), so `_apply_v2` drops rather than migrates.
+SUPERSEDED_TABLES = ("adapter", "adapter_file", "checkpoint")
 
 
 @pytest.fixture
@@ -55,10 +65,46 @@ def ddl_for(conn, name):
     return row[0] if row else None
 
 
+def add_model(conn, *, file_kind="adapter", sha256="h", **columns):
+    """Insert one content row and return its id."""
+    columns = {
+        "file_kind": file_kind,
+        "sha256": sha256,
+        "provenance": "external",
+        **columns,
+    }
+    placeholders = ", ".join("?" for _ in columns)
+    cursor = conn.execute(
+        f"INSERT INTO model ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(columns.values()),
+    )
+    return int(cursor.lastrowid)
+
+
+def add_folder(conn, path):
+    cursor = conn.execute(
+        "INSERT INTO model_folder (path, kind, movable) VALUES (?, 'user', 'per_item')",
+        (path,),
+    )
+    return int(cursor.lastrowid)
+
+
+def add_file(conn, model_id, folder_id, relpath, state="present"):
+    conn.execute(
+        "INSERT INTO model_file (model_id, model_folder_id, relpath, state) "
+        "VALUES (?, ?, ?, ?)",
+        (model_id, folder_id, relpath, state),
+    )
+
+
 class TestFreshHub:
     def test_every_shelf_table_is_created(self, hub):
         apply_migrations(hub)
-        assert SHELF_TABLES == tuple(t for t in SHELF_TABLES if t in table_names(hub))
+        assert set(SHELF_TABLES) <= table_names(hub)
+
+    def test_the_superseded_tables_are_gone(self, hub):
+        apply_migrations(hub)
+        assert not (set(SUPERSEDED_TABLES) & table_names(hub))
 
     def test_the_hub_stays_on_version_two(self, hub):
         # The whole point of amending v2: a build that predates this change has
@@ -68,17 +114,15 @@ class TestFreshHub:
         assert read_schema_version(hub) == 2
         assert CURRENT_SCHEMA_VERSION == 2
 
-    @pytest.mark.parametrize(
-        "table", ("model_folder", "adapter", "checkpoint", "adapter_stack")
-    )
+    @pytest.mark.parametrize("table", ("model_folder", "model", "adapter_stack"))
     def test_ids_never_recycle(self, hub, table):
         # AUTOINCREMENT, per the library.id precedent. Without it SQLite hands a
-        # deleted row's id to the next insert, and a recycled folder id would
-        # silently re-point every adapter_file row at a different folder.
+        # deleted row's id to the next insert, and a recycled id would silently
+        # re-point every model_file row at a different folder or model.
         apply_migrations(hub)
         assert "AUTOINCREMENT" in ddl_for(hub, table)
 
-    def test_the_scan_and_stack_indexes_exist(self, hub):
+    def test_the_scan_stack_and_hash_queue_indexes_exist(self, hub):
         apply_migrations(hub)
         indexes = {
             row[0]
@@ -87,10 +131,20 @@ class TestFreshHub:
             ).fetchall()
         }
         assert {
-            "ix_adapter_file_sha",
-            "ix_adapter_file_folder",
-            "ix_adapter_stack_member",
+            "ix_model_file_model",
+            "ix_model_file_folder",
+            "ix_model_stack_member",
+            "ix_model_hash_queue",
         } <= indexes
+
+    def test_the_hash_queue_index_is_partial(self, hub):
+        # A full index on sha256 would be almost entirely rows the finder never
+        # wants: the queue is a handful of rows in a table of thousands.
+        apply_migrations(hub)
+        sql = hub.execute(
+            "SELECT sql FROM sqlite_master WHERE name='ix_model_hash_queue'"
+        ).fetchone()[0]
+        assert "WHERE sha256 IS NULL" in sql
 
 
 class TestReRunIsSafe:
@@ -114,7 +168,7 @@ class TestReRunIsSafe:
         apply_migrations is for.
         """
         apply_migrations(hub)
-        for table in SHELF_TABLES:
+        for table in ("model_file", "model", "model_folder", "adapter_stack"):
             hub.execute(f"DROP TABLE {table}")
         assert read_schema_version(hub) == 2  # still v2, nothing to upgrade
         assert not (set(SHELF_TABLES) & table_names(hub))
@@ -134,38 +188,80 @@ class TestReRunIsSafe:
             ("/models/loras",)
         ]
 
+    def test_a_pre_reshape_hub_is_reshaped_on_its_next_open(self, hub):
+        """A developer hub opened on an earlier develop still gets the new shape.
+
+        ``CREATE TABLE IF NOT EXISTS`` cannot reshape a table, so without the
+        drop guard such a hub would keep the superseded three tables and gain
+        the new two, with the scan writing to neither.
+        """
+        apply_migrations(hub)
+        hub.execute("DROP TABLE model_file")
+        hub.execute("DROP TABLE model")
+        hub.execute("CREATE TABLE adapter (sha256 TEXT)")
+        hub.execute("CREATE TABLE adapter_file (relpath TEXT)")
+        hub.execute("CREATE TABLE checkpoint (local_path TEXT)")
+        hub.commit()
+
+        apply_migrations(hub)
+
+        assert not (set(SUPERSEDED_TABLES) & table_names(hub))
+        assert {"model", "model_file"} <= table_names(hub)
+
+    def test_the_drop_guard_is_idempotent_and_loses_nothing_after_the_first_open(
+        self, hub
+    ):
+        """Three consecutive opens; only the first may drop anything.
+
+        The guard keys on ``adapter``, which does not exist after the reshape,
+        so it must be false on a fresh hub and false on every re-run. If it
+        ever fired again it would take a populated ``model``/``model_file`` pair
+        with it — the guard drops tables, and a drop cannot be undone.
+        """
+        apply_migrations(hub)
+        folder_id = add_folder(hub, "/models")
+        model_id = add_model(hub, display_name="Clementine v3")
+        add_file(hub, model_id, folder_id, "clem.safetensors")
+        hub.commit()
+
+        for _ in range(2):
+            apply_migrations(hub)
+            assert hub.execute("SELECT display_name FROM model").fetchone() == (
+                "Clementine v3",
+            )
+            assert hub.execute("SELECT COUNT(*) FROM model_file").fetchone()[0] == 1
+            assert hub.execute("SELECT COUNT(*) FROM model_folder").fetchone()[0] == 1
+
 
 class TestConstraints:
-    def test_an_adapter_is_identified_by_its_hash(self, hub):
+    def test_a_model_is_identified_by_its_hash(self, hub):
         apply_migrations(hub)
-        for _ in range(1):
-            hub.execute(
-                "INSERT INTO adapter (sha256, kind, provenance) VALUES (?, ?, ?)",
-                ("abc", "lora", "external"),
-            )
+        add_model(hub, sha256="abc")
         with pytest.raises(sqlite3.IntegrityError):
-            hub.execute(
-                "INSERT INTO adapter (sha256, kind, provenance) VALUES (?, ?, ?)",
-                ("abc", "lora", "trained"),
-            )
+            add_model(hub, sha256="abc", provenance="trained")
+
+    def test_an_adapter_may_not_be_stored_without_a_hash(self, hub):
+        # The CHECK keeps `adapter`'s old NOT NULL exactly where it was
+        # load-bearing: an adapter is hashed on sight, and its sha256 is the
+        # interop identity Civitai lookup and `{sha256}/file` both resolve on.
+        apply_migrations(hub)
+        with pytest.raises(sqlite3.IntegrityError):
+            add_model(hub, file_kind="adapter", sha256=None)
 
     def test_a_checkpoint_may_be_registered_before_it_is_hashed(self, hub):
-        # Deliberately different from `adapter`: a checkpoint can be many
+        # Deliberately different from an adapter: a checkpoint can be many
         # gigabytes and is registered in place long before anything hashes it.
         apply_migrations(hub)
-        hub.execute(
-            "INSERT INTO checkpoint (filename, local_path) VALUES (?, ?)",
-            ("flux1-dev.safetensors", "/models/flux1-dev.safetensors"),
-        )
-        assert hub.execute("SELECT sha256 FROM checkpoint").fetchone() == (None,)
+        add_model(hub, file_kind="checkpoint", sha256=None, filename="flux1-dev")
+        assert hub.execute("SELECT sha256 FROM model").fetchone() == (None,)
 
     def test_two_unhashed_checkpoints_do_not_collide(self, hub):
         # SQLite treats NULLs as distinct under UNIQUE, which is what allows a
         # whole folder to be registered before any of it is hashed.
         apply_migrations(hub)
         for name in ("a.safetensors", "b.safetensors"):
-            hub.execute("INSERT INTO checkpoint (filename) VALUES (?)", (name,))
-        assert hub.execute("SELECT COUNT(*) FROM checkpoint").fetchone()[0] == 2
+            add_model(hub, file_kind="checkpoint", sha256=None, filename=name)
+        assert hub.execute("SELECT COUNT(*) FROM model").fetchone()[0] == 2
 
     def test_one_path_per_folder_is_recorded_once(self, hub):
         apply_migrations(hub)
@@ -180,56 +276,95 @@ class TestConstraints:
             )
 
     def test_the_same_file_may_sit_in_two_folders(self, hub):
-        # One adapter, many paths. That is what a copy into a second registered
+        # One model, many paths. That is what a copy into a second registered
         # folder is, and what a duplicate after an interrupted move is.
         apply_migrations(hub)
-        hub.execute(
-            "INSERT INTO adapter (sha256, kind, provenance) VALUES ('h', 'lora', 'external')"
-        )
+        model_id = add_model(hub)
         for path in ("/a", "/b"):
-            hub.execute(
-                "INSERT INTO model_folder (path, kind, movable) VALUES (?, 'user', 'per_item')",
-                (path,),
-            )
-        for folder_id in (1, 2):
-            hub.execute(
-                "INSERT INTO adapter_file "
-                "(adapter_sha256, model_folder_id, relpath, state) "
-                "VALUES ('h', ?, 'x.safetensors', 'present')",
-                (folder_id,),
-            )
-        assert hub.execute("SELECT COUNT(*) FROM adapter_file").fetchone()[0] == 2
+            add_file(hub, model_id, add_folder(hub, path), "x.safetensors")
+        assert hub.execute("SELECT COUNT(*) FROM model_file").fetchone()[0] == 2
+
+    def test_a_location_cannot_name_a_model_that_does_not_exist(self, hub):
+        # The FK is what keeps `model_file` from outliving its content row.
+        apply_migrations(hub)
+        folder_id = add_folder(hub, "/models")
+        with pytest.raises(sqlite3.IntegrityError):
+            add_file(hub, 9999, folder_id, "ghost.safetensors")
+
+
+class TestUnknownIsFirstClass:
+    """``unknown`` is shown, never promoted, and correctable in one statement."""
+
+    def test_an_unknown_file_stores_as_unknown_and_is_not_an_adapter(self, hub):
+        apply_migrations(hub)
+        add_model(hub, file_kind="unknown", sha256="u", kind=None)
+        add_model(hub, file_kind="adapter", sha256="a", kind="lora")
+
+        assert hub.execute(
+            "SELECT file_kind FROM model WHERE sha256 = 'u'"
+        ).fetchone() == ("unknown",)
+        adapters = hub.execute(
+            "SELECT sha256 FROM model WHERE file_kind = 'adapter'"
+        ).fetchall()
+        assert adapters == [("a",)]
+
+    def test_correcting_an_unknown_to_checkpoint_keeps_its_locations(self, hub):
+        # The correction is the point of storing `unknown` rather than guessing.
+        # Under the superseded shape it was a cross-table move; here it is one
+        # UPDATE and the location rows never move.
+        apply_migrations(hub)
+        model_id = add_model(hub, file_kind="unknown", sha256="u", kind=None)
+        add_file(hub, model_id, add_folder(hub, "/a"), "vae.safetensors")
+        add_file(hub, model_id, add_folder(hub, "/b"), "vae.safetensors")
+        hub.commit()
+
+        hub.execute(
+            "UPDATE model SET file_kind = 'checkpoint' WHERE id = ?", (model_id,)
+        )
+
+        assert hub.execute("SELECT file_kind FROM model").fetchall() == [
+            ("checkpoint",)
+        ]
+        assert hub.execute(
+            "SELECT COUNT(*) FROM model_file WHERE model_id = ?", (model_id,)
+        ).fetchone() == (2,)
 
 
 class TestTombstone:
-    def test_dropping_a_folders_files_keeps_the_adapter_and_its_curation(self, hub):
-        """Why folder removal needs no confirmation prompt.
+    """Why folder removal needs no confirmation prompt.
 
-        Removing a folder drops ``adapter_file`` rows and keeps the ``adapter``
-        row, so the display name the user typed survives and re-adding the
-        folder re-links by sha256. Nothing a user authored is destroyed, which
-        is the whole basis for not interrupting them with a dialog.
-        """
+    Removing a folder drops ``model_file`` rows and keeps the ``model`` row, so
+    the display name the user typed survives and re-adding the folder re-links.
+    Nothing a user authored is destroyed, which is the whole basis for not
+    interrupting them with a dialog.
+    """
+
+    @pytest.mark.parametrize(
+        "file_kind, sha256",
+        (
+            ("adapter", "h"),
+            # The case the superseded shape could not do at all: a checkpoint
+            # carried its path inline, so removing the folder either destroyed
+            # the row or left it pointing at a folder that was gone.
+            ("checkpoint", None),
+        ),
+    )
+    def test_dropping_a_folders_files_keeps_the_model_and_its_curation(
+        self, hub, file_kind, sha256
+    ):
         apply_migrations(hub)
-        hub.execute(
-            "INSERT INTO adapter (sha256, kind, provenance, display_name) "
-            "VALUES ('h', 'lora', 'external', 'Clementine v3')"
+        model_id = add_model(
+            hub, file_kind=file_kind, sha256=sha256, display_name="Clementine v3"
         )
-        hub.execute(
-            "INSERT INTO model_folder (path, kind, movable) "
-            "VALUES ('/models', 'user', 'per_item')"
-        )
-        hub.execute(
-            "INSERT INTO adapter_file "
-            "(adapter_sha256, model_folder_id, relpath, state) "
-            "VALUES ('h', 1, 'clem.safetensors', 'present')"
-        )
+        folder_id = add_folder(hub, "/models")
+        add_file(hub, model_id, folder_id, "clem.safetensors")
         hub.commit()
 
-        hub.execute("DELETE FROM adapter_file WHERE model_folder_id = 1")
-        hub.execute("DELETE FROM model_folder WHERE id = 1")
+        hub.execute("DELETE FROM model_file WHERE model_folder_id = ?", (folder_id,))
+        hub.execute("DELETE FROM model_folder WHERE id = ?", (folder_id,))
         hub.commit()
 
-        assert hub.execute("SELECT display_name FROM adapter").fetchone() == (
+        assert hub.execute("SELECT display_name FROM model").fetchone() == (
             "Clementine v3",
         )
+        assert hub.execute("SELECT COUNT(*) FROM model_file").fetchone()[0] == 0


### PR DESCRIPTION
B2 shipped `adapter` + `adapter_file` + `checkpoint`, where `adapter` got a location table with state and a tombstone and `checkpoint` got an inline `local_path` with no folder reference, no state and no tombstone.

The integration plan §3 ("File location needs its own row", ruled 2026-08-08) already says *"The same split applies to `checkpoint`"*. This implements it: one content table `model` (what a file IS) and one location table `model_file` (where a copy sits), for adapters and checkpoints alike.

## This is a free in-place edit of `_apply_v2`, not a new migration step

`v1.10.0-dev.1` was tagged 2026-08-08 09:32; the shelf tables landed at 22:22 the same day.

```
$ git show v1.10.0-dev.1:pixlstash/hub/schema.py | grep -c "CREATE TABLE IF NOT EXISTS adapter"
0
```

**No released build has put these tables on any user's disk.** Nothing on develop writes them (the scan, #794, is unmerged) and no route or UI reads them, so `_apply_v2` drops the superseded three rather than migrating them. `model_folder` and `adapter_stack` are NOT dropped: a developer may have registered folders, and neither changes shape.

The drop is one-shot and self-idempotent. `CREATE TABLE IF NOT EXISTS` silently skips a *reshape*, so a hub opened on an earlier develop would otherwise keep the old three tables and gain the new two, with the scan writing to neither. The guard keys on `adapter`, which does not exist after the reshape, so it is false on a fresh hub and false on every re-run.

## What the shape buys

- **A checkpoint tombstones the way an adapter does.** Removing a folder drops location rows and keeps curation. The inline `local_path` could not do that.
- **A checkpoint at two paths is two `model_file` rows**, not two content rows racing for one `sha256 UNIQUE`. That is what closes the re-hash-forever loop #795's merge otherwise has (24 GB per cycle).
- **The record-type discriminator disappears.** `("adapter"|"adapter_seen"|"checkpoint")` in the scanner existed only because there were two tables.
- **`file_kind` carries what the file is** (`adapter`/`checkpoint`/`unknown`), owner-correctable, `unknown` first-class and never promoted. Correcting one is a single `UPDATE` with its locations intact, not a cross-table move.
- `CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL)` keeps `adapter.sha256 NOT NULL` exactly where it was load-bearing, while letting a checkpoint register unhashed.
- `ix_model_hash_queue ON model(id) WHERE sha256 IS NULL` is the hash finder's whole query as a partial index, mirroring 0095 in the vault.

## Tests

`tests/test_hub_model_shelf_schema.py` rewritten for the new shape. Every behaviour the old suite covered is kept (table list, id recycling, index presence, double-apply, existing-hub upgrade, unhashed rows not colliding, one path per folder, same file in two folders, the tombstone), plus:

- the CHECK rejects an adapter with no hash and accepts a checkpoint with none;
- a pre-reshape hub is reshaped on its next open;
- the drop guard is idempotent across three consecutive opens and loses nothing;
- a checkpoint tombstones exactly the way an adapter does (parametrised with the adapter case);
- `file_kind='unknown'` stores as unknown, is excluded from an adapter-filtered query, and is correctable to checkpoint by one `UPDATE` with its `model_file` rows intact;
- the `model_id` FK rejects a location naming a model that does not exist.

24 passed. Mutation-tested: removing the CHECK, disabling the drop guard, widening the drop list to a surviving table, dropping the FK, and making the hash-queue index non-partial each fail the suite.