### PR TITLE
Serve the model shelf's adapter and checkpoint reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,7 @@ jobs:
           tests/test_migrations.py
           tests/test_model_file_classification.py
           tests/test_model_folder_scanner.py
+          tests/test_model_shelf_api.py
           tests/test_model_shelf_fixtures.py
           tests/test_model_shelf_library_fixture.py
           tests/test_model_shelf_scan_invariants.py

--- a/docs/authz-coverage-matrix.md
+++ b/docs/authz-coverage-matrix.md
@@ -536,6 +536,14 @@ and the declarations themselves are pinned by
 | GET | `/api/v1/telemetry/install-id` | owner_only |  | Owner-only read of the installation's anonymous install ID. Not any_token: the ID is a stable installation identifier and a resource-scoped share token must not be able to read it |
 | POST | `/api/v1/telemetry/install-id/recreate` | owner_only |  | Owner-only rotation of the install ID; POST is blocked for READ tokens, so only an unscoped owner reaches it. Sibling of GET /telemetry/install-id |
 
+### model_shelf.py (added 2026-08-09 — model shelf B5 read routes)
+
+| Method | Effective path | Policy | id_param / body_ids | Rationale (current enforcement) |
+|---|---|---|---|---|
+| GET | `/api/v1/adapters` | owner_only |  | Model-shelf list. `owner_only` on the **default** library pin: `library_independent` is left `False` even though `model` is a hub table, because the response joins hub content to the active vault's `adapter_attachment` rows, so it does return library content and a token stamped for a non-active library must be refused. `character_id=` / `set_id=` filter through that vault table, not through a column, so the filter is a hub query plus a vault query intersected in Python — no join spans the two databases. Accepted residual (shelf plan B5): an owner pinned to library A sees machine-level model filenames, including ones only used in B |
+| GET | `/api/v1/adapters/{sha256}` | owner_only |  | Detail for one adapter (or one `unknown`, which is hashed on sight and therefore hash-addressable). Same pin reasoning as the list. A checkpoint hash 404s here rather than being served, so the two blocks stay separate |
+| GET | `/api/v1/checkpoints` | owner_only |  | The same `model` query filtered to `file_kind='checkpoint'`. No by-hash detail sibling: a checkpoint registers with `sha256` NULL until `MissingCheckpointHashFinder` reads it, so `model.id` is its only identifier. `unknown` is never returned here |
+
 ### other
 
 | Method | Effective path | Policy | id_param / body_ids | Rationale (current enforcement) |

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -465,6 +465,8 @@ Public guest scoring and shared-link endpoints.
 <!-- AUTOGEN:start name="routes" -->
 | Method | Path                                                                          | Tags            | Summary                                                    |
 | ------ | ----------------------------------------------------------------------------- | --------------- | ---------------------------------------------------------- |
+| GET    | /api/v1/adapters                                                              | model_shelf     | List adapters on the shelf                                 |
+| GET    | /api/v1/adapters/{sha256}                                                     | model_shelf     | One adapter by hash                                        |
 | GET    | /api/v1/characters                                                            | characters      | List characters                                            |
 | POST   | /api/v1/characters                                                            | characters      | Create character                                           |
 | POST   | /api/v1/characters/likeness-search                                            | characters      | Search characters by face likeness                         |
@@ -479,6 +481,7 @@ Public guest scoring and shared-link endpoints.
 | GET    | /api/v1/characters/{id}/summary                                               | characters      | Get character category summary                             |
 | GET    | /api/v1/characters/{id}/{field}                                               | characters      | Get character field                                        |
 | GET    | /api/v1/check-session                                                         | auth            | Check Session                                              |
+| GET    | /api/v1/checkpoints                                                           | model_shelf     | List checkpoints on the shelf                              |
 | POST   | /api/v1/dedup/auto-stack                                                      | dedup           | Bulk auto-stack the exact tier                             |
 | POST   | /api/v1/dedup/counts                                                          | dedup           | Live duplicate counts, global and scoped                   |
 | GET    | /api/v1/dedup/groups                                                          | dedup           | One page of the duplicate queue                            |

--- a/pixlstash/authz/registry.py
+++ b/pixlstash/authz/registry.py
@@ -322,6 +322,21 @@ ROUTE_POLICIES: dict[tuple[str, str], RoutePolicy] = {
             "reason above; do not re-derive it from the pivot."
         ),
     ),
+    # ── model_shelf.py (the model shelf's reads; shelf plan B5) ──────────────
+    # OWNER_ONLY on the DEFAULT library pin. ``library_independent`` is left at
+    # False on purpose even though ``model`` lives in the hub: these routes join
+    # hub content to the active vault's ``adapter_attachment`` rows, so they DO
+    # return library content and a token stamped for another library must not
+    # reach them. Scoped by omission, exactly as §16.1 intends.
+    #
+    # Accepted residual (shelf plan B5, stated in the PR): an owner token pinned
+    # to library A sees machine-level model filenames, including ones only ever
+    # used in library B. That is inherent to the hub holding models while tokens
+    # are pinned per library; there is no cross-principal leak in a single-owner
+    # product, and the attachment names stay per-vault.
+    ("GET", "/api/v1/adapters"): RoutePolicy(_OWNER),
+    ("GET", "/api/v1/adapters/{sha256}"): RoutePolicy(_OWNER),
+    ("GET", "/api/v1/checkpoints"): RoutePolicy(_OWNER),
     # ── filesystem.py (§16.3 host-capability; Step-3 → LOCAL_OWNER_ONLY) ─────
     ("GET", "/api/v1/filesystem/browse"): RoutePolicy(
         _LOCAL,

--- a/pixlstash/routes/model_shelf.py
+++ b/pixlstash/routes/model_shelf.py
@@ -1,0 +1,385 @@
+"""The model shelf's read API: adapters, checkpoints, and what they are attached to.
+
+Two route blocks, one table. ``/adapters`` and ``/checkpoints`` converge on the
+same ``model`` query filtered by ``file_kind``; the blocks stay separate only
+because their **addressing** differs. An adapter always carries a sha256 (the
+hub's ``CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL)`` makes that an
+invariant, not a hope), so it is addressable as ``/adapters/{sha256}``. A
+checkpoint may be 24 GB and registers instantly with ``sha256`` NULL, so until
+``MissingCheckpointHashFinder`` has read it there is no hash to address it by —
+hence a list route and no by-hash detail route on that side. Every row carries
+its hub ``model.id`` for that reason: it is AUTOINCREMENT, never recycled, and it
+is the only identifier an unhashed checkpoint has.
+
+**``unknown`` is never rendered as a checkpoint.** ``file_kind='unknown'`` is a
+first-class stored value (a marker-free file too small to be a base model is most
+likely an adapter format we have not met yet), and it appears in neither list by
+default. It surfaces on the *adapters* block under an explicit
+``?file_kind=unknown``, because an unknown is hashed on sight by the scanner and
+is therefore hash-addressable exactly as an adapter is. ``/checkpoints`` never
+returns one.
+
+**A null ``base_model`` is a bulk state, not an edge case.** Measured against 91
+real adapters, 37 % carry no title, no base model and no trigger word at all. So
+``base_model`` is serialised as ``null`` rather than coerced to a string, is never
+a reason to drop a row from the list, and is selectable through the filter as the
+explicit sentinel ``base_model=UNASSIGNED``.
+
+The queries themselves live in
+:mod:`pixlstash.services.model_shelf_service`, including the hub/vault seam the
+``character_id`` / ``set_id`` filter has to cross. Sorting by ``added_at`` /
+``file_mtime`` and by the stack aggregates is B7's half of the shelf; the list is
+ordered by ``model.id`` here, and locations and attachments each arrive in a
+single whole-page query, so adding those aggregates is a change to one SELECT
+rather than the unpicking of an N+1.
+
+Authorization is declared, never inline: every route here is ``OWNER_ONLY`` in
+``pixlstash/authz/registry.py`` and takes the **default** library pin
+(``library_independent`` is left at ``False``, so the pin runs before the policy
+branch). See ``docs/backend_architecture.md`` §16.1.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, ConfigDict, Field
+
+from pixlstash.db_models.adapter_attachment import ENTITY_CHARACTER, ENTITY_SET
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services.model_shelf_service import (
+    attached_hashes,
+    fetch_attachments,
+    fetch_locations,
+    fetch_model_by_hash,
+    fetch_models,
+)
+from pixlstash.utils.adapter_header import FILE_ADAPTER, FILE_CHECKPOINT, FILE_UNKNOWN
+
+logger = get_logger(__name__)
+
+# What ``GET /adapters`` will serve. ``checkpoint`` is deliberately absent: it has
+# its own block because it is not addressable by hash, and folding it in here
+# would be the "unknown renders as checkpoint" defect in the other direction.
+ADAPTER_BLOCK_FILE_KINDS = (FILE_ADAPTER, FILE_UNKNOWN)
+
+
+class ModelLocation(BaseModel):
+    """Where one copy of a model sits, and whether it was there at the last scan."""
+
+    model_config = ConfigDict(extra="allow")
+
+    folder_id: int = Field(description="``model_folder.id`` this copy lives under.")
+    folder_path: str = Field(description="The registered folder, as registered.")
+    relpath: str = Field(description="Path of this copy relative to the folder.")
+    state: str = Field(
+        description=(
+            "``present``, ``missing`` or ``unreachable``. ``missing`` is a fact "
+            "(the folder was readable and the file was not in it); "
+            "``unreachable`` is the absence of one (we could not look), and only "
+            "``missing`` is something a forget/cleanup action may act on."
+        )
+    )
+    file_mtime: Optional[int] = Field(
+        default=None,
+        description="``st_mtime_ns`` of this copy at the last scan; null if never seen.",
+    )
+
+
+class ModelAttachment(BaseModel):
+    """One character or set in **this library** that uses the model."""
+
+    model_config = ConfigDict(extra="allow")
+
+    entity_type: str = Field(description="``character`` or ``set``.")
+    entity_id: int = Field(
+        description="Row id in this library's vault. Meaningless in another library."
+    )
+
+
+class ModelResponse(BaseModel):
+    """One row of the shelf: what the file is, where its copies are, who uses it."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int = Field(
+        description=(
+            "Hub ``model.id``. AUTOINCREMENT, so it is never reissued to a "
+            "different file. This is the only identifier an unhashed checkpoint "
+            "has, which is why it is on every row and not only on the ones a "
+            "sha256 could address."
+        )
+    )
+    sha256: Optional[str] = Field(
+        default=None,
+        description=(
+            "Full-file SHA-256, the interop identity (Civitai lookup, the ComfyUI "
+            "node). Never null for an adapter or an unknown; null for a checkpoint "
+            "MissingCheckpointHashFinder has not read yet."
+        ),
+    )
+    file_kind: str = Field(
+        description="``adapter``, ``checkpoint`` or ``unknown``. Owner-correctable."
+    )
+    kind: Optional[str] = Field(
+        default=None,
+        description="Adapter algorithm (``lora``, ``lokr``, …). Null for a checkpoint.",
+    )
+    display_name: Optional[str] = None
+    filename: Optional[str] = None
+    base_model: Optional[str] = Field(
+        default=None,
+        description=(
+            "What the trainer said this was trained against, verbatim. Null for "
+            "the large minority of real adapters that record nothing — shown as "
+            "'Not set', never dropped, and selectable with base_model=UNASSIGNED."
+        ),
+    )
+    trigger_words: Optional[str] = None
+    provenance: str = Field(
+        description="``external`` for anything found on disk; ``trained`` for a run we ran."
+    )
+    training_run_id: Optional[int] = None
+    training_step: Optional[int] = None
+    param_count: Optional[int] = None
+    file_size: Optional[int] = None
+    hashed_at: Optional[str] = None
+    stack_id: Optional[int] = None
+    stack_position: Optional[int] = None
+    run_key: Optional[str] = None
+    added_at: Optional[str] = Field(
+        default=None, description="``model.created_at`` — when the shelf first saw it."
+    )
+    locations: list[ModelLocation] = Field(
+        default_factory=list,
+        description="Every registered copy. Empty means every copy was forgotten.",
+    )
+    attachments: list[ModelAttachment] = Field(
+        default_factory=list,
+        description=(
+            "Characters and sets in the active library that use this model. "
+            "Returned on the list as well as on the detail so the shelf never "
+            "has to fetch them one row at a time."
+        ),
+    )
+
+
+class AdapterListResponse(BaseModel):
+    """Body of ``GET /adapters``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    adapters: list[ModelResponse]
+
+
+class CheckpointListResponse(BaseModel):
+    """Body of ``GET /checkpoints``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    checkpoints: list[ModelResponse]
+
+
+def _to_response(
+    row: dict,
+    locations: dict[int, list[dict]],
+    attachments: dict[str, list[dict]],
+) -> ModelResponse:
+    return ModelResponse(
+        id=int(row["id"]),
+        sha256=row["sha256"],
+        file_kind=row["file_kind"],
+        kind=row["kind"],
+        display_name=row["display_name"],
+        filename=row["filename"],
+        base_model=row["base_model"],
+        trigger_words=row["trigger_words"],
+        provenance=row["provenance"],
+        training_run_id=row["training_run_id"],
+        training_step=row["training_step"],
+        param_count=row["param_count"],
+        file_size=row["file_size"],
+        hashed_at=row["hashed_at"],
+        stack_id=row["stack_id"],
+        stack_position=row["stack_position"],
+        run_key=row["run_key"],
+        added_at=row["created_at"],
+        locations=[ModelLocation(**loc) for loc in locations.get(int(row["id"]), [])],
+        attachments=[
+            ModelAttachment(**att) for att in attachments.get(row["sha256"] or "", [])
+        ],
+    )
+
+
+def create_router(server) -> APIRouter:
+    """Create the adapter/checkpoint read router.
+
+    Args:
+        server: The Server instance, for ``hub`` (the model tables) and ``vault``
+            (the attachments).
+
+    Returns:
+        The configured router.
+    """
+    router = APIRouter()
+
+    def _build_list(
+        file_kinds: tuple[str, ...],
+        *,
+        base_model: Optional[str],
+        kind: Optional[str],
+        q: Optional[str],
+        character_id: Optional[int],
+        set_id: Optional[int],
+    ) -> list[ModelResponse]:
+        """The shared body of both list routes: three queries, whatever the size."""
+        if character_id is not None and set_id is not None:
+            raise HTTPException(
+                status_code=400, detail="Give character_id or set_id, not both."
+            )
+
+        rows = fetch_models(
+            server.hub, file_kinds, base_model=base_model, kind=kind, q=q
+        )
+
+        if character_id is not None or set_id is not None:
+            entity_type = ENTITY_CHARACTER if character_id is not None else ENTITY_SET
+            entity_id = character_id if character_id is not None else set_id
+            allowed = attached_hashes(server.vault, entity_type, int(entity_id))
+            # Intersected in Python rather than pushed into the hub query as an
+            # IN list: the two tables live in different SQLite files, and a list
+            # of attachment hashes would also meet the bound-parameter limit on
+            # a well-used character.
+            rows = [row for row in rows if row["sha256"] in allowed]
+
+        if not rows:
+            return []
+        # Hoisted deliberately: both are whole-page lookups, so calling them
+        # inside the comprehension would be the N+1 this route exists to avoid.
+        locations = fetch_locations(server.hub)
+        attachments = fetch_attachments(server.vault)
+        return [_to_response(row, locations, attachments) for row in rows]
+
+    @router.get(
+        "/adapters",
+        summary="List adapters on the shelf",
+        description=(
+            "Every adapter registered on this machine, with each copy's location "
+            "and the characters/sets in the active library that use it. "
+            "`file_kind=unknown` returns the unclassified files instead — they "
+            "are hashed and addressable exactly as adapters are, and they are "
+            "never folded into /checkpoints. `base_model=UNASSIGNED` selects the "
+            "rows that record no base model."
+        ),
+        tags=["model_shelf"],
+        response_model=AdapterListResponse,
+    )
+    def list_adapters(
+        request: Request,
+        file_kind: str = Query(
+            FILE_ADAPTER,
+            description="`adapter` (default) or `unknown`. Checkpoints have their own route.",
+        ),
+        base_model: Optional[str] = Query(
+            None,
+            description=(
+                "Exact match on the recorded base model, or `UNASSIGNED` for the "
+                "rows that record none. Omit for all."
+            ),
+        ),
+        kind: Optional[str] = Query(
+            None, description="Adapter algorithm, e.g. `lora` or `lokr`."
+        ),
+        character_id: Optional[int] = Query(
+            None, description="Only adapters attached to this character."
+        ),
+        set_id: Optional[int] = Query(
+            None, description="Only adapters attached to this picture set."
+        ),
+        q: Optional[str] = Query(
+            None,
+            description="Substring of the display name, filename or trigger words.",
+        ),
+    ):
+        server.auth.ensure_secure_when_required(request)
+        if file_kind not in ADAPTER_BLOCK_FILE_KINDS:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"file_kind must be one of {list(ADAPTER_BLOCK_FILE_KINDS)}; "
+                    "checkpoints are served by GET /checkpoints."
+                ),
+            )
+        return AdapterListResponse(
+            adapters=_build_list(
+                (file_kind,),
+                base_model=base_model,
+                kind=kind,
+                q=q,
+                character_id=character_id,
+                set_id=set_id,
+            )
+        )
+
+    @router.get(
+        "/adapters/{sha256}",
+        summary="One adapter by hash",
+        description=(
+            "Resolves on the interop identity, so it answers for an unclassified "
+            "file too. A checkpoint is deliberately not reachable here: it may "
+            "have no hash yet, so its block addresses rows by id instead."
+        ),
+        tags=["model_shelf"],
+        response_model=ModelResponse,
+    )
+    def get_adapter(sha256: str, request: Request):
+        server.auth.ensure_secure_when_required(request)
+        row = fetch_model_by_hash(server.hub, sha256)
+        if row is None:
+            raise HTTPException(status_code=404, detail="No such adapter.")
+        if row["file_kind"] == FILE_CHECKPOINT:
+            raise HTTPException(
+                status_code=404,
+                detail="That hash is a checkpoint; see GET /checkpoints.",
+            )
+        return _to_response(
+            row,
+            fetch_locations(server.hub, int(row["id"])),
+            fetch_attachments(server.vault, sha256=sha256),
+        )
+
+    @router.get(
+        "/checkpoints",
+        summary="List checkpoints on the shelf",
+        description=(
+            "The same query as /adapters, filtered to `file_kind='checkpoint'`. "
+            "`sha256` is null until MissingCheckpointHashFinder has read the "
+            "file, so `id` is the identifier to hold on to. Unclassified files "
+            "are never returned here."
+        ),
+        tags=["model_shelf"],
+        response_model=CheckpointListResponse,
+    )
+    def list_checkpoints(
+        request: Request,
+        base_model: Optional[str] = Query(
+            None, description="Exact match, or `UNASSIGNED` for the rows with none."
+        ),
+        q: Optional[str] = Query(
+            None, description="Substring of the display name or filename."
+        ),
+    ):
+        server.auth.ensure_secure_when_required(request)
+        return CheckpointListResponse(
+            checkpoints=_build_list(
+                (FILE_CHECKPOINT,),
+                base_model=base_model,
+                kind=None,
+                q=q,
+                character_id=None,
+                set_id=None,
+            )
+        )
+
+    return router

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -91,6 +91,7 @@ from pixlstash.routes.import_folders import (
 )
 from pixlstash.routes.filesystem import create_router as create_filesystem_router
 from pixlstash.routes.libraries import create_router as create_libraries_router
+from pixlstash.routes.model_shelf import create_router as create_model_shelf_router
 from pixlstash.routes.guest_scores import create_router as create_guest_scores_router
 from pixlstash.routes.share import create_router as create_share_router
 from pixlstash.routes.taggers import create_router as create_taggers_router
@@ -1443,6 +1444,12 @@ class Server(
         self.api.include_router(
             create_libraries_router(self),
             prefix=API_V1_PREFIX,
+            dependencies=gate,
+        )
+        self.api.include_router(
+            create_model_shelf_router(self),
+            prefix=API_V1_PREFIX,
+            tags=["model_shelf"],
             dependencies=gate,
         )
         self.api.include_router(

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -1446,10 +1446,12 @@ class Server(
             prefix=API_V1_PREFIX,
             dependencies=gate,
         )
+        # No router-level ``tags=``: every route in this module declares
+        # ``tags=["model_shelf"]`` itself, and FastAPI concatenates the two into
+        # a duplicated tag that reaches OpenAPI and the generated route table.
         self.api.include_router(
             create_model_shelf_router(self),
             prefix=API_V1_PREFIX,
-            tags=["model_shelf"],
             dependencies=gate,
         )
         self.api.include_router(

--- a/pixlstash/services/model_shelf_service.py
+++ b/pixlstash/services/model_shelf_service.py
@@ -1,0 +1,199 @@
+"""Reads for the model shelf: one hub query, one locations query, one vault query.
+
+The shelf's rows straddle two SQLite files and this module is where that seam is
+handled once. ``model`` / ``model_file`` / ``model_folder`` are **hub** tables
+(what is on this disk is a fact about this machine); ``adapter_attachment`` is a
+**vault** table (which character uses a LoRA is a fact about this library). No
+foreign key and no SQL join can cross the two, so a filter that mixes them is two
+queries intersected in Python — and, importantly, *two* queries no matter how
+many rows come back.
+
+Everything here is shaped so the B7 sorting work is a change to one SELECT rather
+than the unpicking of an N+1: the list is one hub query, the locations for the
+whole page are one more, and the attachments for the whole page are one vault
+query. Nothing is fetched per row.
+
+Both list blocks — adapters and checkpoints — go through :func:`fetch_models`.
+There is one content table, so there is one query; ``file_kind`` is the only
+thing that differs.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlmodel import Session, select
+
+from pixlstash.database import DBPriority
+from pixlstash.db_models.adapter_attachment import AdapterAttachment
+from pixlstash.pixl_logging import get_logger
+
+logger = get_logger(__name__)
+
+# "Has no base model recorded", as a filter value. The same spelling the project
+# filter already uses for "has none", so the frontend has one idiom rather than
+# two. A real base model literally named UNASSIGNED would be unreachable through
+# this filter; free text makes that theoretically possible and practically not.
+UNSET = "UNASSIGNED"
+
+# SQLite LIKE wildcards, escaped before a caller-supplied search term reaches
+# one, or a search for ``sd_xl`` would also match ``sdaxl``.
+_LIKE_ESCAPE = str.maketrans({"\\": "\\\\", "%": "\\%", "_": "\\_"})
+
+MODEL_COLUMNS = (
+    "id",
+    "file_kind",
+    "kind",
+    "sha256",
+    "display_name",
+    "filename",
+    "base_model",
+    "trigger_words",
+    "provenance",
+    "training_run_id",
+    "training_step",
+    "param_count",
+    "file_size",
+    "hashed_at",
+    "stack_id",
+    "stack_position",
+    "run_key",
+    "created_at",
+)
+
+
+def fetch_models(
+    hub,
+    file_kinds: tuple[str, ...],
+    *,
+    base_model: Optional[str] = None,
+    kind: Optional[str] = None,
+    q: Optional[str] = None,
+) -> list[dict]:
+    """Return the shelf rows of the given ``file_kind``s, oldest id first.
+
+    Args:
+        hub: The open :class:`~pixlstash.hub.db.HubDatabase`.
+        file_kinds: Which ``model.file_kind`` values to serve. One query, not one
+            per kind: there is one content table.
+        base_model: Exact match, or :data:`UNSET` to select the rows that record
+            none. ``None`` means no filter — a null base model is a bulk state
+            (37 % of a measured 91-file folder), so it is never dropped by
+            default.
+        kind: Adapter algorithm (``lora``, ``lokr``, …).
+        q: Substring of the display name, filename or trigger words.
+            Case-insensitive for ASCII, which is what SQLite's default LIKE
+            gives, and wildcard-escaped.
+
+    Returns:
+        One dict per row, keyed by :data:`MODEL_COLUMNS`.
+    """
+    where = [f"file_kind IN ({','.join('?' * len(file_kinds))})"]
+    params: list = list(file_kinds)
+
+    if base_model is not None:
+        if base_model == UNSET:
+            where.append("base_model IS NULL")
+        else:
+            where.append("base_model = ?")
+            params.append(base_model)
+    if kind:
+        where.append("kind = ?")
+        params.append(kind)
+    if q and q.strip():
+        term = f"%{q.strip().translate(_LIKE_ESCAPE)}%"
+        where.append(
+            "(display_name LIKE ? ESCAPE '\\' OR filename LIKE ? ESCAPE '\\' "
+            "OR trigger_words LIKE ? ESCAPE '\\')"
+        )
+        params.extend([term, term, term])
+
+    sql = (
+        f"SELECT {', '.join(MODEL_COLUMNS)} FROM model "
+        f"WHERE {' AND '.join(where)} ORDER BY id"
+    )
+    return [dict(row) for row in hub.fetchall(sql, tuple(params))]
+
+
+def fetch_model_by_hash(hub, sha256: str) -> Optional[dict]:
+    """Return the one model row carrying *sha256*, or None."""
+    rows = hub.fetchall(
+        f"SELECT {', '.join(MODEL_COLUMNS)} FROM model WHERE sha256 = ?",
+        (sha256,),
+    )
+    return dict(rows[0]) if rows else None
+
+
+def fetch_locations(hub, model_id: Optional[int] = None) -> dict[int, list[dict]]:
+    """Return ``model_id -> [location, …]`` in a single query.
+
+    One query for the whole page, grouped in Python — not one per row, and not a
+    join onto ``model`` that would duplicate every model row once per copy.
+
+    Args:
+        hub: The open hub database.
+        model_id: Restrict to one model (the detail route). Omit for the page.
+    """
+    sql = (
+        "SELECT mf.model_id, mf.model_folder_id, mf.relpath, mf.state, "
+        "mf.file_mtime, f.path AS folder_path "
+        "FROM model_file mf JOIN model_folder f ON f.id = mf.model_folder_id"
+    )
+    params: tuple = ()
+    if model_id is not None:
+        sql += " WHERE mf.model_id = ?"
+        params = (model_id,)
+
+    grouped: dict[int, list[dict]] = {}
+    for row in hub.fetchall(sql, params):
+        grouped.setdefault(int(row["model_id"]), []).append(
+            {
+                "folder_id": int(row["model_folder_id"]),
+                "folder_path": row["folder_path"],
+                "relpath": row["relpath"],
+                "state": row["state"],
+                "file_mtime": row["file_mtime"],
+            }
+        )
+    return grouped
+
+
+def fetch_attachments(vault, *, sha256: Optional[str] = None) -> dict[str, list[dict]]:
+    """Return ``sha256 -> [{entity_type, entity_id}, …]`` from the **vault**.
+
+    The cross-database half. These rows travel with the library while the models
+    do not, which is why this is a second query and can never become a join.
+
+    Args:
+        vault: The active :class:`~pixlstash.vault.Vault`.
+        sha256: Restrict to one model (the detail route). Omit for the page.
+    """
+
+    def fetch(session: Session):
+        statement = select(AdapterAttachment)
+        if sha256 is not None:
+            statement = statement.where(AdapterAttachment.adapter_sha256 == sha256)
+        return list(session.exec(statement).all())
+
+    grouped: dict[str, list[dict]] = {}
+    for row in vault.db.run_task(fetch, priority=DBPriority.IMMEDIATE):
+        grouped.setdefault(row.adapter_sha256, []).append(
+            {"entity_type": row.entity_type, "entity_id": row.entity_id}
+        )
+    return grouped
+
+
+def attached_hashes(vault, entity_type: str, entity_id: int) -> set[str]:
+    """Return the sha256 set one character or set uses, read from the vault."""
+
+    def fetch(session: Session):
+        return list(
+            session.exec(
+                select(AdapterAttachment.adapter_sha256).where(
+                    AdapterAttachment.entity_type == entity_type,
+                    AdapterAttachment.entity_id == entity_id,
+                )
+            ).all()
+        )
+
+    return set(vault.db.run_task(fetch, priority=DBPriority.IMMEDIATE))

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -144,6 +144,7 @@ def test_services_no_direct_db_calls():
         "pixlstash/services/impossible_tag_clear_service.py",  # vault-injection pattern; bulk impossible-tag clear/undo
         "pixlstash/services/keep_cover_only_service.py",  # vault-injection pattern; thin wrappers around the *_in_session keep-cover-only preview and collapse
         "pixlstash/services/mixed_stack_service.py",  # vault-injection pattern; thin wrappers around the *_in_session mixed-stack list, actions and Keep
+        "pixlstash/services/model_shelf_service.py",  # vault-injection pattern; the adapter_attachment reads are the vault half of a hub/vault join no session can span
         "pixlstash/services/picture_stats.py",  # pending session injection refactor
         "pixlstash/services/search_query_service.py",  # vault-injection pattern; DB queries for search endpoints
         "pixlstash/services/share_service.py",  # vault-injection pattern

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -1,0 +1,457 @@
+"""The model shelf's read API (shelf plan B5): behaviour and both authz directions.
+
+Environment sharing
+-------------------
+One ``Server`` per module, built once. The shelf's own data lives in the **hub**
+and is written here with plain SQL, which costs microseconds; the expensive part
+is the server boot, so it is paid once. Per test, the autouse fixture wipes and
+re-seeds the three shelf tables and the vault's ``adapter_attachment`` rows, and
+re-mints every credential — so no test can inherit another test's token, and a
+negative assertion cannot pass because the credential was dead rather than
+because the scope was refused.
+
+The seeded shelf is deliberately shaped around the three decisions B5 had to
+make, so a regression in any of them is a failing assertion rather than a
+judgement call:
+
+* two adapters **with** a base model and two **without** — a null base model is a
+  bulk state (37 % of a measured 91-file folder), so it is carried by the filter
+  as an explicit ``UNASSIGNED`` rather than dropped;
+* one ``file_kind='unknown'``, which must appear in neither list by default and
+  must **never** be returned by ``/checkpoints``;
+* one checkpoint with ``sha256`` NULL, which is what a 24 GB file looks like
+  before ``MissingCheckpointHashFinder`` has read it: listable, carrying a stable
+  ``model.id``, and not addressable by hash.
+
+Both authz directions on every route, per §16.1: the owner cookie 200s (over-
+blocking is its own regression) and every scoped/unscoped share token is 403'd by
+the gate's ``OWNER_ONLY`` declaration — with an in-scope positive control proving
+the refused token is live.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, delete
+
+from pixlstash.authz.policy import AccessPolicy
+from pixlstash.authz.registry import ROUTE_POLICIES
+from pixlstash.database import DBPriority
+from pixlstash.db_models.adapter_attachment import AdapterAttachment
+from pixlstash.server import Server
+from tests.authz_guard import no_spa_fallback  # noqa: F401
+
+API = "/api/v1"
+
+# The SPA catch-all answers an unmatched GET with 200, which would make a
+# positive assertion vacuous if a path were misspelled.
+pytestmark = pytest.mark.usefixtures("no_spa_fallback")
+
+_SHELF_ROUTES = (
+    ("GET", "/api/v1/adapters"),
+    ("GET", "/api/v1/adapters/{sha256}"),
+    ("GET", "/api/v1/checkpoints"),
+)
+
+
+# Hashes are only ever compared, never interpreted, so a readable stand-in beats
+# 64 characters of hex. Padded to full length so nothing accidentally depends on
+# the shape.
+def _h(name: str) -> str:
+    return (name + "0" * 64)[:64]
+
+
+ADAPTER_WITH_BASE = _h("adapterbase")
+ADAPTER_WITH_BASE_2 = _h("adapterbase2")
+ADAPTER_NO_BASE = _h("adapternobase")
+ADAPTER_NO_BASE_2 = _h("adapternobase2")
+UNKNOWN_HASH = _h("unknownfile")
+CHECKPOINT_HASHED = _h("checkpointhashed")
+
+# (sha256, file_kind, kind, display_name, filename, base_model)
+_SEED_MODELS = (
+    (ADAPTER_WITH_BASE, "adapter", "lora", "Alice", "alice.safetensors", "SDXL 1.0"),
+    (ADAPTER_WITH_BASE_2, "adapter", "lokr", "Bob", "bob.safetensors", "Flux.1 dev"),
+    (ADAPTER_NO_BASE, "adapter", "lora", None, "sd_xl_noname.safetensors", None),
+    (ADAPTER_NO_BASE_2, "adapter", "lora", "Dana", "dana.safetensors", None),
+    (UNKNOWN_HASH, "unknown", None, None, "mystery.safetensors", None),
+    (
+        CHECKPOINT_HASHED,
+        "checkpoint",
+        None,
+        "Base XL",
+        "base_xl.safetensors",
+        "SDXL 1.0",
+    ),
+    # The one that has no hash yet: a 24 GB file the hash finder has not read.
+    (None, "checkpoint", None, None, "huge_unhashed.safetensors", None),
+)
+
+
+def _seed_hub(server) -> dict[str, int]:
+    """Write the shelf tables from scratch. Returns filename -> model.id."""
+    with server.hub.transaction() as conn:
+        conn.execute("DELETE FROM model_file")
+        conn.execute("DELETE FROM model")
+        conn.execute("DELETE FROM model_folder")
+        conn.execute(
+            "INSERT INTO model_folder (id, path, kind, movable, created_at) "
+            "VALUES (1, '/models/loras', 'user', 'per_item', '2026-08-09T00:00:00Z')"
+        )
+        ids: dict[str, int] = {}
+        for sha, file_kind, kind, display_name, filename, base_model in _SEED_MODELS:
+            cursor = conn.execute(
+                "INSERT INTO model (file_kind, kind, sha256, display_name, filename, "
+                "base_model, provenance, file_size, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'external', 4096, '2026-08-09T00:00:00Z')",
+                (file_kind, kind, sha, display_name, filename, base_model),
+            )
+            model_id = int(cursor.lastrowid)
+            ids[filename] = model_id
+            conn.execute(
+                "INSERT INTO model_file (model_id, model_folder_id, relpath, state, "
+                "seen_at, file_mtime) VALUES (?, 1, ?, 'present', ?, 17)",
+                (model_id, filename, "2026-08-09T00:00:00Z"),
+            )
+    return ids
+
+
+def _clear_attachments(server) -> None:
+    def wipe(session: Session):
+        session.exec(delete(AdapterAttachment))
+        session.commit()
+
+    server.vault.db.run_task(wipe, priority=DBPriority.IMMEDIATE)
+
+
+def _attach(server, sha256: str, entity_type: str, entity_id: int) -> None:
+    def add(session: Session):
+        session.add(
+            AdapterAttachment(
+                adapter_sha256=sha256, entity_type=entity_type, entity_id=entity_id
+            )
+        )
+        session.commit()
+
+    server.vault.db.run_task(add, priority=DBPriority.IMMEDIATE)
+
+
+@pytest.fixture(scope="module")
+def shelf_env():
+    """One Server, one owner login, one character and one set to attach to."""
+    tmp = tempfile.TemporaryDirectory()
+    server = Server(f"{tmp.name}/server-config.json")
+    server.__enter__()
+    try:
+        owner = TestClient(server.api, raise_server_exceptions=True)
+        r = owner.post(
+            f"{API}/login", json={"username": "owner", "password": "ownerpass1"}
+        )
+        assert r.status_code == 200, r.text
+
+        r = owner.post(f"{API}/characters", json={"name": "Shelf Character"})
+        assert r.status_code in {200, 201}, r.text
+        character_id = r.json().get("id") or r.json()["character"]["id"]
+
+        r = owner.post(f"{API}/picture_sets", json={"name": "Shelf Set"})
+        assert r.status_code in {200, 201}, r.text
+        set_id = r.json()["picture_set"]["id"]
+
+        yield SimpleNamespace(
+            server=server, owner=owner, character_id=character_id, set_id=set_id
+        )
+    finally:
+        server.__exit__(None, None, None)
+        tmp.cleanup()
+
+
+@pytest.fixture(autouse=True)
+def fresh_shelf(shelf_env):
+    """Re-seed the shelf and re-mint credentials before every test.
+
+    Identity, not counts: every assertion below names the rows it expects, so
+    accumulated state in the shared server cannot make one pass for the wrong
+    reason.
+    """
+    server = shelf_env.server
+    shelf_env.model_ids = _seed_hub(server)
+    _clear_attachments(server)
+    # The owner session is what every positive control runs on; prove it is live
+    # before any refusal is measured against it.
+    r = shelf_env.owner.get(f"{API}/adapters")
+    assert r.status_code == 200, (
+        f"the shared owner session cannot read the shelf ({r.status_code}: "
+        f"{r.text}) — every refusal below would prove nothing"
+    )
+    yield shelf_env
+
+
+def _mint(owner_client, description: str, **restriction) -> str:
+    r = owner_client.post(
+        f"{API}/users/me/token",
+        json={"description": description, "scope": "READ", **restriction},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["token"]
+
+
+def _bearer(server, token: str) -> TestClient:
+    client = TestClient(server.api)
+    client.headers.update({"Authorization": f"Bearer {token}"})
+    return client
+
+
+def _names(payload: list[dict]) -> set[str]:
+    return {row["filename"] for row in payload}
+
+
+# ===========================================================================
+# Declarations — the registry entry is the route's only authorization
+# ===========================================================================
+
+
+def test_every_shelf_route_is_declared_owner_only():
+    """§16.1: the declaration IS the enforcement. A missing entry is a 403 at
+    runtime and a red guardrail, so pin the three cells explicitly."""
+    for key in _SHELF_ROUTES:
+        assert key in ROUTE_POLICIES, f"{key} has no ROUTE_POLICIES entry"
+        declared = ROUTE_POLICIES[key]
+        assert declared.policy is AccessPolicy.OWNER_ONLY, (
+            f"{key} declares {declared.policy}, not OWNER_ONLY"
+        )
+        assert declared.library_independent is False, (
+            f"{key} exempts itself from the library pin; the shelf joins hub "
+            "content to the active vault's attachments and must stay pinned"
+        )
+
+
+# ===========================================================================
+# The list, and the three decisions B5 had to make
+# ===========================================================================
+
+
+def test_adapters_list_returns_adapters_only(shelf_env):
+    r = shelf_env.owner.get(f"{API}/adapters")
+    assert r.status_code == 200, r.text
+    assert _names(r.json()["adapters"]) == {
+        "alice.safetensors",
+        "bob.safetensors",
+        "sd_xl_noname.safetensors",
+        "dana.safetensors",
+    }
+
+
+def test_null_base_model_rows_are_listed_not_dropped(shelf_env):
+    """DoD 5: a null base model is a bulk state. It must reach the client as
+    ``null`` on a listed row, never as a dropped row or a coerced string."""
+    rows = shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+    by_name = {row["filename"]: row for row in rows}
+    assert by_name["sd_xl_noname.safetensors"]["base_model"] is None
+    assert by_name["dana.safetensors"]["base_model"] is None
+    assert by_name["alice.safetensors"]["base_model"] == "SDXL 1.0"
+
+
+def test_base_model_filter_carries_not_set_as_an_explicit_value(shelf_env):
+    """The picker's "Not set" option selects exactly the null rows, and the
+    named-value filter excludes them."""
+    r = shelf_env.owner.get(f"{API}/adapters", params={"base_model": "UNASSIGNED"})
+    assert r.status_code == 200, r.text
+    assert _names(r.json()["adapters"]) == {
+        "sd_xl_noname.safetensors",
+        "dana.safetensors",
+    }
+
+    r = shelf_env.owner.get(f"{API}/adapters", params={"base_model": "SDXL 1.0"})
+    assert _names(r.json()["adapters"]) == {"alice.safetensors"}
+
+
+def test_unknown_is_neither_adapter_nor_checkpoint_by_default(shelf_env):
+    """DoD 5: ``unknown`` never renders as a checkpoint. It is absent from both
+    lists until it is asked for by name, and ``/checkpoints`` never serves it."""
+    adapters = shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+    assert "mystery.safetensors" not in _names(adapters)
+
+    checkpoints = shelf_env.owner.get(f"{API}/checkpoints").json()["checkpoints"]
+    assert "mystery.safetensors" not in _names(checkpoints)
+    assert all(row["file_kind"] == "checkpoint" for row in checkpoints)
+
+    r = shelf_env.owner.get(f"{API}/adapters", params={"file_kind": "unknown"})
+    assert r.status_code == 200, r.text
+    assert _names(r.json()["adapters"]) == {"mystery.safetensors"}
+
+
+def test_checkpoint_cannot_be_requested_from_the_adapter_block(shelf_env):
+    r = shelf_env.owner.get(f"{API}/adapters", params={"file_kind": "checkpoint"})
+    assert r.status_code == 400, r.text
+    assert "GET /checkpoints" in r.text
+
+
+def test_unhashed_checkpoint_is_listed_and_addressed_by_id(shelf_env):
+    """A checkpoint registers with ``sha256`` NULL. It must still be listable,
+    and ``model.id`` (AUTOINCREMENT, never reissued) is its only identifier."""
+    rows = shelf_env.owner.get(f"{API}/checkpoints").json()["checkpoints"]
+    by_name = {row["filename"]: row for row in rows}
+    assert set(by_name) == {"base_xl.safetensors", "huge_unhashed.safetensors"}
+
+    unhashed = by_name["huge_unhashed.safetensors"]
+    assert unhashed["sha256"] is None
+    assert unhashed["id"] == shelf_env.model_ids["huge_unhashed.safetensors"]
+
+
+def test_checkpoint_hash_is_not_served_by_the_adapter_detail_route(shelf_env):
+    """The blocks stay separate: a hashed checkpoint is a real row, but it is not
+    an adapter, and serving it from ``/adapters/{sha256}`` would fold the two."""
+    r = shelf_env.owner.get(f"{API}/adapters/{CHECKPOINT_HASHED}")
+    assert r.status_code == 404, r.text
+    assert "checkpoint" in r.text
+
+
+def test_adapter_detail_carries_locations(shelf_env):
+    r = shelf_env.owner.get(f"{API}/adapters/{ADAPTER_WITH_BASE}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["filename"] == "alice.safetensors"
+    assert body["locations"] == [
+        {
+            "folder_id": 1,
+            "folder_path": "/models/loras",
+            "relpath": "alice.safetensors",
+            "state": "present",
+            "file_mtime": 17,
+        }
+    ]
+    # An unknown is hashed on sight, so it is addressable here too.
+    assert shelf_env.owner.get(f"{API}/adapters/{UNKNOWN_HASH}").status_code == 200
+
+
+def test_search_escapes_sqlite_like_wildcards(shelf_env):
+    """``sd_xl`` must not also match ``sdaxl``: an unescaped ``_`` is a wildcard."""
+    r = shelf_env.owner.get(f"{API}/adapters", params={"q": "sd_xl"})
+    assert _names(r.json()["adapters"]) == {"sd_xl_noname.safetensors"}
+    r = shelf_env.owner.get(f"{API}/adapters", params={"q": "sdaxl"})
+    assert r.json()["adapters"] == []
+
+
+# ===========================================================================
+# The cross-database filter — hub query + vault query, joined in Python
+# ===========================================================================
+
+
+def test_character_and_set_filters_read_the_vault_attachment_table(shelf_env):
+    server = shelf_env.server
+    _attach(server, ADAPTER_WITH_BASE, "character", shelf_env.character_id)
+    _attach(server, ADAPTER_NO_BASE, "set", shelf_env.set_id)
+
+    r = shelf_env.owner.get(
+        f"{API}/adapters", params={"character_id": shelf_env.character_id}
+    )
+    assert r.status_code == 200, r.text
+    assert _names(r.json()["adapters"]) == {"alice.safetensors"}
+
+    r = shelf_env.owner.get(f"{API}/adapters", params={"set_id": shelf_env.set_id})
+    assert _names(r.json()["adapters"]) == {"sd_xl_noname.safetensors"}
+
+    # And an entity with nothing attached filters to empty rather than to all.
+    r = shelf_env.owner.get(f"{API}/adapters", params={"character_id": 999999})
+    assert r.json()["adapters"] == []
+
+
+def test_attachments_are_returned_on_the_list_not_one_row_at_a_time(shelf_env):
+    """The shelf shows who uses a LoRA. Serving that on the list is what keeps
+    F3 from issuing one detail request per row."""
+    _attach(shelf_env.server, ADAPTER_WITH_BASE, "character", shelf_env.character_id)
+    rows = shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+    by_name = {row["filename"]: row for row in rows}
+    assert by_name["alice.safetensors"]["attachments"] == [
+        {"entity_type": "character", "entity_id": shelf_env.character_id}
+    ]
+    assert by_name["dana.safetensors"]["attachments"] == []
+
+
+def test_character_and_set_filters_are_mutually_exclusive(shelf_env):
+    r = shelf_env.owner.get(
+        f"{API}/adapters",
+        params={"character_id": shelf_env.character_id, "set_id": shelf_env.set_id},
+    )
+    assert r.status_code == 400, r.text
+
+
+# ===========================================================================
+# Authorization — both directions, on every route
+# ===========================================================================
+
+
+def _shelf_paths() -> list[str]:
+    return [
+        f"{API}/adapters",
+        f"{API}/adapters/{ADAPTER_WITH_BASE}",
+        f"{API}/checkpoints",
+    ]
+
+
+def test_owner_reaches_every_shelf_route(shelf_env):
+    """The positive direction. Over-blocking is its own regression."""
+    for path in _shelf_paths():
+        r = shelf_env.owner.get(path)
+        assert r.status_code == 200, (
+            f"{path} refused the owner: {r.status_code} {r.text}"
+        )
+
+
+def test_resource_scoped_share_token_is_refused_on_every_shelf_route(shelf_env):
+    """The negative direction, with a live-credential control in front of it: the
+    same token performs an in-scope read first, so a 403 below is a scope
+    refusal and not a dead token."""
+    token = _mint(
+        shelf_env.owner,
+        "shelf character token",
+        resource_type="character",
+        resource_id=shelf_env.character_id,
+    )
+    client = _bearer(shelf_env.server, token)
+
+    control = client.get(f"{API}/pictures")
+    assert control.status_code == 200, (
+        f"the freshly minted scoped token cannot do an in-scope read "
+        f"({control.status_code}: {control.text}) — the refusals below would "
+        "prove nothing"
+    )
+
+    for path in _shelf_paths():
+        r = client.get(path)
+        assert r.status_code == 403, (
+            f"{path} served a resource-scoped share token: {r.status_code} {r.text}"
+        )
+
+
+def test_unscoped_read_token_is_refused_on_every_shelf_route(shelf_env):
+    """``OWNER_ONLY`` rejects an unscoped READ token too, not only a
+    resource-scoped one — this is the sibling vector that the scope-filter
+    policies (``SCOPED_LIST``) would let through."""
+    token = _mint(shelf_env.owner, "shelf global read token")
+    client = _bearer(shelf_env.server, token)
+
+    control = client.get(f"{API}/pictures")
+    assert control.status_code == 200, (
+        f"the unscoped READ token cannot read at all ({control.status_code}: "
+        f"{control.text}) — the refusals below would prove nothing"
+    )
+
+    for path in _shelf_paths():
+        r = client.get(path)
+        assert r.status_code == 403, (
+            f"{path} served an unscoped READ token: {r.status_code} {r.text}"
+        )
+
+
+def test_unauthenticated_is_refused_on_every_shelf_route(shelf_env):
+    anon = TestClient(shelf_env.server.api)
+    for path in _shelf_paths():
+        r = anon.get(path)
+        assert r.status_code == 401, (
+            f"{path} answered an unauthenticated caller: {r.status_code} {r.text}"
+        )


### PR DESCRIPTION
Model shelf **B5, part 1 of 3**: the read API. Stack: this PR → `feature/model-shelf-api-folders` → `feature/model-shelf-api-attachments`. **Do not merge before the independent adversarial CSO review** — this adds an authz surface and the author must not certify their own security work.

## What lands

- `GET /api/v1/adapters?file_kind=&base_model=&kind=&character_id=&set_id=&q=`
- `GET /api/v1/adapters/{sha256}`
- `GET /api/v1/checkpoints?base_model=&q=`

Two route blocks, one query. `pixlstash/services/model_shelf_service.py` owns the SQL; the handlers are glue. `/checkpoints` is the same `fetch_models` call with `file_kind='checkpoint'` — the blocks are separate only because addressing differs (§4's ruling), not because there are two query paths.

## The three decisions §3 B5 asked for

**A null `base_model` is a bulk state.** 37 % of a measured 91-adapter folder records none. So it is serialised as `null` (never coerced), never a reason to drop a row, and selectable as `base_model=UNASSIGNED` — the spelling the project filter already uses for "has none". DoD item 5's "carried by the picker filter as an explicit *not set*" is built in from the start rather than retrofitted, so F1/F2 can rely on it. No facet endpoint: "Not set" is a static option the picker can always offer, so nothing has to be counted server-side to know it exists.

**`unknown` never renders as checkpoint.** It appears in neither list by default. It surfaces on the *adapters* block under an explicit `?file_kind=unknown`, because the scanner hashes an unknown on sight, which makes it hash-addressable exactly as an adapter is; `GET /adapters/{sha256}` therefore answers for one. `?file_kind=checkpoint` on the adapters block is a 400 naming the other route. `/checkpoints` filters to `file_kind='checkpoint'` and can never return an unknown.

**An unhashed checkpoint is addressed by `model.id`.** It has no hash until `MissingCheckpointHashFinder` reads it, so there is deliberately no `/checkpoints/{sha256}` sibling. Every row on both blocks carries `id` — hub AUTOINCREMENT, never reissued — because it is the only identifier such a row has. A hashed checkpoint's sha256 404s on `/adapters/{sha256}` rather than being served, so the blocks cannot quietly merge.

## The cross-database filter

`character_id` / `set_id` filter through `adapter_attachment`, a **vault** table, while `model` is in the **hub**. No join spans two SQLite files, so it is one vault query for the entity's hash set plus one hub query, intersected in Python on sha256 — not an `IN` list, which would also meet the bound-parameter limit on a well-used character. Attachments come back on the list as well as the detail (one whole-page vault query), so F3 never issues one detail request per row.

Sorting aggregates (`added_at`, `file_mtime`, stack `member_count` / `total_size` / `newest_member_at`) are **B7's** half and are not built here. The list is deliberately shaped so they are a change to one SELECT: models are one query, locations one more, attachments one more — nothing per row. Ordered by `model.id` for now. No pagination; 1,800 rows is the real dataset and the shelf renders all of it.

## Authorization

All three routes are `OWNER_ONLY` in `ROUTE_POLICIES` with matrix rows in the same commit. **No inline scope check anywhere** — the gate owns it.

`library_independent` is left at its `False` default. That is not an oversight to be optimised away later: the responses join hub content to the *active vault's* `adapter_attachment` rows, so they do return library content, and `_enforce_library_pin` runs before every policy branch. A shelf route is scoped by omission.

**Accepted residual, stated rather than papered over:** an owner token pinned to library A sees machine-level model filenames, including ones only ever used in library B. That is inherent to the hub holding models while tokens are pinned per library. Single owner, no cross-principal leak; attachment names stay per-vault.

## Explicitly deferred (not in this stack)

`GET /adapters/{sha256}/file`, `POST /adapters` (multipart upload), `POST /adapters/resolve`, `POST /checkpoints/register`, and the §4.1 `local_path` / zero-copy capability response. Those are node- and import-facing and belong with the ComfyUI phase and B7.

## Tests

`tests/test_model_shelf_api.py`, 17 tests, **2.66 s**. One module-scoped `Server`; the shelf tables are seeded with plain SQL per test (microseconds) and the credentials are re-minted per test so no test inherits another's token.

Both directions on every route: owner cookie 200 (over-blocking is its own regression), resource-scoped share token 403, unscoped READ token 403, unauthenticated 401 — each negative preceded by an in-scope positive control on the same credential, so a 403 is a scope refusal and not a dead token.

**Mutation-tested, both directions of the guard:**
- `("GET", "/api/v1/adapters"): _OWNER` → `_ANY`: 3 failures (the declaration test plus *both* runtime negatives). Restored.
- the gate's `OWNER_ONLY` branch stripped of its `_enforce_unscoped_owner` call: 2 failures (both runtime negatives). Restored.

`tests/test_architecture_guardrails.py` and `tests/test_ci_shards.py`: 150 passed. `ruff format` + `ruff check pixlstash` clean.

## Size

1,073 lines, over §1 rule 1. 457 are the test module and a large share of the rest is the per-field API documentation this repo requires. The seam §4 names ("two blocks, one query") is explicitly *not* a split point — separating `/checkpoints` from `/adapters` would ship the shared query untested from one side. Same call the owner made on #794.

## One note for the reviewer

`pixlstash/services/model_shelf_service.py` is added to `_direct_db_call_service_allowlist` in the guardrail. The `adapter_attachment` reads are the vault half of a hub/vault join, and no single injected `Session` can span the two databases, so the wrapper is the seam rather than transitional debt.
