### PR TITLE
Exclude the WorkPlanner's probes from the switch-time vault assertion

### DIFF
--- a/tests/test_authz_library_pin.py
+++ b/tests/test_authz_library_pin.py
@@ -332,9 +332,19 @@ class TestLibraryIndependentRoutes:
         vault_reads = []
         real_read = server.vault.db.run_immediate_read_task
 
-        def observed_read(*args, **kwargs):
-            vault_reads.append(True)
-            return real_read(*args, **kwargs)
+        # Record WHAT was read, for the reason spelled out in
+        # TestPinnedRoutes.test_guest_enrichment_never_runs_for_a_pinned_route:
+        # the WorkPlanner thread probes the vault on its own schedule, so a
+        # bare "nothing was read" assertion fails whenever one of those probes
+        # lands inside the request.
+        def observed_read(callback, *args, **kwargs):
+            vault_reads.append(
+                (
+                    getattr(callback, "__module__", ""),
+                    getattr(callback, "__name__", repr(callback)),
+                )
+            )
+            return real_read(callback, *args, **kwargs)
 
         monkeypatch.setattr(server.vault.db, "run_immediate_read_task", observed_read)
         server.library_coordinator.state = SwitchState.SWITCHING
@@ -348,7 +358,12 @@ class TestLibraryIndependentRoutes:
             server.library_coordinator.state = SwitchState.READY
 
         assert response.status_code == 403
-        assert vault_reads == []
+        # Enrichment lives in ``pixlstash.auth``; the background probes come
+        # from ``pixlstash.tasks`` and are none of this test's business.
+        auth_reads = [read for read in vault_reads if read[0] == "pixlstash.auth"]
+        assert auth_reads == [], (
+            f"authentication read the guest vault during a switch: {vault_reads}"
+        )
 
 
 class TestTheDeclarationContract:


### PR DESCRIPTION
`TestLibraryIndependentRoutes::test_hub_only_auth_during_switch_never_enriches_from_guest_vault` fails intermittently on slow runners:

```
assert vault_reads == []
E  Left contains 15 more items, first extra item: True
```

All 574 other tests in the shard passed; the request returned its expected 403. The 15 reads are the WorkPlanner probing the vault on its own thread, which has nothing to do with the request.

This is a known failure mode that was diagnosed and fixed once already. 948fa47a: *"The WorkPlanner probes the vault on its own thread, so asserting that nothing was read fails on any machine slow enough to catch one."* 8a6ecedb then fixed `TestPinnedRoutes` by recording `(module, name)` and filtering to `pixlstash.auth`, with a comment claiming it "cannot go timing-dependent again".

That fix was never applied to this sibling in `TestLibraryIndependentRoutes`, which still appended a bare `True` and asserted the list was empty. This mirrors the sibling exactly: background probes come from `pixlstash.tasks` and are excluded; `_lookup_by_token` is defined in `pixlstash/auth.py`, so a regressed pin still trips the assertion.

Surfaced on #797, whose only file (`tests/test_picture_sets_query_cost.py`) is not in the failing shard's list.

**Verification:** `test_authz_library_pin.py` + `test_authz_gate_step4.py`, 36 passed. Not verified empirically: I could not drive the failing direction (a guest lookup during a switch needs a granted lease, which is the thing the pin withholds), so the non-vacuity argument here is by construction and by parity with the sibling, not by a demonstrated red test.