### PR TITLE
Automate the SECURITY.md supported-versions table at release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,6 +456,7 @@ jobs:
           tests/test_scope_table.py
           tests/test_score_agreement_stats.py
           tests/test_scrapheap_retention.py
+          tests/test_security_supported_versions.py
           tests/test_server.py
           tests/test_share_link_library_pin.py
           tests/test_sidebar_counts_query_cost.py

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -151,6 +151,17 @@ jobs:
               f.write("changed=true\n")
           EOF
 
+      # Run from main's checkout, not release/. Unlike the OpenAPI docs, the
+      # table is a property of main's security policy rather than of the
+      # release's own code, so main always has the current script and a
+      # manual re-run on a tag cut before this landed still works.
+      - name: Update SECURITY.md supported versions
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          python main/scripts/update_security_supported_versions.py \
+            main/SECURITY.md "$RELEASE_TAG"
+
       - name: Open pull request with updated website files
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
@@ -176,7 +187,12 @@ jobs:
               back the PATH-encoded version-check URLs so Cloudflare zone analytics can
               bucket active installs by type (docker vs pip vs electron vs other).
               Updated/skipped in lock-step with the legacy `latest-version.json` above.
+            - `SECURITY.md` — the supported-versions table, rewritten so the new
+              minor is the only supported one and the minor it replaces is demoted.
+              Skipped for pre-releases and for anything that is not a newer minor
+              than the table already names.
           add-paths: |
+            SECURITY.md
             website/latest-version.json
             website/latest-version/docker.json
             website/latest-version/pip.json

--- a/scripts/update_security_supported_versions.py
+++ b/scripts/update_security_supported_versions.py
@@ -1,0 +1,140 @@
+"""Rewrite the supported-versions table in ``SECURITY.md`` for a new release.
+
+PixlStash supports exactly one minor series: the latest. The table therefore
+always has three rows — the supported minor, the one it just demoted, and a
+catch-all ``< previous`` row — and it was maintained by hand at release time.
+``.github/workflows/release-version.yml`` runs this script against the ``main``
+checkout so the table lands in the same bot PR as the other website updates.
+
+The demoted minor is read back out of the existing table rather than computed
+by subtracting one, because ``2.0.0`` follows ``1.9.x`` and arithmetic would
+produce ``2.-1``. That makes the current table a required input: if it cannot
+be parsed the script fails instead of writing a fresh table over a file whose
+shape it did not recognise.
+
+Usage
+-----
+::
+
+    python scripts/update_security_supported_versions.py SECURITY.md v1.10.0
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+SUPPORTED = ":white_check_mark:"
+UNSUPPORTED = ":x:"
+
+# Column widths are those of the widest cell in each column. The right column
+# is always the ":white_check_mark:" marker; the left one is the "Version"
+# header until a version string outgrows it (``< 1.10.x`` is 8 characters).
+_MIN_VERSION_WIDTH = len("Version")
+_SUPPORTED_WIDTH = len(SUPPORTED)
+
+# The existing table, which must be present and well-formed for us to know
+# which minor is being demoted.
+_TABLE_RE = re.compile(
+    r"^\| Version +\| Supported +\|\n"
+    r"^\| -+ \| -+ \|\n"
+    # The trailing lookahead makes a fourth row a parse *failure* rather than
+    # a silent partial match that would leave an orphaned row behind.
+    r"(?:^\|[^\n]*\|\n){3}(?!\|)",
+    re.MULTILINE,
+)
+_SUPPORTED_ROW_RE = re.compile(
+    rf"^\| (\d+)\.(\d+)\.x +\| {re.escape(SUPPORTED)} +\|$", re.MULTILINE
+)
+
+
+def render_table(major: int, minor: int, prev_major: int, prev_minor: int) -> str:
+    """Render the three-row table for *major.minor*, demoting the previous."""
+    prev = f"{prev_major}.{prev_minor}.x"
+    versions = ["Version", f"{major}.{minor}.x", prev, f"< {prev}"]
+    width = max(_MIN_VERSION_WIDTH, *(len(v) for v in versions))
+
+    def row(version: str, mark: str) -> str:
+        return f"| {version:<{width}} | {mark:<{_SUPPORTED_WIDTH}} |"
+
+    return (
+        "\n".join(
+            [
+                row("Version", "Supported"),
+                row("-" * width, "-" * _SUPPORTED_WIDTH),
+                row(f"{major}.{minor}.x", SUPPORTED),
+                row(prev, UNSUPPORTED),
+                row(f"< {prev}", UNSUPPORTED),
+            ]
+        )
+        + "\n"
+    )
+
+
+def update_supported_versions(text: str, tag: str) -> tuple[str, str]:
+    """Return ``(new_text, message)`` for *text* after release *tag*.
+
+    ``new_text`` is *text* unchanged when the release must not move the table
+    (a pre-release, or anything not strictly newer than the current minor).
+    Raises :class:`ValueError` if the existing table cannot be parsed.
+    """
+    try:
+        version = Version(tag.lstrip("v"))
+    except InvalidVersion:
+        return text, f"Release tag '{tag}' is not a valid version; skipping."
+
+    if version.is_prerelease:
+        return text, f"Release {version} is a pre-release; skipping."
+
+    table_match = _TABLE_RE.search(text)
+    if table_match is None:
+        raise ValueError(
+            "could not find the supported-versions table; expected a "
+            "'| Version | Supported |' header, a dashed separator and exactly "
+            "three rows"
+        )
+    supported_match = _SUPPORTED_ROW_RE.search(table_match.group(0))
+    if supported_match is None:
+        raise ValueError(
+            "the supported-versions table has no supported row; expected one "
+            f"row of the form '| <major>.<minor>.x | {SUPPORTED} |'"
+        )
+
+    current = (int(supported_match.group(1)), int(supported_match.group(2)))
+    new = (version.major, version.minor)
+    if new <= current:
+        return text, (
+            f"Release {version} is not a newer minor than the currently "
+            f"supported {current[0]}.{current[1]}.x; skipping."
+        )
+
+    table = render_table(new[0], new[1], current[0], current[1])
+    return text[: table_match.start()] + table + text[table_match.end() :], (
+        f"Supported versions now {new[0]}.{new[1]}.x "
+        f"(demoted {current[0]}.{current[1]}.x)."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="Path to the SECURITY.md to update")
+    parser.add_argument("tag", help="Release tag, e.g. v1.10.0")
+    args = parser.parse_args(argv)
+
+    text = args.path.read_text(encoding="utf-8")
+    try:
+        new_text, message = update_supported_versions(text, args.tag)
+    except ValueError as exc:
+        print(f"{args.path}: {exc}", file=sys.stderr)
+        return 1
+
+    if new_text != text:
+        args.path.write_text(new_text, encoding="utf-8")
+    print(f"{args.path}: {message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_security_supported_versions.py
+++ b/tests/test_security_supported_versions.py
@@ -1,0 +1,172 @@
+"""Tests for ``scripts/update_security_supported_versions.py``.
+
+The table is release-facing prose, so these assert on the exact rendered text
+including column padding rather than on a loose regex: ``1.10.x`` is one
+character wider than ``1.9.x`` and must still line the columns up.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from update_security_supported_versions import (  # noqa: E402
+    main,
+    update_supported_versions,
+)
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "update_security_supported_versions.py"
+)
+
+TABLE_1_9 = """| Version | Supported          |
+| ------- | ------------------ |
+| 1.9.x   | :white_check_mark: |
+| 1.8.x   | :x:                |
+| < 1.8.x | :x:                |
+"""
+
+TABLE_1_10 = """| Version | Supported          |
+| ------- | ------------------ |
+| 1.10.x  | :white_check_mark: |
+| 1.9.x   | :x:                |
+| < 1.9.x | :x:                |
+"""
+
+TABLE_2_0 = """| Version | Supported          |
+| ------- | ------------------ |
+| 2.0.x   | :white_check_mark: |
+| 1.9.x   | :x:                |
+| < 1.9.x | :x:                |
+"""
+
+# Every cell in the left column outgrows the "Version" header here, so the
+# whole column widens rather than letting `< 1.10.x` overhang the separator.
+TABLE_2_0_FROM_1_10 = """| Version  | Supported          |
+| -------- | ------------------ |
+| 2.0.x    | :white_check_mark: |
+| 1.10.x   | :x:                |
+| < 1.10.x | :x:                |
+"""
+
+PREAMBLE = """# Security Policy
+
+## Supported Versions
+
+PixlStash does not currently support older releases with security updates.
+
+"""
+
+EPILOGUE = """
+## Reporting a Vulnerability
+
+Please submit vulnerability reports to lindkvis@gmail.com.
+"""
+
+
+def document(table: str) -> str:
+    return PREAMBLE + table + EPILOGUE
+
+
+def test_minor_bump_rewrites_the_table_and_keeps_the_prose():
+    text, message = update_supported_versions(document(TABLE_1_9), "v1.10.0")
+    assert text == document(TABLE_1_10)
+    assert "1.10.x" in message and "demoted 1.9.x" in message
+
+
+def test_major_bump_demotes_the_table_minor_not_major_minus_one():
+    # 2.-1.x is what naive arithmetic would produce here.
+    text, _ = update_supported_versions(document(TABLE_1_9), "v2.0.0")
+    assert text == document(TABLE_2_0)
+
+
+def test_a_wider_version_widens_the_whole_column():
+    text, _ = update_supported_versions(document(TABLE_1_10), "v2.0.0")
+    assert text == document(TABLE_2_0_FROM_1_10)
+
+
+def test_the_widened_table_is_still_parseable_on_the_next_release():
+    """Two consecutive releases must chain without a manual repair."""
+    text, _ = update_supported_versions(document(TABLE_2_0_FROM_1_10), "v2.1.0")
+    assert "| 2.1.x   | :white_check_mark: |" in text
+    assert "| < 2.0.x | :x:                |" in text
+
+
+@pytest.mark.parametrize(
+    "tag, reason",
+    [
+        ("v1.9.4", "patch release of the supported minor"),
+        ("v1.10.0-dev.1", "pre-release"),
+        ("v1.10.0rc1", "pre-release"),
+        ("v1.8.7", "older minor"),
+        ("v1.9.0", "same minor"),
+    ],
+)
+def test_no_op_releases_leave_the_table_untouched(tag, reason):
+    original = document(TABLE_1_9)
+    text, message = update_supported_versions(original, tag)
+    assert text == original, reason
+    assert "skipping" in message
+
+
+def test_unparseable_table_raises_instead_of_rewriting():
+    mangled = PREAMBLE + "| Release | Status |\n| --- | --- |\n" + EPILOGUE
+    with pytest.raises(ValueError, match="could not find the supported-versions table"):
+        update_supported_versions(mangled, "v1.10.0")
+
+
+def test_a_fourth_row_raises_rather_than_leaving_an_orphan():
+    """A longer table must fail, not match its first three rows and strand the rest."""
+    four_rows = TABLE_1_9 + "| < 1.7.x | :x:                |\n"
+    with pytest.raises(ValueError, match="could not find the supported-versions table"):
+        update_supported_versions(document(four_rows), "v1.10.0")
+
+
+def test_table_without_a_supported_row_raises():
+    no_check = TABLE_1_9.replace(":white_check_mark:", ":x:               ")
+    with pytest.raises(ValueError, match="no supported row"):
+        update_supported_versions(document(no_check), "v1.10.0")
+
+
+def test_main_writes_the_file_and_reports(tmp_path, capsys):
+    path = tmp_path / "SECURITY.md"
+    path.write_text(document(TABLE_1_9), encoding="utf-8")
+
+    assert main([str(path), "v1.10.0"]) == 0
+    assert path.read_text(encoding="utf-8") == document(TABLE_1_10)
+    assert "1.10.x" in capsys.readouterr().out
+
+
+def test_main_exits_nonzero_and_leaves_the_file_alone_on_a_bad_table(tmp_path):
+    path = tmp_path / "SECURITY.md"
+    mangled = PREAMBLE + "| Release | Status |\n" + EPILOGUE
+    path.write_text(mangled, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(path), "v1.10.0"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "SECURITY.md" in result.stderr
+    assert path.read_text(encoding="utf-8") == mangled
+
+
+def test_the_repository_security_file_is_a_recognised_table():
+    """The workflow points at the real file; keep its *shape* parseable.
+
+    Deliberately asserts nothing about which versions the real table names --
+    those move with every release and with branch merges. This fails only if
+    someone reformats the table out from under the script.
+    """
+    security = Path(__file__).resolve().parents[1] / "SECURITY.md"
+    text = security.read_text(encoding="utf-8")
+    # A release far beyond anything shipped is guaranteed to be a newer minor,
+    # so a rewrite proves the parser recognised the table.
+    updated, message = update_supported_versions(text, "v99.0.0")
+    assert updated != text, message


### PR DESCRIPTION
`SECURITY.md`'s supported-versions table was maintained by hand at release time. `release-version.yml` now rewrites it in the same bot PR as the other release website updates.

`scripts/update_security_supported_versions.py <path> <tag>`:

- **Skips pre-releases** (`v1.10.0-dev.1`, `v1.9.0rc1`), mirroring the existing `latest-version.json` step's `is_prerelease` check.
- **Never downgrades and is idempotent within a minor** — anything not a strictly newer minor than the table already names is a no-op, exit 0.
- **Derives the demoted minor from the current table**, not by subtracting one, so `v2.0.0` demotes `1.9`, not `2.-1`.
- **Fails loudly (exit 1, file untouched)** if the table is missing, has no supported row, or has more than three rows. It never writes a fresh table over a shape it did not recognise.
- Only the parsed `major`/`minor` **integers** ever reach the file, so a crafted tag cannot inject table content even if the workflow's tag regex were removed.

Before / after for `v1.10.0`:

```
| 1.9.x   | :white_check_mark: |      | 1.10.x  | :white_check_mark: |
| 1.8.x   | :x:                |  ->  | 1.9.x   | :x:                |
| < 1.8.x | :x:                |      | < 1.9.x | :x:                |
```

The column widens if a version outgrows the `Version` header (`< 1.10.x`), so consecutive releases chain without a manual repair.

The step runs the script from **main's** checkout rather than the release tag's: the table is a property of main's security policy, not of the release's own code, so main always has the current script and a manual re-run on an older tag still works.

### Security

`release-version.yml` is a privileged workflow (`RELEASE_BOT_TOKEN`, opens PRs against `main`). Reviewed by `chief-security-officer` before push; no guardrail in `tests/test_ci_shards.py` was edited.

- Target path is a hardcoded literal and the tag is the second positional, so it cannot become the path; the tag crosses into the shell only via step `env` and a quoted variable, satisfying `test_privileged_workflow_run_blocks_do_not_interpolate_expressions`.
- No new `uses:`, no new checkout, no new secret, no permissions change.
- The step fails closed ahead of `create-pull-request`, so a bad table cannot be committed.
- `add-paths` widens the bot PR's commit surface from `website/**` to include `SECURITY.md`. Not a permission change (the token could always write anywhere); `main` branch protection remains the control.

Two review findings were applied: the four-row parse leak (`(?!\|)`) and running the script from `main/` instead of `release/`.

### Tests

`tests/test_security_supported_versions.py` (15 tests), added to the `backend` gate in `ci.yml` in alphabetical position. Covers the minor bump, the major bump, patch/pre-release/older no-ops, column widening and chaining, and unparseable tables raising. Assertions are on exact rendered text including padding, built from synthetic tables — the only check against the real `SECURITY.md` is that its *shape* still parses, never its version numbers.

`tests/test_ci_shards.py` passes (133), full new suite plus guardrails 148 passed.