### PR TITLE
Filter the switch-time vault observer to auth reads

### DIFF
--- a/tests/test_authz_library_pin.py
+++ b/tests/test_authz_library_pin.py
@@ -332,9 +332,21 @@ class TestLibraryIndependentRoutes:
         vault_reads = []
         real_read = server.vault.db.run_immediate_read_task
 
-        def observed_read(*args, **kwargs):
-            vault_reads.append(True)
-            return real_read(*args, **kwargs)
+        # Record WHO read, not merely that something did: the WorkPlanner
+        # probes the vault from its own thread every few seconds, and a bare
+        # "nothing was read" assertion fails on any machine slow enough for one
+        # to land inside this request (issue #807). Those probes come from
+        # ``pixlstash.tasks``; the guest-session enrichment this test forbids is
+        # ``_lookup_by_token``, defined in ``pixlstash.auth``, so filtering by
+        # module keeps the claim live while dropping the unrelated traffic.
+        def observed_read(callback, *args, **kwargs):
+            vault_reads.append(
+                (
+                    getattr(callback, "__module__", ""),
+                    getattr(callback, "__name__", repr(callback)),
+                )
+            )
+            return real_read(callback, *args, **kwargs)
 
         monkeypatch.setattr(server.vault.db, "run_immediate_read_task", observed_read)
         server.library_coordinator.state = SwitchState.SWITCHING
@@ -348,7 +360,10 @@ class TestLibraryIndependentRoutes:
             server.library_coordinator.state = SwitchState.READY
 
         assert response.status_code == 403
-        assert vault_reads == []
+        auth_reads = [read for read in vault_reads if read[0] == "pixlstash.auth"]
+        assert auth_reads == [], (
+            f"hub-only auth enriched from the guest vault mid-switch: {vault_reads}"
+        )
 
 
 class TestTheDeclarationContract:


### PR DESCRIPTION
Refs #807.

`TestLibraryIndependentRoutes::test_hub_only_auth_during_switch_never_enriches_from_guest_vault`
wrapped `server.vault.db.run_immediate_read_task`, appended a bare `True` per
observed read, and asserted the list was empty. The WorkPlanner probes the vault
from its own thread, so on a slow enough runner one of its probes lands inside
the request and the test fails with `assert [True, True, ...] == []` — as it did
in run 31300985317, backend shard 2/8, where the request itself returned its
expected 403 and the other 291 tests in the shard passed.

Same fix the sibling `TestPinnedRoutes` test already got in 8a6ecedb: record
`(__module__, __name__)` per read and assert on the `pixlstash.auth` ones. The
background probes come from `pixlstash.tasks` and drop out; the guest-session
enrichment this test forbids is `_lookup_by_token`, defined in
`pixlstash/auth.py`, so it does not.

## The non-vacuity gate

#807 called this out explicitly: filtering to `pixlstash.auth` is worthless if
the list is now *always* empty. It is not. Mutating `pixlstash/auth.py` so the
guest lookup falls back to `self.vault_db` when the middleware granted no lease
— i.e. exactly the regression the test's name forbids:

```python
if (
    (lease is not None or self.vault_db is not None)
    and raw_gs
    and re.fullmatch(r"[A-Za-z0-9_\-]{1,64}", raw_gs)
):
    ...
    _db = lease.db if lease is not None else self.vault_db
    gs = _db.run_immediate_read_task(_lookup_by_token)
```

**RED** with the mutation applied:

```
        assert response.status_code == 403
        auth_reads = [read for read in vault_reads if read[0] == "pixlstash.auth"]
>       assert auth_reads == [], (
            f"hub-only auth enriched from the guest vault mid-switch: {vault_reads}"
        )
E       AssertionError: hub-only auth enriched from the guest vault mid-switch: [('pixlstash.auth', '_lookup_by_token')]
E       assert [('pixlstash....up_by_token')] == []
E         Left contains one more item: ('pixlstash.auth', '_lookup_by_token')

tests/test_authz_library_pin.py:364: AssertionError
1 failed, 1 warning in 2.18s
EXIT=1
```

The assertion caught the exact call it exists to catch, not some incidental
read. Mutation reverted (`git checkout -- pixlstash/auth.py`; the diff on this
branch is the test file only), **GREEN**:

```
$ .venv/bin/python -m pytest -q --fast-captions --force-cpu \
      tests/test_authz_library_pin.py tests/test_authz_gate_step4.py
36 passed, 10 warnings in 69.38s
EXIT=0
```

## Flake re-runs

- `tests/test_authz_library_pin.py` three times: `15 passed` each, exit 0.
- `--ci-shard 2/8` across `test_authz_library_pin.py test_authz_gate_step4.py
  test_auth_read_path.py test_library_switch.py test_share_link_library_pin.py`:
  `10 passed, 75 deselected`, exit 0. Confirmed by `--collect-only` that this
  test lands in shard 2/8 of that set, so it really ran there.
- The single test 8x with three concurrent pytest processes loading the machine:
  0 failures.

`ruff format` and `ruff check pixlstash` clean.

## Sweep for the same bug shape elsewhere

The pattern — an observer on a shared surface that appends a bare sentinel and
asserts the list empty — was swept across all 165 files / 2568 tests in
`tests/`, checking every `monkeypatch.setattr`/`patch.object` target, every
`run_task`/`run_immediate_read_task`/`submit_task` wrapper, engine-level
listeners (`before_cursor_execute`, `set_trace_callback`), `nonlocal` counters,
`assert_not_called`/`call_count == 0`, and every `== []`/`== 0`/`len(...) == 0`
cross-referenced against the mutations of the same name.

**No other instance of the bug.** The two vault-read observers in
`test_authz_library_pin.py` were the only pair, and both are now filtered.
Everything else that observes a genuinely shared surface already filters by
thread id, function identity, event type, or SQL shape.

Three near-misses were found and are deliberately **not** changed here, because
none is currently reachable by a background thread and none can be given the
red/green demonstration above without inventing the reachability first:

- `tests/test_sidebar_counts_query_cost.py:335,343` — engine-level query counter
  on the shared `server.vault.db._engine` incrementing a bare `count`, but
  gated on SQL-text needles that only two route modules emit; no background
  finder issues those queries.
- `tests/test_hub_engine.py:717` — patches process-wide `sqlite3.connect` and
  asserts `connects == []`; it records the database path but does not filter on
  it. The module stands up no server, so only a thread leaked from an earlier
  test in the same worker could trip it.
- `tests/test_hub_bootstrap.py:1236` — patches global `os.open`/`os.fsync`; the
  read-only fd set is keyed on raw fd numbers, so a reused fd number across
  threads is a theoretical false positive. Same low reachability.

Each of those is a one-line hardening if it ever goes flaky; adding the filters
now would be speculative churn on assertions I could not drive red.

Untouched, as required: `docs/authz-coverage-matrix.md`,
`.github/workflows/ci.yml`, `tests/ci_test_durations.json`.
