### PR TITLE
Close the scanner and shelf-schema nits from #782

### DIFF
--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -330,7 +330,11 @@ CREATE TABLE IF NOT EXISTS model (
     stack_position        INTEGER,
     run_key               TEXT,
     created_at            TEXT,
-    CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL)
+    CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL),
+    -- Same shape one column over: every producer already supplies an algorithm
+    -- for an adapter ('unknown' is a first-class value, never NULL), so an
+    -- adapter with no kind at all is a state the code cannot reach.
+    CHECK (file_kind <> 'adapter' OR kind IS NOT NULL)
 )
 """
 
@@ -481,8 +485,10 @@ def _apply_v2(conn: sqlite3.Connection) -> None:
     # and `adapter_stack` are NOT dropped: a developer may have registered
     # folders, and neither table changes shape.
     existing = {
-        row[0]
-        for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        row[0]: row[1]
+        for row in conn.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'table'"
+        )
     }
     # `adapter` does not exist after the reshape, so this guard is false on a
     # fresh hub and false on every subsequent re-run.
@@ -495,6 +501,22 @@ def _apply_v2(conn: sqlite3.Connection) -> None:
         # ix_adapter_* indexes need no separate statement.
         for table in _V2_SUPERSEDED_SHELF_TABLES:
             conn.execute(f"DROP TABLE IF EXISTS {table}")
+
+    # The `kind` CHECK was added after the reshape and SQLite has no
+    # ALTER TABLE ADD CONSTRAINT, so a hub that already holds the pre-CHECK
+    # `model` table needs the same drop-and-rescan treatment. Legitimate for
+    # the same reason and only while v2 is unreleased: nothing a person typed
+    # lives in these two tables yet (the shelf UI is unbuilt), `model_folder`
+    # survives, and the next scan refills them from disk. Child first, so the
+    # FK the drop enforces has nothing pointing at it.
+    model_ddl = existing.get("model")
+    if model_ddl is not None and "kind IS NOT NULL" not in model_ddl:
+        logger.info(
+            "Rebuilding the model table to pick up the adapter-kind CHECK; "
+            "the next folder scan refills it from disk."
+        )
+        conn.execute("DROP TABLE IF EXISTS model_file")
+        conn.execute("DROP TABLE IF EXISTS model")
 
     for statement in _V2_MODEL_SHELF_TABLES:
         conn.execute(statement)

--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -433,6 +433,90 @@ SCHEMA_MIGRATIONS: tuple[tuple[int, tuple[str, ...]], ...] = (
 )
 
 
+def _rebuild_model_with_kind_check(conn: sqlite3.Connection) -> None:
+    """Add the adapter-kind CHECK to an existing ``model`` table, rows and all.
+
+    SQLite has no ``ALTER TABLE ADD CONSTRAINT``, so the constraint can only
+    arrive by rebuilding: create the new shape, copy every row into it, drop the
+    old table, rename. The copy is what makes this cheap: ``model.id`` and
+    ``sha256`` come across unchanged, so every ``model_file`` row still points
+    at its content row and nothing has to be re-derived. Dropping the shelf
+    instead would re-hash every adapter and re-queue every checkpoint through
+    ``MissingCheckpointHashFinder`` at up to 24 GB each, to recover digests the
+    hub already had.
+
+    ``model_file`` is carried out and back in Python rather than left in place
+    because foreign keys are on for the whole migration
+    (``HubDatabase._configure``): ``DROP TABLE model`` runs an implicit DELETE
+    whose FK violations are checked immediately, so a child row referencing it
+    aborts the drop. ``PRAGMA defer_foreign_keys`` does not help, because
+    re-creating the parent by rename never decrements the counter that delete
+    increments, and ``PRAGMA foreign_keys=OFF`` is a silent no-op inside a
+    transaction.
+
+    One SAVEPOINT around the lot, because this runs both inside the migration's
+    transaction and (via the tail re-run) outside one. That is the difference
+    between a crash mid-rebuild and a hub whose ``model_file`` rows are gone.
+
+    Raises:
+        sqlite3.IntegrityError: A stored adapter row has no ``kind`` and the new
+            CHECK rejects it. No producer emits that row, so it is a genuine
+            surprise and is left to surface rather than worked around.
+    """
+    # Columns are named from the *stored* tables, not assumed to line up
+    # positionally with the DDL above: a column this build does not know about
+    # fails the copy loudly instead of being silently dropped.
+    model_columns = ", ".join(
+        row[1] for row in conn.execute("PRAGMA table_info(model)").fetchall()
+    )
+    file_columns = [
+        row[1] for row in conn.execute("PRAGMA table_info(model_file)").fetchall()
+    ]
+    file_names = ", ".join(file_columns)
+    saved_files = conn.execute(f"SELECT {file_names} FROM model_file").fetchall()
+
+    offenders = conn.execute(
+        "SELECT COUNT(*) FROM model WHERE file_kind = 'adapter' AND kind IS NULL"
+    ).fetchone()[0]
+    if offenders:
+        logger.error(
+            "%d adapter row(s) in this hub have no kind, which the new CHECK "
+            "rejects, so the model table cannot be rebuilt. Nothing writes that "
+            "row, so this is unexpected: inspect them with SELECT id, filename "
+            "FROM model WHERE file_kind = 'adapter' AND kind IS NULL.",
+            offenders,
+        )
+
+    logger.info(
+        "Rebuilding the model table to add the adapter-kind CHECK, carrying "
+        "%d model row(s) and %d location row(s) across.",
+        conn.execute("SELECT COUNT(*) FROM model").fetchone()[0],
+        len(saved_files),
+    )
+    conn.execute("SAVEPOINT model_kind_check")
+    try:
+        conn.execute("DROP TABLE model_file")
+        conn.execute(
+            _V2_MODEL.replace("IF NOT EXISTS model", "IF NOT EXISTS model_new")
+        )
+        conn.execute(
+            f"INSERT INTO model_new ({model_columns}) SELECT {model_columns} FROM model"
+        )
+        conn.execute("DROP TABLE model")
+        conn.execute("ALTER TABLE model_new RENAME TO model")
+        conn.execute(_V2_MODEL_FILE)
+        conn.executemany(
+            f"INSERT INTO model_file ({file_names}) "
+            f"VALUES ({', '.join('?' * len(file_columns))})",
+            saved_files,
+        )
+    except sqlite3.Error:
+        conn.execute("ROLLBACK TO model_kind_check")
+        conn.execute("RELEASE model_kind_check")
+        raise
+    conn.execute("RELEASE model_kind_check")
+
+
 def _apply_v2(conn: sqlite3.Connection) -> None:
     """Add v2 library bootstrap state without rewriting an existing hub."""
     columns = {row[1] for row in conn.execute("PRAGMA table_info(library)").fetchall()}
@@ -502,21 +586,15 @@ def _apply_v2(conn: sqlite3.Connection) -> None:
         for table in _V2_SUPERSEDED_SHELF_TABLES:
             conn.execute(f"DROP TABLE IF EXISTS {table}")
 
-    # The `kind` CHECK was added after the reshape and SQLite has no
-    # ALTER TABLE ADD CONSTRAINT, so a hub that already holds the pre-CHECK
-    # `model` table needs the same drop-and-rescan treatment. Legitimate for
-    # the same reason and only while v2 is unreleased: nothing a person typed
-    # lives in these two tables yet (the shelf UI is unbuilt), `model_folder`
-    # survives, and the next scan refills them from disk. Child first, so the
-    # FK the drop enforces has nothing pointing at it.
+    # The `kind` CHECK was added after the reshape, and unlike the tables above
+    # `model` holds rows worth keeping by then, so it is rebuilt rather than
+    # dropped. Keyed on the stored DDL, so it is false on a fresh hub (the
+    # CREATE below already carries the CHECK) and false on every re-run after
+    # the rebuild. The indexes the drops take with them are recreated by the
+    # statement loop that follows.
     model_ddl = existing.get("model")
     if model_ddl is not None and "kind IS NOT NULL" not in model_ddl:
-        logger.info(
-            "Rebuilding the model table to pick up the adapter-kind CHECK; "
-            "the next folder scan refills it from disk."
-        )
-        conn.execute("DROP TABLE IF EXISTS model_file")
-        conn.execute("DROP TABLE IF EXISTS model")
+        _rebuild_model_with_kind_check(conn)
 
     for statement in _V2_MODEL_SHELF_TABLES:
         conn.execute(statement)

--- a/pixlstash/services/model_folder_scanner.py
+++ b/pixlstash/services/model_folder_scanner.py
@@ -286,6 +286,11 @@ class ModelFolderScanner:
         ``model.sha256`` naming bytes that are no longer on disk, in the column
         Civitai lookup and the public ``{sha256}/file`` route both resolve on.
 
+        Only a row that was ``present`` last time is eligible, which is why
+        ``_known_files`` filters on that state: a file that went ``missing`` and
+        came back is a file we did not watch, so size and mtime prove nothing
+        about it (``cp -p`` of different bytes onto the name preserves both).
+
         The comparison is against *this folder's* row. Trusting another folder's
         row for the same relpath would file one file under another's digest.
         """
@@ -365,12 +370,18 @@ class ModelFolderScanner:
     def _known_files(
         self, folder_id: int
     ) -> dict[str, tuple[int, Optional[int], Optional[int]]]:
-        """Return ``{relpath: (model_id, file_size, file_mtime)}`` for this folder."""
+        """Return ``{relpath: (model_id, file_size, file_mtime)}`` for this folder.
+
+        ``present`` rows only. These feed ``_describe``'s unchanged-file fast
+        path, and a row that was ``missing`` or ``unreachable`` last time is a
+        file whose bytes nobody watched, so its recorded size and mtime are not
+        evidence that its digest still names what is on disk.
+        """
         rows = self._hub.fetchall(
             "SELECT mf.relpath, mf.model_id, mf.file_mtime, m.file_size "
             "FROM model_file mf JOIN model m ON m.id = mf.model_id "
-            "WHERE mf.model_folder_id = ?",
-            (folder_id,),
+            "WHERE mf.model_folder_id = ? AND mf.state = ?",
+            (folder_id, STATE_PRESENT),
         )
         return {
             row["relpath"]: (row["model_id"], row["file_size"], row["file_mtime"])

--- a/tests/test_hub_model_shelf_schema.py
+++ b/tests/test_hub_model_shelf_schema.py
@@ -17,12 +17,15 @@ Two rules under test throughout:
    could not do.
 """
 
+import re
 import sqlite3
 
 import pytest
 
 from pixlstash.hub.schema import (
     CURRENT_SCHEMA_VERSION,
+    _V2_MODEL,
+    _V2_MODEL_FILE,
     apply_migrations,
     read_schema_version,
 )
@@ -68,8 +71,8 @@ def ddl_for(conn, name):
 def add_model(conn, *, file_kind="adapter", sha256="h", **columns):
     """Insert one content row and return its id.
 
-    ``kind`` defaults the way the scanner writes it — an algorithm for an
-    adapter, NULL for anything else — so the suite's rows are shaped the way
+    ``kind`` defaults the way the scanner writes it, an algorithm for an
+    adapter and NULL for anything else, so the suite's rows are shaped the way
     real ones are. A helper that left it NULL on an adapter would be the one
     thing that lets a constraint or query regression pass unnoticed.
     """
@@ -86,6 +89,25 @@ def add_model(conn, *, file_kind="adapter", sha256="h", **columns):
         tuple(columns.values()),
     )
     return int(cursor.lastrowid)
+
+
+def _install_pre_check_model_table(conn):
+    """Put back the `model` shape a hub opened on an earlier develop still has.
+
+    Derived from the shipped DDL with the adapter-kind CHECK cut out, so it
+    stays the real pre-CHECK shape column for column instead of drifting from
+    it. Both tables go, because `model_file`'s foreign key would block the drop.
+    """
+    ddl = re.sub(
+        r",\s*(--[^\n]*\n\s*)*CHECK \(file_kind <> 'adapter' OR kind IS NOT NULL\)",
+        "",
+        _V2_MODEL,
+    )
+    assert "kind IS NOT NULL" not in ddl, "the pre-CHECK DDL still carries the CHECK"
+    conn.execute("DROP TABLE model_file")
+    conn.execute("DROP TABLE model")
+    conn.execute(ddl)
+    conn.execute(_V2_MODEL_FILE)
 
 
 def add_folder(conn, path):
@@ -215,33 +237,82 @@ class TestReRunIsSafe:
         assert not (set(SUPERSEDED_TABLES) & table_names(hub))
         assert {"model", "model_file"} <= table_names(hub)
 
-    def test_a_hub_with_the_pre_check_model_table_is_rebuilt(self, hub):
-        """The adapter-kind CHECK lands on a hub that already has `model`.
+    def test_a_hub_with_the_pre_check_model_table_keeps_its_rows(self, hub):
+        """The adapter-kind CHECK reaches a populated hub without costing it data.
 
-        SQLite has no ``ALTER TABLE ADD CONSTRAINT``, so the table is replaced
-        rather than altered. Legitimate only while v2 is unreleased: nothing a
-        person typed lives in ``model``/``model_file`` yet, ``model_folder``
-        survives, and the next scan refills them from disk.
+        SQLite has no ``ALTER TABLE ADD CONSTRAINT``, so the table is rebuilt:
+        new shape, copy, drop, rename. The copy is the point: ``model.id`` and
+        ``sha256`` come across unchanged, so the shelf is not re-hashed and no
+        checkpoint is re-queued at 24 GB to recover a digest the hub had.
         """
         apply_migrations(hub)
-        hub.execute("DROP TABLE model_file")
-        hub.execute("DROP TABLE model")
-        hub.execute(
-            "CREATE TABLE model (id INTEGER PRIMARY KEY AUTOINCREMENT, "
-            "file_kind TEXT NOT NULL, kind TEXT, sha256 TEXT UNIQUE, "
-            "display_name TEXT, provenance TEXT NOT NULL, "
-            "CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL))"
-        )
+        _install_pre_check_model_table(hub)
         folder_id = add_folder(hub, "/models")
+        adapter_id = add_model(hub, sha256="abc", kind="lora", display_name="Clem v3")
+        checkpoint_id = add_model(hub, file_kind="checkpoint", sha256=None, kind=None)
+        add_file(hub, adapter_id, folder_id, "clem.safetensors")
+        add_file(hub, checkpoint_id, folder_id, "flux.safetensors")
         hub.commit()
 
         apply_migrations(hub)
 
-        with pytest.raises(sqlite3.IntegrityError):
-            add_model(hub, file_kind="adapter", kind=None)
-        # The registration is the only thing in here a developer typed, and the
-        # rebuild leaves it alone.
+        assert hub.execute(
+            "SELECT id, sha256, display_name FROM model ORDER BY id"
+        ).fetchall() == [(adapter_id, "abc", "Clem v3"), (checkpoint_id, None, None)]
+        assert hub.execute(
+            "SELECT model_id, relpath, state FROM model_file ORDER BY relpath"
+        ).fetchall() == [
+            (adapter_id, "clem.safetensors", "present"),
+            (checkpoint_id, "flux.safetensors", "present"),
+        ]
         assert hub.execute("SELECT id FROM model_folder").fetchall() == [(folder_id,)]
+        assert hub.execute("PRAGMA foreign_key_check").fetchall() == []
+        # And the constraint the rebuild was for is now live.
+        with pytest.raises(sqlite3.IntegrityError):
+            add_model(hub, file_kind="adapter", sha256="new", kind=None)
+
+    def test_the_rebuild_leaves_the_indexes_where_they_belong(self, hub):
+        # Dropping `model` takes its indexes with it and the rename carries
+        # nothing stale over, so the CREATE INDEX block is what puts them back.
+        apply_migrations(hub)
+        _install_pre_check_model_table(hub)
+        hub.commit()
+
+        apply_migrations(hub)
+
+        indexes = {
+            row[0]: (row[1], row[2])
+            for row in hub.execute(
+                "SELECT name, tbl_name, sql FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
+        assert indexes["ix_model_stack_member"][0] == "model"
+        assert indexes["ix_model_file_model"][0] == "model_file"
+        assert indexes["ix_model_file_folder"][0] == "model_file"
+        # The partial hash-queue index in particular: a full one would be almost
+        # entirely rows MissingCheckpointHashFinder never wants.
+        table, sql = indexes["ix_model_hash_queue"]
+        assert table == "model"
+        assert "WHERE sha256 IS NULL" in sql
+
+    def test_an_adapter_with_no_kind_stops_the_rebuild_loudly(self, hub):
+        # Nothing emits that row. If one exists anyway the copy must fail rather
+        # than fall back to dropping the table, which is how the rows would be
+        # lost quietly.
+        apply_migrations(hub)
+        _install_pre_check_model_table(hub)
+        folder_id = add_folder(hub, "/models")
+        model_id = add_model(hub, sha256="abc", kind=None)
+        add_file(hub, model_id, folder_id, "clem.safetensors")
+        hub.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            apply_migrations(hub)
+
+        assert hub.execute("SELECT id, sha256 FROM model").fetchall() == [
+            (model_id, "abc")
+        ]
+        assert hub.execute("SELECT COUNT(*) FROM model_file").fetchone() == (1,)
 
     def test_the_drop_guard_is_idempotent_and_loses_nothing_after_the_first_open(
         self, hub

--- a/tests/test_hub_model_shelf_schema.py
+++ b/tests/test_hub_model_shelf_schema.py
@@ -66,10 +66,17 @@ def ddl_for(conn, name):
 
 
 def add_model(conn, *, file_kind="adapter", sha256="h", **columns):
-    """Insert one content row and return its id."""
+    """Insert one content row and return its id.
+
+    ``kind`` defaults the way the scanner writes it — an algorithm for an
+    adapter, NULL for anything else — so the suite's rows are shaped the way
+    real ones are. A helper that left it NULL on an adapter would be the one
+    thing that lets a constraint or query regression pass unnoticed.
+    """
     columns = {
         "file_kind": file_kind,
         "sha256": sha256,
+        "kind": "lora" if file_kind == "adapter" else None,
         "provenance": "external",
         **columns,
     }
@@ -208,6 +215,34 @@ class TestReRunIsSafe:
         assert not (set(SUPERSEDED_TABLES) & table_names(hub))
         assert {"model", "model_file"} <= table_names(hub)
 
+    def test_a_hub_with_the_pre_check_model_table_is_rebuilt(self, hub):
+        """The adapter-kind CHECK lands on a hub that already has `model`.
+
+        SQLite has no ``ALTER TABLE ADD CONSTRAINT``, so the table is replaced
+        rather than altered. Legitimate only while v2 is unreleased: nothing a
+        person typed lives in ``model``/``model_file`` yet, ``model_folder``
+        survives, and the next scan refills them from disk.
+        """
+        apply_migrations(hub)
+        hub.execute("DROP TABLE model_file")
+        hub.execute("DROP TABLE model")
+        hub.execute(
+            "CREATE TABLE model (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "file_kind TEXT NOT NULL, kind TEXT, sha256 TEXT UNIQUE, "
+            "display_name TEXT, provenance TEXT NOT NULL, "
+            "CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL))"
+        )
+        folder_id = add_folder(hub, "/models")
+        hub.commit()
+
+        apply_migrations(hub)
+
+        with pytest.raises(sqlite3.IntegrityError):
+            add_model(hub, file_kind="adapter", kind=None)
+        # The registration is the only thing in here a developer typed, and the
+        # rebuild leaves it alone.
+        assert hub.execute("SELECT id FROM model_folder").fetchall() == [(folder_id,)]
+
     def test_the_drop_guard_is_idempotent_and_loses_nothing_after_the_first_open(
         self, hub
     ):
@@ -247,6 +282,21 @@ class TestConstraints:
         apply_migrations(hub)
         with pytest.raises(sqlite3.IntegrityError):
             add_model(hub, file_kind="adapter", sha256=None)
+
+    def test_an_adapter_may_not_be_stored_without_a_kind(self, hub):
+        # No producer emits it: AdapterInfo.kind is typed str and
+        # detect_adapter_kind returns 'unknown' rather than None on every path.
+        # The CHECK is what keeps it that way once something else writes rows.
+        apply_migrations(hub)
+        with pytest.raises(sqlite3.IntegrityError):
+            add_model(hub, file_kind="adapter", kind=None)
+
+    def test_a_checkpoint_needs_no_kind(self, hub):
+        # The other direction: `kind` names an adapter algorithm, so demanding
+        # one of a checkpoint would be its own bug.
+        apply_migrations(hub)
+        add_model(hub, file_kind="checkpoint", sha256=None, kind=None)
+        assert hub.execute("SELECT kind FROM model").fetchone() == (None,)
 
     def test_a_checkpoint_may_be_registered_before_it_is_hashed(self, hub):
         # Deliberately different from an adapter: a checkpoint can be many

--- a/tests/test_model_folder_scanner.py
+++ b/tests/test_model_folder_scanner.py
@@ -17,7 +17,6 @@ about the claims the rest of the feature is built on:
 4. **A scan re-derives facts and never overwrites choices.**
 """
 
-import hashlib
 import json
 import os
 import struct
@@ -31,6 +30,7 @@ from pixlstash.services.model_folder_scanner import (
     STATE_PRESENT,
     STATE_UNREACHABLE,
     ModelFolderScanner,
+    sha256_file,
 )
 
 SKIP_AS_ROOT = pytest.mark.skipif(
@@ -139,7 +139,7 @@ class TestAdapters:
 
         scanner.scan_folder(folder_id, str(folder), "user")
 
-        expected = hashlib.sha256(open(path, "rb").read()).hexdigest()
+        expected = sha256_file(path)
         rows = adapters(hub)
         assert set(rows) == {expected}
         assert rows[expected]["file_kind"] == "adapter"
@@ -557,9 +557,43 @@ class TestScanCost:
         assert os.path.getsize(path) == next(iter(models(hub).values()))["file_size"]
         scanner.scan_folder(folder_id, str(folder), "user")
 
-        on_disk = hashlib.sha256(open(path, "rb").read()).hexdigest()
+        on_disk = sha256_file(str(path))
         assert on_disk != stale
         assert digest_at(hub, "a.safetensors") == on_disk
+
+    def test_a_returning_file_is_rehashed_even_when_size_and_mtime_match(
+        self, hub, scanner, tmp_path
+    ):
+        # A restore that preserves timestamps (`cp -p`, `rsync -a`) can put
+        # different bytes back under the same name with the same size and the
+        # same mtime. Nothing watched the file while it was missing, so the fast
+        # path must not trust the digest it recorded before it vanished.
+        folder = tmp_path / "loras"
+        folder.mkdir()
+        path = folder / "a.safetensors"
+        write_adapter(path, name="AAAA")
+        folder_id = register_folder(hub, folder)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        stale = digest_at(hub, "a.safetensors")
+        mtime_ns = os.stat(path).st_mtime_ns
+
+        os.remove(path)
+        scanner.scan_folder(folder_id, str(folder), "user")
+        assert located(hub)["a.safetensors"]["state"] == STATE_MISSING
+
+        write_adapter(path, name="BBBB")
+        os.utime(path, ns=(mtime_ns, mtime_ns))
+        # Both halves of the fast-path comparison still match, which is exactly
+        # what makes this the case the previous state has to veto.
+        assert located(hub)["a.safetensors"]["file_mtime"] == os.stat(path).st_mtime_ns
+        assert next(iter(models(hub).values()))["file_size"] == os.path.getsize(path)
+
+        scanner.scan_folder(folder_id, str(folder), "user")
+
+        on_disk = sha256_file(str(path))
+        assert on_disk != stale
+        assert digest_at(hub, "a.safetensors") == on_disk
+        assert located(hub)["a.safetensors"]["state"] == STATE_PRESENT
 
 
 class TestFolderKinds:


### PR DESCRIPTION
Closes items 12, 13 and 14 of #782.

**12 - the scan fast path trusted a row it did not watch.** `_describe()` took a
file as unchanged on size + mtime alone, so a file that went `missing` and came
back as different bytes carrying the same size and the same mtime (`cp -p`,
`rsync -a`) kept its old `sha256`, the column Civitai lookup and the public
`{sha256}/file` route resolve on. `_known_files()` now returns `present` rows
only, which is the whole veto: a row in any other state falls through to the
ordinary parse-and-hash path. The cost is one rehash per returning file.

**13 -** the digest assertions in `tests/test_model_folder_scanner.py` now use
the suite's own `sha256_file` instead of an unclosed `open(...).read()` (two
sites, not just the one the issue names).

**14 - `model.kind` could be NULL on an adapter row.** Second CHECK added,
mirroring the sha256 one: `CHECK (file_kind <> 'adapter' OR kind IS NOT NULL)`.
No producer ever emitted that row (`AdapterInfo.kind` is `str`,
`detect_adapter_kind()` returns `"unknown"`), so this only closes a state the
schema permitted and the code cannot reach. `add_model()` in
`tests/test_hub_model_shelf_schema.py` now defaults `kind` the way the scanner
writes it, an algorithm for an adapter and NULL otherwise, so the suite's rows
stop being shaped in a way real data never is.

### Getting the CHECK onto a hub that already has the table

SQLite has no `ALTER TABLE ADD CONSTRAINT` and `CREATE TABLE IF NOT EXISTS`
cannot reshape, so `_apply_v2` gains a guard beside the existing
superseded-table drop: a hub whose stored `model` DDL lacks the new CHECK is
**rebuilt, not dropped**. New shape, copy every row in by name, drop the old
table, rename. `model.id` and `sha256` come across unchanged, so no adapter is
re-hashed and no checkpoint is re-queued through `MissingCheckpointHashFinder`
at up to 24 GB each to recover a digest the hub already had.

`model_file` is carried out and back in Python rather than left in place.
Foreign keys are ON for the whole migration (`HubDatabase._configure` sets
`PRAGMA foreign_keys=ON` before `apply_migrations`), and `DROP TABLE model` runs
an implicit DELETE whose FK violations are checked immediately, so a child row
referencing it aborts the drop. Verified, along with the two obvious ways out:
`PRAGMA defer_foreign_keys=ON` gets as far as COMMIT and then fails, because
re-creating the parent by rename never decrements the counter the delete
incremented; `PRAGMA legacy_alter_table=ON` does not stop the rename rewriting
`model_file`'s REFERENCES clause. The whole rebuild sits in one SAVEPOINT, so it
is atomic whether or not a transaction is already open, and it was exercised in
both modes.

Columns are named from the *stored* tables via `PRAGMA table_info`, so nothing
depends on column order and a column this build does not know about fails the
copy loudly instead of being dropped silently. A stored adapter row with no
`kind` logs an error with the offending row count and then lets the
`IntegrityError` surface: there is no fallback to dropping.

The guard stays keyed on the stored DDL, so it is false on a fresh hub and false
on every re-run after the rebuild. The `_V2_SUPERSEDED_SHELF_TABLES` drop for the
pre-reshape `adapter` tables is untouched.

### Evidence

Tests both directions per item: a returning file with matching size+mtime is
rehashed while an ordinary unchanged file still is not
(`test_an_unchanged_file_is_not_rehashed` guards that half); an adapter with
NULL `kind` is rejected while a checkpoint with NULL `kind` is still accepted; a
populated pre-CHECK hub keeps every `model` and `model_file` row **with the same
ids** across the rebuild, with `PRAGMA foreign_key_check` clean; the indexes land
back on the right tables and `ix_model_hash_queue` is still partial; and a hub
holding an adapter row with no `kind` fails the open with its rows intact.

- `.venv/bin/python -m pytest -s -vvv --fast-captions --force-cpu` on the two
  touched files: **55 passed**.
- With the neighbouring shelf/hub suites: **292 passed**.
- Negative controls: the three behavioural tests for items 12/14 fail with the
  source changes stashed, and the two rows-survive tests fail against the
  earlier drop-based implementation, which is the data loss they exist to catch.
- End-to-end through the real `HubDatabase` open path on a hub rewound to the
  pre-CHECK shape: rows and ids preserved, FK check clean, CHECK live, partial
  index restored, second open a no-op.
- `ruff format` and `ruff check` clean. Both test files were already listed in
  the `backend` job, so no CI gate change.
