### PR TITLE
Install CPU-only torch in the e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,18 +612,32 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          # Own namespace, on purpose, and NOT the composite's `pip-cpu-` key.
-          # This job installs `pip install .` while every setup-backend job
+          # Deliberately the SAME key as the setup-backend composite, so this
+          # job and the backend shards share one pip download cache instead of
+          # keeping two near-identical copies per ref.
+          #
+          # The trade-off is real and was decided on a measurement, not a
+          # guess. This job installs `pip install .` while the composite
           # installs `.[test,dev]`, and actions/cache only writes on a key
-          # miss — so one shared key would let whichever job raced first fix
-          # the contents, and an e2e win would make the backend shards
-          # re-download the test/dev wheels on every run without ever getting
-          # to re-save them. A separate namespace costs ~0.5 GB of the 10 GB
-          # repo ceiling and buys zero interaction between the two lanes.
-          # `-cpu-` because the old `pip-` prefix would restore the 2.79 GB
-          # CUDA-fat cache and re-save those nvidia wheels forever.
-          key: pip-e2e-cpu-${{ runner.os }}-py3.12-${{ hashFiles('setup.py', 'requirements.txt') }}
-          restore-keys: pip-e2e-cpu-${{ runner.os }}-py3.12-
+          # miss — so whichever job races to the miss first fixes the contents
+          # for both, and the loser re-downloads its delta on every run
+          # without ever getting a miss to re-save. That delta was the whole
+          # question, so it was measured: a separate `pip-e2e-cpu-` namespace
+          # saved 494 MB against the composite's 507 MB. The test/dev extras
+          # are ~13 MB of small pure-Python wheels; that is the entire cost of
+          # losing the race. Against it, a second namespace costs ~494 MB on
+          # every active ref, in a repo already evicting entries against
+          # GitHub's 10 GB limit — which is what makes runs miss cache and
+          # install cold in the first place. 13 MB per run beats 494 MB per
+          # ref. Contents cannot diverge dangerously either way: pip's HTTP
+          # cache is keyed by URL, so a subset or superset just means pip
+          # downloads whatever is not there.
+          #
+          # `-cpu-` is not optional in either design: restore-keys is a prefix
+          # match, so the old `pip-` prefix would restore the 2.79 GB CUDA-fat
+          # cache and re-save those nvidia wheels forever.
+          key: pip-cpu-${{ runner.os }}-py3.12-${{ hashFiles('setup.py', 'requirements.txt') }}
+          restore-keys: pip-cpu-${{ runner.os }}-py3.12-
 
       - name: Install backend
         if: steps.fixture.outputs.present == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,15 +591,6 @@ jobs:
     # its absence is a coverage failure, never permission to skip the lane.
     runs-on: ubuntu-latest
     steps:
-      - name: Remove unused tools
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-
       - uses: actions/checkout@v6
 
       - name: Require committed e2e fixture
@@ -621,14 +612,53 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: pip-${{ runner.os }}-py3.12-${{ hashFiles('setup.py', 'requirements.txt') }}
-          restore-keys: pip-${{ runner.os }}-py3.12-
+          # Own namespace, on purpose, and NOT the composite's `pip-cpu-` key.
+          # This job installs `pip install .` while every setup-backend job
+          # installs `.[test,dev]`, and actions/cache only writes on a key
+          # miss — so one shared key would let whichever job raced first fix
+          # the contents, and an e2e win would make the backend shards
+          # re-download the test/dev wheels on every run without ever getting
+          # to re-save them. A separate namespace costs ~0.5 GB of the 10 GB
+          # repo ceiling and buys zero interaction between the two lanes.
+          # `-cpu-` because the old `pip-` prefix would restore the 2.79 GB
+          # CUDA-fat cache and re-save those nvidia wheels forever.
+          key: pip-e2e-cpu-${{ runner.os }}-py3.12-${{ hashFiles('setup.py', 'requirements.txt') }}
+          restore-keys: pip-e2e-cpu-${{ runner.os }}-py3.12-
 
       - name: Install backend
         if: steps.fixture.outputs.present == 'true'
         run: |
+          set -euo pipefail
           python -m pip install --upgrade pip
+          # CPU-only torch, CI ONLY — same treatment the setup-backend
+          # composite got, which this job cannot share because it has its own
+          # inline Python setup. This runner only drives Chromium against a
+          # browse-only backend (workers disabled, no ML models), so the CUDA
+          # payload PyPI's torch drags in (nvidia-*-cu13, triton, ~2.5 GB
+          # unpacked) is pure cost: it was most of the 92 s install and the
+          # reason this job's pip cache was 2.79 GB.
+          # The specifiers are pyproject.toml's own, so CI resolves exactly
+          # the version it resolves today and just takes the +cpu build of it;
+          # `pip install .` below then finds the requirement already satisfied
+          # and leaves it alone. --index-url, not --extra-index-url: it
+          # confines this one invocation to PyTorch's own index instead of
+          # letting a second index shadow PyPI names. Nothing a user installs
+          # changes — `pip install -e .` still resolves the GPU build.
+          pip install --index-url https://download.pytorch.org/whl/cpu \
+            "torch~=2.12" "torchvision~=0.27"
           pip install .
+          df -h /
+          # Fail loudly if a pin change ever lets PyPI's CUDA torch win again.
+          # sed, not `grep -q`: under `pipefail` an early-exiting grep SIGPIPEs
+          # pip and the guard fires on its own plumbing instead of the version.
+          torch_version="$(pip show torch | sed -n 's/^Version: //p')"
+          case "$torch_version" in
+            *+cpu) echo "torch $torch_version" ;;
+            *)
+              echo "::error::torch is $torch_version, not a +cpu build; the CUDA wheels are back."
+              exit 1
+              ;;
+          esac
 
       - name: Set up Node
         if: steps.fixture.outputs.present == 'true'
@@ -644,6 +674,12 @@ jobs:
           cd frontend
           npm ci
           npx playwright install --with-deps chromium
+          # This job used to reclaim runner disk with jlumbroso/free-disk-space
+          # (88 s) before installing anything. That step is gone; this `df` is
+          # what replaces the assumption with a measurement, on the fullest
+          # point of the job — after Python, Node, npm deps and Chromium are
+          # all on disk. If it ever gets tight, put the reclaim step back.
+          df -h /
 
       - name: Run Playwright e2e
         if: steps.fixture.outputs.present == 'true'


### PR DESCRIPTION
Closes part of #796. Follows #801, which gave this treatment to the shared `.github/actions/setup-backend` composite. The `e2e` job does not use that composite — it has its own inline Python setup, which is why #801 missed it.

**Root cause:** the `e2e` job runs a bare `pip install .` on Linux, so it pulls the full CUDA stack (`nvidia-*-cu13`, `triton`, all gated `platform_system == "Linux"`) onto a runner whose entire job is to drive Chromium against a browse-only backend — workers disabled, no ML models loaded. That was most of the 92 s install and all of the **2.79 GB** pip cache. The repo was at **12.53 GB of Actions cache against GitHub's 10 GB limit**, so entries get evicted and runs keep missing cache and installing cold.

**Fix:** install `torch`/`torchvision` from PyTorch's own CPU index before the project install, using pyproject's own specifiers. `2.13.0+cpu` satisfies `torch~=2.12`, so `pip install .` reports `Requirement already satisfied: torch~=2.12 … (2.13.0+cpu)` and leaves it. No packaging file changed — a user's `pip install -e .` still resolves the GPU build, and `install-smoke.yml` still exercises that path unchanged.

### Measured: run 31296000291 (before) vs 31303049420 (after)

The "after" run had a **cold** pip cache by design, since the key moved namespace.

| Step | Before | After (cold cache) |
|---|---|---|
| `jlumbroso/free-disk-space` | 88 s | removed |
| checkout | 7 s | 5 s |
| Cache pip packages (restore) | 29 s (2.79 GB) | 1 s (miss, new namespace) |
| Install backend | 92 s | 88 s |
| Install frontend deps + Chromium | 26 s | 33 s |
| Run Playwright e2e | 221 s | 216 s |
| **job total** | **477 s** | **356 s** |

**121 s off an 8-minute job (25%), with the cache still cold.** Saved pip cache: **2851 MB → 494 MB**.

### Cache key: shares the composite's `pip-cpu-` key

This was the one real design choice, and it went the opposite way from my first commit — because the first run produced the number the decision actually turned on.

The two lanes install different sets (`pip install .` here, `.[test,dev]` in the composite) and `actions/cache` **only writes on a key miss**, so with a shared key whichever job races to the miss first fixes the contents, and the loser re-downloads its delta every run without ever getting a miss to re-save. The size of that delta is the whole question, so it got measured rather than assumed: a separate `pip-e2e-cpu-` namespace saved **494 MB** against the composite's **507 MB**. The test/dev extras are ~13 MB of small pure-Python wheels — that is the entire cost of losing the race, and it self-heals whenever `hashFiles('setup.py','requirements.txt')` changes.

Against that, a second namespace costs ~494 MB **on every active ref** (caches are per-ref; the same key currently exists on 6 refs), in a repo already evicting entries against the 10 GB limit — which is the thing making runs miss cache and install cold in the first place. **13 MB per run beats 494 MB per ref**, so the key is shared. Contents cannot diverge dangerously either way: pip's HTTP cache is keyed by URL, so a subset or a superset just means pip downloads whatever is not there.

The `-cpu-` part is not optional under either design: `restore-keys` is a prefix match, so keeping the old `pip-` prefix would restore the 2.79 GB CUDA-fat cache and re-save those nvidia wheels indefinitely.

Once this merges, `pip-Linux-py3.12-*` (2851 MB, still on `develop`) has no consumer left on Linux and can be deleted for an immediate reclaim.

### `free-disk-space` removed — measured, not assumed

#801 removed this from the composite after measuring 84 GB free. This job's disk profile is genuinely different: it also installs Node, npm deps and Chromium. So the PR adds `df -h /` after the backend install **and** at the fullest point of the job, after npm deps and Chromium are on disk, and the numbers below come from this PR's own run with the reclaim step already gone:

```
after backend install:      /dev/root  145G   61G   84G  42% /
after npm deps + Chromium:  /dev/root  145G   62G   83G  43% /
```

**83 GB free at peak.** Node, npm deps and Chromium together cost ~1 GB. There is no case for spending 88 s reclaiming disk, so the step is gone. Both `df` calls stay in permanently, so the claim is re-measured every run rather than trusted; if it ever gets tight, the step goes back.

### Verified
- **Zero CUDA wheels on the runner.** `grep -icE 'nvidia[-_][a-z0-9]*[-_]cu|triton'` over the full job log returns exactly one hit, and it is the workflow's own comment text echoed by the runner. The only `nvidia` package installed is `nvidia-ml-py`, a small pure-Python declared dependency. The guard echoes `torch 2.13.0+cpu`; `torchvision` resolved to `0.28.0+cpu`.
- **Playwright stayed green: `93 passed (3.6m)`**, identical to the 93 that passed before the change. That is the actual proof CPU wheels are sufficient for this job.
- The `joycaption: Failed to list JoyCaption artifacts from cache` lines in the log are pre-existing and unrelated — exactly 100 of them in the before run and 100 in the after run.

### Guards
- The install step asserts `torch` is a `+cpu` build, so a future pin change that lets PyPI's CUDA torch win fails the job instead of silently paying back the time and the disk. This copies #801's **working** form — `sed` + `case`, not `pip show torch | grep -q`, which SIGPIPEs pip under `pipefail` and fires the guard on its own plumbing.
- `set -euo pipefail` added to the install step.

### Security
Reviewed by `chief-security-officer` before push: **APPROVE**, no blockers.
- `--index-url` (not `--extra-index-url`) confines that one invocation to PyTorch's own index rather than opening dependency-confusion shadowing of PyPI names. `download.pytorch.org/whl/cpu` is already load-bearing here — `scripts/build_desktop_runtime.py` installs end users' bundled runtime from the same index.
- Removing `free-disk-space` is a net **reduction** in supply-chain surface: it deletes the only third-party action in this job. Confirmed by grep that `HF_TOKEN`, the only secret in this workflow, is referenced by `checks`, `backend` and `backend_windows` and never by `e2e`; the job has no job-level `permissions:` or `env:` and inherits only workflow-level `contents: read`. It was never a secret-bearing target.
- No `${{ }}` in any `run:` block. Action pinning unchanged. Sharing the cache key introduces no poisoning surface — actions/cache scoping is unchanged by a key name.

### Scope
`e2e` only. `backend`, `backend_windows`, `backend_release_sweep` and `.github/actions/setup-backend` untouched; no packaging file touched. `backend_windows` still has the same CUDA-on-a-CPU-runner install and is still worth the same fix, separately.
