### PR TITLE
Fill the CI model cache from one job instead of eight shards

### DIFF
--- a/.github/actions/model-cache/action.yml
+++ b/.github/actions/model-cache/action.yml
@@ -1,0 +1,68 @@
+name: HuggingFace model cache
+description: >-
+  Restore (default) or save the HuggingFace model set the backend tests load.
+  The single source of truth for the cache's paths and key: every job restores,
+  and exactly one job — `warm_models` in ci.yml — saves.
+
+  RESTORE-ONLY for readers, deliberately. `actions/cache` writes only on a key
+  MISS, so a model missing from an entry that keeps hitting its primary key can
+  never be added to it. CLIP was missing from the 1.77 GB entry for exactly that
+  reason, so every shard re-fetched ~600 MB of weights on every run until
+  HuggingFace 429'd `backend shard 8` (run 31304213276).
+
+inputs:
+  mode:
+    description: "'restore' (the default, for readers) or 'save'."
+    required: false
+    default: restore
+  key:
+    description: "Required with mode: save — the key `restore` reported."
+    required: false
+    default: ''
+
+outputs:
+  key:
+    description: The primary key the cache was looked up under.
+    value: ${{ steps.restore.outputs.cache-primary-key }}
+  hit:
+    description: '"true" when the cache restored on its primary key.'
+    value: ${{ steps.restore.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    # Two distinct on-disk locations, both required:
+    #  * ~/.cache/huggingface — the HF hub cache used by CLIP, SBert and
+    #    Florence.
+    #  * ~/.local/share/pixlstash/downloaded_models — platformdirs
+    #    user_data_dir, where the WD14 and PixlStash taggers land because they
+    #    call hf_hub_download(local_dir=...), which bypasses the hub cache
+    #    entirely.
+    # A warm cache makes needs_download() (a pure file-existence check) return
+    # False, so download() is never issued; and for the models that have no such
+    # check, a cache hit lets huggingface_hub fall back to the cached file when
+    # its HEAD revalidation 429s, instead of raising LocalEntryNotFoundError.
+    #
+    # The key hashes EVERY file that names a model, plus the prefetch script
+    # itself, so any change to the model set busts it. restore-keys keeps the
+    # previous set warm across unrelated commits, so a bust only costs the
+    # delta.
+    - name: Restore the model cache
+      id: restore
+      if: inputs.mode != 'save'
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          ~/.cache/huggingface
+          ~/.local/share/pixlstash/downloaded_models
+        key: hf-models-${{ runner.os }}-${{ hashFiles('pixlstash/tagger_plugins/clip_service.py', 'pixlstash/tagger_plugins/sbert.py', 'pixlstash/tagger_plugins/wd14.py', 'pixlstash/tagger_plugins/pixlstash_tagger.py', 'pixlstash/tagger_plugins/florence2.py', 'scripts/prefetch_ci_models.py') }}
+        restore-keys: hf-models-${{ runner.os }}-
+
+    - name: Save the model cache
+      if: inputs.mode == 'save'
+      uses: actions/cache/save@v5
+      with:
+        path: |
+          ~/.cache/huggingface
+          ~/.local/share/pixlstash/downloaded_models
+        key: ${{ inputs.key }}

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -6,6 +6,9 @@ description: >-
   in particular so they all compute the same cache keys and therefore all hit
   the same warm caches.
 
+  The model cache is restored, never written, here — see ./model-cache. Exactly
+  one job writes it: `warm_models` in ci.yml.
+
 runs:
   using: composite
   steps:
@@ -64,24 +67,5 @@ runs:
             ;;
         esac
 
-    - name: Cache HuggingFace models
-      uses: actions/cache@v4
-      with:
-        # Two distinct on-disk locations, both required:
-        #  * ~/.cache/huggingface — the HF hub cache used by CLIP/SBert/
-        #    Florence via from_pretrained_local_first.
-        #  * ~/.local/share/pixlstash/downloaded_models — platformdirs
-        #    user_data_dir, where the WD14 and PixlStash taggers land because
-        #    they call hf_hub_download(local_dir=...), which bypasses the hub
-        #    cache entirely. The old key cached only the hub dir and was thus
-        #    a no-op for the taggers that actually 429'd.
-        # A warm cache makes needs_download() (a pure file-existence check)
-        # return False, so download() — and its HEAD revalidation, the call
-        # that returns 429 — is never issued. Key off the tagger plugins so a
-        # model/revision bump busts the cache; restore-keys keeps it warm
-        # across unrelated commits.
-        path: |
-          ~/.cache/huggingface
-          ~/.local/share/pixlstash/downloaded_models
-        key: hf-models-${{ runner.os }}-${{ hashFiles('pixlstash/tagger_plugins/wd14.py', 'pixlstash/tagger_plugins/pixlstash_tagger.py', 'pixlstash/tagger_plugins/florence2.py') }}
-        restore-keys: hf-models-${{ runner.os }}-
+    - name: Restore the HuggingFace model cache
+      uses: ./.github/actions/model-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,61 @@ jobs:
         run: npm run check:config
 
   # ---------------------------------------------------------------------------
+  # The single writer of the HuggingFace model cache. Every other job restores
+  # it read-only (see .github/actions/setup-backend).
+  #
+  # Why a job and not a step in the shards: `actions/cache` writes only on a key
+  # MISS, so a model missing from an entry that keeps hitting its primary key can
+  # never be added to it. CLIP was missing from the 1.77 GB entry for exactly
+  # that reason, so all eight shards re-fetched ~600 MB of weights on every run
+  # until HuggingFace 429'd `backend shard 8` (run 31304213276). Adding the
+  # missing files to the key alone would not fix it: the first run after a bust
+  # would have eight runners cold-downloading the same weights at the same
+  # moment, which is the same stampede. One job downloads the set once, and the
+  # eight shards then start against a cache that is complete by construction.
+  #
+  # Cost to the blocking gate: this sits in front of the shards, so it is pure
+  # critical path. On the normal warm path that is only checkout + a cache
+  # restore (~1 min) — the Python install is skipped, because nothing needs to
+  # be downloaded. The shards get that back by no longer downloading models.
+  #
+  # restore + explicit save, rather than `actions/cache`, so the write happens
+  # ONLY when the prefetch succeeded. An auto-save post-step runs even after a
+  # failed step, which would freeze a half-downloaded model set under the
+  # primary key and recreate the bug this job exists to fix.
+  # ---------------------------------------------------------------------------
+  warm_models:
+    name: warm model cache
+    runs-on: ubuntu-latest
+    # See the `backend` job for the rationale and the read-only token
+    # requirement. Absent on fork PRs by design; the prefetch then runs
+    # anonymously, which one sequential job is far more likely to survive than
+    # eight parallel ones were.
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: models
+        uses: ./.github/actions/model-cache
+
+      # Only needed to run the prefetch, so it is skipped whenever the cache is
+      # already complete — which is every run that does not change the model set.
+      - if: steps.models.outputs.hit != 'true'
+        uses: ./.github/actions/setup-backend
+
+      - name: Download every model the gate loads
+        if: steps.models.outputs.hit != 'true'
+        run: python scripts/prefetch_ci_models.py
+
+      - name: Save the model cache
+        if: success() && steps.models.outputs.hit != 'true'
+        uses: ./.github/actions/model-cache
+        with:
+          mode: save
+          key: ${{ steps.models.outputs.key }}
+
+  # ---------------------------------------------------------------------------
   # The backend gate. Split across 8 runners instead of one job with 22
   # sequential steps.
   #
@@ -270,6 +325,19 @@ jobs:
   backend:
     name: backend shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
+    # The shards only read the model cache; `warm_models` is what fills it.
+    # Waiting on it is the serialisation that stops eight runners cold-fetching
+    # the same weights at once.
+    #
+    # `needs:` alone would turn a failed warming job into eight SKIPPED shards,
+    # not eight failed ones — the skipped-is-not-failed ambiguity this repo
+    # already had to design against once (see the removed `build` aggregator
+    # note below). Warming is an optimisation, never a correctness gate, so
+    # `!cancelled()` keeps the ordering and drops the veto: if warming breaks,
+    # the shards still run, still report red or green on their own merits, and
+    # `warm model cache` is the red check that says why they were slow.
+    needs: warm_models
+    if: ${{ !cancelled() }}
     strategy:
       # Every shard must report: one shard failing tells you nothing about the
       # other seven, and a partial picture costs another full round trip.
@@ -485,8 +553,11 @@ jobs:
   # ---------------------------------------------------------------------------
   backend_release_sweep:
     name: backend-full block ${{ matrix.shard }} (informational, release-prep only)
-    if: startsWith(github.head_ref || github.ref_name, 'rc-prep') || startsWith(github.head_ref || github.ref_name, 'release') || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    if: ${{ !cancelled() && (startsWith(github.head_ref || github.ref_name, 'rc-prep') || startsWith(github.head_ref || github.ref_name, 'release') || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
+    # Same reason as the gate: read the model cache, never fill it, and never
+    # let a failed warming job silently skip the sweep instead of running it.
+    needs: warm_models
     strategy:
       # Every block must report, for the same reason as the gate: one red block
       # says nothing about the other five, and release prep cannot afford
@@ -736,8 +807,11 @@ jobs:
           pip install .[test,dev]
 
       - name: Cache HuggingFace models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
+          # Read/write, unlike Linux: these four shards run a small OS-sensitive
+          # subset that loads no CLIP or SBert, so there is no eight-way
+          # stampede to serialise and this cache self-heals on its own key bust.
           # See the Linux setup-backend action for the rationale. The taggers
           # download via hf_hub_download(local_dir=...) into platformdirs'
           # Windows user_data_dir —

--- a/scripts/prefetch_ci_models.py
+++ b/scripts/prefetch_ci_models.py
@@ -1,0 +1,95 @@
+"""Download every model the CI backend gate loads, into the cached locations.
+
+CI's model cache is written by exactly one warming job (``warm_models`` in
+``.github/workflows/ci.yml``) and only read by the eight ``backend`` shards, so
+whatever this script misses is a model those eight shards fetch from
+HuggingFace *in parallel, on every run*. That is what produced the 429
+stampede that killed ``backend shard 8`` in run 31304213276: CLIP was absent
+from a cache entry that kept hitting its primary key, so ``actions/cache``
+never rewrote it and every run re-downloaded the weights.
+
+Prefetching through each service's own entry point, rather than a duplicated
+list of repo ids, is what keeps the set honest: a model swap edits the service,
+and the service is what runs here.
+
+Two on-disk locations are involved, and both are in the cached paths:
+
+* ``~/.cache/huggingface`` — the HF hub cache, where CLIP, SBert and Florence
+  land.
+* ``<user_data_dir>/downloaded_models`` — where the WD14 and PixlStash taggers
+  land, because they call ``hf_hub_download(local_dir=...)``, which bypasses
+  the hub cache entirely.
+
+Failures are fatal on purpose. The warming job only saves the cache when this
+script exits 0, so a half-downloaded model set is discarded and retried on the
+next run instead of being frozen under the primary key.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+from huggingface_hub import snapshot_download
+from platformdirs import user_data_dir
+
+from pixlstash.tagger_plugins.clip_service import ClipService
+from pixlstash.tagger_plugins.florence2 import (
+    DEFAULT_FLORENCE_VARIANT,
+    FLORENCE_MODEL_VARIANTS,
+)
+from pixlstash.tagger_plugins.pixlstash_tagger import PixlStashTaggerService
+from pixlstash.tagger_plugins.sbert import SBertService
+from pixlstash.tagger_plugins.wd14 import WD14Service
+
+logger = logging.getLogger("prefetch_ci_models")
+
+
+def main() -> int:
+    """Populate both cache locations with the gate's full model set."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    model_dir = os.path.join(user_data_dir("pixlstash"), "downloaded_models")
+    os.makedirs(model_dir, exist_ok=True)
+
+    logger.info("CLIP ...")
+    ClipService("cpu").ensure_ready()
+
+    logger.info("SBert ...")
+    SBertService("cpu").ensure_ready()
+
+    # Only the default Florence variant: the other variant is exercised solely
+    # by tests/test_florence_model_variant.py, which never loads a model.
+    florence = FLORENCE_MODEL_VARIANTS[DEFAULT_FLORENCE_VARIANT]
+    logger.info("Florence-2 (%s) ...", florence["model"])
+    snapshot_download(florence["model"], revision=florence["revision"])
+
+    # Both taggers report readiness with a pure file-existence check, and
+    # PixlStashTaggerService.download() logs and swallows its own failures, so
+    # needs_download() is the only honest confirmation that the bytes landed.
+    logger.info("WD14 tagger ...")
+    wd14 = WD14Service(device="cpu", model_dir=model_dir, batch_size_fn=lambda: 1)
+    wd14.download()
+
+    logger.info("PixlStash tagger ...")
+    tagger = PixlStashTaggerService(
+        device="cpu", model_dir=model_dir, batch_size_fn=lambda: 1
+    )
+    tagger.download()
+
+    missing = [
+        name
+        for name, service in (("WD14", wd14), ("PixlStash tagger", tagger))
+        if service.needs_download()
+    ]
+    if missing:
+        logger.error("Still missing after download: %s", ", ".join(missing))
+        return 1
+
+    logger.info("Model cache is complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The bug

`backend shard 8` died in fixture setup with `429 Too Many Requests` for CLIP
(run 31304213276, attempt 1). Not a flake — the failure was structural:

```
Cache hit for: hf-models-Linux-865615c4...          <- primary key, 1.1 GB restored
huggingface_hub.errors.LocalEntryNotFoundError: ... we cannot find the
  requested files in the local cache                <- CLIP is not in it
[Post] Cache hit occurred on the primary key ..., not saving cache.
```

`actions/cache` writes only on a key **miss**, so a model absent from an entry
that keeps hitting its primary key can never be added to it. The key did not
hash `clip_service.py`, so it never busted either. The entry was frozen
permanently incomplete, and all eight shards re-fetched ~600 MB of CLIP on
every run. Eight shards x three concurrent PRs is what tripped the limit.

## The fix

A new `warm_models` job is the cache's **only writer**; every other job
restores it read-only.

- **`scripts/prefetch_ci_models.py`** downloads CLIP, SBert, Florence-2-base,
  WD14 and the PixlStash tagger through the services' own entry points, so the
  prefetch set cannot drift from the code that loads it. Exits non-zero if the
  taggers still report `needs_download()`.
- **`.github/actions/model-cache`** is the single source of truth for the
  cache's paths and key (`mode: restore` / `mode: save`). The key now hashes
  every file that names a model, so this cannot silently rot again.
- **`warm_models`** probes the cache and, only on a miss, installs and
  prefetches, then saves **explicitly on success**. An auto-save post-step runs
  even after a failed step, which would freeze a half-downloaded set under the
  primary key — the same bug in a new coat.
- **`backend` and `backend_release_sweep`** get `needs: warm_models`. That
  ordering is the whole point: simply adding the missing files to the key would
  make all eight shards miss at once and race for the same weights, which is
  the same stampede.

`needs:` alone would turn a failed warming job into eight *skipped* shards
rather than eight failed ones, so both jobs also carry `!cancelled()`. Warming
is an optimisation, never a correctness gate: if it breaks, the shards still
run and still report on their own merits, and `warm model cache` is the red
check that says why they were slow. `!cancelled()` rather than `always()` so a
superseded run is still cancelled.

## Wall clock (measured on this PR's own run, 31309603406)

`warm model cache` took **2 min 25 s** on its cold path and the shards started
2 s later: checkout 7 s, cache restore 17 s, install 96 s, prefetch 12 s,
save 8 s.

- **Warm path (every normal PR):** steps 4 and 5 are skipped entirely, so the
  job is checkout + restore + finalize, **~40 s** on the blocking gate's
  critical path. The shards get most of that back by no longer downloading
  models themselves.
- **First run after merge:** a key miss, so ~2.5 min as measured. Note the
  prefetch was only 12 s here because `restore-keys` prefix-restored an entry
  that already happened to carry CLIP and SBert; a genuinely empty cache would
  add the real download of the full set, call it 4-5 min. Either way it happens
  **once, in one job**, and it cannot stampede — that is the property being
  bought.

## Also

`backend_windows` moves `actions/cache@v4` -> `@v5` (Node 20 deprecation).
It stays read/write on purpose: its OS-sensitive subset loads no CLIP or
SBert, so there is no eight-way stampede to serialise and it self-heals on its
own key bust.

## Verification

- `yaml.safe_load` on the workflow and both composite actions.
- `pytest tests/test_ci_shards.py` (133 passed), which parses the workflow,
  plus `test_architecture_guardrails.py` and `test_except_hygiene_guardrail.py`.
- `scripts/prefetch_ci_models.py` run end to end locally, exit 0, all five
  model families resolved.
- `ruff format` + `ruff check` clean.

Security-reviewed by `chief-security-officer` before push: **APPROVE**. No
change to `HF_TOKEN`'s exposure (it was already job-wide on every pytest job,
withheld from forks), and the potential cache writers per run drop from ~15 to
1. One condition was raised (the skipped-vs-failed ambiguity above) and closed
by the `!cancelled()` guard. Pre-existing follow-up noted, not introduced here:
WD14 downloads from a floating `main` ref with no pinned revision.
