### PR TITLE
Share one environment per library shape in the read-token tests

### DIFF
--- a/tests/test_read_token_security.py
+++ b/tests/test_read_token_security.py
@@ -14,40 +14,75 @@ Coverage
 8. All picture data uploaded before token issuance survives every attack attempt
    intact (scores, filenames).
 
-Most classes here still create the server fresh per test function with a real
-temporary database and a small library of generated pictures, so each scenario
-gets an isolated, realistically-populated vault (see ``_good_picture_files``).
+Environment sharing
+-------------------
+Booting a Server and pushing a library through the import pipeline costs
+seconds; the assertions those libraries serve cost milliseconds. This module
+therefore builds each of the three library shapes it needs **once per module**
+(``_picture_library_env``, ``_two_set_env``, ``_comfyui_stack_env``) and resets
+per test. Module scope rather than class scope because ``--ci-shard``
+(tests/conftest.py) partitions *individual tests*, so a class-scoped fixture is
+rebuilt once per shard per class and barely amortises.
 
-``TestReadTokenBlocksWrites`` is the exception: booting a Server and importing
-the library costs ~1.5-2.3 s and its assertions cost milliseconds, so it shares
-one environment for the whole class (``read_token_write_env``) and re-mints
-*credentials* per test instead (``read_token``). That split is deliberate — a
-shared credential is exactly what would let one test's revocation turn a later
-test's 403 from "wrong scope" into "no credential". ``read_token`` is therefore
-also the canary for the shared environment: it re-establishes the owner
-session, mints a fresh token, proves that token on an in-scope read and
-re-checks the library's ids and scores, all before each negative assertion
-runs. It is a per-test fixture rather than a trailing "runs last" test because
-``--ci-shard`` (tests/conftest.py) partitions tests individually, so a trailing
-test would land in one shard and watch nothing in the other three.
+What is emphatically **not** shared is the credential. Every per-test fixture
+below deletes every token row, drops every session, flushes the token cache
+(bumping its revocation epoch), clears the login lockout and the rate-limit
+window, and then re-establishes the owner session from a fresh login before
+minting the token the test will use.
+
+Two separate things make that safe, and it is worth not confusing them. The
+load-bearing one is structural: authentication runs as middleware *before*
+routing, so a revoked, expired or absent credential is answered **401** on
+every endpoint shape this module touches, while a live-but-wrong-scope
+credential is answered 403/404 by the authz gate. A dead credential therefore
+cannot satisfy any of the assertions below, all of which require 403 or 404.
+The per-test wipe is defence in depth on top of that — it stops one test's
+token from being the one a later test unknowingly exercises — and the in-scope
+positive control below is what proves the credential is live rather than
+assuming it.
+
+Each per-test fixture also re-proves the environment before the test body runs:
+the freshly minted token is exercised on an **in-scope read** (the positive
+control adjacent to every negative one), and the library's **identity** — which
+picture ids exist, which set holds which, which scores they carry — is
+re-checked. Identity, never counts: a missing object answers a request the same
+way a scope refusal does. These checks live in the fixture rather than in a
+trailing "canary" test because the shard split would leave such a test watching
+only its own shard.
+
+Two classes deliberately keep a per-test Server: ``TestLoginBruteForce`` and
+``TestRateLimiter`` exist to assert on server-lifetime lockout and rate-limit
+state, which is the one thing a shared server cannot honestly provide. They
+never import a picture, so they only pay the (cheap) boot.
 """
 
 import io
 import json
 import tempfile
 import time
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
+from sqlmodel import Session, delete, select, update
 
 import pixlstash.routes.pictures._character_likeness as likeness_module
 import pixlstash.routes.pictures._listing as listing_module
 import pixlstash.utils.rate_limiter as rl_module
-from pixlstash.db_models import Picture, PictureStack
+from pixlstash.db_models import (
+    Character,
+    CharacterProjectMember,
+    Picture,
+    PictureSetMember,
+    PictureStack,
+    Tag,
+    UserToken,
+)
 from pixlstash.server import Server
+from pixlstash.utils.rate_limiter import RateLimitMiddleware
 from tests.utils import upload_pictures_and_wait
 
 # ---------------------------------------------------------------------------
@@ -190,98 +225,185 @@ def _assert_pictures_intact(authed_client, original_ids: list, original_scores: 
         )
 
 
+def _setup_two_picture_sets(tmp: str):
+    """Create two picture sets with one picture each.
+
+    Returns a namespace carrying the server, the owner client and the ids. The
+    set-A share token is *not* minted here — ``TestResourceScopedReadTokenIsolation``
+    re-mints it per test so no test can inherit another test's credential.
+    """
+    config_path = f"{tmp}/server-config.json"
+    server = Server(config_path)
+    server.__enter__()
+    client = TestClient(server.api, raise_server_exceptions=True)
+
+    r = client.post(
+        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+    )
+    assert r.status_code == 200, r.text
+
+    # Upload two pictures.
+    for png_bytes, name in [
+        (_make_png_bytes(64, 64), "picA.png"),
+        (_make_png_bytes(48, 48), "picB.png"),
+    ]:
+        import_status = upload_pictures_and_wait(
+            client, [("file", (name, png_bytes, "image/png"))], timeout_s=15
+        )
+        assert import_status["status"] == "completed", f"Import failed: {import_status}"
+
+    r = client.get(f"{API}/pictures")
+    assert r.status_code == 200, r.text
+    all_ids = [p["id"] for p in r.json()]
+    assert len(all_ids) >= 2
+
+    pic_a_id, pic_b_id = all_ids[0], all_ids[1]
+
+    # Create two picture sets.
+    r = client.post(f"{API}/picture_sets", json={"name": "Set A"})
+    assert r.status_code == 200, r.text
+    set_a_id = r.json()["picture_set"]["id"]
+
+    r = client.post(f"{API}/picture_sets", json={"name": "Set B"})
+    assert r.status_code == 200, r.text
+    set_b_id = r.json()["picture_set"]["id"]
+
+    # Add pictures to their respective sets.
+    r = client.post(f"{API}/picture_sets/{set_a_id}/members/{pic_a_id}")
+    assert r.status_code in {200, 201, 204}, r.text
+
+    r = client.post(f"{API}/picture_sets/{set_b_id}/members/{pic_b_id}")
+    assert r.status_code in {200, 201, 204}, r.text
+
+    # A project that actually exists, so the cross-resource-type refusals below
+    # are measured against a real object. Aiming them at a made-up id would let
+    # a plain "no such project" answer stand in for a scope refusal.
+    r = client.post(f"{API}/projects", json={"name": "Real Project"})
+    assert r.status_code in {200, 201}, r.text
+    project_id = r.json()["id"]
+
+    return SimpleNamespace(
+        server=server,
+        owner_client=client,
+        set_a=set_a_id,
+        set_b=set_b_id,
+        pic_a=pic_a_id,
+        pic_b=pic_b_id,
+        project=project_id,
+    )
+
+
 # ---------------------------------------------------------------------------
-# 0. An ALL-scope token cannot be restricted to a resource (F1/F3 footgun)
+# Shared environments and the per-test credential reset
 # ---------------------------------------------------------------------------
 
 
-class TestAllScopeResourceTokenRejected:
-    """Minting an ``ALL``+``resource_type`` token must be rejected.
+def _clear_rate_limit_window(server) -> None:
+    """Empty the global rate limiter's sliding window on *server*.
 
-    The auth middleware only builds ``request.state.token_scope`` for non-ALL
-    scopes, so such a token would bypass every object-scope guard
-    (``enforce_picture_scope`` / ``fetch_scope_allowed_picture_ids`` read
-    ``token_scope``) *and* pass the owner-only token-creation check — it is a
-    full owner token wearing a "restricted" label. See the F3 finding in
-    docs/reviews/feature-slick-grid-updates.md.
+    The limiter counts every request to an auth-excluded path, and
+    ``POST /login`` is one — so the per-test re-login below is itself a counted
+    event. Over a shared server those events accumulate inside the 60 s window
+    and would eventually 429 the re-login (loudly, but for the wrong reason),
+    and they would silently defang ``test_data_intact_after_rate_limit_barrage``
+    by exhausting its patched limit before the barrage starts.
+
+    The middleware instance only exists inside the built stack, so it is fetched
+    by walking it. A miss raises rather than passing quietly: the reset would
+    otherwise stop doing anything the day the middleware moves.
+    """
+    if server.api.middleware_stack is None:
+        server.api.middleware_stack = server.api.build_middleware_stack()
+    node = server.api.middleware_stack
+    while node is not None:
+        if isinstance(node, RateLimitMiddleware):
+            with node._lock:
+                node._events.clear()
+            return
+        node = getattr(node, "app", None)
+    raise AssertionError(
+        "RateLimitMiddleware not found in the app's middleware stack — the "
+        "per-test rate-limit reset is no longer resetting anything"
+    )
+
+
+def _reset_owner_credentials(server, owner_client) -> None:
+    """Destroy every credential this module minted, then re-establish the owner.
+
+    Deleting the token rows, dropping the sessions and flushing the token cache
+    (which bumps the revocation epoch) means no token minted by an earlier test
+    can still authenticate anything: a test that reaches for one gets a 401, not
+    a plausible-looking 403. The lockout counters and the rate-limit window are
+    cleared because a test that hammers bad passwords or public paths would
+    otherwise 429 the re-login below.
+
+    The re-login is itself an assertion. It proves the owner password is still
+    ``ownerpass1``, which is precisely what the "READ token cannot change the
+    password" tests are protecting, and it fails loudly instead of letting a
+    dirty environment masquerade as a scope refusal.
     """
 
-    def test_all_scope_with_resource_type_is_rejected(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, _ = _setup_server_with_pictures(tmp)
-            try:
-                r = owner_client.post(
-                    f"{API}/users/me/token",
-                    json={
-                        "description": "sneaky scoped write token",
-                        "scope": "ALL",
-                        "resource_type": "picture",
-                        "resource_id": picture_ids[0],
-                    },
-                )
-                assert r.status_code == 400, (
-                    "ALL-scope token must not be restrictable to a resource, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def _wipe(session: Session):
+        session.exec(delete(UserToken))
+        session.commit()
 
-    def test_read_scope_with_resource_type_still_allowed(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, _ = _setup_server_with_pictures(tmp)
-            try:
-                r = owner_client.post(
-                    f"{API}/users/me/token",
-                    json={
-                        "description": "legit resource share",
-                        "scope": "READ",
-                        "resource_type": "picture",
-                        "resource_id": picture_ids[0],
-                    },
-                )
-                assert r.status_code == 200, (
-                    f"READ resource share must still mint, got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    server.hub_engine.run_task(_wipe)
+    server.auth._clear_all_sessions()
+    server.auth._flush_token_cache()
+    server.auth._failed_login_attempts = 0
+    server.auth._login_lockout_until = 0.0
+    _clear_rate_limit_window(server)
 
-    def test_all_scope_without_resource_still_allowed(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, _picture_ids, _ = _setup_server_with_pictures(tmp)
-            try:
-                r = owner_client.post(
-                    f"{API}/users/me/token",
-                    json={"description": "owner token", "scope": "ALL"},
-                )
-                assert r.status_code == 200, (
-                    f"ALL owner token must still mint, got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    r = owner_client.post(
+        f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+    )
+    assert r.status_code == 200, (
+        f"owner re-login failed — the shared environment is dirty: {r.text}"
+    )
 
 
-# ---------------------------------------------------------------------------
-# 1. READ token must not perform write operations
-# ---------------------------------------------------------------------------
+def _mint_read_token(owner_client, description: str, **restriction) -> str:
+    """Mint a fresh READ token as the owner and return its secret value."""
+    r = owner_client.post(
+        f"{API}/users/me/token",
+        json={"description": description, "scope": "READ", **restriction},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["token"]
 
 
-@pytest.fixture(scope="class")
-def read_token_write_env():
-    """One Server + imported picture library shared by ``TestReadTokenBlocksWrites``.
+def _prove_token_reads(server, token: str, path: str = "/pictures", **params) -> set:
+    """Exercise *token* on an in-scope read and return the picture ids it saw.
 
-    Booting the Server and running the library through the import pipeline is
-    ~1.5-2.3 s; the assertions it serves are single HTTP calls. Every write in
-    the class is expected to be *refused*, so the environment is read-only in
-    practice and safe to share — and any write that did land is caught by the
-    integrity check in ``read_token``, which re-checks ids and scores before
-    every single test.
+    This is the positive control that sits in front of every negative assertion
+    in this module: if the freshly minted token cannot read what it is entitled
+    to, the refusals the test is about would prove nothing, and the fixture says
+    so instead of letting the test pass.
+    """
+    r = TestClient(server.api).get(
+        f"{API}{path}", headers={"Authorization": f"Bearer {token}"}, params=params
+    )
+    assert r.status_code == 200, (
+        f"a fresh READ token cannot perform an in-scope read on {path} "
+        f"({r.status_code}: {r.text}) — the refusals below would prove nothing"
+    )
+    body = r.json()
+    if isinstance(body, dict):
+        body = body["pictures"]
+    return {row["id"] for row in body}
 
-    Deliberately class-scoped, not module-scoped: the blast radius of the
-    sharing stays inside the one class that opted into it. Note that
-    ``--ci-shard`` (tests/conftest.py) partitions tests individually, so in CI
-    this class is split across shards and each shard builds its own copy of
-    this fixture — which is why the guard lives in the per-test fixture and not
-    in a trailing "runs last" test that no shard is guaranteed to receive.
+
+@pytest.fixture(scope="module")
+def _picture_library_env():
+    """One Server holding the five-picture scored fixture library.
+
+    Every test served by this environment expects its writes to be *refused*,
+    so the library is read-only in practice; anything that did land is caught by
+    the ids-and-scores check in ``_SharedPictureLibrary.library_env`` before the
+    next test asserts anything.
+
+    Private on purpose: reach it through ``_SharedPictureLibrary``, never
+    directly, or the test gets no credential reset and no integrity check.
     """
     with tempfile.TemporaryDirectory() as tmp:
         server, owner_client, picture_ids, _ = _setup_server_with_pictures(tmp)
@@ -296,182 +418,426 @@ def read_token_write_env():
             server.__exit__(None, None, None)
 
 
-class TestReadTokenBlocksWrites:
-    """A READ token must be rejected for every mutating HTTP method.
+class _SharedPictureLibrary:
+    """Mixin for the classes that run against ``_picture_library_env``.
 
-    The Server is shared across the class (``read_token_write_env``) but the
-    credential is not: ``read_token`` re-mints one per test, proves it works on
-    an in-scope read, and re-checks the library's ids and scores first, so a
-    403 below can only mean "wrong scope".
+    The reset is ``autouse`` so a test added later cannot opt out of it by
+    forgetting to request the fixture; it still returns the environment so tests
+    can take ``library_env`` as an argument.
     """
 
     @pytest.fixture(autouse=True)
-    def read_token(self, read_token_write_env):
-        """Mint a fresh global READ token per test, and re-prove the environment.
+    def library_env(self, _picture_library_env):
+        env = _picture_library_env
+        _reset_owner_credentials(env.server, env.owner_client)
+        token = _mint_read_token(env.owner_client, "per-test read")
 
-        This is the canary for the shared environment, and it deliberately runs
-        before *every* test rather than as a trailing "runs last" test: CI
-        partitions this class across shards (``--ci-shard``, tests/conftest.py
-        deals tests individually), so no single test is guaranteed to run after
-        the ones it would be watching.
-
-        Three things are re-established or re-checked here, and each is a way a
-        negative assertion below could otherwise pass for the wrong reason:
-
-        * a fresh owner session and a fresh READ token, so a revoked token or a
-          dead session cannot turn "read scope cannot write" into "no
-          credential";
-        * an in-scope read with that token — the positive control adjacent to
-          every negative assertion. If the token cannot read, the test never
-          runs;
-        * the exact picture *ids* and their scores, not just a count. A missing
-          picture answers a write with 403 exactly like a scope refusal does,
-          so "the object is still there" has to be asserted separately.
-        """
-        env = read_token_write_env
-
-        # Re-establish the owner session too; a failure here means a previous
-        # test changed the password or killed the session, and the class should
-        # say so rather than silently 403 everywhere.
-        r = env.owner_client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
-        )
-        assert r.status_code == 200, (
-            f"owner re-login failed — shared environment is dirty: {r.text}"
-        )
-
-        r = env.owner_client.post(
-            f"{API}/users/me/token",
-            json={"description": "per-test read", "scope": "READ"},
-        )
-        assert r.status_code == 200, r.text
-        token = r.json()["token"]
-
-        probe = TestClient(env.server.api).get(
-            f"{API}/pictures", headers={"Authorization": f"Bearer {token}"}
-        )
-        assert probe.status_code == 200, (
-            f"fresh READ token cannot perform an in-scope read ({probe.status_code}: "
-            f"{probe.text}) — the 403s below would prove nothing"
-        )
-        assert {str(p["id"]) for p in probe.json()} == {
-            str(pid) for pid in env.picture_ids
-        }, (
-            "shared library no longer holds exactly the fixture pictures: "
-            f"{sorted(p['id'] for p in probe.json())} != {sorted(env.picture_ids)}"
+        seen = _prove_token_reads(env.server, token)
+        assert seen == set(env.picture_ids), (
+            "the shared library no longer holds exactly the fixture pictures: "
+            f"{sorted(seen)} != {sorted(env.picture_ids)}"
         )
         _assert_pictures_intact(env.owner_client, env.picture_ids, env.scores)
-        return token
 
-    def test_cannot_upload_picture(self, read_token_write_env, read_token):
+        return SimpleNamespace(
+            server=env.server,
+            owner_client=env.owner_client,
+            picture_ids=env.picture_ids,
+            scores=env.scores,
+            read_token=token,
+        )
+
+
+@pytest.fixture(scope="module")
+def _two_set_env():
+    """One Server holding two single-picture sets, shared by the isolation tests.
+
+    The planner is stopped once the two imports are done. Nothing after setup
+    imports a picture, so it has no legitimate work left here — but several of
+    these tests hand-write ``Tag``, ``Character`` and ``PictureStack`` rows, and
+    on a warm long-lived server a ``TagTask`` (which deletes a picture's tags
+    before rewriting them) or a stack-cohesion sweep would clobber them. Same
+    move as tests/test_smart_score_invalidation.py.
+
+    Private on purpose: reach it through ``TestResourceScopedReadTokenIsolation.env``,
+    never directly, or the test gets no reset and no integrity check.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        env = _setup_two_picture_sets(tmp)
+        try:
+            env.server.vault._work_planner.stop()
+            yield env
+        finally:
+            env.server.__exit__(None, None, None)
+
+
+def _picture_set_members(server, set_id: int) -> set:
+    """Read a picture set's membership straight from the DB."""
+
+    def _read(session: Session):
+        return set(
+            session.exec(
+                select(PictureSetMember.picture_id).where(
+                    PictureSetMember.set_id == set_id
+                )
+            ).all()
+        )
+
+    return server.vault.db.run_task(_read)
+
+
+def _reset_two_set_library(env) -> None:
+    """Put the shared two-set library back on the shape its tests assume.
+
+    Five kinds of row are written by tests in that class and would otherwise be
+    inherited by the ones that follow:
+
+    * tags — one test asserts a per-tag count *exactly*, so a leftover tag row
+      turns that count into someone else's;
+    * a character named ``Ref``, created by two different tests;
+    * the ComfyUI model/LoRA vocab columns, seeded straight onto the pictures;
+    * a stack spanning both sets;
+    * **set membership**. This one is the trap: forming a stack is
+      stack-atomic for picture-set membership, so stacking ``pic_b`` onto
+      ``pic_a`` pulls ``pic_b`` into Set A — and Set A is the scope every
+      negative assertion in that class is measured against. Membership is
+      therefore rebuilt from scratch, not just left alone.
+
+    No foreign-key pragma is used. The statement order below leaves every
+    reference satisfied at all times — children before parents, and the
+    ``Picture`` rows detached from their stack *before* the stacks go — which
+    makes deferral unnecessary. That is deliberate: with pysqlite a
+    ``PRAGMA defer_foreign_keys = ON`` issued before any DML runs in its own
+    autocommit transaction and is gone again by the time the DELETEs open
+    theirs, so it can look like protection while providing none (measured in
+    #821). An ordering that never needs the pragma cannot silently lose it.
+    """
+
+    def _wipe(session: Session):
+        session.exec(delete(Tag))
+        session.exec(delete(CharacterProjectMember))
+        session.exec(delete(Character))
+        # Detach the pictures first so the stack rows are unreferenced.
+        session.exec(
+            update(Picture).values(
+                stack_id=None,
+                stack_position=None,
+                comfyui_models=None,
+                comfyui_loras=None,
+            )
+        )
+        session.exec(delete(PictureStack))
+        session.exec(delete(PictureSetMember))
+        session.add(PictureSetMember(set_id=env.set_a, picture_id=env.pic_a))
+        session.add(PictureSetMember(set_id=env.set_b, picture_id=env.pic_b))
+        session.commit()
+
+    env.server.vault.db.run_task(_wipe)
+
+
+# The ComfyUI stack fixture. Which seeded pictures carry the filtered
+# model/LoRA, and how the two stacks are laid out once ``_form_stacks`` runs
+# (``*`` = matches the filter)::
+#
+#     shared stack : cover*  sibling_a*  sibling_b*
+#     other stack  : quiet_cover   quiet_member*
+#     loose        : lone*
+#
+# Only ``cover`` is ever inside the token's grant. ``quiet_cover`` is the one
+# that must come back for the *owner* purely through the member branch.
+STACK_MODEL = "shared-model.safetensors"
+STACK_LORA = "shared-lora.safetensors"
+STACK_FILTER_PARAMS = ("comfyui_model", "comfyui_lora")
+_STACK_MATCHING = {"cover", "sibling_a", "sibling_b", "quiet_member", "lone"}
+_SHARED_STACK = ("cover", "sibling_a", "sibling_b")
+_OTHER_STACK = ("quiet_cover", "quiet_member")
+_STACK_PATHS = {
+    name: f"/home/owner/private/{name}.png"
+    for name in (*_SHARED_STACK, *_OTHER_STACK, "lone")
+}
+
+
+def _seed_stack_pictures(server) -> dict:
+    """Create the six unstacked pictures with their ComfyUI metadata.
+
+    ``comfyui_models`` / ``comfyui_loras`` are pipeline-populated JSON columns
+    with no owner-facing write API, so they are seeded directly via the DB task
+    runner (same pattern as ``_seed_comfyui_vocab``).
+    """
+
+    def _seed(session):
+        ids = {}
+        for name, file_path in _STACK_PATHS.items():
+            matching = name in _STACK_MATCHING
+            pic = Picture(
+                file_path=file_path,
+                comfyui_models=json.dumps(
+                    [STACK_MODEL if matching else "unrelated-model"]
+                ),
+                comfyui_loras=json.dumps(
+                    [STACK_LORA if matching else "unrelated-lora"]
+                ),
+            )
+            session.add(pic)
+            session.commit()
+            session.refresh(pic)
+            ids[name] = pic.id
+        return ids
+
+    return server.vault.db.run_task(_seed)
+
+
+def _form_stacks(server, ids: dict) -> None:
+    """Stack the seeded pictures, keeping ``lone`` unstacked.
+
+    Done in the DB rather than through the stack API so the stack can be formed
+    at an arbitrary point relative to picture-set membership -- the set-scoped
+    test below depends on forming it *after*.
+    """
+
+    def _stack(session):
+        for names in (_SHARED_STACK, _OTHER_STACK):
+            stack = PictureStack()
+            session.add(stack)
+            session.commit()
+            session.refresh(stack)
+            for position, name in enumerate(names):
+                pic = session.get(Picture, ids[name])
+                pic.stack_id = stack.id
+                pic.stack_position = position
+                session.add(pic)
+        session.commit()
+
+    server.vault.db.run_task(_stack)
+
+
+def _stack_layout(server) -> dict:
+    """Return ``{file_path: (stack members by file_path, position)}`` for the vault.
+
+    Used as the shared ComfyUI environment's integrity check: it pins *which*
+    pictures exist, where they live on disk and how they are stacked, rather
+    than how many there are.
+    """
+
+    def _read(session: Session):
+        rows = session.exec(
+            select(Picture.file_path, Picture.stack_id, Picture.stack_position)
+        ).all()
+        return {path: (stack_id, position) for path, stack_id, position in rows}
+
+    return server.vault.db.run_task(_read)
+
+
+@pytest.fixture(scope="module")
+def _comfyui_stack_env():
+    """One Server holding the straddling ComfyUI stack fixture.
+
+    Read-only for every test it serves: the pictures and stacks are written once
+    here, directly in the DB, and only queried afterwards. The planner is stopped
+    for the same reason as ``_two_set_env`` — these rows point at file paths that
+    do not exist, and a warm sweep has no business rewriting them.
+
+    Private on purpose: reach it through
+    ``TestComfyuiFilterCannotEscapeTokenScope.env``, never directly, or the test
+    gets no credential reset and no stack-layout check.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        server = Server(f"{tmp}/server-config.json")
+        server.__enter__()
+        try:
+            owner_client = TestClient(server.api, raise_server_exceptions=True)
+            r = owner_client.post(
+                f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+            )
+            assert r.status_code == 200, r.text
+
+            ids = _seed_stack_pictures(server)
+            _form_stacks(server, ids)
+            server.vault._work_planner.stop()
+
+            yield SimpleNamespace(server=server, owner_client=owner_client, ids=ids)
+        finally:
+            server.__exit__(None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# 0. An ALL-scope token cannot be restricted to a resource (F1/F3 footgun)
+# ---------------------------------------------------------------------------
+
+
+class TestAllScopeResourceTokenRejected(_SharedPictureLibrary):
+    """Minting an ``ALL``+``resource_type`` token must be rejected.
+
+    The auth middleware only builds ``request.state.token_scope`` for non-ALL
+    scopes, so such a token would bypass every object-scope guard
+    (``enforce_picture_scope`` / ``fetch_scope_allowed_picture_ids`` read
+    ``token_scope``) *and* pass the owner-only token-creation check — it is a
+    full owner token wearing a "restricted" label. See the F3 finding in
+    docs/reviews/feature-slick-grid-updates.md.
+    """
+
+    def test_all_scope_with_resource_type_is_rejected(self, library_env):
+        r = library_env.owner_client.post(
+            f"{API}/users/me/token",
+            json={
+                "description": "sneaky scoped write token",
+                "scope": "ALL",
+                "resource_type": "picture",
+                "resource_id": library_env.picture_ids[0],
+            },
+        )
+        assert r.status_code == 400, (
+            "ALL-scope token must not be restrictable to a resource, "
+            f"got {r.status_code}: {r.text}"
+        )
+
+    def test_read_scope_with_resource_type_still_allowed(self, library_env):
+        r = library_env.owner_client.post(
+            f"{API}/users/me/token",
+            json={
+                "description": "legit resource share",
+                "scope": "READ",
+                "resource_type": "picture",
+                "resource_id": library_env.picture_ids[0],
+            },
+        )
+        assert r.status_code == 200, (
+            f"READ resource share must still mint, got {r.status_code}: {r.text}"
+        )
+
+    def test_all_scope_without_resource_still_allowed(self, library_env):
+        r = library_env.owner_client.post(
+            f"{API}/users/me/token",
+            json={"description": "owner token", "scope": "ALL"},
+        )
+        assert r.status_code == 200, (
+            f"ALL owner token must still mint, got {r.status_code}: {r.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 1. READ token must not perform write operations
+# ---------------------------------------------------------------------------
+
+
+class TestReadTokenBlocksWrites(_SharedPictureLibrary):
+    """A READ token must be rejected for every mutating HTTP method.
+
+    The Server is shared (``_picture_library_env``) but the credential is not:
+    ``library_env`` re-mints one per test, proves it works on an in-scope read,
+    and re-checks the library's ids and scores first, so a 403 below can only
+    mean "wrong scope".
+    """
+
+    def test_cannot_upload_picture(self, library_env):
         png = _make_png_bytes()
-        r = TestClient(read_token_write_env.server.api).post(
+        r = TestClient(library_env.server.api).post(
             f"{API}/pictures/import",
             files=[("file", ("new.png", png, "image/png"))],
-            headers={"Authorization": f"Bearer {read_token}"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not be able to upload pictures, got {r.status_code}: {r.text}"
         )
 
-    def test_cannot_delete_picture(self, read_token_write_env, read_token):
-        target_id = read_token_write_env.picture_ids[0]
-        r = TestClient(read_token_write_env.server.api).delete(
+    def test_cannot_delete_picture(self, library_env):
+        target_id = library_env.picture_ids[0]
+        r = TestClient(library_env.server.api).delete(
             f"{API}/pictures/{target_id}",
-            headers={"Authorization": f"Bearer {read_token}"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not delete pictures, got {r.status_code}: {r.text}"
         )
 
-    def test_cannot_patch_picture_score(self, read_token_write_env, read_token):
-        target_id = read_token_write_env.picture_ids[0]
-        r = TestClient(read_token_write_env.server.api).patch(
+    def test_cannot_patch_picture_score(self, library_env):
+        target_id = library_env.picture_ids[0]
+        r = TestClient(library_env.server.api).patch(
             f"{API}/pictures/{target_id}",
             json={"score": 1},
-            headers={"Authorization": f"Bearer {read_token}"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not PATCH pictures, got {r.status_code}: {r.text}"
         )
 
-    def test_cannot_batch_apply_scores(self, read_token_write_env, read_token):
-        payload = {"scores": {str(pid): 1 for pid in read_token_write_env.picture_ids}}
-        r = TestClient(read_token_write_env.server.api).post(
+    def test_cannot_batch_apply_scores(self, library_env):
+        payload = {"scores": {str(pid): 1 for pid in library_env.picture_ids}}
+        r = TestClient(library_env.server.api).post(
             f"{API}/pictures/apply-scores",
             json=payload,
-            headers={"Authorization": f"Bearer {read_token}"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not batch-set scores, got {r.status_code}: {r.text}"
         )
 
-    def test_cannot_change_password(self, read_token_write_env, read_token):
-        r = TestClient(read_token_write_env.server.api).post(
+    def test_cannot_change_password(self, library_env):
+        r = TestClient(library_env.server.api).post(
             f"{API}/users/me/auth",
             json={
                 "current_password": "ownerpass1",
                 "new_password": "hacked12345",
             },
-            headers={"Authorization": f"Bearer {read_token}"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not change password, got {r.status_code}: {r.text}"
         )
 
-    def test_cannot_create_new_token(self, read_token_write_env, read_token):
-        r = TestClient(read_token_write_env.server.api).post(
+    def test_cannot_create_new_token(self, library_env):
+        r = TestClient(library_env.server.api).post(
             f"{API}/users/me/token",
             json={"description": "escalated", "scope": "ALL"},
-            headers={"Authorization": f"Bearer {read_token}"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not create tokens, got {r.status_code}: {r.text}"
         )
 
-    def test_cannot_delete_token(self, read_token_write_env, read_token):
+    def test_cannot_delete_token(self, library_env):
         # The owner creates a second token to give us an ID to target.
-        r2 = read_token_write_env.owner_client.post(
+        r2 = library_env.owner_client.post(
             f"{API}/users/me/token",
             json={"description": "victim token", "scope": "READ"},
         )
         assert r2.status_code == 200, r2.text
         victim_id = r2.json()["token_id"]
 
-        r = TestClient(read_token_write_env.server.api).delete(
+        r = TestClient(library_env.server.api).delete(
             f"{API}/users/me/token/{victim_id}",
-            headers={"Authorization": f"Bearer {read_token}"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not delete tokens, got {r.status_code}: {r.text}"
         )
 
-    def test_cannot_upload_watermark(self, read_token_write_env, read_token):
+    def test_cannot_upload_watermark(self, library_env):
         png = _make_png_bytes()
-        r = TestClient(read_token_write_env.server.api).post(
+        r = TestClient(library_env.server.api).post(
             f"{API}/users/me/watermark",
             files=[("file", ("wm.png", png, "image/png"))],
-            headers={"Authorization": f"Bearer {read_token}"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not upload watermark, got {r.status_code}: {r.text}"
         )
 
-    def test_cannot_patch_user_config(self, read_token_write_env, read_token):
-        r = TestClient(read_token_write_env.server.api).patch(
+    def test_cannot_patch_user_config(self, library_env):
+        r = TestClient(library_env.server.api).patch(
             f"{API}/users/me/config",
             json={"max_vram_gb": 0},
-            headers={"Authorization": f"Bearer {read_token}"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not PATCH user config, got {r.status_code}: {r.text}"
         )
 
-    def test_cannot_restore_deleted_pictures(self, read_token_write_env, read_token):
-        r = TestClient(read_token_write_env.server.api).post(
+    def test_cannot_restore_deleted_pictures(self, library_env):
+        r = TestClient(library_env.server.api).post(
             f"{API}/pictures/scrapheap/restore",
-            json={"picture_ids": read_token_write_env.picture_ids[:2]},
-            headers={"Authorization": f"Bearer {read_token}"},
+            json={"picture_ids": library_env.picture_ids[:2]},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
         )
         assert r.status_code == 403, (
             f"READ token should not restore pictures, got {r.status_code}: {r.text}"
@@ -483,149 +849,101 @@ class TestReadTokenBlocksWrites:
 # ---------------------------------------------------------------------------
 
 
-class TestReadTokenBlocksOwnerData:
-    """A READ token must not be able to read privileged owner data."""
+class TestReadTokenBlocksOwnerData(_SharedPictureLibrary):
+    """A READ token must not be able to read privileged owner data.
 
-    def test_cannot_read_user_config(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/users/me/config",
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token should not read user config (contains secrets), "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    Every 403 below is paired with the in-scope 200 that ``library_env`` already
+    proved on ``GET /pictures`` with the very same token: the credential is
+    known-good, so the refusal can only be about what it is refusing to reach.
+    """
 
-    def test_cannot_list_tokens(self):
+    def test_cannot_read_user_config(self, library_env):
+        r = TestClient(library_env.server.api).get(
+            f"{API}/users/me/config",
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token should not read user config (contains secrets), "
+            f"got {r.status_code}: {r.text}"
+        )
+
+    def test_cannot_list_tokens(self, library_env):
         """READ token must not enumerate the owner's other token metadata."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/users/me/token",
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token should not list all tokens (information disclosure), "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = TestClient(library_env.server.api).get(
+            f"{API}/users/me/token",
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token should not list all tokens (information disclosure), "
+            f"got {r.status_code}: {r.text}"
+        )
 
-    def test_cannot_read_filesystem_roots(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/server-config/filesystem-roots",
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token must not expose filesystem root paths, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_cannot_read_filesystem_roots(self, library_env):
+        r = TestClient(library_env.server.api).get(
+            f"{API}/server-config/filesystem-roots",
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token must not expose filesystem root paths, "
+            f"got {r.status_code}: {r.text}"
+        )
 
-    def test_cannot_read_watch_folders(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/server-config/watch-folders",
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token must not expose watch folder paths, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_cannot_read_watch_folders(self, library_env):
+        r = TestClient(library_env.server.api).get(
+            f"{API}/server-config/watch-folders",
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token must not expose watch folder paths, "
+            f"got {r.status_code}: {r.text}"
+        )
 
-    def test_cannot_browse_filesystem(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/filesystem/browse",
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token must not browse server filesystem, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_cannot_browse_filesystem(self, library_env):
+        r = TestClient(library_env.server.api).get(
+            f"{API}/filesystem/browse",
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token must not browse server filesystem, "
+            f"got {r.status_code}: {r.text}"
+        )
 
-    def test_cannot_detect_sidecars(self):
+    def test_cannot_detect_sidecars(self, library_env, tmp_path):
         """READ token must not walk the server filesystem via sidecar detection."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/reference-folders/detect-sidecars",
-                    params={"path": tmp},
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token must not probe the filesystem via detect-sidecars, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = TestClient(library_env.server.api).get(
+            f"{API}/reference-folders/detect-sidecars",
+            params={"path": str(tmp_path)},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token must not probe the filesystem via detect-sidecars, "
+            f"got {r.status_code}: {r.text}"
+        )
 
-    def test_cannot_access_shared_resource_ids(self):
+    def test_cannot_access_shared_resource_ids(self, library_env):
         """READ token must not enumerate which resources have been shared."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/users/me/shared-resource-ids",
-                    params={"resource_type": "picture"},
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token must not enumerate shared resource IDs, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = TestClient(library_env.server.api).get(
+            f"{API}/users/me/shared-resource-ids",
+            params={"resource_type": "picture"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token must not enumerate shared resource IDs, "
+            f"got {r.status_code}: {r.text}"
+        )
 
-    def test_cannot_revoke_tokens_for_resource(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).delete(
-                    f"{API}/users/me/tokens/by-resource",
-                    params={"resource_type": "picture", "resource_id": picture_ids[0]},
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token must not revoke tokens, got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_cannot_revoke_tokens_for_resource(self, library_env):
+        r = TestClient(library_env.server.api).delete(
+            f"{API}/users/me/tokens/by-resource",
+            params={
+                "resource_type": "picture",
+                "resource_id": library_env.picture_ids[0],
+            },
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token must not revoke tokens, got {r.status_code}: {r.text}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -636,183 +954,153 @@ class TestReadTokenBlocksOwnerData:
 class TestResourceScopedReadTokenIsolation:
     """A token scoped to resource A must not expose resource B."""
 
-    def _setup_two_picture_sets(self, tmp: str):
-        """Create two picture sets with one picture each; issue a token for set A only."""
-        config_path = f"{tmp}/server-config.json"
-        server = Server(config_path)
-        server.__enter__()
-        client = TestClient(server.api, raise_server_exceptions=True)
+    @pytest.fixture(autouse=True)
+    def env(self, _two_set_env):
+        """Reset the shared two-set library and re-mint the set-A share token.
 
-        r = client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        ``autouse`` so a test added later cannot skip the reset by forgetting to
+        request the fixture. Three things happen before every test body, each
+        closing a way one of the negative assertions below could pass for the
+        wrong reason:
+
+        * the vault-side rows the tests write (tags, characters, stacks) are
+          dropped, so no test inherits another's library shape;
+        * every token is deleted and the owner session re-established from a
+          fresh login, so a revoked credential cannot masquerade as a scope
+          refusal;
+        * the library's **identity** is re-asserted — exactly ``{pic_a, pic_b}``
+          exist, set A holds exactly ``pic_a``, set B exactly ``pic_b`` — and the
+          new token is proven on an in-scope read that must return exactly
+          ``{pic_a}``. A deleted picture answers a request just like a scope
+          refusal, so "it is still there" has to be checked separately.
+        """
+        e = _two_set_env
+        _reset_two_set_library(e)
+        _reset_owner_credentials(e.server, e.owner_client)
+        token_a = _mint_read_token(
+            e.owner_client,
+            "set A token",
+            resource_type="picture_set",
+            resource_id=e.set_a,
+        )
+
+        r = e.owner_client.get(f"{API}/pictures")
+        assert r.status_code == 200, r.text
+        assert {p["id"] for p in r.json()} == {e.pic_a, e.pic_b}, (
+            "the shared two-set library no longer holds exactly its two "
+            f"fixture pictures: {sorted(p['id'] for p in r.json())}"
+        )
+        assert _picture_set_members(e.server, e.set_a) == {e.pic_a}, (
+            "set A no longer holds exactly pic_a — the scope every negative "
+            "assertion below is measured against has moved"
+        )
+        assert _picture_set_members(e.server, e.set_b) == {e.pic_b}, (
+            "set B no longer holds exactly pic_b — the out-of-scope picture "
+            "every negative assertion below reaches for has moved"
+        )
+        assert _prove_token_reads(e.server, token_a) == {e.pic_a}, (
+            "the fresh set-A token does not see exactly its own picture"
+        )
+
+        return SimpleNamespace(
+            server=e.server,
+            owner_client=e.owner_client,
+            set_a=e.set_a,
+            set_b=e.set_b,
+            pic_a=e.pic_a,
+            pic_b=e.pic_b,
+            project=e.project,
+            token_a=token_a,
+        )
+
+    def test_scoped_token_cannot_list_all_picture_sets(self, env):
+        r = TestClient(env.server.api).get(
+            f"{API}/picture_sets",
+            headers={"Authorization": f"Bearer {env.token_a}"},
         )
         assert r.status_code == 200, r.text
-
-        # Upload two pictures.
-        for png_bytes, name in [
-            (_make_png_bytes(64, 64), "picA.png"),
-            (_make_png_bytes(48, 48), "picB.png"),
-        ]:
-            import_status = upload_pictures_and_wait(
-                client, [("file", (name, png_bytes, "image/png"))], timeout_s=15
-            )
-            assert import_status["status"] == "completed", (
-                f"Import failed: {import_status}"
-            )
-
-        r = client.get(f"{API}/pictures")
-        assert r.status_code == 200, r.text
-        all_ids = [p["id"] for p in r.json()]
-        assert len(all_ids) >= 2
-
-        pic_a_id, pic_b_id = all_ids[0], all_ids[1]
-
-        # Create two picture sets.
-        r = client.post(f"{API}/picture_sets", json={"name": "Set A"})
-        assert r.status_code == 200, r.text
-        set_a_id = r.json()["picture_set"]["id"]
-
-        r = client.post(f"{API}/picture_sets", json={"name": "Set B"})
-        assert r.status_code == 200, r.text
-        set_b_id = r.json()["picture_set"]["id"]
-
-        # Add pictures to their respective sets.
-        r = client.post(
-            f"{API}/picture_sets/{set_a_id}/members/{pic_a_id}",
+        returned_ids = {ps["id"] for ps in r.json()}
+        assert env.set_b not in returned_ids, (
+            "Token for set A exposed set B in the listing"
         )
-        assert r.status_code in {200, 201, 204}, r.text
-
-        r = client.post(
-            f"{API}/picture_sets/{set_b_id}/members/{pic_b_id}",
+        assert env.set_a in returned_ids, (
+            "Token for set A was wrongly blocked from its own set in the listing"
         )
-        assert r.status_code in {200, 201, 204}, r.text
 
-        # Create a READ token scoped only to Set A.
-        r = client.post(
-            f"{API}/users/me/token",
-            json={
-                "description": "set A token",
-                "scope": "READ",
-                "resource_type": "picture_set",
-                "resource_id": set_a_id,
-            },
+    def test_scoped_token_cannot_fetch_other_picture_set(self, env):
+        r = TestClient(env.server.api).get(
+            f"{API}/picture_sets/{env.set_b}",
+            headers={"Authorization": f"Bearer {env.token_a}"},
         )
-        assert r.status_code == 200, r.text
-        token_a = r.json()["token"]
+        assert r.status_code in {403, 404}, (
+            f"Token for set A must not read set B, got {r.status_code}: {r.text}"
+        )
+        # Positive: its own set is still readable (over-blocking is a regression).
+        r = TestClient(env.server.api).get(
+            f"{API}/picture_sets/{env.set_a}",
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, (
+            f"Token for set A was wrongly blocked from set A: {r.text}"
+        )
 
-        return server, client, set_a_id, set_b_id, pic_a_id, pic_b_id, token_a
+    def test_scoped_token_cannot_access_pictures_outside_set(self, env):
+        r = TestClient(env.server.api).get(
+            f"{API}/pictures/{env.pic_b}/metadata",
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code in {403, 404}, (
+            f"Token for set A must not read picture from set B, "
+            f"got {r.status_code}: {r.text}"
+        )
+        r = TestClient(env.server.api).get(
+            f"{API}/pictures/{env.pic_a}/metadata",
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, (
+            f"Token for set A was wrongly blocked from its own picture: {r.text}"
+        )
 
-    def test_scoped_token_cannot_list_all_picture_sets(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/picture_sets",
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                returned_ids = {ps["id"] for ps in r.json()}
-                assert set_b not in returned_ids, (
-                    "Token for set A exposed set B in the listing"
-                )
-            finally:
-                server.__exit__(None, None, None)
-
-    def test_scoped_token_cannot_fetch_other_picture_set(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/picture_sets/{set_b}",
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code in {403, 404}, (
-                    f"Token for set A must not read set B, got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
-
-    def test_scoped_token_cannot_access_pictures_outside_set(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/pictures/{pic_b}/metadata",
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code in {403, 404}, (
-                    f"Token for set A must not read picture from set B, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
-
-    def test_stats_cannot_leak_out_of_scope_pictures(self):
+    def test_stats_cannot_leak_out_of_scope_pictures(self, env):
         """GET /pictures/stats must be limited to the token's authorised set."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/pictures/stats",
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                data = r.json()
-                assert data["total"] <= 1, (
-                    f"Token for set A (1 picture) reported total={data['total']}; "
-                    "out-of-scope pictures from set B leaked into stats"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = TestClient(env.server.api).get(
+            f"{API}/pictures/stats",
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        # Exactly one pins both directions: 2 is the leak, 0 is over-blocking.
+        assert data["total"] == 1, (
+            f"Token for set A (1 picture) reported total={data['total']}; "
+            "expected exactly 1 (2 leaks set B, 0 over-blocks set A)"
+        )
 
-    def test_search_cannot_leak_out_of_scope_pictures(self):
+    def test_search_cannot_leak_out_of_scope_pictures(self, env):
         """GET /pictures/search must not return pictures outside the token's set."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/pictures/search",
-                    params={"query": "picture"},
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                result_ids = {p["id"] for p in r.json()}
-                assert pic_b not in result_ids, (
-                    "Token for set A returned picture from set B in /pictures/search"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = TestClient(env.server.api).get(
+            f"{API}/pictures/search",
+            params={"query": "picture"},
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        result_ids = {p["id"] for p in r.json()}
+        assert env.pic_b not in result_ids, (
+            "Token for set A returned picture from set B in /pictures/search"
+        )
 
-    def test_likeness_groups_cannot_leak_out_of_scope_pictures(self):
+    def test_likeness_groups_cannot_leak_out_of_scope_pictures(self, env):
         """GET /pictures/likeness-groups must not include pictures outside the token's set."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).get(
-                    f"{API}/pictures/likeness-groups",
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                all_ids = {pid for group in r.json() for pid in group}
-                assert pic_b not in all_ids, (
-                    "Token for set A returned picture from set B in /pictures/likeness-groups"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = TestClient(env.server.api).get(
+            f"{API}/pictures/likeness-groups",
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        all_ids = {pid for group in r.json() for pid in group}
+        assert env.pic_b not in all_ids, (
+            "Token for set A returned picture from set B in /pictures/likeness-groups"
+        )
 
-    def test_picture_scoped_token_cannot_list_whole_library(self):
+    def test_picture_scoped_token_cannot_list_whole_library(self, env):
         """A single-picture share token must only ever resolve its own picture.
 
         Regression for the BOLA hole where /pictures, /pictures/stream and
@@ -820,44 +1108,34 @@ class TestResourceScopedReadTokenIsolation:
         ``resource_type='picture'`` token fall through to an unrestricted query,
         leaking the entire library's grid metadata.
         """
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
+        pic_token = _mint_read_token(
+            env.owner_client,
+            "single picture token",
+            resource_type="picture",
+            resource_id=env.pic_a,
+        )
+
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {pic_token}"}
+        for path in ("/pictures", "/pictures?fields=grid"):
+            r = client.get(f"{API}{path}", headers=hdr)
+            assert r.status_code == 200, r.text
+            ids = {p["id"] for p in r.json()}
+            # Exactly the granted picture: a wider set is the leak, an empty
+            # one is over-blocking.
+            assert ids == {env.pic_a}, (
+                f"Single-picture token returned {ids} via {path}; "
+                f"expected exactly {{{env.pic_a}}}"
             )
-            try:
-                # Mint a token scoped to a single picture (pic_a).
-                r = owner_client.post(
-                    f"{API}/users/me/token",
-                    json={
-                        "description": "single picture token",
-                        "scope": "READ",
-                        "resource_type": "picture",
-                        "resource_id": pic_a,
-                    },
-                )
-                assert r.status_code == 200, r.text
-                pic_token = r.json()["token"]
+        # The count endpoint must not count the whole library either.
+        r = client.get(f"{API}/pictures/count", headers=hdr)
+        assert r.status_code == 200, r.text
+        assert r.json().get("count") == 1, (
+            f"Single-picture token saw count={r.json().get('count')}; "
+            "expected exactly 1"
+        )
 
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {pic_token}"}
-                for path in ("/pictures", "/pictures?fields=grid"):
-                    r = client.get(f"{API}{path}", headers=hdr)
-                    assert r.status_code == 200, r.text
-                    ids = {p["id"] for p in r.json()}
-                    assert ids <= {pic_a}, (
-                        f"Single-picture token leaked other pictures via {path}: {ids}"
-                    )
-                # The count endpoint must not count the whole library either.
-                r = client.get(f"{API}/pictures/count", headers=hdr)
-                assert r.status_code == 200, r.text
-                assert r.json().get("count") in (0, 1), (
-                    f"Single-picture token saw count={r.json().get('count')}; "
-                    "out-of-scope pictures leaked into /pictures/count"
-                )
-            finally:
-                server.__exit__(None, None, None)
-
-    def test_picture_scoped_token_cannot_widen_via_character_likeness_sort(self):
+    def test_picture_scoped_token_cannot_widen_via_character_likeness_sort(self, env):
         """CVE-class regression: sort=CHARACTER_LIKENESS resolves candidates
         without ever consulting query_params["id"] (see the "CHARACTER_LIKENESS
         sort branch is a known pre-existing exception" comment in
@@ -875,179 +1153,158 @@ class TestResourceScopedReadTokenIsolation:
         given by _listing.py, so this test isolates exactly the wiring
         question: does the picture-scope narrowing ever reach that call.
         """
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
+        r = env.owner_client.post(f"{API}/characters", json={"name": "Ref"})
+        assert r.status_code == 200, r.text
+        ref_char_id = r.json()["character"]["id"]
+
+        pic_token = _mint_read_token(
+            env.owner_client,
+            "single picture token",
+            resource_type="picture",
+            resource_id=env.pic_a,
+        )
+
+        def fake_find_pictures_by_character_likeness_sql(
+            _server,
+            _character_id,
+            _reference_character_id,
+            _offset,
+            _limit,
+            _descending,
+            candidate_ids=None,
+            deleted_only=False,
+            stack_leaders_only=False,
+        ):
+            # Mirrors the real function's contract: candidate_ids is
+            # None (no restriction) unless a set/character/project
+            # scope narrowed it upstream. Echo both known pictures
+            # when unrestricted, exactly like an unfiltered
+            # Face-join query would.
+            ids = (
+                sorted(set(candidate_ids)) if candidate_ids else [env.pic_a, env.pic_b]
             )
-            try:
-                r = owner_client.post(f"{API}/characters", json={"name": "Ref"})
-                assert r.status_code == 200, r.text
-                ref_char_id = r.json()["character"]["id"]
+            return [{"id": pid, "character_likeness": 0.0} for pid in ids]
 
-                r = owner_client.post(
-                    f"{API}/users/me/token",
-                    json={
-                        "description": "single picture token",
-                        "scope": "READ",
-                        "resource_type": "picture",
-                        "resource_id": pic_a,
-                    },
-                )
-                assert r.status_code == 200, r.text
-                pic_token = r.json()["token"]
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {pic_token}"}
+        with patch.object(
+            listing_module,
+            "find_pictures_by_character_likeness_sql",
+            fake_find_pictures_by_character_likeness_sql,
+        ):
+            r = client.get(
+                f"{API}/pictures",
+                params={
+                    "sort": "CHARACTER_LIKENESS",
+                    "reference_character_id": str(ref_char_id),
+                },
+                headers=hdr,
+            )
+        assert r.status_code == 200, r.text
+        ids = {p["id"] for p in r.json()}
+        # Exactly the granted picture: the stub echoes back whatever
+        # candidate_ids it was handed, so a wider set means the narrowing never
+        # reached the call and an empty one means it over-narrowed.
+        assert ids == {env.pic_a}, (
+            "Single-picture token returned "
+            f"{ids} via sort=CHARACTER_LIKENESS; expected {{{env.pic_a}}}"
+        )
 
-                def fake_find_pictures_by_character_likeness_sql(
-                    _server,
-                    _character_id,
-                    _reference_character_id,
-                    _offset,
-                    _limit,
-                    _descending,
-                    candidate_ids=None,
-                    deleted_only=False,
-                    stack_leaders_only=False,
-                ):
-                    # Mirrors the real function's contract: candidate_ids is
-                    # None (no restriction) unless a set/character/project
-                    # scope narrowed it upstream. Echo both known pictures
-                    # when unrestricted, exactly like an unfiltered
-                    # Face-join query would.
-                    ids = (
-                        sorted(set(candidate_ids)) if candidate_ids else [pic_a, pic_b]
-                    )
-                    return [{"id": pid, "character_likeness": 0.0} for pid in ids]
-
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {pic_token}"}
-                with patch.object(
-                    listing_module,
-                    "find_pictures_by_character_likeness_sql",
-                    fake_find_pictures_by_character_likeness_sql,
-                ):
-                    r = client.get(
-                        f"{API}/pictures",
-                        params={
-                            "sort": "CHARACTER_LIKENESS",
-                            "reference_character_id": str(ref_char_id),
-                        },
-                        headers=hdr,
-                    )
-                assert r.status_code == 200, r.text
-                ids = {p["id"] for p in r.json()}
-                assert ids <= {pic_a}, (
-                    "Single-picture token leaked other pictures via "
-                    f"sort=CHARACTER_LIKENESS: {ids}"
-                )
-            finally:
-                server.__exit__(None, None, None)
-
-    def test_scoped_token_cannot_read_other_picture_tags(self):
+    def test_scoped_token_cannot_read_other_picture_tags(self, env):
         """Set-A token must not read tags/predictions of a set-B picture, but
         must still read its own (no over-blocking)."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {env.token_a}"}
+        for path in (
+            f"/pictures/{env.pic_b}/tags",
+            f"/pictures/{env.pic_b}/tag_predictions",
+        ):
+            r = client.get(f"{API}{path}", headers=hdr)
+            assert r.status_code in {403, 404}, (
+                f"Set-A token read {path} belonging to set B, "
+                f"got {r.status_code}: {r.text}"
             )
-            try:
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {token_a}"}
-                for path in (
-                    f"/pictures/{pic_b}/tags",
-                    f"/pictures/{pic_b}/tag_predictions",
-                ):
-                    r = client.get(f"{API}{path}", headers=hdr)
-                    assert r.status_code in {403, 404}, (
-                        f"Set-A token read {path} belonging to set B, "
-                        f"got {r.status_code}: {r.text}"
-                    )
-                # In-scope picture must still be readable.
-                r = client.get(f"{API}/pictures/{pic_a}/tags", headers=hdr)
-                assert r.status_code == 200, (
-                    f"Set-A token wrongly blocked from its own picture's tags: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        # In-scope picture must still be readable.
+        r = client.get(f"{API}/pictures/{env.pic_a}/tags", headers=hdr)
+        assert r.status_code == 200, (
+            f"Set-A token wrongly blocked from its own picture's tags: {r.text}"
+        )
 
-    def test_scoped_token_cannot_read_cross_resource_summaries(self):
+    def test_scoped_token_cannot_read_cross_resource_summaries(self, env):
         """A picture_set-scoped token must not read project or character
-        summaries (different resource type) or aggregate category counts."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {token_a}"}
-                for path in (
-                    "/projects/1/summary",
-                    "/characters/1/summary",
-                    "/characters/ALL/summary",
-                ):
-                    r = client.get(f"{API}{path}", headers=hdr)
-                    assert r.status_code == 403, (
-                        f"picture_set token reached {path}, "
-                        f"got {r.status_code}: {r.text}"
-                    )
-            finally:
-                server.__exit__(None, None, None)
+        summaries (different resource type) or aggregate category counts.
 
-    def test_scoped_token_cannot_list_project_attachments(self):
+        The project id is a **real** one from the fixture, so the 403 cannot be
+        a "no such project" answer wearing a scope refusal's status code. The
+        owner reads the same path successfully at the end, which is what makes
+        the refusal above about the token rather than about the object.
+        """
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {env.token_a}"}
+        for path in (
+            f"/projects/{env.project}/summary",
+            "/characters/1/summary",
+            "/characters/ALL/summary",
+        ):
+            r = client.get(f"{API}{path}", headers=hdr)
+            assert r.status_code == 403, (
+                f"picture_set token reached {path}, got {r.status_code}: {r.text}"
+            )
+
+        r = env.owner_client.get(f"{API}/projects/{env.project}/summary")
+        assert r.status_code == 200, (
+            "the project the refusal above was measured against does not "
+            f"exist for the owner either: {r.status_code} {r.text}"
+        )
+
+    def test_scoped_token_cannot_list_project_attachments(self, env):
         """A picture_set-scoped token must be rejected by the project-attachment
         endpoints (wrong resource type), regardless of include_attachments."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {token_a}"}
-                r = client.get(f"{API}/projects/1/attachments", headers=hdr)
-                assert r.status_code == 403, (
-                    f"picture_set token reached project attachments, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {env.token_a}"}
+        r = client.get(f"{API}/projects/{env.project}/attachments", headers=hdr)
+        assert r.status_code == 403, (
+            f"picture_set token reached project attachments, "
+            f"got {r.status_code}: {r.text}"
+        )
+        r = env.owner_client.get(f"{API}/projects/{env.project}/attachments")
+        assert r.status_code == 200, (
+            "the project the refusal above was measured against is not "
+            f"readable by the owner either: {r.status_code} {r.text}"
+        )
 
-    def test_export_cannot_include_out_of_scope_pictures(self):
+    def test_export_cannot_include_out_of_scope_pictures(self, env):
         """GET /pictures/export must not package pictures outside the token's set."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
+        scoped = TestClient(env.server.api)
+        r = scoped.get(
+            f"{API}/pictures/export",
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        task_id = r.json()["task_id"]
+
+        deadline = time.monotonic() + 30
+        status = None
+        while time.monotonic() < deadline:
+            sr = scoped.get(
+                f"{API}/pictures/export/status",
+                params={"task_id": task_id},
+                headers={"Authorization": f"Bearer {env.token_a}"},
             )
-            try:
-                scoped = TestClient(server.api)
-                r = scoped.get(
-                    f"{API}/pictures/export",
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                task_id = r.json()["task_id"]
+            assert sr.status_code == 200, sr.text
+            status = sr.json()
+            if status["status"] in ("completed", "failed"):
+                break
+            time.sleep(0.1)
 
-                deadline = time.monotonic() + 30
-                status = None
-                while time.monotonic() < deadline:
-                    sr = scoped.get(
-                        f"{API}/pictures/export/status",
-                        params={"task_id": task_id},
-                        headers={"Authorization": f"Bearer {token_a}"},
-                    )
-                    assert sr.status_code == 200, sr.text
-                    status = sr.json()
-                    if status["status"] in ("completed", "failed"):
-                        break
-                    time.sleep(0.1)
-
-                assert status and status["status"] == "completed", (
-                    f"Export task did not complete in time: {status}"
-                )
-                # `total` is set after scope filtering — must be 1, not 2
-                assert status["total"] == 1, (
-                    f"Export for set A (1 picture) reported total={status['total']}; "
-                    "out-of-scope pictures from set B may have been included"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        assert status and status["status"] == "completed", (
+            f"Export task did not complete in time: {status}"
+        )
+        # `total` is set after scope filtering — must be 1, not 2
+        assert status["total"] == 1, (
+            f"Export for set A (1 picture) reported total={status['total']}; "
+            "out-of-scope pictures from set B may have been included"
+        )
 
     # -- Batch POST endpoints (READ_SAFE_POST_PATHS) must scope-filter -------
     #
@@ -1056,179 +1313,134 @@ class TestResourceScopedReadTokenIsolation:
     # ever receive data for ids inside its grant; posting an out-of-scope id
     # (pic_b) must never leak it back.  Regression guard for the BOLA fix.
 
-    def test_bulk_fetch_tags_cannot_leak_out_of_scope_pictures(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).post(
-                    f"{API}/pictures/tags/bulk_fetch",
-                    json={"picture_ids": [pic_a, pic_b]},
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                returned_ids = {entry["id"] for entry in r.json()}
-                assert pic_b not in returned_ids, (
-                    "bulk_fetch tags leaked out-of-scope picture B to a set-A token"
-                )
-                assert returned_ids <= {pic_a}, (
-                    f"bulk_fetch tags returned unexpected ids {returned_ids}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_bulk_fetch_tags_cannot_leak_out_of_scope_pictures(self, env):
+        r = TestClient(env.server.api).post(
+            f"{API}/pictures/tags/bulk_fetch",
+            json={"picture_ids": [env.pic_a, env.pic_b]},
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        returned_ids = {entry["id"] for entry in r.json()}
+        assert env.pic_b not in returned_ids, (
+            "bulk_fetch tags leaked out-of-scope picture B to a set-A token"
+        )
+        assert returned_ids <= {env.pic_a}, (
+            f"bulk_fetch tags returned unexpected ids {returned_ids}"
+        )
 
-    def test_thumbnails_batch_cannot_leak_out_of_scope_pictures(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).post(
-                    f"{API}/pictures/thumbnails",
-                    json={"ids": [pic_a, pic_b]},
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                assert str(pic_b) not in r.json(), (
-                    "thumbnail batch leaked out-of-scope picture B to a set-A token"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_thumbnails_batch_cannot_leak_out_of_scope_pictures(self, env):
+        r = TestClient(env.server.api).post(
+            f"{API}/pictures/thumbnails",
+            json={"ids": [env.pic_a, env.pic_b]},
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        assert str(env.pic_b) not in r.json(), (
+            "thumbnail batch leaked out-of-scope picture B to a set-A token"
+        )
 
-    def test_set_membership_cannot_leak_out_of_scope_pictures(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).post(
-                    f"{API}/picture_sets/membership",
-                    json={"picture_ids": [pic_a, pic_b]},
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                result = r.json()
-                assert str(set_b) not in result, (
-                    "set membership leaked out-of-scope set B to a set-A token"
-                )
-                leaked = {pid for pids in result.values() for pid in pids}
-                assert pic_b not in leaked, (
-                    "set membership leaked out-of-scope picture B to a set-A token"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_set_membership_cannot_leak_out_of_scope_pictures(self, env):
+        r = TestClient(env.server.api).post(
+            f"{API}/picture_sets/membership",
+            json={"picture_ids": [env.pic_a, env.pic_b]},
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        result = r.json()
+        assert str(env.set_b) not in result, (
+            "set membership leaked out-of-scope set B to a set-A token"
+        )
+        leaked = {pid for pids in result.values() for pid in pids}
+        assert env.pic_b not in leaked, (
+            "set membership leaked out-of-scope picture B to a set-A token"
+        )
 
-    def test_project_membership_cannot_leak_out_of_scope_pictures(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).post(
-                    f"{API}/projects/membership",
-                    json={"picture_ids": [pic_a, pic_b]},
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                result = r.json()
-                assert pic_b not in result["unassigned_picture_ids"], (
-                    "project membership leaked out-of-scope picture B (unassigned)"
-                )
-                leaked = {
-                    pid
-                    for pids in result["project_assignments"].values()
-                    for pid in pids
-                }
-                assert pic_b not in leaked, (
-                    "project membership leaked out-of-scope picture B (assigned)"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_project_membership_cannot_leak_out_of_scope_pictures(self, env):
+        r = TestClient(env.server.api).post(
+            f"{API}/projects/membership",
+            json={"picture_ids": [env.pic_a, env.pic_b]},
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        result = r.json()
+        assert env.pic_b not in result["unassigned_picture_ids"], (
+            "project membership leaked out-of-scope picture B (unassigned)"
+        )
+        leaked = {
+            pid for pids in result["project_assignments"].values() for pid in pids
+        }
+        assert env.pic_b not in leaked, (
+            "project membership leaked out-of-scope picture B (assigned)"
+        )
 
-    def test_character_membership_cannot_leak_out_of_scope_pictures(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                r = TestClient(server.api).post(
-                    f"{API}/characters/membership",
-                    json={"picture_ids": [pic_a, pic_b]},
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                result = r.json()
-                assert pic_b not in result["pictures_with_faces"], (
-                    "character membership leaked out-of-scope picture B (faces)"
-                )
-                leaked = {
-                    pid
-                    for pids in result["character_assignments"].values()
-                    for pid in pids
-                }
-                assert pic_b not in leaked, (
-                    "character membership leaked out-of-scope picture B (assigned)"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_character_membership_cannot_leak_out_of_scope_pictures(self, env):
+        r = TestClient(env.server.api).post(
+            f"{API}/characters/membership",
+            json={"picture_ids": [env.pic_a, env.pic_b]},
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        result = r.json()
+        assert env.pic_b not in result["pictures_with_faces"], (
+            "character membership leaked out-of-scope picture B (faces)"
+        )
+        leaked = {
+            pid for pids in result["character_assignments"].values() for pid in pids
+        }
+        assert env.pic_b not in leaked, (
+            "character membership leaked out-of-scope picture B (assigned)"
+        )
 
-    def test_unassigned_listing_cannot_leak_out_of_scope_pictures(self):
+    def test_unassigned_listing_cannot_leak_out_of_scope_pictures(self, env):
         """character_id=UNASSIGNED must honour token scope. Regression for the
         bypass where an empty intersected id list fell through to no filter and
         the set/character scope was never applied to the UNASSIGNED branch."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {env.token_a}"}
+        listed = None
+        for path in (
+            "/pictures?character_id=UNASSIGNED",
+            f"/pictures?character_id=UNASSIGNED&id={env.pic_b}",
+        ):
+            r = client.get(f"{API}{path}", headers=hdr)
+            assert r.status_code == 200, r.text
+            ids = {p["id"] for p in r.json()}
+            assert env.pic_b not in ids, (
+                f"UNASSIGNED listing leaked out-of-scope picture via {path}: {ids}"
             )
-            try:
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {token_a}"}
-                for path in (
-                    "/pictures?character_id=UNASSIGNED",
-                    f"/pictures?character_id=UNASSIGNED&id={pic_b}",
-                ):
-                    r = client.get(f"{API}{path}", headers=hdr)
-                    assert r.status_code == 200, r.text
-                    ids = {p["id"] for p in r.json()}
-                    assert pic_b not in ids, (
-                        f"UNASSIGNED listing leaked out-of-scope picture via {path}: {ids}"
-                    )
-                r = client.get(
-                    f"{API}/pictures/count?character_id=UNASSIGNED", headers=hdr
-                )
-                assert r.status_code == 200, r.text
-                assert r.json().get("count") <= 1, (
-                    f"UNASSIGNED count leaked out-of-scope pictures: {r.json()}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+            assert ids <= {env.pic_a}, (
+                f"UNASSIGNED listing returned ids outside the grant via {path}: {ids}"
+            )
+            if listed is None:
+                listed = ids
+        r = client.get(f"{API}/pictures/count?character_id=UNASSIGNED", headers=hdr)
+        assert r.status_code == 200, r.text
+        # Pinned against the row set rather than a literal: the fixture pictures
+        # carry a "no face found" sentinel, so whether pic_a lands in the
+        # UNASSIGNED bucket at all is the endpoint's business — but the count
+        # and the listing must agree, and neither may exceed the grant.
+        assert r.json().get("count") == len(listed), (
+            f"UNASSIGNED count {r.json()} disagrees with the rows it returned: "
+            f"{sorted(listed)}"
+        )
 
-    def test_scoped_token_cannot_read_other_picture_fields(self):
+    def test_scoped_token_cannot_read_other_picture_fields(self, env):
         """GET /pictures/{id}/{field} must enforce scope. Regression: it sat
         unguarded between get_picture and get_picture_metadata."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {env.token_a}"}
+        for field in ("file_path", "width", "thumbnail"):
+            r = client.get(f"{API}/pictures/{env.pic_b}/{field}", headers=hdr)
+            assert r.status_code in {403, 404}, (
+                f"Set-A token read pic_b field '{field}', got {r.status_code}: {r.text}"
             )
-            try:
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {token_a}"}
-                for field in ("file_path", "width", "thumbnail"):
-                    r = client.get(f"{API}/pictures/{pic_b}/{field}", headers=hdr)
-                    assert r.status_code in {403, 404}, (
-                        f"Set-A token read pic_b field '{field}', "
-                        f"got {r.status_code}: {r.text}"
-                    )
-                # In-scope field still readable (no over-block).
-                r = client.get(f"{API}/pictures/{pic_a}/width", headers=hdr)
-                assert r.status_code == 200, (
-                    f"Set-A token wrongly blocked from its own picture field: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        # In-scope field still readable (no over-block).
+        r = client.get(f"{API}/pictures/{env.pic_a}/width", headers=hdr)
+        assert r.status_code == 200, (
+            f"Set-A token wrongly blocked from its own picture field: {r.text}"
+        )
 
-    def test_scoped_token_cannot_read_other_picture_character_likeness(self):
+    def test_scoped_token_cannot_read_other_picture_character_likeness(self, env):
         """GET /pictures/{id}/character_likeness must enforce scope. Regression
         (R2): it sat unguarded alongside get_picture / get_picture_metadata /
         get_picture_field and leaked picture existence, likeness scores, and the
@@ -1238,122 +1450,103 @@ class TestResourceScopedReadTokenIsolation:
         and GPU-free; the out-of-scope (negative) path is rejected by
         ``enforce_picture_scope`` before any ML/DB work runs.
         """
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
+        # A reference character is required by the endpoint's query.
+        r = env.owner_client.post(f"{API}/characters", json={"name": "Ref"})
+        assert r.status_code == 200, r.text
+        ref_char_id = r.json()["character"]["id"]
+
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {env.token_a}"}
+        params = {"reference_character_id": str(ref_char_id)}
+
+        # Negative: set-A token must not read set-B picture likeness.
+        r = client.get(
+            f"{API}/pictures/{env.pic_b}/character_likeness",
+            params=params,
+            headers=hdr,
+        )
+        assert r.status_code in {403, 404}, (
+            f"Set-A token read pic_b character_likeness, got {r.status_code}: {r.text}"
+        )
+
+        # Positive: in-scope picture still readable (no over-block).
+        # Stub the ML helpers so any face-bearing path is deterministic
+        # and never touches the GPU.
+        def _fake_select_reference_faces(session, character_id, max_refs=10):
+            return []
+
+        def _fake_compute_likeness(reference_faces, candidate_faces):
+            return {}
+
+        with (
+            patch.object(
+                likeness_module,
+                "select_reference_faces_for_character",
+                _fake_select_reference_faces,
+            ),
+            patch.object(
+                likeness_module,
+                "compute_character_likeness_for_faces",
+                _fake_compute_likeness,
+            ),
+        ):
+            r = client.get(
+                f"{API}/pictures/{env.pic_a}/character_likeness",
+                params=params,
+                headers=hdr,
             )
-            try:
-                # A reference character is required by the endpoint's query.
-                r = owner_client.post(f"{API}/characters", json={"name": "Ref"})
-                assert r.status_code == 200, r.text
-                ref_char_id = r.json()["character"]["id"]
+        assert r.status_code == 200, (
+            f"Set-A token wrongly blocked from its own picture's "
+            f"character_likeness: {r.text}"
+        )
+        body = r.json()
+        assert body["picture_id"] == env.pic_a
+        assert "ready" in body, (
+            f"character_likeness response missing 'ready' flag: {body}"
+        )
 
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {token_a}"}
-                params = {"reference_character_id": str(ref_char_id)}
-
-                # Negative: set-A token must not read set-B picture likeness.
-                r = client.get(
-                    f"{API}/pictures/{pic_b}/character_likeness",
-                    params=params,
-                    headers=hdr,
-                )
-                assert r.status_code in {403, 404}, (
-                    f"Set-A token read pic_b character_likeness, "
-                    f"got {r.status_code}: {r.text}"
-                )
-
-                # Positive: in-scope picture still readable (no over-block).
-                # Stub the ML helpers so any face-bearing path is deterministic
-                # and never touches the GPU.
-                def _fake_select_reference_faces(session, character_id, max_refs=10):
-                    return []
-
-                def _fake_compute_likeness(reference_faces, candidate_faces):
-                    return {}
-
-                with (
-                    patch.object(
-                        likeness_module,
-                        "select_reference_faces_for_character",
-                        _fake_select_reference_faces,
-                    ),
-                    patch.object(
-                        likeness_module,
-                        "compute_character_likeness_for_faces",
-                        _fake_compute_likeness,
-                    ),
-                ):
-                    r = client.get(
-                        f"{API}/pictures/{pic_a}/character_likeness",
-                        params=params,
-                        headers=hdr,
-                    )
-                assert r.status_code == 200, (
-                    f"Set-A token wrongly blocked from its own picture's "
-                    f"character_likeness: {r.text}"
-                )
-                body = r.json()
-                assert body["picture_id"] == pic_a
-                assert "ready" in body, (
-                    f"character_likeness response missing 'ready' flag: {body}"
-                )
-            finally:
-                server.__exit__(None, None, None)
-
-    def test_scoped_token_cannot_read_stack_outside_scope(self):
+    def test_scoped_token_cannot_read_stack_outside_scope(self, env):
         """Stack read endpoints must not leak out-of-scope pictures. Regression
         for unscoped /stacks/{id}/pictures and /pictures/{id}/stack.
 
         Uses a single-picture token (allow-set is exactly {pic_a}) so that
         stacking pic_a with pic_b cannot widen scope via set-membership
         propagation the way a set-scoped token would.
+
+        The stack this creates is dropped again by ``env``'s reset, so the next
+        test still sees the unstacked two-picture library it was written for.
         """
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
+        # Single-picture share token for pic_a only.
+        pic_token = _mint_read_token(
+            env.owner_client,
+            "single picture token",
+            resource_type="picture",
+            resource_id=env.pic_a,
+        )
+
+        # Owner stacks pic_a and pic_b together.
+        r = env.owner_client.post(
+            f"{API}/stacks", json={"picture_ids": [env.pic_a, env.pic_b]}
+        )
+        assert r.status_code in {200, 201}, r.text
+        r = env.owner_client.get(f"{API}/pictures/{env.pic_a}/stack")
+        assert r.status_code == 200, r.text
+        stack_id = r.json().get("id")
+        assert stack_id is not None, f"no stack id in {r.json()}"
+
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {pic_token}"}
+        r = client.get(f"{API}/stacks/{stack_id}/pictures?fields=metadata", headers=hdr)
+        assert r.status_code in {200, 404}, r.text
+        if r.status_code == 200:
+            ids = {row.get("id") for row in r.json()}
+            assert ids <= {env.pic_a}, (
+                f"Stack pictures leaked out-of-scope picture(s): {ids}"
             )
-            try:
-                # Single-picture share token for pic_a only.
-                r = owner_client.post(
-                    f"{API}/users/me/token",
-                    json={
-                        "description": "single picture token",
-                        "scope": "READ",
-                        "resource_type": "picture",
-                        "resource_id": pic_a,
-                    },
-                )
-                assert r.status_code == 200, r.text
-                pic_token = r.json()["token"]
-
-                # Owner stacks pic_a and pic_b together.
-                r = owner_client.post(
-                    f"{API}/stacks", json={"picture_ids": [pic_a, pic_b]}
-                )
-                assert r.status_code in {200, 201}, r.text
-                r = owner_client.get(f"{API}/pictures/{pic_a}/stack")
-                assert r.status_code == 200, r.text
-                stack_id = r.json().get("id")
-                assert stack_id is not None, f"no stack id in {r.json()}"
-
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {pic_token}"}
-                r = client.get(
-                    f"{API}/stacks/{stack_id}/pictures?fields=metadata", headers=hdr
-                )
-                assert r.status_code in {200, 404}, r.text
-                if r.status_code == 200:
-                    ids = {row.get("id") for row in r.json()}
-                    assert ids <= {pic_a}, (
-                        f"Stack pictures leaked out-of-scope picture(s): {ids}"
-                    )
-                r = client.get(f"{API}/pictures/{pic_b}/stack", headers=hdr)
-                assert r.status_code in {403, 404}, (
-                    f"pic_a token learned pic_b's stack, got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = client.get(f"{API}/pictures/{env.pic_b}/stack", headers=hdr)
+        assert r.status_code in {403, 404}, (
+            f"pic_a token learned pic_b's stack, got {r.status_code}: {r.text}"
+        )
 
     def _seed_comfyui_vocab(self, server, pic_a, pic_b):
         """Write distinct ComfyUI model/LoRA JSON onto each picture.
@@ -1376,118 +1569,102 @@ class TestResourceScopedReadTokenIsolation:
 
         server.vault.db.run_task(_set)
 
-    def test_comfyui_models_cannot_leak_out_of_scope_vocab(self):
+    def test_comfyui_models_cannot_leak_out_of_scope_vocab(self, env):
         """GET /pictures/comfyui_models must only return model names drawn from
         pictures inside the token's grant; owner/unscoped sees the union."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                self._seed_comfyui_vocab(server, pic_a, pic_b)
+        self._seed_comfyui_vocab(env.server, env.pic_a, env.pic_b)
 
-                # Negative: Set-A token must not see Set-B-only models.
-                r = TestClient(server.api).get(
-                    f"{API}/pictures/comfyui_models",
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                scoped = set(r.json())
-                assert "model-b-only" not in scoped, (
-                    f"Set-A token leaked out-of-scope model vocab: {scoped}"
-                )
-                assert scoped <= {"model-a-only"}, (
-                    f"Set-A token returned unexpected models: {scoped}"
-                )
+        # Negative: Set-A token must not see Set-B-only models.
+        r = TestClient(env.server.api).get(
+            f"{API}/pictures/comfyui_models",
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        scoped = set(r.json())
+        assert "model-b-only" not in scoped, (
+            f"Set-A token leaked out-of-scope model vocab: {scoped}"
+        )
+        assert scoped <= {"model-a-only"}, (
+            f"Set-A token returned unexpected models: {scoped}"
+        )
 
-                # Positive: owner/unscoped sees the union (no over-block).
-                r = owner_client.get(f"{API}/pictures/comfyui_models")
-                assert r.status_code == 200, r.text
-                owner_models = set(r.json())
-                assert {"model-a-only", "model-b-only"} <= owner_models, (
-                    f"Owner did not see full model vocab: {owner_models}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        # Positive: owner/unscoped sees the union (no over-block).
+        r = env.owner_client.get(f"{API}/pictures/comfyui_models")
+        assert r.status_code == 200, r.text
+        owner_models = set(r.json())
+        assert {"model-a-only", "model-b-only"} <= owner_models, (
+            f"Owner did not see full model vocab: {owner_models}"
+        )
 
-    def test_comfyui_loras_cannot_leak_out_of_scope_vocab(self):
+    def test_comfyui_loras_cannot_leak_out_of_scope_vocab(self, env):
         """GET /pictures/comfyui_loras must only return LoRA names drawn from
         pictures inside the token's grant; owner/unscoped sees the union."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                self._seed_comfyui_vocab(server, pic_a, pic_b)
+        self._seed_comfyui_vocab(env.server, env.pic_a, env.pic_b)
 
-                # Negative: Set-A token must not see Set-B-only LoRAs.
-                r = TestClient(server.api).get(
-                    f"{API}/pictures/comfyui_loras",
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                scoped = set(r.json())
-                assert "lora-b-only" not in scoped, (
-                    f"Set-A token leaked out-of-scope LoRA vocab: {scoped}"
-                )
-                assert scoped <= {"lora-a-only"}, (
-                    f"Set-A token returned unexpected LoRAs: {scoped}"
-                )
+        # Negative: Set-A token must not see Set-B-only LoRAs.
+        r = TestClient(env.server.api).get(
+            f"{API}/pictures/comfyui_loras",
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        scoped = set(r.json())
+        assert "lora-b-only" not in scoped, (
+            f"Set-A token leaked out-of-scope LoRA vocab: {scoped}"
+        )
+        assert scoped <= {"lora-a-only"}, (
+            f"Set-A token returned unexpected LoRAs: {scoped}"
+        )
 
-                # Positive: owner/unscoped sees the union (no over-block).
-                r = owner_client.get(f"{API}/pictures/comfyui_loras")
-                assert r.status_code == 200, r.text
-                owner_loras = set(r.json())
-                assert {"lora-a-only", "lora-b-only"} <= owner_loras, (
-                    f"Owner did not see full LoRA vocab: {owner_loras}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        # Positive: owner/unscoped sees the union (no over-block).
+        r = env.owner_client.get(f"{API}/pictures/comfyui_loras")
+        assert r.status_code == 200, r.text
+        owner_loras = set(r.json())
+        assert {"lora-a-only", "lora-b-only"} <= owner_loras, (
+            f"Owner did not see full LoRA vocab: {owner_loras}"
+        )
 
-    def test_list_all_tags_cannot_leak_out_of_scope_vocab(self):
+    def test_list_all_tags_cannot_leak_out_of_scope_vocab(self, env):
         """GET /tags must only return tag values (and counts) drawn from
-        pictures inside the token's grant; owner/unscoped sees the union."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
-            )
-            try:
-                # Seed distinct tags per picture via the owner API.
-                r = owner_client.post(
-                    f"{API}/pictures/{pic_a}/tags", json={"tag": "tag-a-only"}
-                )
-                assert r.status_code == 200, r.text
-                r = owner_client.post(
-                    f"{API}/pictures/{pic_b}/tags", json={"tag": "tag-b-only"}
-                )
-                assert r.status_code == 200, r.text
+        pictures inside the token's grant; owner/unscoped sees the union.
 
-                # Negative: Set-A token must not see the Set-B-only tag, and the
-                # counts it does see must reflect only the in-scope picture.
-                r = TestClient(server.api).get(
-                    f"{API}/tags",
-                    headers={"Authorization": f"Bearer {token_a}"},
-                )
-                assert r.status_code == 200, r.text
-                scoped = {row["tag"]: row["count"] for row in r.json()}
-                assert "tag-b-only" not in scoped, (
-                    f"Set-A token leaked out-of-scope tag vocab: {scoped}"
-                )
-                assert scoped.get("tag-a-only") == 1, (
-                    f"Set-A token tag count wrong (must reflect only Set A): {scoped}"
-                )
+        ``env`` truncates the tag table before every test, so the exact count
+        asserted below is this test's own tag and nothing another test left
+        behind.
+        """
+        # Seed distinct tags per picture via the owner API.
+        r = env.owner_client.post(
+            f"{API}/pictures/{env.pic_a}/tags", json={"tag": "tag-a-only"}
+        )
+        assert r.status_code == 200, r.text
+        r = env.owner_client.post(
+            f"{API}/pictures/{env.pic_b}/tags", json={"tag": "tag-b-only"}
+        )
+        assert r.status_code == 200, r.text
 
-                # Positive: owner/unscoped sees the union (no over-block).
-                r = owner_client.get(f"{API}/tags")
-                assert r.status_code == 200, r.text
-                owner_tags = {row["tag"] for row in r.json()}
-                assert {"tag-a-only", "tag-b-only"} <= owner_tags, (
-                    f"Owner did not see full tag vocab: {owner_tags}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        # Negative: Set-A token must not see the Set-B-only tag, and the
+        # counts it does see must reflect only the in-scope picture.
+        r = TestClient(env.server.api).get(
+            f"{API}/tags",
+            headers={"Authorization": f"Bearer {env.token_a}"},
+        )
+        assert r.status_code == 200, r.text
+        scoped = {row["tag"]: row["count"] for row in r.json()}
+        assert "tag-b-only" not in scoped, (
+            f"Set-A token leaked out-of-scope tag vocab: {scoped}"
+        )
+        assert scoped.get("tag-a-only") == 1, (
+            f"Set-A token tag count wrong (must reflect only Set A): {scoped}"
+        )
 
-    def test_scoped_token_cannot_read_other_picture_comfyui_workflow(self):
+        # Positive: owner/unscoped sees the union (no over-block).
+        r = env.owner_client.get(f"{API}/tags")
+        assert r.status_code == 200, r.text
+        owner_tags = {row["tag"] for row in r.json()}
+        assert {"tag-a-only", "tag-b-only"} <= owner_tags, (
+            f"Owner did not see full tag vocab: {owner_tags}"
+        )
+
+    def test_scoped_token_cannot_read_other_picture_comfyui_workflow(self, env):
         """GET /comfyui/pictures/{id}/workflow must enforce scope (R1).
 
         Negative: a Set-A token is rejected on a Set-B picture by
@@ -1499,42 +1676,29 @@ class TestResourceScopedReadTokenIsolation:
         """
         import pixlstash.routes.comfyui as comfyui_module
 
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, set_a, set_b, pic_a, pic_b, token_a = (
-                self._setup_two_picture_sets(tmp)
+        client = TestClient(env.server.api)
+        hdr = {"Authorization": f"Bearer {env.token_a}"}
+
+        def _fake_extract(_metadata):
+            return {"workflow": {"nodes": []}, "models": [], "loras": []}
+
+        # Negative: Set-A token must not reach Set-B picture's workflow.
+        # Stubbed extractor would happily return data, so a pass here
+        # proves the scope gate (not a missing-workflow 404) blocked it.
+        with patch.object(comfyui_module, "extract_comfy_workflow_info", _fake_extract):
+            r = client.get(f"{API}/comfyui/pictures/{env.pic_b}/workflow", headers=hdr)
+            assert r.status_code in {403, 404}, (
+                f"Set-A token read pic_b ComfyUI workflow, "
+                f"got {r.status_code}: {r.text}"
             )
-            try:
-                client = TestClient(server.api)
-                hdr = {"Authorization": f"Bearer {token_a}"}
 
-                def _fake_extract(_metadata):
-                    return {"workflow": {"nodes": []}, "models": [], "loras": []}
-
-                # Negative: Set-A token must not reach Set-B picture's workflow.
-                # Stubbed extractor would happily return data, so a pass here
-                # proves the scope gate (not a missing-workflow 404) blocked it.
-                with patch.object(
-                    comfyui_module, "extract_comfy_workflow_info", _fake_extract
-                ):
-                    r = client.get(
-                        f"{API}/comfyui/pictures/{pic_b}/workflow", headers=hdr
-                    )
-                    assert r.status_code in {403, 404}, (
-                        f"Set-A token read pic_b ComfyUI workflow, "
-                        f"got {r.status_code}: {r.text}"
-                    )
-
-                    # Positive: the in-scope picture is still served (no
-                    # over-block) and returns the extracted workflow.
-                    r = client.get(
-                        f"{API}/comfyui/pictures/{pic_a}/workflow", headers=hdr
-                    )
-                    assert r.status_code == 200, (
-                        f"Set-A token wrongly scope-blocked from its own "
-                        f"picture's workflow: {r.status_code} {r.text}"
-                    )
-            finally:
-                server.__exit__(None, None, None)
+            # Positive: the in-scope picture is still served (no
+            # over-block) and returns the extracted workflow.
+            r = client.get(f"{API}/comfyui/pictures/{env.pic_a}/workflow", headers=hdr)
+            assert r.status_code == 200, (
+                f"Set-A token wrongly scope-blocked from its own "
+                f"picture's workflow: {r.status_code} {r.text}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1570,111 +1734,57 @@ class TestComfyuiFilterCannotEscapeTokenScope:
     stacked after set membership is granted, which the last test does.
     """
 
-    MODEL = "shared-model.safetensors"
-    LORA = "shared-lora.safetensors"
-    FILTER_PARAMS = ("comfyui_model", "comfyui_lora")
+    FILTER_PARAMS = STACK_FILTER_PARAMS
 
-    # Which seeded pictures carry the filtered model/LoRA, and how the two
-    # stacks are laid out once _form_stacks runs (``*`` = matches the filter)::
-    #
-    #     shared stack : cover*  sibling_a*  sibling_b*
-    #     other stack  : quiet_cover   quiet_member*
-    #     loose        : lone*
-    #
-    # Only ``cover`` is ever inside the token's grant. ``quiet_cover`` is the
-    # one that must come back for the *owner* purely through the member branch.
-    _MATCHING = {"cover", "sibling_a", "sibling_b", "quiet_member", "lone"}
-    _SHARED_STACK = ("cover", "sibling_a", "sibling_b")
-    _OTHER_STACK = ("quiet_cover", "quiet_member")
+    @pytest.fixture(autouse=True)
+    def env(self, _comfyui_stack_env):
+        """Re-mint the single-picture share token and re-pin the stack layout.
+
+        Nothing in this class writes, so the reset is about the credential and
+        about proving the fixture still *is* the straddling shape these
+        assertions depend on: the six pictures at their exact file paths, and
+        the two stacks holding exactly the members they were seeded with. The
+        layout is asserted by identity — a picture quietly moved between stacks
+        would turn "the filter did not widen scope" into a tautology.
+        """
+        e = _comfyui_stack_env
+        _reset_owner_credentials(e.server, e.owner_client)
+        token = _mint_read_token(
+            e.owner_client,
+            "single picture share",
+            resource_type="picture",
+            resource_id=e.ids["cover"],
+        )
+
+        layout = _stack_layout(e.server)
+        assert set(layout) == set(_STACK_PATHS.values()), (
+            "the shared ComfyUI stack library no longer holds exactly its "
+            f"fixture pictures: {sorted(layout)}"
+        )
+        shared_stack = {layout[_STACK_PATHS[n]][0] for n in _SHARED_STACK}
+        other_stack = {layout[_STACK_PATHS[n]][0] for n in _OTHER_STACK}
+        assert len(shared_stack) == 1 and None not in shared_stack, (
+            f"the straddled stack has come apart: {shared_stack}"
+        )
+        assert len(other_stack) == 1 and None not in other_stack, (
+            f"the second stack has come apart: {other_stack}"
+        )
+        assert shared_stack != other_stack, "the two stacks have merged"
+        assert layout[_STACK_PATHS["lone"]][0] is None, (
+            "the loose picture has been stacked"
+        )
+        assert _prove_token_reads(
+            e.server, token, "/pictures", fields="grid", limit=500
+        ) == {e.ids["cover"]}, (
+            "the fresh single-picture token does not see exactly its own picture"
+        )
+
+        return SimpleNamespace(
+            server=e.server, owner_client=e.owner_client, ids=e.ids, token=token
+        )
 
     def _filter_value(self, filter_param: str) -> str:
-        return self.MODEL if filter_param == "comfyui_model" else self.LORA
-
-    def _seed_pictures(self, server) -> dict:
-        """Create the six unstacked pictures with their ComfyUI metadata.
-
-        ``comfyui_models`` / ``comfyui_loras`` are pipeline-populated JSON
-        columns with no owner-facing write API, so they are seeded directly via
-        the DB task runner (same pattern as ``_seed_comfyui_vocab`` above).
-        """
-
-        def _seed(session):
-            ids = {}
-            for name in (
-                *self._SHARED_STACK,
-                *self._OTHER_STACK,
-                "lone",
-            ):
-                matching = name in self._MATCHING
-                pic = Picture(
-                    file_path=f"/home/owner/private/{name}.png",
-                    comfyui_models=json.dumps(
-                        [self.MODEL if matching else "unrelated-model"]
-                    ),
-                    comfyui_loras=json.dumps(
-                        [self.LORA if matching else "unrelated-lora"]
-                    ),
-                )
-                session.add(pic)
-                session.commit()
-                session.refresh(pic)
-                ids[name] = pic.id
-            return ids
-
-        return server.vault.db.run_task(_seed)
-
-    def _form_stacks(self, server, ids: dict) -> None:
-        """Stack the seeded pictures, keeping ``lone`` unstacked.
-
-        Done in the DB rather than through the stack API so the stack can be
-        formed at an arbitrary point relative to picture-set membership -- the
-        set-scoped test below depends on forming it *after*.
-        """
-
-        def _stack(session):
-            for names in (self._SHARED_STACK, self._OTHER_STACK):
-                stack = PictureStack()
-                session.add(stack)
-                session.commit()
-                session.refresh(stack)
-                for position, name in enumerate(names):
-                    pic = session.get(Picture, ids[name])
-                    pic.stack_id = stack.id
-                    pic.stack_position = position
-                    session.add(pic)
-            session.commit()
-
-        server.vault.db.run_task(_stack)
-
-    def _setup(self, tmp: str):
-        """Start a server, seed the straddling stack, mint a picture token.
-
-        Returns ``(server, owner_client, ids, picture_token)`` where the token
-        grants READ on ``ids["cover"]`` and nothing else.
-        """
-        server = Server(f"{tmp}/server-config.json")
-        server.__enter__()
-        owner_client = TestClient(server.api, raise_server_exceptions=True)
-
-        r = owner_client.post(
-            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
-        )
-        assert r.status_code == 200, r.text
-
-        ids = self._seed_pictures(server)
-        self._form_stacks(server, ids)
-
-        r = owner_client.post(
-            f"{API}/users/me/token",
-            json={
-                "description": "single picture share",
-                "scope": "READ",
-                "resource_type": "picture",
-                "resource_id": ids["cover"],
-            },
-        )
-        assert r.status_code == 200, r.text
-        return server, owner_client, ids, r.json()["token"]
+        return STACK_MODEL if filter_param == "comfyui_model" else STACK_LORA
 
     @staticmethod
     def _ids_from(response) -> set[int]:
@@ -1692,7 +1802,7 @@ class TestComfyuiFilterCannotEscapeTokenScope:
             params=params,
         )
 
-    def test_picture_token_cannot_widen_the_grid_via_comfyui_filter(self):
+    def test_picture_token_cannot_widen_the_grid_via_comfyui_filter(self, env):
         """``GET /pictures?fields=grid&comfyui_model=...`` stays inside scope.
 
         ``fields=grid`` implies ``stack_leaders_only``, so this is the default
@@ -1702,41 +1812,36 @@ class TestComfyuiFilterCannotEscapeTokenScope:
         of every stack that contained a match, library-wide.
         """
         for filter_param in self.FILTER_PARAMS:
-            with tempfile.TemporaryDirectory() as tmp:
-                server, _owner, ids, token = self._setup(tmp)
-                try:
-                    r = self._scoped_get(
-                        server,
-                        token,
-                        "/pictures",
-                        {
-                            "fields": "grid",
-                            "limit": 500,
-                            filter_param: self._filter_value(filter_param),
-                        },
-                    )
-                    returned = self._ids_from(r)
-                    out_of_scope = returned - {ids["cover"]}
-                    assert not out_of_scope, (
-                        f"Single-picture token leaked ids {sorted(out_of_scope)} "
-                        f"via /pictures?fields=grid&{filter_param}=..."
-                    )
-                    # Positive: the granted picture is still served. The whole
-                    # point of the narrowing is to return this row and no other.
-                    assert returned == {ids["cover"]}, (
-                        f"In-scope picture {ids['cover']} was dropped from "
-                        f"/pictures?fields=grid&{filter_param}=...: {returned}"
-                    )
-                    # The grid projection carries file_path, so the leak handed
-                    # out on-disk locations of pictures that were never shared.
-                    paths = {row.get("file_path") for row in r.json()}
-                    assert paths == {"/home/owner/private/cover.png"}, (
-                        f"Grid rows exposed out-of-scope file paths: {paths}"
-                    )
-                finally:
-                    server.__exit__(None, None, None)
+            r = self._scoped_get(
+                env.server,
+                env.token,
+                "/pictures",
+                {
+                    "fields": "grid",
+                    "limit": 500,
+                    filter_param: self._filter_value(filter_param),
+                },
+            )
+            returned = self._ids_from(r)
+            out_of_scope = returned - {env.ids["cover"]}
+            assert not out_of_scope, (
+                f"Single-picture token leaked ids {sorted(out_of_scope)} "
+                f"via /pictures?fields=grid&{filter_param}=..."
+            )
+            # Positive: the granted picture is still served. The whole
+            # point of the narrowing is to return this row and no other.
+            assert returned == {env.ids["cover"]}, (
+                f"In-scope picture {env.ids['cover']} was dropped from "
+                f"/pictures?fields=grid&{filter_param}=...: {returned}"
+            )
+            # The grid projection carries file_path, so the leak handed
+            # out on-disk locations of pictures that were never shared.
+            paths = {row.get("file_path") for row in r.json()}
+            assert paths == {_STACK_PATHS["cover"]}, (
+                f"Grid rows exposed out-of-scope file paths: {paths}"
+            )
 
-    def test_picture_token_cannot_widen_the_stream_via_comfyui_filter(self):
+    def test_picture_token_cannot_widen_the_stream_via_comfyui_filter(self, env):
         """``/pictures/stream`` is a separate handler and leaked identically.
 
         Both the ``fields=grid`` form and the explicit ``stack_leaders_only``
@@ -1744,36 +1849,31 @@ class TestComfyuiFilterCannotEscapeTokenScope:
         query by two different routes.
         """
         for filter_param in self.FILTER_PARAMS:
-            with tempfile.TemporaryDirectory() as tmp:
-                server, _owner, ids, token = self._setup(tmp)
-                try:
-                    value = self._filter_value(filter_param)
-                    for extra in (
-                        {"fields": "grid"},
-                        {"stack_leaders_only": "true"},
-                    ):
-                        r = self._scoped_get(
-                            server,
-                            token,
-                            "/pictures/stream",
-                            {"batch_limit": 500, filter_param: value, **extra},
-                        )
-                        returned = self._ids_from(r)
-                        out_of_scope = returned - {ids["cover"]}
-                        assert not out_of_scope, (
-                            f"Single-picture token leaked ids "
-                            f"{sorted(out_of_scope)} via /pictures/stream "
-                            f"({extra}, {filter_param})"
-                        )
-                        assert returned == {ids["cover"]}, (
-                            f"In-scope picture {ids['cover']} was dropped from "
-                            f"/pictures/stream ({extra}, {filter_param}): "
-                            f"{returned}"
-                        )
-                finally:
-                    server.__exit__(None, None, None)
+            value = self._filter_value(filter_param)
+            for extra in (
+                {"fields": "grid"},
+                {"stack_leaders_only": "true"},
+            ):
+                r = self._scoped_get(
+                    env.server,
+                    env.token,
+                    "/pictures/stream",
+                    {"batch_limit": 500, filter_param: value, **extra},
+                )
+                returned = self._ids_from(r)
+                out_of_scope = returned - {env.ids["cover"]}
+                assert not out_of_scope, (
+                    f"Single-picture token leaked ids "
+                    f"{sorted(out_of_scope)} via /pictures/stream "
+                    f"({extra}, {filter_param})"
+                )
+                assert returned == {env.ids["cover"]}, (
+                    f"In-scope picture {env.ids['cover']} was dropped from "
+                    f"/pictures/stream ({extra}, {filter_param}): "
+                    f"{returned}"
+                )
 
-    def test_picture_token_cannot_widen_the_count_via_comfyui_filter(self):
+    def test_picture_token_cannot_widen_the_count_via_comfyui_filter(self, env):
         """``/pictures/count`` leaked the size of the library, not just rows.
 
         The count runs ``SELECT COUNT(*)`` over the same WHERE clause, so the
@@ -1782,32 +1882,27 @@ class TestComfyuiFilterCannotEscapeTokenScope:
         number before.
         """
         for filter_param in self.FILTER_PARAMS:
-            with tempfile.TemporaryDirectory() as tmp:
-                server, _owner, ids, token = self._setup(tmp)
-                try:
-                    r = self._scoped_get(
-                        server,
-                        token,
-                        "/pictures/count",
-                        {
-                            "stack_leaders_only": "true",
-                            filter_param: self._filter_value(filter_param),
-                        },
-                    )
-                    assert r.status_code == 200, r.text
-                    count = r.json()["count"]
-                    # Exactly one: the granted picture matches the filter, so
-                    # this pins both directions at once -- an inflated count is
-                    # the leak, a zero count is over-blocking.
-                    assert count == 1, (
-                        f"Single-picture token saw count={count} for "
-                        f"{filter_param}; expected 1 (only picture "
-                        f"{ids['cover']} is in scope)"
-                    )
-                finally:
-                    server.__exit__(None, None, None)
+            r = self._scoped_get(
+                env.server,
+                env.token,
+                "/pictures/count",
+                {
+                    "stack_leaders_only": "true",
+                    filter_param: self._filter_value(filter_param),
+                },
+            )
+            assert r.status_code == 200, r.text
+            count = r.json()["count"]
+            # Exactly one: the granted picture matches the filter, so
+            # this pins both directions at once -- an inflated count is
+            # the leak, a zero count is over-blocking.
+            assert count == 1, (
+                f"Single-picture token saw count={count} for "
+                f"{filter_param}; expected 1 (only picture "
+                f"{env.ids['cover']} is in scope)"
+            )
 
-    def test_owner_still_gets_the_legitimate_stack_expansion(self):
+    def test_owner_still_gets_the_legitimate_stack_expansion(self, env):
         """The over-blocking direction: the feature the fragment exists for.
 
         For an unscoped owner the collapsed grid must return one tile per
@@ -1816,32 +1911,27 @@ class TestComfyuiFilterCannotEscapeTokenScope:
         Tightening the parentheses must not cost the member branch its reach.
         """
         for filter_param in self.FILTER_PARAMS:
-            with tempfile.TemporaryDirectory() as tmp:
-                server, owner_client, ids, _token = self._setup(tmp)
-                try:
-                    value = self._filter_value(filter_param)
-                    r = owner_client.get(
-                        f"{API}/pictures",
-                        params={"fields": "grid", "limit": 500, filter_param: value},
-                    )
-                    returned = self._ids_from(r)
-                    expected = {ids["cover"], ids["quiet_cover"], ids["lone"]}
-                    assert returned == expected, (
-                        f"Owner's collapsed grid for {filter_param} returned "
-                        f"{sorted(returned)}, expected {sorted(expected)} "
-                        "(one leader per matching stack, plus the loose match)"
-                    )
-                    r = owner_client.get(
-                        f"{API}/pictures/count",
-                        params={"stack_leaders_only": "true", filter_param: value},
-                    )
-                    assert r.status_code == 200, r.text
-                    assert r.json()["count"] == len(expected), (
-                        f"Owner count for {filter_param} disagrees with the "
-                        f"row set: {r.json()['count']} vs {len(expected)}"
-                    )
-                finally:
-                    server.__exit__(None, None, None)
+            value = self._filter_value(filter_param)
+            r = env.owner_client.get(
+                f"{API}/pictures",
+                params={"fields": "grid", "limit": 500, filter_param: value},
+            )
+            returned = self._ids_from(r)
+            expected = {env.ids["cover"], env.ids["quiet_cover"], env.ids["lone"]}
+            assert returned == expected, (
+                f"Owner's collapsed grid for {filter_param} returned "
+                f"{sorted(returned)}, expected {sorted(expected)} "
+                "(one leader per matching stack, plus the loose match)"
+            )
+            r = env.owner_client.get(
+                f"{API}/pictures/count",
+                params={"stack_leaders_only": "true", filter_param: value},
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["count"] == len(expected), (
+                f"Owner count for {filter_param} disagrees with the "
+                f"row set: {r.json()['count']} vs {len(expected)}"
+            )
 
     def test_set_token_cannot_widen_via_comfyui_filter_on_a_late_stack(self):
         """The set-scoped straddle: pictures stacked *after* set membership.
@@ -1865,7 +1955,7 @@ class TestComfyuiFilterCannotEscapeTokenScope:
                 # Order matters: seed loose pictures, put ONE of them in the set
                 # while nothing is stacked (so the stack-atomic add pulls in
                 # nothing), and only then form the stacks around it.
-                ids = self._seed_pictures(server)
+                ids = _seed_stack_pictures(server)
 
                 r = owner_client.post(f"{API}/picture_sets", json={"name": "Shared"})
                 assert r.status_code == 200, r.text
@@ -1876,7 +1966,7 @@ class TestComfyuiFilterCannotEscapeTokenScope:
                 )
                 assert r.status_code in {200, 201, 204}, r.text
 
-                self._form_stacks(server, ids)
+                _form_stacks(server, ids)
 
                 r = owner_client.post(
                     f"{API}/users/me/token",
@@ -1950,64 +2040,56 @@ class TestComfyuiFilterCannotEscapeTokenScope:
 # ---------------------------------------------------------------------------
 
 
-class TestExpiredToken:
-    def test_expired_token_is_rejected(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, _ = _setup_server_with_pictures(tmp)
-            try:
-                from datetime import datetime, timedelta
+class TestExpiredToken(_SharedPictureLibrary):
+    """Expiry is honoured in both directions on the same shared library.
 
-                past = (datetime.utcnow() - timedelta(days=1)).isoformat()
-                r = owner_client.post(
-                    f"{API}/users/me/token",
-                    json={
-                        "description": "expired",
-                        "scope": "READ",
-                        "expires_at": past,
-                    },
-                )
-                assert r.status_code == 200, r.text
-                expired_token = r.json()["token"]
+    The negative (expired → 401) and the positive (expiring today → 200) run
+    against the same server and the same freshly re-minted credentials, so the
+    401 can only be about the expiry stamp.
+    """
 
-                r = TestClient(server.api).get(
-                    f"{API}/pictures",
-                    headers={"Authorization": f"Bearer {expired_token}"},
-                )
-                assert r.status_code == 401, (
-                    f"Expired token should be rejected, got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_expired_token_is_rejected(self, library_env):
+        past = (datetime.utcnow() - timedelta(days=1)).isoformat()
+        r = library_env.owner_client.post(
+            f"{API}/users/me/token",
+            json={
+                "description": "expired",
+                "scope": "READ",
+                "expires_at": past,
+            },
+        )
+        assert r.status_code == 200, r.text
+        expired_token = r.json()["token"]
 
-    def test_today_token_still_valid(self):
+        r = TestClient(library_env.server.api).get(
+            f"{API}/pictures",
+            headers={"Authorization": f"Bearer {expired_token}"},
+        )
+        assert r.status_code == 401, (
+            f"Expired token should be rejected, got {r.status_code}: {r.text}"
+        )
+
+    def test_today_token_still_valid(self, library_env):
         """A token with expires_at=today (normalized to end-of-day) should still work."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, _ = _setup_server_with_pictures(tmp)
-            try:
-                from datetime import datetime
+        today_str = datetime.utcnow().strftime("%Y-%m-%d")
+        r = library_env.owner_client.post(
+            f"{API}/users/me/token",
+            json={
+                "description": "today token",
+                "scope": "READ",
+                "expires_at": today_str,
+            },
+        )
+        assert r.status_code == 200, r.text
+        today_token = r.json()["token"]
 
-                today_str = datetime.utcnow().strftime("%Y-%m-%d")
-                r = owner_client.post(
-                    f"{API}/users/me/token",
-                    json={
-                        "description": "today token",
-                        "scope": "READ",
-                        "expires_at": today_str,
-                    },
-                )
-                assert r.status_code == 200, r.text
-                today_token = r.json()["token"]
-
-                r = TestClient(server.api).get(
-                    f"{API}/pictures",
-                    headers={"Authorization": f"Bearer {today_token}"},
-                )
-                assert r.status_code == 200, (
-                    f"Token expiring today should still be valid, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = TestClient(library_env.server.api).get(
+            f"{API}/pictures",
+            headers={"Authorization": f"Bearer {today_token}"},
+        )
+        assert r.status_code == 200, (
+            f"Token expiring today should still be valid, got {r.status_code}: {r.text}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -2015,100 +2097,82 @@ class TestExpiredToken:
 # ---------------------------------------------------------------------------
 
 
-class TestNoPrivilegeEscalation:
-    def test_read_token_cannot_create_all_scope_token(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).post(
-                    f"{API}/users/me/token",
-                    json={"description": "escalated ALL token", "scope": "ALL"},
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token must not create ALL-scope token, "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+class TestNoPrivilegeEscalation(_SharedPictureLibrary):
+    def test_read_token_cannot_create_all_scope_token(self, library_env):
+        r = TestClient(library_env.server.api).post(
+            f"{API}/users/me/token",
+            json={"description": "escalated ALL token", "scope": "ALL"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token must not create ALL-scope token, got {r.status_code}: {r.text}"
+        )
 
-    def test_read_token_cannot_create_read_token(self):
+    def test_read_token_cannot_create_read_token(self, library_env):
         """Even creating another READ token via a READ token must be blocked."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = TestClient(server.api).post(
-                    f"{API}/users/me/token",
-                    json={"description": "cloned read token", "scope": "READ"},
-                    headers={"Authorization": f"Bearer {read_token}"},
-                )
-                assert r.status_code == 403, (
-                    f"READ token must not clone itself, got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = TestClient(library_env.server.api).post(
+            f"{API}/users/me/token",
+            json={"description": "cloned read token", "scope": "READ"},
+            headers={"Authorization": f"Bearer {library_env.read_token}"},
+        )
+        assert r.status_code == 403, (
+            f"READ token must not clone itself, got {r.status_code}: {r.text}"
+        )
 
-    def test_invalid_token_value_rejected(self):
+    def test_invalid_token_value_rejected(self, library_env):
         """A completely fabricated token must not authenticate."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, _ = _setup_server_with_pictures(tmp)
-            try:
-                fake = "AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDDEEEEEEEEFFFFFFFF"
-                r = TestClient(server.api).get(
-                    f"{API}/pictures",
-                    headers={"Authorization": f"Bearer {fake}"},
-                )
-                assert r.status_code == 401, (
-                    f"Fabricated token should be rejected, got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        fake = "AAAAAAAABBBBBBBBCCCCCCCCDDDDDDDDEEEEEEEEFFFFFFFF"
+        r = TestClient(library_env.server.api).get(
+            f"{API}/pictures",
+            headers={"Authorization": f"Bearer {fake}"},
+        )
+        assert r.status_code == 401, (
+            f"Fabricated token should be rejected, got {r.status_code}: {r.text}"
+        )
 
-    def test_tampered_token_prefix_rejected(self):
-        """Modifying the first byte of a valid token must invalidate it."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                # Flip the first character.
-                flipped = ("X" if read_token[0] != "X" else "Y") + read_token[1:]
-                r = TestClient(server.api).get(
-                    f"{API}/pictures",
-                    headers={"Authorization": f"Bearer {flipped}"},
-                )
-                assert r.status_code == 401, (
-                    f"Tampered token prefix should be rejected, got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+    def test_tampered_token_prefix_rejected(self, library_env):
+        """Modifying the first byte of a valid token must invalidate it.
 
-    def test_token_in_query_param_only_works_for_read(self):
+        The unmodified original was already proven to read this library by
+        ``library_env``, so the 401 is about the flipped byte and nothing else.
+        """
+        read_token = library_env.read_token
+        flipped = ("X" if read_token[0] != "X" else "Y") + read_token[1:]
+        r = TestClient(library_env.server.api).get(
+            f"{API}/pictures",
+            headers={"Authorization": f"Bearer {flipped}"},
+        )
+        assert r.status_code == 401, (
+            f"Tampered token prefix should be rejected, got {r.status_code}: {r.text}"
+        )
+
+    def test_token_in_query_param_only_works_for_read(self, library_env):
         """?token= query param must only accept READ-scoped tokens, not ALL."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, _ = _setup_server_with_pictures(tmp)
-            try:
-                r = owner_client.post(
-                    f"{API}/users/me/token",
-                    json={"description": "all scope", "scope": "ALL"},
-                )
-                assert r.status_code == 200, r.text
-                all_token = r.json()["token"]
+        r = library_env.owner_client.post(
+            f"{API}/users/me/token",
+            json={"description": "all scope", "scope": "ALL"},
+        )
+        assert r.status_code == 200, r.text
+        all_token = r.json()["token"]
 
-                r = TestClient(server.api).get(
-                    f"{API}/pictures",
-                    params={"token": all_token},
-                )
-                assert r.status_code == 401, (
-                    f"ALL-scope token in ?token= param should be rejected (only READ allowed via URL), "
-                    f"got {r.status_code}: {r.text}"
-                )
-            finally:
-                server.__exit__(None, None, None)
+        r = TestClient(library_env.server.api).get(
+            f"{API}/pictures",
+            params={"token": all_token},
+        )
+        assert r.status_code == 401, (
+            f"ALL-scope token in ?token= param should be rejected (only READ allowed via URL), "
+            f"got {r.status_code}: {r.text}"
+        )
+        # Positive: the READ token this fixture minted *is* accepted the same
+        # way, so the 401 above is the scope check and not a broken ?token= path.
+        r = TestClient(library_env.server.api).get(
+            f"{API}/pictures",
+            params={"token": library_env.read_token},
+        )
+        assert r.status_code == 200, (
+            f"READ token in ?token= param must still be accepted, "
+            f"got {r.status_code}: {r.text}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -2117,6 +2181,16 @@ class TestNoPrivilegeEscalation:
 
 
 class TestLoginBruteForce:
+    """Deliberately NOT on a shared server.
+
+    The subject of these tests *is* the server-lifetime lockout counter, and
+    every other class in this module clears that counter before each test so it
+    cannot poison them. A shared server would mean the thing under test is also
+    the thing the reset destroys, so a "locked out" assertion could pass or fail
+    for reasons that have nothing to do with the lockout. These tests import no
+    pictures, so a fresh Server here costs only the boot.
+    """
+
     def test_lockout_after_five_failures(self):
         """After 5 wrong passwords the server returns 429 with Retry-After."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -2220,6 +2294,11 @@ class TestLoginBruteForce:
 
 
 class TestRateLimiter:
+    """Deliberately NOT on a shared server, for the same reason as
+    ``TestLoginBruteForce``: the sliding window these tests assert on is exactly
+    what every other class's reset empties. They import no pictures either.
+    """
+
     def test_login_path_rate_limited_after_limit(self):
         """Exceeding _LIMIT requests to the login path returns 429 with Retry-After."""
         with patch.object(rl_module, "_LIMIT", 5):
@@ -2320,133 +2399,135 @@ class TestRateLimiter:
 # ---------------------------------------------------------------------------
 
 
-class TestDataIntegrityUnderAttack:
-    """Upload real pictures, run all attack patterns, verify nothing changed."""
+class TestDataIntegrityUnderAttack(_SharedPictureLibrary):
+    """Run every attack pattern against the shared library; nothing may change.
 
-    def test_data_intact_after_write_attempts(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                # Record baseline scores.
-                r = owner_client.get(f"{API}/pictures")
-                assert r.status_code == 200, r.text
-                original_scores = {str(p["id"]): p.get("score") for p in r.json()}
+    ``library_env`` already re-asserted the ids and scores before each test
+    starts, so the baseline these attacks are measured against is a checked one
+    rather than whatever the previous test left behind.
 
-                attack_client = TestClient(server.api)
-                headers = {"Authorization": f"Bearer {read_token}"}
+    Both state-poisoning tests below (the lockout and the rate-limit barrage)
+    leave server-lifetime counters set. ``_reset_owner_credentials`` clears the
+    lockout *and* the rate-limit window at the start of every test, so neither
+    one silently defangs the next.
+    """
 
-                # Attempt to clobber every score to 1.
-                attack_client.post(
-                    f"{API}/pictures/apply-scores",
-                    json={"scores": {str(pid): 1 for pid in picture_ids}},
-                    headers=headers,
-                )
+    def test_data_intact_after_write_attempts(self, library_env):
+        picture_ids = library_env.picture_ids
+        attack_client = TestClient(library_env.server.api)
+        headers = {"Authorization": f"Bearer {library_env.read_token}"}
 
-                # Attempt to delete every picture.
-                for pid in picture_ids:
-                    attack_client.delete(f"{API}/pictures/{pid}", headers=headers)
+        # Attempt to clobber every score to 1.
+        attack_client.post(
+            f"{API}/pictures/apply-scores",
+            json={"scores": {str(pid): 1 for pid in picture_ids}},
+            headers=headers,
+        )
 
-                # Attempt PATCH on first picture.
-                attack_client.patch(
-                    f"{API}/pictures/{picture_ids[0]}",
-                    json={"score": 1, "deleted": True},
-                    headers=headers,
-                )
+        # Attempt to delete every picture.
+        for pid in picture_ids:
+            attack_client.delete(f"{API}/pictures/{pid}", headers=headers)
 
-                # Attempt to upload a replacement picture.
-                attack_client.post(
-                    f"{API}/pictures/import",
-                    files=[("file", ("evil.png", _make_png_bytes(), "image/png"))],
-                    headers=headers,
-                )
+        # Attempt PATCH on first picture.
+        attack_client.patch(
+            f"{API}/pictures/{picture_ids[0]}",
+            json={"score": 1, "deleted": True},
+            headers=headers,
+        )
 
-                _assert_pictures_intact(owner_client, picture_ids, original_scores)
-            finally:
-                server.__exit__(None, None, None)
+        # Attempt to upload a replacement picture.
+        attack_client.post(
+            f"{API}/pictures/import",
+            files=[("file", ("evil.png", _make_png_bytes(), "image/png"))],
+            headers=headers,
+        )
 
-    def test_data_intact_after_privilege_escalation_attempts(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, read_token = _setup_server_with_pictures(
-                tmp
-            )
-            try:
-                r = owner_client.get(f"{API}/pictures")
-                original_scores = {str(p["id"]): p.get("score") for p in r.json()}
+        _assert_pictures_intact(
+            library_env.owner_client, picture_ids, library_env.scores
+        )
 
-                attack_client = TestClient(server.api)
-                headers = {"Authorization": f"Bearer {read_token}"}
+    def test_data_intact_after_privilege_escalation_attempts(self, library_env):
+        attack_client = TestClient(library_env.server.api)
+        headers = {"Authorization": f"Bearer {library_env.read_token}"}
 
-                # Try to create a super-token.
-                attack_client.post(
-                    f"{API}/users/me/token",
-                    json={"description": "escalated", "scope": "ALL"},
-                    headers=headers,
-                )
+        # Try to create a super-token.
+        attack_client.post(
+            f"{API}/users/me/token",
+            json={"description": "escalated", "scope": "ALL"},
+            headers=headers,
+        )
 
-                # Try to change password.
-                attack_client.post(
-                    f"{API}/users/me/auth",
-                    json={
-                        "current_password": "ownerpass1",
-                        "new_password": "hacked12345",
-                    },
-                    headers=headers,
-                )
+        # Try to change password.
+        attack_client.post(
+            f"{API}/users/me/auth",
+            json={
+                "current_password": "ownerpass1",
+                "new_password": "hacked12345",
+            },
+            headers=headers,
+        )
 
-                # Still able to log in with the original password.
-                fresh_client = TestClient(server.api)
-                r = fresh_client.post(
-                    f"{API}/login",
-                    json={"username": "owner", "password": "ownerpass1"},
-                )
-                assert r.status_code == 200, (
-                    f"Owner password must be unchanged after attack attempts, "
-                    f"got {r.status_code}: {r.text}"
-                )
+        # Still able to log in with the original password.
+        fresh_client = TestClient(library_env.server.api)
+        r = fresh_client.post(
+            f"{API}/login",
+            json={"username": "owner", "password": "ownerpass1"},
+        )
+        assert r.status_code == 200, (
+            f"Owner password must be unchanged after attack attempts, "
+            f"got {r.status_code}: {r.text}"
+        )
 
-                _assert_pictures_intact(owner_client, picture_ids, original_scores)
-            finally:
-                server.__exit__(None, None, None)
+        _assert_pictures_intact(
+            library_env.owner_client, library_env.picture_ids, library_env.scores
+        )
 
-    def test_data_intact_after_brute_force_lockout(self):
+    def test_data_intact_after_brute_force_lockout(self, library_env):
         """Trigger the login lockout, then verify pictures and scores are untouched."""
-        with tempfile.TemporaryDirectory() as tmp:
-            server, owner_client, picture_ids, _ = _setup_server_with_pictures(tmp)
-            try:
-                r = owner_client.get(f"{API}/pictures")
-                original_scores = {str(p["id"]): p.get("score") for p in r.json()}
+        attack_client = TestClient(library_env.server.api)
+        for i in range(5):
+            r = attack_client.post(
+                f"{API}/login",
+                json={"username": "owner", "password": f"wrongpass{i}"},
+            )
+            assert r.status_code == 401, (
+                f"attempt {i + 1} should have been a plain auth failure, "
+                f"got {r.status_code}: {r.text} — the lockout this test is "
+                "about was never reached"
+            )
+        r = attack_client.post(
+            f"{API}/login", json={"username": "owner", "password": "wrongpass5"}
+        )
+        assert r.status_code == 429, (
+            f"the 6th failure should have hit the lockout, got {r.status_code}"
+        )
 
-                # Trigger lockout.
-                attack_client = TestClient(server.api)
-                for i in range(6):
-                    attack_client.post(
-                        f"{API}/login",
-                        json={"username": "owner", "password": f"wrongpass{i}"},
-                    )
+        _assert_pictures_intact(
+            library_env.owner_client, library_env.picture_ids, library_env.scores
+        )
 
-                _assert_pictures_intact(owner_client, picture_ids, original_scores)
-            finally:
-                server.__exit__(None, None, None)
-
-    def test_data_intact_after_rate_limit_barrage(self):
+    def test_data_intact_after_rate_limit_barrage(self, library_env):
         """Fire requests well past the rate limit; data must survive the barrage."""
         with patch.object(rl_module, "_LIMIT", 5):
-            with tempfile.TemporaryDirectory() as tmp:
-                server, owner_client, picture_ids, _ = _setup_server_with_pictures(tmp)
-                try:
-                    r = owner_client.get(f"{API}/pictures")
-                    original_scores = {str(p["id"]): p.get("score") for p in r.json()}
+            # Hammer the login endpoint way past the limit.
+            attack_client = TestClient(library_env.server.api)
+            details = []
+            for i in range(20):
+                r = attack_client.post(
+                    f"{API}/login",
+                    json={"username": "anyuser", "password": f"anypassword{i}"},
+                )
+                if r.status_code == 429:
+                    details.append(r.json().get("detail", ""))
+            # The status code alone proves nothing: the login *lockout* also
+            # answers 429 after five bad passwords, and it would fire on this
+            # barrage whether the rate limiter existed or not. Only the
+            # limiter's own detail string distinguishes them.
+            assert any("Too many requests" in d for d in details), (
+                "the barrage never tripped the rate limiter (only the login "
+                f"lockout, if anything) — its window was dirty: {details}"
+            )
 
-                    # Hammer the login endpoint way past the limit.
-                    attack_client = TestClient(server.api)
-                    for i in range(20):
-                        attack_client.post(
-                            f"{API}/login",
-                            json={"username": "anyuser", "password": f"anypassword{i}"},
-                        )
-
-                    _assert_pictures_intact(owner_client, picture_ids, original_scores)
-                finally:
-                    server.__exit__(None, None, None)
+        _assert_pictures_intact(
+            library_env.owner_client, library_env.picture_ids, library_env.scores
+        )


### PR DESCRIPTION
Part of #796. `tests/test_read_token_security.py` was the most expensive file in the suite. It built a fresh `Server` — and pushed a library through the whole import pipeline — inside almost every test body, to serve assertions that cost milliseconds.

**213 s -> 63 s (3.4x)** on an uninterrupted old-then-new A/B on this same base, 68 tests and exit 0 on both sides. All eight `--ci-shard N/8` shards green.

## What changed

Three module-scoped environments, one per library shape the file actually needs:

| fixture | library | serves |
|---|---|---|
| `_picture_library_env` | 5 imported pictures with manual scores | 32 tests across 6 classes |
| `_two_set_env` | 2 pictures in 2 single-picture sets, plus a real project | `TestResourceScopedReadTokenIsolation` (21) |
| `_comfyui_stack_env` | 6 DB-seeded pictures in a straddling stack | `TestComfyuiFilterCannotEscapeTokenScope` (4) |

Module, not class: the gate shards individual tests, so a class-scoped fixture is rebuilt once per shard per class. The class-scoped `read_token_write_env` from #804 is gone — there is one scope in the file now.

`_two_set_env` and `_comfyui_stack_env` stop the planner after setup (neither imports anything afterwards, and both hold hand-written `Tag`/`Character`/`PictureStack` rows a warm `TagTask` or cohesion sweep would clobber; the ComfyUI rows point at paths that do not exist). `_picture_library_env` keeps its planner — `test_cannot_upload_picture` needs the import endpoint live — and nothing in the finder set writes the manual `score` column its assertions read.

`TestLoginBruteForce` and `TestRateLimiter` deliberately keep per-test Servers: their subject *is* the server-lifetime lockout counter and rate-limit window, which is exactly what every other class's reset destroys. They import no pictures, so they only pay the boot.

## Keeping the negative assertions honest

This file exists to prove that a read-scoped token cannot write, cannot see owner data and cannot escape scope. A shared environment is the change that can make those pass for the wrong reason, so every environment goes through an **autouse** per-test fixture (not a trailing canary — the sharder would strand it in one shard) that:

- **re-mints credentials**: deletes every `UserToken` row, drops every session, flushes the token cache (bumping the revocation epoch), zeroes the login lockout, empties the rate-limit window, then re-establishes the owner session from a fresh login. The re-login is itself the assertion that the password is still `ownerpass1`;
- **proves the new token on an in-scope read** — the positive control adjacent to every negative one. If the token cannot read what it is entitled to, the test never runs;
- **re-asserts the library by identity**: which picture ids exist, which set holds which, which scores they carry, which stack holds which member. Never counts — a missing object refuses a request exactly like a wrong scope does.

The identity check earned itself immediately: it caught that forming a stack is **stack-atomic for picture-set membership**, so `test_scoped_token_cannot_read_stack_outside_scope` was pulling `pic_b` into Set A — the scope every other assertion in that class is measured against. Four tests errored in the fixture with `assert {1, 2} == {1}` rather than passing quietly. `_reset_two_set_library` now rebuilds membership from scratch.

No `PRAGMA defer_foreign_keys`: the reset is ordered so references stay satisfied throughout (children before parents, pictures detached from their stack before the stacks go), which makes the pragma unnecessary. Per #821 a pysqlite pragma issued before any DML runs in its own autocommit transaction and is gone by the time the DELETEs open theirs — it can look like protection while providing none. An ordering that never needs it cannot silently lose it.

## Mutation check

Both defence layers removed at once, per #821's finding that these negatives are guarded twice and one layer alone leaves the other refusing. Each mutation was verified to reach executable code, not the docstring copy of `AUTHZ_GATE_ENFORCING`:

```
$ sed -i '148s/^AUTHZ_GATE_ENFORCING = True$/AUTHZ_GATE_ENFORCING = False  # MUTATION/' pixlstash/authz/gate.py
$ sed -i '2532s/if token_scope is not None and token_scope.scope == "READ":/if False:  # MUTATION/' pixlstash/auth.py
$ python -c "from pixlstash.authz.gate import AUTHZ_GATE_ENFORCING; assert AUTHZ_GATE_ENFORCING is False"
verified at import time: AUTHZ_GATE_ENFORCING = False

$ pytest -q --fast-captions --force-cpu tests/test_read_token_security.py
7 failed, 33 passed, 1 warning, 28 errors in 60.24s        # RED
```

35 tests reported the loss. Most of the 28 errors are the integrity fixture firing: once the read token could really delete a picture, every later test in the shared environment refused to start rather than quietly asserting against a corrupted library.

```
$ git checkout pixlstash/auth.py pixlstash/authz/gate.py
restored: AUTHZ_GATE_ENFORCING = True

$ pytest -q --fast-captions --force-cpu tests/test_read_token_security.py
68 passed, 1 warning in 59.49s                             # GREEN
```

Each layer alone also goes red on its own (gate only: 6 failures; write-block only: 1 failure + 27 fixture errors).

## Independent security sign-off

A separate `chief-security-officer` review was run before merge, tasked to refute rather than bless. It probed **27 endpoint shapes** with a live wrong-scope token, a revoked token and no credential: dead and absent credentials return **401 on every one**, never 403/404, because auth is middleware that answers before routing. No assertion in this file can be satisfied by a dead credential. It also neutered both resets via a pytest plugin and confirmed each fails loudly rather than silently. Findings addressed here:

- `assert 429 in statuses` in the barrage test was satisfied by the **login lockout**, not the rate limiter (both answer 429). Now asserts on the limiter's own `detail` string.
- The cross-resource-type refusals aimed at `/projects/1/...`, which never existed — a "no such project" answer could stand in for a scope refusal. The fixture now creates a real project, the tests target it, and the owner reads the same path successfully in the same test.
- `_reset_two_set_library` did not reset the ComfyUI vocab columns it lets tests seed. It does now.
- The `sort=CHARACTER_LIKENESS` assertion tightened from `ids <= {pic_a}` to `== {pic_a}` (the stub echoes `candidate_ids`, so over-narrowing was passing silently).
- Softened the module docstring, which claimed the credential wipe was "the entire safety argument". The load-bearing property is the 401/403 split; the wipe is defence in depth.

Left as `<=` on purpose, with the reason in the code: `/pictures/count?character_id=UNASSIGNED` cannot be pinned to a literal because the fixture pictures carry a "no face found" sentinel, so it is pinned against the row set the listing returned instead.

Out of scope, reported not fixed: `GET /pictures/{id}/stack` is a weak existence oracle for a scoped token (a nonexistent or unstacked picture returns `200 {"id": null}` while an out-of-scope *stacked* picture returns `404`). Pre-existing in `pixlstash/`, untouched here.

## Not touched

`pixlstash/`, `docs/authz-coverage-matrix.md`, `tests/ci_test_durations.json`, `.github/workflows/ci.yml`.
