### PR TITLE
Share one server across the picture-mutation scope tests

### DIFF
--- a/tests/test_picture_mutation_scope.py
+++ b/tests/test_picture_mutation_scope.py
@@ -43,7 +43,7 @@ import pixlstash.routes.pictures._misc as misc_module
 from pixlstash.db_models import Picture, UserToken
 from pixlstash.routes.pictures import _helpers as helpers_module
 from pixlstash.server import Server
-from tests.authz_guard import no_spa_fallback  # noqa: F401
+from tests.authz_guard import assert_real_route, no_spa_fallback  # noqa: F401
 from tests.utils import upload_pictures_and_wait
 
 API = "/api/v1"
@@ -83,11 +83,15 @@ def _tables_to_wipe(server):
 
     Returned children-first (reverse dependency order), which together with
     restoring ``picture`` before the deletes keeps every foreign key satisfied
-    at all times: the only reference out of a preserved table into a wiped one
-    is ``picture.stack_id`` -> ``picturestack``, and the restore puts that back
-    to NULL first. No ``PRAGMA foreign_keys`` fiddling is needed, and none is
-    wanted — a failed delete with enforcement switched off stays off on the
-    pooled connection and silently weakens every later test.
+    at all times. ``Picture`` points out of the preserved set into the wiped one
+    three times — ``stack_id`` -> ``picturestack``, ``project_id`` -> ``project``
+    and ``reference_folder_id`` -> ``reference_folder`` — and the restore puts
+    all three back to their imported values (NULL, for this fixture) before the
+    referenced rows go. Foreign keys really are enforced here
+    (``pixlstash/database.py``), so a fixture that imported into a project or a
+    reference folder would need that restore, not a ``PRAGMA``: switching
+    enforcement off leaves it off on the pooled connection if a delete raises,
+    silently weakening every later test.
     """
     engine = server.vault.db._engine
     present = set(sa.inspect(engine).get_table_names())
@@ -458,6 +462,10 @@ def test_remove_tag_everywhere_scoped_token_blocked(env, scoped):
     server, client, picture_ids, _ = env
     anon, tok = scoped
     target = picture_ids[1]
+    # The READ-token write block runs in middleware, ahead of routing, so a
+    # renamed or deleted route answers 403 exactly like a live guarded one.
+    # No other assertion in this file proves this route exists.
+    assert_real_route(server.api, "POST", f"{API}/pictures/{target}/tags/remove_all")
     r = anon.post(
         f"{API}/pictures/{target}/tags/remove_all",
         json={"tag": "x"},
@@ -489,6 +497,11 @@ def test_delete_face_scoped_token_blocked(env, scoped):
     assert r.status_code == 200, r.text
     face_index = r.json().get("face_index", 0)
 
+    # Middleware answers 403 before routing, so the owner's POST above does not
+    # prove this different route still exists.
+    assert_real_route(
+        server.api, "DELETE", f"{API}/pictures/{target}/face/{face_index}"
+    )
     r = anon.delete(f"{API}/pictures/{target}/face/{face_index}", headers=_bearer(tok))
     assert r.status_code == 403, r.text
 
@@ -774,6 +787,10 @@ def test_assign_face_owner_not_blocked(env, monkeypatch):
 def test_comfyui_i2i_scoped_token_blocked(env, scoped):
     server, client, picture_ids, _ = env
     anon, tok = scoped
+    # The owner counterpart asserts 404, which a deleted route also returns, so
+    # neither test would notice this route disappearing. Middleware 403s ahead
+    # of routing, so this one would not notice either.
+    assert_real_route(server.api, "POST", f"{API}/comfyui/run_i2i")
     r = anon.post(
         f"{API}/comfyui/run_i2i",
         json={"workflow_name": "nonexistent", "picture_ids": [picture_ids[1]]},
@@ -799,6 +816,9 @@ def test_comfyui_i2i_owner_passes_scope_guard(env, monkeypatch):
 def test_comfyui_t2i_source_picture_scoped_token_blocked(env, scoped):
     server, client, picture_ids, _ = env
     anon, tok = scoped
+    # This route has no owner counterpart anywhere in the file, so nothing else
+    # would notice it being renamed away; middleware 403s before routing.
+    assert_real_route(server.api, "POST", f"{API}/comfyui/run_t2i")
     r = anon.post(
         f"{API}/comfyui/run_t2i",
         json={"workflow_name": "nonexistent", "source_picture_id": picture_ids[1]},

--- a/tests/test_picture_mutation_scope.py
+++ b/tests/test_picture_mutation_scope.py
@@ -27,15 +27,20 @@ import gc
 import json
 import os
 import tempfile
+import time
+from types import SimpleNamespace
 
 import pytest
+import sqlalchemy as sa
 from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, delete
 
 import pixlstash.routes.tags as tags_module
 import pixlstash.routes.characters_faces as characters_faces_module
 import pixlstash.routes.comfyui as comfyui_module
 import pixlstash.routes.pictures._crud as crud_module
 import pixlstash.routes.pictures._misc as misc_module
+from pixlstash.db_models import Picture, UserToken
 from pixlstash.routes.pictures import _helpers as helpers_module
 from pixlstash.server import Server
 from tests.authz_guard import no_spa_fallback  # noqa: F401
@@ -61,41 +66,299 @@ def _good_picture_files():
     return results
 
 
-@pytest.fixture
-def env():
-    """A live server with >=2 imported pictures and a reference character."""
+def _tables_to_wipe(server):
+    """Vault tables that carry test state and must be emptied between tests.
+
+    Every table in the live vault schema, minus the ones that already hold rows
+    on a freshly started server (``library_settings``, ``metadata``,
+    ``snapshot``) — those are start-up state, not test state — and minus
+    ``picture`` itself, whose rows are the fixture library and are restored
+    column-by-column by ``_reset_library`` rather than re-imported.
+
+    Deriving the list from the schema instead of hand-listing models keeps it
+    complete: a table added later is wiped without anyone remembering to add it
+    here, and a forgotten table is exactly how a shared environment starts
+    making assertions pass for the wrong reason. Must be called *before* the
+    fixture library is imported, or ``picture`` and ``tag`` look seeded.
+
+    Returned children-first (reverse dependency order), which together with
+    restoring ``picture`` before the deletes keeps every foreign key satisfied
+    at all times: the only reference out of a preserved table into a wiped one
+    is ``picture.stack_id`` -> ``picturestack``, and the restore puts that back
+    to NULL first. No ``PRAGMA foreign_keys`` fiddling is needed, and none is
+    wanted — a failed delete with enforcement switched off stays off on the
+    pooled connection and silently weakens every later test.
+    """
+    engine = server.vault.db._engine
+    present = set(sa.inspect(engine).get_table_names())
+    with engine.connect() as connection:
+        seeded = {
+            name
+            for name in present
+            if connection.execute(
+                sa.select(sa.func.count()).select_from(sa.table(name))
+            ).scalar()
+        }
+    seeded.add(Picture.__tablename__)
+    return [
+        table
+        for table in reversed(SQLModel.metadata.sorted_tables)
+        if table.name in present and table.name not in seeded
+    ]
+
+
+def _picture_rows(server):
+    """Every column of every fixture picture, for restoring between tests.
+
+    Snapshotting the whole row rather than the handful of columns these tests
+    are known to write (``deleted``, ``deleted_at``, ``score``, ``stack_id``,
+    ``project_id``, …) means a handler that starts writing one more column does
+    not quietly leak it into the next test.
+    """
+    columns = [column.name for column in Picture.__table__.columns]
+    return server.vault.db.run_immediate_read_task(
+        lambda session: [
+            {name: getattr(row, name) for name in columns}
+            for row in session.exec(sa.select(Picture)).scalars().all()
+        ]
+    )
+
+
+def _quiesce_background_work(server):
+    """Take every work finder out of the planner and let the pipeline settle.
+
+    The per-test ``Server`` this module used to build was hiding the import
+    pipeline rather than avoiding it: a vault that had just come up had nothing
+    to backfill and no models loaded, so the sweeps were still in a long
+    backoff when the test ended. A shared server is warm, and the sweeps land
+    *inside* the tests instead — where they rewrite the very rows the fixtures
+    hand-place. ``TagTask`` runs ``delete(Tag).where(picture_id.in_(...))``
+    before writing its own labels, ``FaceExtractionTask`` adds ``Face`` rows
+    beside the ones a test just created and indexes by position, and the dedup
+    sweep stacks pictures, which changes how many rows a bulk delete touches.
+
+    Nothing in this module needs derived data — every assertion is a status
+    code against hand-made objects — so every finder goes, not a curated
+    subset. The planner thread itself keeps running (a route that wakes it must
+    still find it alive) and so does the task runner, so routes that submit
+    work directly are unaffected. Stopping the planner around the removal keeps
+    ``_run_finders_once`` from indexing a list that is shrinking underneath it.
+
+    Waiting the pipeline out per test instead was measured slower than the
+    per-test servers this replaces (PR #814), which is why it is switched off
+    once here rather than polled for.
+
+    Returns the names of the finders it removed, so the per-test fixture can
+    re-check before every test that they are still gone.
+    """
+    planner = server.vault._work_planner
+    planner.stop()
+    removed = set()
+    for task_type in list(server.vault._planner_work_finders):
+        finder = server.vault._planner_work_finders.pop(task_type)
+        planner._task_finders.remove(finder)
+        planner._task_finders_by_name.pop(finder.finder_name(), None)
+        removed.add(finder.finder_name())
+    planner.start()
+
+    # Work already queued or running when the finders went is still ours to
+    # wait for: it would otherwise write into the first test's freshly reset
+    # library.
+    runner = server.vault._task_runner
+    runner.cancel_pending_tasks()
+    deadline = time.monotonic() + 60.0
+    while time.monotonic() < deadline:
+        with runner._active_task_lock:
+            active = list(runner._active_tasks.values())
+        if not active:
+            return removed
+        time.sleep(0.05)
+    raise AssertionError(
+        f"import pipeline did not settle within 60s; still running: {active}"
+    )
+
+
+@pytest.fixture(scope="module")
+def _shared_env():
+    """One Server, one imported library, shared by every test in this module.
+
+    Building a Server and importing four photographs costs ~1.4 s, and tearing
+    it down costs another ~2 s that has nothing to do with the Server object:
+    ``Vault.stop()`` joins the import pipeline the upload started (face
+    detection loads its ONNX models *during* the join), then releases those
+    models again, closes the engine and collects. All of it is per-Server work,
+    so it is paid once here instead of 30 times, and per-test isolation comes
+    from the autouse ``fresh_state`` fixture below.
+    """
     temp_dir = tempfile.TemporaryDirectory()
-    config_path = os.path.join(temp_dir.name, "server-config.json")
-    with open(config_path, "w") as fh:
-        fh.write(json.dumps({"port": 8000}))
-    server = Server(config_path)
-    server.__enter__()
     try:
-        client = TestClient(server.api, raise_server_exceptions=True)
-        r = client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
-        )
-        assert r.status_code == 200, r.text
+        config_path = os.path.join(temp_dir.name, "server-config.json")
+        with open(config_path, "w") as fh:
+            fh.write(json.dumps({"port": 8000}))
+        server = Server(config_path)
+        try:
+            client = TestClient(server.api, raise_server_exceptions=True)
+            r = client.post(
+                f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            )
+            assert r.status_code == 200, r.text
 
-        files = [("file", (n, d, c)) for n, d, c in _good_picture_files()[:4]]
-        assert files, "No test pictures found in pictures/good/"
-        st = upload_pictures_and_wait(client, files, timeout_s=30)
-        assert st["status"] == "completed", st
+            # Before the import, or the library itself counts as seeded.
+            wipe_tables = _tables_to_wipe(server)
 
-        r = client.get(f"{API}/pictures")
-        assert r.status_code == 200, r.text
-        picture_ids = [p["id"] for p in r.json()]
-        assert len(picture_ids) >= 2, "Need at least two pictures for the scope test"
+            files = [("file", (n, d, c)) for n, d, c in _good_picture_files()[:4]]
+            assert files, "No test pictures found in pictures/good/"
+            st = upload_pictures_and_wait(client, files, timeout_s=30)
+            assert st["status"] == "completed", st
 
-        r = client.post(f"{API}/characters", json={"name": "ScopeChar"})
-        assert r.status_code == 200, r.text
-        character_id = r.json()["character"]["id"]
+            disabled_finders = _quiesce_background_work(server)
 
-        yield server, client, picture_ids, character_id
+            r = client.get(f"{API}/pictures")
+            assert r.status_code == 200, r.text
+            picture_ids = [p["id"] for p in r.json()]
+            assert len(picture_ids) >= 2, (
+                "Need at least two pictures for the scope test"
+            )
+
+            yield SimpleNamespace(
+                server=server,
+                client=client,
+                picture_ids=picture_ids,
+                wipe_tables=wipe_tables,
+                disabled_finders=disabled_finders,
+                picture_rows=_picture_rows(server),
+            )
+        finally:
+            server.close()
     finally:
-        server.__exit__(None, None, None)
         temp_dir.cleanup()
         gc.collect()
+
+
+def _reset_library(shared):
+    """Put the shared vault back to its just-imported state.
+
+    Restores the pictures first and deletes everything else second — see
+    ``_tables_to_wipe`` for why that order keeps the foreign keys satisfied
+    without disabling them.
+    """
+    picture_table = Picture.__table__
+
+    def _reset(session):
+        for row in shared.picture_rows:
+            session.execute(
+                sa.update(picture_table)
+                .where(picture_table.c.id == row["id"])
+                .values(**row)
+            )
+        for table in shared.wipe_tables:
+            session.exec(delete(table))
+        session.commit()
+
+    shared.server.vault.db.run_task(_reset)
+
+    # Tokens live in the hub, not the vault. Flushing through the helper bumps
+    # the revocation epoch too, which a bare _token_cache.clear() skips.
+    def _wipe_tokens(session):
+        session.exec(delete(UserToken))
+        session.commit()
+
+    shared.server.hub_engine.run_task(_wipe_tokens)
+    shared.server.auth._flush_token_cache()
+
+
+@pytest.fixture(autouse=True)
+def fresh_state(_shared_env):
+    """Reset the shared library and re-mint every credential, before each test.
+
+    This is the canary for the shared environment as well as its reset, and it
+    is deliberately a per-test fixture rather than a trailing "runs last"
+    canary test: the CI gate partitions *individual* tests across shards
+    (``--ci-shard``, tests/conftest.py), so a trailing test would land in one
+    shard and watch nothing in the others.
+
+    A negative assertion in this module is a 403. Four different accidents
+    produce that same 403 without any scope guard being involved, and each one
+    is handled here before the test body runs:
+
+    * a credential a previous test revoked, or a session it killed — so the
+      owner logs in again and the share token is minted fresh every time;
+    * a share token that never worked at all — so it is proved on an in-scope
+      read first. If it cannot read, the test does not run;
+    * the target picture having been deleted by a previous test — so the
+      owner's listing is checked against the exact fixture *ids*, not a count:
+      a missing picture and a scope refusal are indistinguishable from a status
+      code;
+    * a backfill finder rewriting the row under the test — so the finders
+      ``_quiesce_background_work`` removed are re-checked by name.
+    """
+    shared = _shared_env
+    _reset_library(shared)
+
+    running = {
+        finder.finder_name()
+        for finder in shared.server.vault._work_planner._task_finders
+    }
+    assert running.isdisjoint(shared.disabled_finders), (
+        "a background finder that rewrites this module's fixture data is "
+        f"running again: {sorted(running & shared.disabled_finders)}"
+    )
+
+    r = shared.client.post(
+        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+    )
+    assert r.status_code == 200, (
+        f"owner re-login failed — the shared environment is dirty: {r.text}"
+    )
+
+    listed = shared.client.get(f"{API}/pictures")
+    assert listed.status_code == 200, listed.text
+    assert [p["id"] for p in listed.json()] == shared.picture_ids, (
+        "the fixture library is not back to its imported state; a picture a "
+        "previous test deleted answers a mutation with 403 exactly like a "
+        "scope refusal does"
+    )
+
+    r = shared.client.post(f"{API}/characters", json={"name": "ScopeChar"})
+    assert r.status_code == 200, r.text
+    character_id = r.json()["character"]["id"]
+
+    r = shared.client.post(
+        f"{API}/users/me/token",
+        json={
+            "description": "set share",
+            "scope": "READ",
+            "resource_type": "picture_set",
+            "resource_id": 1,
+        },
+    )
+    assert r.status_code == 200, r.text
+    token = r.json()["token"]
+
+    anon = TestClient(shared.server.api, raise_server_exceptions=True)
+    probe = anon.get(f"{API}/pictures", headers=_bearer(token))
+    assert probe.status_code == 200, (
+        f"the freshly minted share token cannot authenticate ({probe.status_code}: "
+        f"{probe.text}) — every 403 below would prove nothing. An unknown or "
+        "revoked token answers 401 here, not 200."
+    )
+    assert probe.json() == [], (
+        "the share token is scoped to a picture set that holds nothing, so it "
+        f"must see no pictures at all; it sees {probe.json()}"
+    )
+
+    yield SimpleNamespace(character_id=character_id, token=token, anon=anon)
+
+
+@pytest.fixture
+def env(_shared_env, fresh_state):
+    """A live server with >=2 imported pictures and a reference character."""
+    return (
+        _shared_env.server,
+        _shared_env.client,
+        _shared_env.picture_ids,
+        fresh_state.character_id,
+    )
 
 
 def _scope_to(monkeypatch, modules, allowed_ids):
@@ -138,7 +401,7 @@ def _bearer(token: str) -> dict:
 
 
 @pytest.fixture
-def scoped(env):
+def scoped(fresh_state):
     """A cookie-less ``anon`` client plus a real resource-scoped READ (share)
     token, for exercising the live object-authorization stack on the
     single-picture mutation routes.
@@ -149,20 +412,12 @@ def scoped(env):
     someone else's pictures. The routes are also declared ``PICTURE_SCOPED`` in
     ``pixlstash/authz/registry.py``; the gate's per-object membership contract is
     proven in ``tests/test_authz_gate_step4.py``.
+
+    Both are minted fresh per test by ``fresh_state``, which also proves the
+    token authenticates before handing it over — a shared credential is exactly
+    what would turn a later test's 403 from "wrong scope" into "no credential".
     """
-    server, client, _picture_ids, _char = env
-    r = client.post(
-        f"{API}/users/me/token",
-        json={
-            "description": "set share",
-            "scope": "READ",
-            "resource_type": "picture_set",
-            "resource_id": 1,
-        },
-    )
-    assert r.status_code == 200, r.text
-    anon = TestClient(server.api, raise_server_exceptions=True)
-    return anon, r.json()["token"]
+    return fresh_state.anon, fresh_state.token
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Issue #796 (CI speed). `tests/test_picture_mutation_scope.py` built a fresh `Server` and re-imported four photographs for every one of its 30 tests. It now builds one, module-scoped, and resets state plus re-mints every credential per test.

## Measured

| | wall clock | tests |
|---|---|---|
| before (`df5ed0fb^`) | 165.97 s | 30 passed |
| after (`df5ed0fb`) | 19.46 s | 30 passed |

One uninterrupted old-then-new A/B in a dedicated worktree, `.venv/bin/python -m pytest -q --fast-captions --force-cpu tests/test_picture_mutation_scope.py`, exit code checked directly. Test count unchanged; nothing under `pixlstash/` changed; `docs/authz-coverage-matrix.md` untouched.

## What the per-test teardown actually was

CI recorded 7.5-8.8 s of *teardown* per test against ~3 s of setup, which looked like Python object destruction and is not. `Server.close()` → `Vault.stop()` **joins the import pipeline that the test's own upload started**: the face-extraction worker is still running, so the join sits there while insightface loads its five ONNX models (`det_10g`, `w600k_r50`, …) — models the test never uses. `Vault.stop()` then releases those same models, closes the engine and runs `gc.collect()`. Locally: 0.94 s in the task-runner join, 0.98 s in the rest of `close()`, 0.25 s in tempdir cleanup + gc, ≈2.2 s total, and the same shape stretched by CI's slower CPU-only runners.

All of it is per-`Server` work, none of it per-test, which is exactly the case a module fixture collapses.

## Background work on a warm server

A shared server is warm, so the sweeps that used to sit in backoff now land *inside* the tests, where they rewrite fixture rows (`TagTask` deletes a picture's tags before writing its own; `FaceExtractionTask` adds `Face` rows beside hand-created ones that are addressed by index; the dedup sweep stacks pictures, which changes how many rows a bulk delete touches). `_quiesce_background_work` therefore removes **every** finder from the `WorkPlanner` once, after the one import — nothing in this module reads derived data. The planner thread and task runner keep running, so routes that submit or wake work still behave. Queued work is cancelled and in-flight work waited out once, at module setup.

## What the autouse fixture resets, and why each item is a way a 403 could lie

`fresh_state` runs before every test (autouse fixture, never a trailing canary — `--ci-shard` deals *individual* tests, so a canary would guard one shard and watch nothing in the other seven):

- restores every column of every fixture `Picture` from a snapshot, then wipes every vault table except the three that hold rows on a fresh server and `picture` itself. The wipe list is derived from the live schema, so a table added later is covered without anyone remembering it. Pictures are restored *before* the deletes, which keeps `picture.stack_id → picturestack` satisfied without touching `PRAGMA foreign_keys` (enforcement left off on a pooled connection by a raising delete would silently weaken every later test);
- deletes every `UserToken` from the hub and flushes the token cache through the helper that also bumps the revocation epoch;
- logs the owner in again, and asserts it worked;
- asserts the owner's `GET /pictures` returns **exactly the fixture ids** — identity, not a count. A picture a previous test deleted answers a mutation with 403 exactly like a scope refusal does;
- recreates the reference character;
- mints a fresh share token and **proves it on an in-scope read** (200, and exactly `[]`). An unknown or revoked token answers 401 there, so a negative below cannot be "no credential";
- re-checks by name that no removed finder is running again.

## Mutation check

Guard removed in the worktree, uncommitted; restored afterwards.

**RED — batch (`SCOPED_LIST`) guard.** `pixlstash/routes/pictures/_crud.py:325`, `scope_allowed = fetch_scope_allowed_picture_ids(server, request)` → `scope_allowed = None`:

```
FAILED tests/test_picture_mutation_scope.py::test_set_project_denied_when_all_out_of_scope
1 failed, 29 passed, 2 warnings in 17.60s
```

**RED — single-picture (`PICTURE_SCOPED`) guards.** These negatives are covered twice over, and the file proves it: neutering *only* the READ-token write block in `pixlstash/auth.py` (~2532) leaves 30 passing, because the central authz gate still refuses; neutering *only* `AUTHZ_GATE_ENFORCING` leaves the middleware refusing. With **both** removed:

```
FAILED tests/test_picture_mutation_scope.py::test_add_tag_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_clear_tags_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_remove_tag_everywhere_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_create_face_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_delete_face_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_delete_picture_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_bulk_delete_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_patch_picture_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_comfyui_i2i_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_comfyui_t2i_source_picture_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_comfyui_recipe_read_scoped_token_blocked
FAILED tests/test_picture_mutation_scope.py::test_comfyui_run_recipe_scoped_token_blocked
12 failed, 18 passed, 2 warnings in 17.65s
```

**GREEN — both guards restored** (`git checkout -- pixlstash/auth.py pixlstash/authz/gate.py`, tree clean apart from the test file):

```
30 passed, 2 warnings in 18.82s
```

## Order independence

Green in file order, in reverse order (30 passed, 17.87 s), and one test at a time — the shape CI actually runs, since the gate may hand a shard a single test from this file.

## Independent security sign-off

CLAUDE.md forbids the author of security work from certifying it, so a `chief-security-officer` review was run against `df5ed0fb` tasked specifically with finding assertions that now pass for the wrong reason. **Verdict: no release blockers.** What it proved rather than assumed:

- replayed all 16 negatives and printed the `detail`: 11 read `'Token is read-only'` (middleware), one reads `'Token is not authorised to access this picture'` (gate membership), four read `'…these pictures'` (inline batch filter). None of the other 403 sources can reach them — a missing or revoked credential is **401**, the login lockout needs five *failed* logins, the rate limiter is **429**;
- sabotaged `_reset_library` into a no-op: **23 tests ERROR** at the id-list assertion. Sabotaged the id-list assertion too: **24 tests pass on a corrupted library**, including `test_patch_picture_scoped_token_blocked` and `test_delete_picture_scoped_token_blocked`. The canary is load-bearing, not decoration;
- confirmed all 8 `--ci-shard i/8` partitions green (4+3+3+4+4+4+4+4 = 30), and that `fresh_state` reaches all 30 tests;
- confirmed the reset is complete: after a representative mutation spread, every vault and hub table returns to baseline and every `Picture` column matches the snapshot; `_failed_login_attempts=0`, `_login_lockout_until=0.0`, token cache and session maps empty. Preserved tables are exactly `alembic_version, library_settings, metadata, picture, snapshot`, and no test writes any of them;
- confirmed the share token's grant names a **real** object: `POST /characters` creates a backing `PictureSet(id=1)`, ids are stable across tests (no `AUTOINCREMENT` anywhere), so `probe.json() == []` is a genuine check — an owner-equivalent token returns 4 pictures there;
- confirmed no authorization guard lives in background work, so removing the finders cannot change why a refusal happens.

**Findings addressed in `99d835ba`:**

- **F1 (low, pre-existing).** The READ-token write block runs in *middleware, ahead of routing*, so a renamed or deleted route answers 403 identically to a live guarded one — and `no_spa_fallback` cannot catch it, because it only fires on 2xx. Four tests had no proof anywhere in the file that their route exists (`remove_all`, `DELETE …/face/{i}`, `run_t2i`, `run_i2i` — the i2i owner counterpart asserts 404, which a deleted route also returns). Each now calls `assert_real_route` first. Proof it bites: pointing one at `/comfyui/run_t2i_GONE` fails with `matches no mounted API route`.
- **F2 (info).** `_tables_to_wipe`'s docstring named one of the three `Picture` columns that point into wiped tables; it now names `stack_id`, `project_id` and `reference_folder_id`, and says why the restore-before-delete order (not a `PRAGMA`) is what keeps them satisfied.

**Noted, not changed:**

- **F3.** This module now does 30 logins against one Server in ~20 s; `/login` is rate limited at 120/60 s, so ~4x headroom. A 429 fails `fresh_state` loudly rather than silently, but it is a growth ceiling worth knowing before another 60 tests land here.
- **F4.** `_picture_rows` snapshots via `run_immediate_read_task` just after the drain; the sub-millisecond window would produce a stable-but-different baseline that the id-list canary surfaces.
- A methodology trap for anyone re-running the mutation check: `AUTHZ_GATE_ENFORCING = True` appears **twice** in `pixlstash/authz/gate.py`, once in the module docstring. A first-occurrence replace mutates the docstring and yields a green run that falsely looks like the gate is redundant. Anchor on `^AUTHZ_GATE_ENFORCING = True$`.

## Not touched

`tests/ci_test_durations.json` still carries the old ~11-12 s per-test figures for this file; refreshing the map is a separate chore (CLAUDE.md: a stale map costs balance, never coverage) and other agents own that file right now. Same for `.github/workflows/ci.yml`, where the file is already listed.
