### PR TITLE
Give each fixture adapter its own payload bytes

### DIFF
--- a/scripts/generate_model_shelf_fixtures.py
+++ b/scripts/generate_model_shelf_fixtures.py
@@ -1,17 +1,37 @@
 """Generate the model-shelf fixture tree on demand.
 
 The shelf (v1.10) has to look right against 1,800 adapters, a real training run
-and a folder that is not there. The real thing is ~100 GB, so it is generated
-rather than committed, and two things keep that honest:
+and a folder that is not there. The real thing is hundreds of gigabytes, so it is
+generated rather than committed, and three things keep that honest:
 
 * **Real headers.** Every ``.safetensors`` carries a genuine length prefix and
-  header JSON, with tensor names and shapes taken from real files, so
+  header JSON, with tensor names, shapes and dtypes taken from real files, so
   :mod:`pixlstash.utils.adapter_header` reads them as it reads a download. Kind,
   parameter count and the adapter/checkpoint split come out unfaked.
-* **Sparse payloads.** The tensor payload is a hole, so ``getsize`` reports the
-  170 MB the adapter really weighs while the disk pays for the header alone.
+* **Sparse payloads.** Nearly all of the tensor payload is a hole, so ``getsize``
+  reports the 180 MB the adapter really weighs while the disk pays for the
+  header and one block behind it.
   :func:`_check_sparse_support` refuses to run where the holes would be
   allocated for real, rather than filling the user's disk.
+* **Distinct bytes.** Real adapters cluster hard on shape — one measured folder
+  of 91 files held 28 distinct name+shape signatures, rank 32 alone being two
+  thirds of them — and they stay distinct because their *weights* differ. A hole
+  is all zeroes, so shape-identical files would hash identically and 1,800 rows
+  would collapse to a few hundred. :func:`_payload_slug` therefore writes
+  :data:`_PAYLOAD_SLUG_BYTES` of seeded noise at the head of each payload: one
+  filesystem block per file, which is what the header already cost.
+
+**The two files in the manual-import stack are byte-identical on purpose** and
+must stay that way — they share a payload seed. "The same file copied into two
+registered folders" and "an interrupted move left two paths" are states the shelf
+has to recognise, so the fixture set owes it one real duplicate pair. It is the
+only one; everything in ``adapters/`` is distinct.
+
+Proportions below (metadata mix, rank mix, dtype mix, size spread) were measured
+against a real 91-file adapter folder on 2026-08-09. That is one owner's library:
+self-trained files carry ``ss_*`` metadata while model-site downloads carry only
+``format``, so the ratio moves with where the files came from. It is here to stop
+the mix being *backwards*, not to be exact.
 
 Run it::
 
@@ -28,26 +48,75 @@ import os
 import random
 import struct
 import sys
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from PIL import Image
 
-# Sizes are in bytes throughout, and every "reported" size below is what a real
-# adapter of that shape weighs: fp16, two bytes per parameter.
-_BYTES_PER_PARAM = 2
+# Bytes per parameter, by the dtype the header declares.
+_DTYPE_BYTES = {"BF16": 2, "F16": 2, "F32": 4}
+
+# Dtype mix, measured 2026-08-09 (74 BF16, 11 F16, 7 F32 of 91). Trainers have
+# largely moved to bf16, and an F32 file is twice the bytes of the same shape,
+# which is most of why two adapters of one rank can differ in size.
+#
+# The measured folder also held four files carrying I64 tensors. Those are
+# auxiliary index/alpha tensors rather than weights, which nothing here models,
+# so they are left out rather than faked as an I64 weight tensor.
+_DTYPE_MIX = ["BF16"] * 74 + ["F16"] * 11 + ["F32"] * 7
 
 # Adapter shapes seen in the wild, as (base label, hidden dim, rank, layers).
-# The parameter count follows from the shape, and the file size follows from
-# the parameter count, so nothing here is an invented number.
+# Repetition is the weighting, and it is deliberately lumpy: the 91-file folder
+# measured on 2026-08-09 held only 28 distinct name+shape signatures, and rank 32
+# was 62 of the 91. A folder of 1,800 differently-shaped adapters would be far
+# less realistic than this. Files stay distinct through their payload, not their
+# shape.
+#
+# The parameter count follows from the shape and the file size follows from the
+# parameter count, so nothing here is an invented number.
 _SHAPES: tuple[tuple[str, int, int, int], ...] = (
-    ("flux.1-dev", 3072, 16, 152),
-    ("flux.1-dev", 3072, 32, 152),
+    ("flux.1-dev", 3072, 32, 456),
+    ("flux.1-dev", 3072, 32, 456),
+    ("flux.1-dev", 3072, 64, 456),
+    ("flux.1-dev", 3072, 32, 456),
     ("sdxl", 2048, 32, 264),
-    ("sdxl", 2048, 64, 264),
-    ("sd15", 768, 32, 192),
-    ("qwen-image", 3584, 16, 120),
+    ("flux.1-dev", 3072, 32, 304),
+    ("flux.1-dev", 3072, 16, 456),
+    ("qwen-image", 3584, 32, 480),
+    ("flux.1-dev", 3072, 32, 456),
+    ("flux.1-dev", 3072, 64, 456),
+    ("sdxl", 2048, 16, 264),
+    ("flux.1-dev", 3072, 32, 456),
+    ("flux.1-dev", 3072, 128, 456),
+    ("flux.1-dev", 3072, 32, 304),
+    ("sdxl", 2048, 32, 264),
+    ("flux.1-dev", 3072, 32, 456),
+    ("qwen-image", 3584, 32, 480),
+    ("flux.1-dev", 3072, 8, 456),
+    ("flux.1-dev", 3072, 32, 456),
+    ("flux.1-dev", 3072, 16, 456),
+    ("flux.1-dev", 3072, 32, 304),
+    ("flux.1-dev", 3072, 64, 456),
+    ("flux.1-dev", 3072, 32, 456),
+    ("flux.1-dev", 3072, 32, 456),
 )
+
+# The rare high-rank adapter: multi-gigabyte, and the reason B4 defers hashing
+# for large files. Two of the 91 measured files were rank 256 or above, so this
+# lands on one file in 59 rather than in the regular rotation.
+_LARGE_SHAPES: tuple[tuple[str, int, int, int], ...] = (
+    ("flux.1-dev", 3072, 256, 456),
+    ("flux.1-dev", 3072, 384, 456),
+)
+_LARGE_EVERY = 59
+_LARGE_OFFSET = 13
+
+# Seeded noise written at the head of every payload, so that two adapters of the
+# same shape are still different files. Real weights differ; a hole is all
+# zeroes, which is what collapsed 1,800 fixtures onto 478 digests. One block per
+# file is the smallest write a filesystem can charge for.
+_PAYLOAD_SLUG_BYTES = 4096
 
 # 30 x 10 = 300 subject/qualifier pairs, so 1,800 files means six variants of
 # each pair: exactly the near-duplicate clutter the shelf's grouping is for.
@@ -67,12 +136,13 @@ _METADATA_NONE = "none"
 _METADATA_FORMAT_ONLY = "format-only"
 _METADATA_AITOOLKIT = "ai-toolkit"
 
-# Distribution measured against a real adapter folder on 2026-08-07: a model
-# site download usually carries nothing but `format`, and rich ai-toolkit
-# metadata is the minority case. Getting this backwards makes the shelf look
-# far more informative than it will be.
+# Distribution measured against a real 91-file adapter folder on 2026-08-09:
+# 57 carried trainer `ss_*` metadata, 22 carried nothing but `format`, 9 carried
+# no metadata block at all. Self-trained files are the ones with metadata, so a
+# library of downloads inverts this; what the shelf must not assume is that the
+# informative case is rare.
 _METADATA_MIX = (
-    [_METADATA_FORMAT_ONLY] * 70 + [_METADATA_AITOOLKIT] * 25 + [_METADATA_NONE] * 5
+    [_METADATA_AITOOLKIT] * 63 + [_METADATA_FORMAT_ONLY] * 27 + [_METADATA_NONE] * 10
 )
 
 # Adapter algorithm mix. LoRA dominates; the rest exist so the shelf's kind
@@ -122,6 +192,26 @@ meta:
 """
 
 
+@dataclass(frozen=True)
+class AdapterPlan:
+    """One adapter in the big folder: everything its bytes depend on.
+
+    Attributes:
+        name: Filename stem, also the payload seed.
+        tensors: Tensor name → shape.
+        metadata: ``__metadata__`` block, or ``None`` for a file without one.
+        dtype: Safetensors dtype for every tensor.
+        payload_seed: Seed for the payload slug. Two plans that agree on
+            everything *including* this describe the same file, byte for byte.
+    """
+
+    name: str
+    tensors: dict[str, list[int]]
+    metadata: dict[str, str] | None
+    dtype: str
+    payload_seed: str
+
+
 @dataclass
 class FixtureTree:
     """Where every §5 fixture ended up, and what it cost."""
@@ -144,9 +234,9 @@ class FixtureTree:
 def _check_sparse_support(root: Path) -> None:
     """Refuse to generate on a filesystem that would allocate the holes.
 
-    A 1,800-adapter folder claims roughly 100 GB. On ext4/btrfs/xfs/APFS that
+    A 1,800-adapter folder claims roughly 440 GB. On ext4/btrfs/xfs/APFS that
     costs a few megabytes because the payloads are holes; on a filesystem
-    without sparse files it would cost 100 GB of real disk, which is not a
+    without sparse files it would cost 440 GB of real disk, which is not a
     surprise anyone should get from a fixture script.
 
     Args:
@@ -162,10 +252,10 @@ def _check_sparse_support(root: Path) -> None:
         allocated = os.stat(probe).st_blocks * 512
     except (AttributeError, OSError) as exc:
         # st_blocks is POSIX-only. On a platform that cannot answer, say so and
-        # stop rather than quietly writing 100 GB.
+        # stop rather than quietly writing 440 GB.
         raise RuntimeError(
             f"Cannot verify sparse-file support under {root} ({exc}). These "
-            "fixtures rely on it: without holes the adapter folder is ~100 GB. "
+            "fixtures rely on it: without holes the adapter folder is ~440 GB. "
             "Pass --adapters with a small count to generate anyway."
         ) from exc
     finally:
@@ -176,9 +266,24 @@ def _check_sparse_support(root: Path) -> None:
         raise RuntimeError(
             f"{root} is on a filesystem without sparse files (a 1 MiB hole "
             f"allocated {allocated} bytes). The adapter folder would really "
-            "weigh ~100 GB here. Point --root at ext4/btrfs/xfs/APFS, or pass "
+            "weigh ~440 GB here. Point --root at ext4/btrfs/xfs/APFS, or pass "
             "--adapters with a small count."
         )
+
+
+def _adapter_shape(index: int) -> tuple[str, int, int, int]:
+    """Return the shape of adapter *index*: base label, dim, rank, layers.
+
+    Args:
+        index: Position in the adapter folder.
+
+    Returns:
+        One entry of :data:`_SHAPES`, or of :data:`_LARGE_SHAPES` for the rare
+        multi-gigabyte file.
+    """
+    if index % _LARGE_EVERY == _LARGE_OFFSET:
+        return _LARGE_SHAPES[(index // _LARGE_EVERY) % len(_LARGE_SHAPES)]
+    return _SHAPES[index % len(_SHAPES)]
 
 
 def _lora_tensors(kind: str, dim: int, rank: int, layers: int) -> dict[str, list[int]]:
@@ -207,8 +312,12 @@ def _lora_tensors(kind: str, dim: int, rank: int, layers: int) -> dict[str, list
             tensors[f"{stem}.lora_B.weight"] = [dim, rank]
             tensors[f"{stem}.dora_scale"] = [dim, 1]
         elif kind == "lokr":
+            # LyCORIS' decomposed form: the second Kronecker factor is itself
+            # low-rank, which is why a real LoKr weighs the same order as the
+            # LoRA it replaces rather than a few hundred kilobytes.
             tensors[f"{stem}.lokr_w1"] = [rank, rank]
-            tensors[f"{stem}.lokr_w2"] = [dim // rank, dim // rank]
+            tensors[f"{stem}.lokr_w2_a"] = [rank, dim]
+            tensors[f"{stem}.lokr_w2_b"] = [dim, rank]
         elif kind == "loha":
             tensors[f"{stem}.hada_w1_a"] = [rank, dim]
             tensors[f"{stem}.hada_w1_b"] = [dim, rank]
@@ -224,27 +333,44 @@ def _lora_tensors(kind: str, dim: int, rank: int, layers: int) -> dict[str, list
     return tensors
 
 
-def write_safetensors(
-    path: Path,
-    tensors: dict[str, list[int]],
-    metadata: dict[str, str] | None = None,
-) -> int:
-    """Write one adapter: a real header, a sparse payload.
-
-    The header is genuine and self-consistent — offsets follow the declared
-    shapes — so the file reads back through
-    :func:`pixlstash.utils.adapter_header.describe_adapter` unchanged. The
-    payload after it is a hole, so the file reports its true size without
-    occupying it.
+def _payload_slug(seed: str) -> bytes:
+    """Return this file's slice of real payload bytes.
 
     Args:
-        path: Destination file.
-        tensors: Tensor name → shape.
-        metadata: ``__metadata__`` block, or ``None`` to omit it entirely.
+        seed: Anything that identifies the file. Two calls with the same seed
+            return the same bytes, which is how the deliberate duplicate pair in
+            :func:`generate_manual_stack` stays a duplicate.
 
     Returns:
-        The file's reported size in bytes.
+        :data:`_PAYLOAD_SLUG_BYTES` of seeded noise.
     """
+    return random.Random(seed).randbytes(_PAYLOAD_SLUG_BYTES)
+
+
+def leading_bytes(
+    tensors: dict[str, list[int]],
+    metadata: dict[str, str] | None = None,
+    *,
+    dtype: str = "BF16",
+    payload_seed: str = "",
+) -> tuple[bytes, int]:
+    """Return one adapter's leading bytes and the file size they imply.
+
+    Everything after these bytes is a hole whose length the header itself
+    declares, so two adapters are byte-identical exactly when their leading
+    bytes match. That makes this the cheap way to check a folder for duplicates:
+    hash what this returns, write nothing.
+
+    Args:
+        tensors: Tensor name → shape.
+        metadata: ``__metadata__`` block, or ``None`` to omit it entirely.
+        dtype: Safetensors dtype for every tensor; sets bytes per parameter.
+        payload_seed: Seed for the payload slug that keeps files distinct.
+
+    Returns:
+        ``(length prefix + header JSON + payload slug, total file size)``.
+    """
+    item_bytes = _DTYPE_BYTES[dtype]
     header: dict[str, object] = {}
     if metadata is not None:
         header["__metadata__"] = metadata
@@ -253,15 +379,52 @@ def write_safetensors(
         count = 1
         for dim in shape:
             count *= dim
-        end = offset + count * _BYTES_PER_PARAM
-        header[name] = {"dtype": "F16", "shape": shape, "data_offsets": [offset, end]}
+        end = offset + count * item_bytes
+        header[name] = {"dtype": dtype, "shape": shape, "data_offsets": [offset, end]}
         offset = end
 
-    raw = json.dumps(header).encode()
-    total = 8 + len(raw) + offset
+    raw = json.dumps(header, separators=(",", ":")).encode()
+    slug = _payload_slug(payload_seed)[:offset]
+    return struct.pack("<Q", len(raw)) + raw + slug, 8 + len(raw) + offset
+
+
+def write_safetensors(
+    path: Path,
+    tensors: dict[str, list[int]],
+    metadata: dict[str, str] | None = None,
+    *,
+    dtype: str = "BF16",
+    payload_seed: str = "",
+) -> int:
+    """Write one adapter: a real header, a slug of payload, then a hole.
+
+    The header is genuine and self-consistent — offsets follow the declared
+    shapes — so the file reads back through
+    :func:`pixlstash.utils.adapter_header.describe_adapter` unchanged. Most of
+    the payload after it is a hole, so the file reports its true size without
+    occupying it.
+
+    Args:
+        path: Destination file.
+        tensors: Tensor name → shape.
+        metadata: ``__metadata__`` block, or ``None`` to omit it entirely.
+        dtype: Safetensors dtype for every tensor.
+        payload_seed: Seed for the payload slug. Files sharing a seed are
+            byte-identical; that is only wanted in the manual-import stack.
+
+    Returns:
+        The file's reported size in bytes.
+    """
+    return _write_leading(
+        path,
+        *leading_bytes(tensors, metadata, dtype=dtype, payload_seed=payload_seed),
+    )
+
+
+def _write_leading(path: Path, head: bytes, total: int) -> int:
+    """Write *head* at the start of *path* and leave the rest of *total* a hole."""
     with open(path, "wb") as handle:
-        handle.write(struct.pack("<Q", len(raw)))
-        handle.write(raw)
+        handle.write(head)
         handle.truncate(total)
     return total
 
@@ -304,23 +467,29 @@ def _aitoolkit_metadata(name: str, base: str, step: int, rank: int) -> dict[str,
     }
 
 
-def generate_adapter_folder(root: Path, count: int = 1800) -> tuple[int, int]:
-    """Write the big folder: ``count`` adapters with real names and sizes.
+def iter_adapters(count: int = 1800) -> Iterator[AdapterPlan]:
+    """Yield the plan for every adapter in the big folder, in folder order.
+
+    This is the single description of that folder:
+    :func:`generate_adapter_folder` writes exactly what it yields, so a caller
+    that only wants to know what the files *are* — whether any two of them would
+    be identical, say — can run :func:`plan_bytes` over this and touch no disk.
 
     Args:
-        root: Folder to fill. Created if absent.
-        count: How many adapters to write.
+        count: How many adapters to describe.
 
-    Returns:
-        ``(reported_bytes, disk_bytes)``.
+    Yields:
+        One :class:`AdapterPlan` per adapter.
     """
-    root.mkdir(parents=True, exist_ok=True)
     rng = random.Random(20261010)
-    reported = 0
-    disk = 0
     for index, name in enumerate(_adapter_names(count)):
-        base, dim, rank, layers = _SHAPES[index % len(_SHAPES)]
+        base, dim, rank, layers = _adapter_shape(index)
         kind = rng.choice(_KIND_MIX)
+        if index % _LARGE_EVERY == _LARGE_OFFSET:
+            # The multi-gigabyte file is the point of this shape, and the other
+            # algorithms cost a fraction of LoRA's parameters at the same rank,
+            # so it does not get to draw one.
+            kind = "lora"
         # A handful of marker-free files, so the shelf has to show `unknown`
         # rather than guessing checkpoint. Their parameter counts stay well
         # under the checkpoint threshold on purpose.
@@ -333,10 +502,43 @@ def generate_adapter_folder(root: Path, count: int = 1800) -> tuple[int, int]:
             metadata = {"format": "pt"}
         else:
             metadata = _aitoolkit_metadata(name, base, (index % 12 + 1) * 250, rank)
-        path = root / f"{name}.safetensors"
-        reported += write_safetensors(
-            path, _lora_tensors(kind, dim, rank, layers), metadata
+        yield AdapterPlan(
+            name=name,
+            tensors=_lora_tensors(kind, dim, rank, layers),
+            metadata=metadata,
+            dtype=rng.choice(_DTYPE_MIX),
+            # The filename: unique within the folder, so no two adapters here
+            # end up as the same file.
+            payload_seed=name,
         )
+
+
+def plan_bytes(plan: AdapterPlan) -> tuple[bytes, int]:
+    """Return the leading bytes and size of the file *plan* describes."""
+    return leading_bytes(
+        plan.tensors,
+        plan.metadata,
+        dtype=plan.dtype,
+        payload_seed=plan.payload_seed,
+    )
+
+
+def generate_adapter_folder(root: Path, count: int = 1800) -> tuple[int, int]:
+    """Write the big folder: ``count`` adapters with real names and sizes.
+
+    Args:
+        root: Folder to fill. Created if absent.
+        count: How many adapters to write.
+
+    Returns:
+        ``(reported_bytes, disk_bytes)``.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    reported = 0
+    disk = 0
+    for plan in iter_adapters(count):
+        path = root / f"{plan.name}.safetensors"
+        reported += _write_leading(path, *plan_bytes(plan))
         disk += os.stat(path).st_blocks * 512
     return reported, disk
 
@@ -387,6 +589,7 @@ def generate_run(
             run / f"{name}_{step:09d}.safetensors",
             _lora_tensors("lora", dim, rank, layers),
             _aitoolkit_metadata(name, base_model, step, rank),
+            payload_seed=f"{name}-{step}",
         )
         for index in range(samples_per_step):
             # <timestamp>__<step>_<index>.jpg; the double underscore is what
@@ -401,6 +604,7 @@ def generate_run(
             run / f"{name}.safetensors",
             _lora_tensors("lora", dim, rank, layers),
             _aitoolkit_metadata(name, base_model, steps[-1], rank),
+            payload_seed=f"{name}-final",
         )
 
     prompt_lines = "\n".join(
@@ -428,6 +632,12 @@ def generate_manual_stack(root: Path) -> Path:
     Nothing here came from a run we can see, so there is no ``samples/`` and no
     ``config.yaml``. The shelf has to stack these on name alone and fall back
     to a placeholder cover.
+
+    **The two files are byte-identical, deliberately** — one shared payload seed.
+    This is the fixture set's one duplicate pair: a copy that landed twice, or a
+    move interrupted between the write and the unlink. Everything in
+    ``adapters/`` is distinct, so a deduplicating shelf that finds nothing here
+    has nothing to find anywhere.
     """
     root.mkdir(parents=True, exist_ok=True)
     for version in (1, 2):
@@ -435,6 +645,7 @@ def generate_manual_stack(root: Path) -> Path:
             root / f"Cyanwood_v{version}.safetensors",
             _lora_tensors("lora", 2048, 32, 264),
             {"format": "pt"},
+            payload_seed="Cyanwood-imported-twice",
         )
     return root
 

--- a/tests/test_model_shelf_fixtures.py
+++ b/tests/test_model_shelf_fixtures.py
@@ -12,8 +12,10 @@ The adapter count is small on purpose: 1,800 files prove nothing 60 do not, and
 the name generator is exercised at full scale separately without touching disk.
 """
 
+import hashlib
 import importlib.util
 import os
+import struct
 import sys
 
 import pytest
@@ -94,7 +96,16 @@ class TestAdapterFolder:
         assert len(kinds) > 1, kinds
 
     def test_both_the_metadata_rich_and_the_bare_case_are_present(self, tree):
-        """The common download carries nothing; ai-toolkit output carries plenty."""
+        """All three provenances, with the informative one in the majority.
+
+        Measured 2026-08-09 over a real 91-file folder: 57 carried trainer
+        ``ss_*`` metadata, 22 carried only ``format``, 9 carried no block at
+        all. The generator used to have that backwards, which made the shelf's
+        "you will have to name this yourself" path look like the common case
+        when it is the minority one. The direction is pinned here; the exact
+        ratio is not, because it moves with how much of a library was
+        downloaded rather than trained.
+        """
         described = [
             describe_adapter(str(path))
             for path in tree.adapter_folder.glob("*.safetensors")
@@ -102,22 +113,59 @@ class TestAdapterFolder:
         assert any(info.has_metadata for info in described)
         assert any(not info.has_metadata for info in described)
         assert any(info.trigger_words for info in described)
+        rich = sum(1 for info in described if info.has_metadata)
+        assert rich > len(described) / 2, f"{rich} of {len(described)}"
+
+    def test_more_than_one_dtype_is_emitted(self):
+        """bf16 dominates, but fp16 and fp32 files exist and weigh differently.
+
+        Two adapters of one rank can differ in size for no reason but dtype, so
+        a shelf reading size as a proxy for rank is reading it wrong.
+        """
+        dtypes = {plan.dtype for plan in generator.iter_adapters(SMALL_ADAPTER_COUNT)}
+        assert dtypes == {"BF16", "F16", "F32"}, dtypes
 
     def test_sizes_are_reported_in_full_but_not_paid_for(self, tree):
         """Real sizes, sparse payloads: that is what makes 1,800 adapters fit.
 
-        Without this the folder is either 300 GB or a folder of 4 KB files that
-        makes a size-sorted shelf meaningless.
+        Without this the folder is either hundreds of real gigabytes or a folder
+        of 4 KB files that makes a size-sorted shelf meaningless.
         """
         sizes = [
             os.path.getsize(path) for path in tree.adapter_folder.glob("*.safetensors")
         ]
-        # The spread is the point: a LoKr really is a few MB and a rank-64 SDXL
-        # LoRA really is hundreds, so a size-sorted shelf has something to sort.
-        assert min(sizes) > 500_000
-        assert max(sizes) > 100 * 1024 * 1024
+        # The spread is the point, and it is wider than it looks: the same
+        # measured folder ran from 17 MB to 20.5 GB, so a size-sorted shelf and
+        # F2's capacity meters both have something real to work with. The
+        # multi-gigabyte end is also the one B4 defers hashing for.
+        assert min(sizes) > 15 * 1024 * 1024
+        assert max(sizes) > 1024**3
         assert tree.reported_bytes == sum(sizes)
         assert tree.disk_bytes < tree.reported_bytes / 50
+
+    def test_no_two_adapters_are_the_same_file(self, tree):
+        """Every adapter is its own file, checked on the bytes that were written.
+
+        This is the regression: real adapters cluster hard on shape, so the
+        generator repeats shapes on purpose, and a sparse payload is all zeroes.
+        That made a file's SHA-256 a pure function of its header, and 1,800
+        fixtures collapsed onto 478 distinct files — the shelf then showed 478
+        rows and one model carried 202 locations. The payload slug is what fixes
+        it, so this hashes the header *and* the slug behind it, straight off
+        disk. Everything after them is a hole the header itself measures, which
+        is why reading the whole 4 GB file would prove nothing extra.
+
+        At 1,800 the same holds by construction rather than by test: the slug is
+        a pure function of the filename, and
+        :meth:`test_names_are_unique_at_full_scale` pins those at full scale.
+        """
+        digests = set()
+        for path in sorted(tree.adapter_folder.glob("*.safetensors")):
+            with open(path, "rb") as handle:
+                (header_len,) = struct.unpack("<Q", handle.read(8))
+                leading = handle.read(header_len + generator._PAYLOAD_SLUG_BYTES)
+            digests.add(hashlib.sha256(leading).hexdigest())
+        assert len(digests) == SMALL_ADAPTER_COUNT
 
     def test_names_are_unique_at_full_scale(self):
         """1,800 files in one folder; two of them cannot share a name."""
@@ -198,6 +246,22 @@ def test_the_manual_stack_has_two_adapters_and_no_samples(tree):
     assert not (tree.manual_stack / "samples").exists()
     for path in files:
         assert describe_adapter(str(path)).file_kind == FILE_ADAPTER
+
+
+def test_the_manual_stack_is_the_deliberate_duplicate_pair(tree):
+    """These two really are one file under two names, and must stay that way.
+
+    A copy that landed in two registered folders, or a move interrupted between
+    the write and the unlink, are states the shelf has to recognise, so the
+    fixture set owes it one duplicate pair. It is the only one: everything in
+    ``adapters/`` is distinct, which is what
+    :meth:`TestAdapterFolder.test_no_two_adapters_are_the_same_file` pins.
+    """
+    digests = {
+        hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(tree.manual_stack.glob("*.safetensors"))
+    }
+    assert len(digests) == 1
 
 
 def test_the_offline_mount_does_not_resolve(tree):


### PR DESCRIPTION
`scripts/generate_model_shelf_fixtures.py` wrote 1,800 adapter files that were
only 478 distinct files: 1,360 duplicates, largest duplicate group 202. The
shelf would have shown 478 rows and one model carrying 202 locations.

## Root cause

Not the header. The payload is a sparse hole, so it is all zeroes, and a file's
SHA-256 became a pure function of its header bytes. Any two files built from the
same shape template with the same metadata were byte-identical.

## Fix

Each file now carries `_PAYLOAD_SLUG_BYTES` (4 KB) of seeded noise at the head of
its payload, the rest still a hole. Real adapters of identical shape differ in
their *weights*, so this is more faithful than the alternative of inventing 1,800
different shapes: a measured 91-file folder held only **28 distinct name+shape
signatures**, with rank 32 at 62 of 91. Shapes stay clustered on purpose.

The deliberate exception is kept and now documented and tested: the two files in
`manual_imports/` share a payload seed and are byte-identical, because "the same
file copied into two registered folders" and "an interrupted move left two paths"
are states the shelf has to handle.

## Also corrected against the same measurement (2026-08-09, 91 files)

- **Metadata mix was backwards.** Was 70% format-only / 25% trainer / 5% none;
  measured 63/24/10 the other way round. Now trainer-metadata-dominant. The
  existing metadata test asserted only presence, so it now also pins the
  *direction* (informative majority) instead of the exact ratio, which moves with
  how much of a library was downloaded rather than trained.
- **Size range was far too small.** Was 500 KB - 100 MiB; measured 17 MB / 229 MB
  / 20.5 GB. Now 34.6 MB / 179.4 MB / 4.30 GB, including a rare high-rank
  multi-gigabyte file (the case B4 defers hashing for). Test floor raised to
  15 MiB, ceiling to 1 GiB.
- **dtype was hardcoded F16.** Now BF16-dominant with F16 and F32 present
  (74/11/7 measured), so two adapters of one rank can differ in size for no
  reason but dtype. I64 is left out: in the measured files it appears as
  auxiliary index tensors, not weights, which nothing here models.
- LoKr switched to LyCORIS' decomposed `lokr_w1`/`lokr_w2_a`/`lokr_w2_b` form, so
  it weighs the same order as the LoRA it replaces rather than a few hundred KB.

## Verification

Full-scale hand run (1,800 adapters): **1,800 distinct digests, largest duplicate
group 1**, 1.4 s wall clock, 438.0 GB reported, 217.3 MB real disk.

Mutation-tested: setting `_PAYLOAD_SLUG_BYTES = 0` turns
`test_no_two_adapters_are_the_same_file` red (54 of 60 distinct).

Suite timing unchanged: 28 tests in 0.99-1.09 s (was 25 tests in 1.28 s). The new
uniqueness test hashes the real bytes of the 60-file tree rather than generating
1,800 files; at full scale the property holds because the slug is a pure function
of the filename and `test_names_are_unique_at_full_scale` already pins those.