### PR TITLE
Drop the build and build-windows aggregator jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,8 +456,8 @@ jobs:
   #    build's critical path.
   #
   # N=6. Two reasons, and the second is the binding one. (1) Concurrency: the
-  # rest of this workflow queues 14 jobs (checks 1 + backend 8 + e2e 1 +
-  # backend_windows 2 + the two aggregators) against the Team plan's
+  # rest of this workflow queues 12 jobs (checks 1 + backend 8 + e2e 1 +
+  # backend_windows 2) against the Team plan's
   # 60-concurrent-job budget, so 6 fits without the sweep queueing behind the
   # gate it is supposed to run alongside — and unlike the gate it runs only
   # during release prep, when there is rarely a queue of feature-branch runs
@@ -469,8 +469,8 @@ jobs:
   # TIME — that imbalance is the price of preserving order.
   #
   # The per-shard check name is NOT stable across a resize, by design: this job
-  # is informational and must never be a required check. Branch protection
-  # requires `build` (below), which aggregates it.
+  # is informational and must never be a required check. Nothing is a required
+  # check in this repo — see the removal note above `e2e`.
   #
   # The old "1.7.0 headline API surface" step is gone: its five files
   # (test_tag_health_api, test_reviews_api, test_tag_predictions_api,
@@ -505,72 +505,22 @@ jobs:
           tests/
 
   # ---------------------------------------------------------------------------
-  # Aggregate status for the Linux side. Exists so branch protection can require
-  # one stable check name instead of a per-shard list that would have to be
-  # re-configured every time the matrix is resized.
+  # REMOVED 2026-08-09 (#796): the `build` and `build-windows` aggregator jobs.
+  # They existed only to give branch protection one stable check name per OS,
+  # and there is no branch protection to serve: `develop` has none, `main` is
+  # protected with no required_status_checks at all, and merges are a human
+  # judgement call by design. `build` also cost real tail latency — it needed
+  # every Linux job, so it queued for its own runner after the gate finished
+  # (up to ~16 min for a 3-second job).
+  #
+  # They carried one property beyond aggregation (CSO condition F2): `skipped`
+  # counted as a FAILURE for `checks`/`backend`, so a `paths:`/`if:` filter
+  # could not leave a green required check that ran zero tests (`skipped` was a
+  # pass only for `backend_release_sweep`, which is skipped outside release
+  # prep by design). That is moot while nothing is required. Anything that
+  # reintroduces a required status check, or adds a `paths:`/`if:` filter to
+  # the gate, MUST restore the skipped-is-failure guard with it.
   # ---------------------------------------------------------------------------
-  build:
-    name: build
-    if: always()
-    needs: [checks, backend, backend_release_sweep, e2e]
-    runs-on: ubuntu-latest
-    steps:
-      # Each dependency is checked against what IT is allowed to report, not
-      # against a shared allowlist. `skipped` is a pass only for
-      # backend_release_sweep, which is skipped outside release prep by design.
-      # For checks/backend, `skipped` must fail: if someone later adds a
-      # `paths:` or `if:` filter to the gate, this check would otherwise go
-      # green having run zero tests — a required check that passes by not
-      # running is worse than no required check at all. (CSO condition F2.)
-      #
-      # `backend` and `backend_release_sweep` are both matrices, and
-      # `needs.<job>.result` collapses a matrix into ONE value: `skipped` only
-      # if every leg was skipped, `failure` if ANY leg failed, `cancelled` if
-      # any was cancelled and none failed, `success` otherwise. So the checks
-      # below already cover partial failure, and they keep working when a
-      # matrix is resized — which is the whole point of aggregating here
-      # instead of listing per-shard check names in branch protection.
-      #
-      # A `failure` from the sweep is still fatal here even though the sweep is
-      # "informational": its pytest step carries `continue-on-error`, so a
-      # failing TEST cannot produce one. A failing JOB therefore means
-      # checkout/setup died and the ordering control did not run at all, which
-      # during release prep is exactly what must not pass silently.
-      - name: Require the blocking backend jobs to have succeeded
-        env:
-          CHECKS_RESULT: ${{ needs.checks.result }}
-          BACKEND_RESULT: ${{ needs.backend.result }}
-          SWEEP_RESULT: ${{ needs.backend_release_sweep.result }}
-          E2E_RESULT: ${{ needs.e2e.result }}
-        run: |
-          set -euo pipefail
-          echo "checks=$CHECKS_RESULT backend=$BACKEND_RESULT sweep=$SWEEP_RESULT e2e=$E2E_RESULT"
-
-          failed=0
-          for job in checks backend e2e; do
-            case "$job" in
-              checks) result="$CHECKS_RESULT" ;;
-              backend) result="$BACKEND_RESULT" ;;
-              e2e) result="$E2E_RESULT" ;;
-            esac
-            if [ "$result" != "success" ]; then
-              echo "::error::Blocking job '$job' reported '$result' (must be 'success')."
-              failed=1
-            fi
-          done
-
-          case "$SWEEP_RESULT" in
-            success|skipped) ;;
-            *)
-              echo "::error::backend_release_sweep reported '$SWEEP_RESULT'."
-              failed=1
-              ;;
-          esac
-
-          if [ "$failed" -ne 0 ]; then
-            exit 1
-          fi
-          echo "All required backend jobs passed."
 
   e2e:
     # Playwright UI tests drive the real SPA against a backend booted on a
@@ -758,26 +708,5 @@ jobs:
           tests/test_watch_folder_worker.py
           tests/test_work_planner.py
 
-  # Aggregate status for Windows, for the same branch-protection reason as
-  # `build`.
-  build-windows:
-    name: build-windows
-    if: always()
-    needs: [backend_windows]
-    runs-on: ubuntu-latest
-    steps:
-      # `success` only — `skipped` must fail here for the same reason as in
-      # `build`: this is a blocking gate, so a filter that stopped the shards
-      # from running must not leave a green required check behind. (CSO
-      # condition F2.)
-      - name: Require every Windows shard to have succeeded
-        env:
-          RESULT: ${{ needs.backend_windows.result }}
-        run: |
-          set -euo pipefail
-          echo "backend-windows result: $RESULT"
-          if [ "$RESULT" != "success" ]; then
-            echo "::error::backend-windows reported '$RESULT' (must be 'success')."
-            exit 1
-          fi
-          echo "Windows shards passed."
+  # The `build-windows` aggregator over this job was removed with `build` in
+  # #796 — see the note where `build` used to be, above `e2e`.

--- a/tests/test_ci_shards.py
+++ b/tests/test_ci_shards.py
@@ -576,17 +576,15 @@ def test_release_critical_suites_cannot_remain_informational(workflow):
     )
 
 
-def test_stable_aggregate_requires_playwright_and_fixture_fails_closed(workflow):
-    """The stable check cannot pass when Playwright did not prove the RC UI."""
-    aggregate = workflow["jobs"]["build"]
-    needs = aggregate.get("needs", [])
-    assert "e2e" in needs, "The stable `build` aggregate must require e2e"
-    aggregate_steps = "\n".join(
-        step.get("run", "") for step in aggregate.get("steps", [])
-    )
-    assert "E2E_RESULT" in aggregate_steps
-    assert "e2e)" in aggregate_steps
+def test_e2e_fixture_check_fails_closed(workflow):
+    """The e2e job cannot go green by skipping Playwright.
 
+    The `build` aggregate that used to carry the other half of this test (that
+    the stable check required e2e at all) was removed in #796: there is no
+    branch protection consuming it, so there is no stable check to require.
+    What still matters is that this job reports red rather than green when the
+    committed fixture is missing.
+    """
     e2e = workflow["jobs"]["e2e"]
     fixture_steps = [
         step for step in e2e.get("steps", []) if step.get("id") == "fixture"


### PR DESCRIPTION
Closes #796. Stacked on #802 (`ci/reshard-gate-to-8`), which rewrites large parts of the same file.

Both jobs existed for exactly one reason, stated in their own comments: give branch protection one stable check name per OS instead of a per-shard list that would need reconfiguring on every matrix resize.

**There is no branch protection to serve.** Verified against live repo config: `develop` has none at all (404 on the protection endpoint), `main` is protected but carries no `required_status_checks` key whatsoever, and the only ruleset in the repo is a disabled Copilot-review rule. Merges here are a human judgement call by design, so the aggregators aggregate for nobody.

`build` is also a measured cost. It `needs` every Linux job, so it starts only after the whole gate finishes and then queues for its own runner. Wait after the last dependency across eight recent runs: 2s, 2s, 2s, 9s, 112s, 196s, 291s, **946s** — up to ~16 min of pure tail latency for a 3-second job.

`build-windows` (needs only `backend_windows`) is **not** on the critical path — it completes while the Linux shards are still running, so removing it saves no wall clock. It goes because its reason for existing is the same dead one.

## What is being given up

Beyond aggregation, `build` treated `skipped` as a **failure** for `checks` and `backend` (CSO condition F2), so a later `paths:`/`if:` filter on the gate could not leave a green required check that had run zero tests. It also encoded that `skipped` is legitimate for `backend_release_sweep`, which is skipped outside release prep by design.

That property is moot only because nothing is required. A tombstone comment where `build` was records what the jobs did, why they went, and that **anything reintroducing a required status check or a `paths:`/`if:` filter on the gate must restore the skipped-is-failure guard**.

## Consumer check

Grepped `build-windows`, `needs:` entries and job-name references across all of `.github/workflows/`, `tests/`, `docs/`, and `.github/copilot-instructions.md`:

- No other workflow gates on either job. No `workflow_run` triggers, no cross-workflow `needs`. The `needs: build` in `publish-pypi.yml` refers to that workflow's own `build` job.
- No doc references them. `test_architecture_guardrails.py` does not parse `ci.yml` at all.
- **One real consumer:** `tests/test_ci_shards.py::test_stable_aggregate_requires_playwright_and_fixture_fails_closed` read `workflow["jobs"]["build"]`. It asserted two things: that the aggregate required `e2e`, and that the `e2e` fixture check fails closed. The first has no aggregate left to assert against; the second is still live coverage. Narrowed to `test_e2e_fixture_check_fails_closed`, keeping the fixture assertions.

Also corrected two comments the removal falsified: the sweep header's job-count arithmetic (14 -> 12) and its claim that branch protection requires `build`.

## Verification

- `.venv/bin/python -m pytest -q --fast-captions --force-cpu tests/test_ci_shards.py tests/test_architecture_guardrails.py` — **168 passed, exit 0**.
- `ci.yml` parses; remaining jobs are `backend`, `backend_release_sweep`, `backend_windows`, `checks`, `e2e`.
- CSO pre-push review: **PASS, no blocking finding.** Confirmed no release/publish workflow consumes either conclusion, no job carries an `if:`/`paths:` filter that could skip silently, and no permissions/secrets change (both deleted jobs had no checkout, no env, no secrets).