### PR TITLE
Add a self-measured test-time ceiling and make the balance guardrail see the whole gate

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -227,12 +227,30 @@ When a file does need its own fixture:
   and `WorkPlanner._inflight_by_finder` drain only on a task's completion path, so
   a cancelled task never releases its ids — and SQLite reuses picture ids from 1
   after a wipe, so a finder then permanently refuses the next test's pictures.
-- **Wipe under `PRAGMA defer_foreign_keys = ON`**, never `foreign_keys` off/on: if
-  a delete raises in between, enforcement stays off on that pooled connection and
-  silently weakens every later test.
+- **Order the wipe instead of reaching for a PRAGMA.** Restore or insert parents
+  first, then delete children, and no foreign-key trickery is needed at all.
+  `PRAGMA defer_foreign_keys = ON` does not work here: with pysqlite a PRAGMA
+  issued before any DML runs in autocommit, so the deferral is already gone by
+  the time the DELETEs open their own transaction. #822 measured it reading back
+  `0`. Never `PRAGMA foreign_keys` off/on either: if a delete raises in between,
+  enforcement stays OFF on that pooled connection and silently weakens every
+  later test. Whichever approach you pick, demonstrate it took effect rather
+  than assume it did.
 - **Anything that used to die with the per-test engine now leaks** — `connect`
   listeners, patched SQLite limits, monkeypatched globals. Undo them in a
   `finally`.
+- **Anchor a mutation check, then confirm it landed.** Proving an assertion can
+  fail means editing the thing it asserts on, and a first-occurrence replace
+  often hits prose instead of code. `AUTHZ_GATE_ENFORCING = True` appears twice
+  in `pixlstash/authz/gate.py`, once inside a docstring: mutate that one and
+  behaviour is unchanged, the suite stays green, and the green reads as "this
+  assertion is dead". Anchor on `^AUTHZ_GATE_ENFORCING = True$` and verify the
+  mutation is in the line you meant.
+- **Assert the route resolves before trusting an authz negative.** Those paths
+  are guarded twice, by the READ-token middleware and by the gate, and the
+  middleware runs ahead of routing. A request to a renamed or nonexistent route
+  therefore returns the same 403 as a genuine in-scope refusal, so a negative
+  test that names its path as a string can pass against a dead path.
 
 For an authz or security suite the shared environment also has to keep the
 negative assertions honest. Re-mint credentials in the autouse fixture, keep the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import warnings
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+import pytest
 from _pytest.config.exceptions import UsageError
 from fastapi.testclient import TestClient
 from pixlstash.server import Server
@@ -43,6 +44,23 @@ _TEST_DURATIONS_PATH = Path(__file__).resolve().parent / "ci_test_durations.json
 # 648 tests on one shard against ~153 on each of the others. The load was
 # balanced and the count was absurd, and the count is not free either.
 _PER_TEST_OVERHEAD_SECONDS = 0.005
+
+# Ceiling on the gate's TOTAL test time, divided by the shard count at runtime
+# so a reshard cannot silently move the effective bar.
+#
+# Measured from THIS run's own per-test report durations, never from
+# ci_test_durations.json: that map is stale between refactors by design, so a
+# guard reading it would be checking its own input and would report a healthy
+# gate for tests it had never timed.
+#
+# Baseline: the last green develop run before this landed (Actions run
+# 31307604252, N=8) summed to 6662 s of test time, worst shard 1005 s, mean
+# 833 s. 12000 s total is 1.8x the measured total and 1500 s per shard is 1.5x
+# the worst shard, so runner noise and an out-of-date balance map cannot trip
+# it. It still fires at roughly half the drift back to the 2844 s/shard the
+# gate had reached before the #796 wave, which is the regression it exists to
+# catch.
+TEST_TIME_BUDGET_SECONDS = 12000.0
 
 
 def _normalize_test_path(path: str):
@@ -379,8 +397,80 @@ def pytest_configure(config):
     Server.DEFAULT_INSIGHTFACE_MODEL_PACK = config.getoption("--insightface-model-pack")
 
 
+def _measured_test_seconds(reporter) -> float:
+    """Sum this run's own setup + call + teardown time over every phase report.
+
+    ``stats`` holds one report per phase under the outcome key it was filed as
+    (passed setup and teardown land under ``""``), which is the same
+    setup+call+teardown total ``scripts/record_test_durations.py`` reconstructs
+    from ``--durations`` output. Non-report entries (warnings, for example) do
+    not carry a duration and are skipped.
+    """
+    return sum(
+        report.duration
+        for reports in reporter.stats.values()
+        for report in reports
+        if hasattr(report, "duration")
+    )
+
+
+def _enforce_test_time_budget(session) -> None:
+    """Turn the shard red when its own measured test time blows the budget.
+
+    Only active under ``--ci-shard``, so a local partial run cannot trip it.
+    Deliberately a signal rather than a correctness gate: every test can pass
+    and this still exits non-zero, which is why the banner says exactly that.
+    The repo has no required status checks; a red step is simply the loudest
+    thing available, and the drift it watches for (the gate creeping from 15 to
+    47 minutes per shard) has no other alarm.
+    """
+    spec = session.config.getoption("--ci-shard")
+    if not spec:
+        return
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is None:
+        # No terminal reporter (-p no:terminal): nothing accumulated the phase
+        # reports this check measures, and there is nowhere to print the
+        # banner, so the budget simply does not apply to that invocation.
+        return
+
+    _, shards = _parse_ci_shard(spec)
+    measured = _measured_test_seconds(reporter)
+    ceiling = TEST_TIME_BUDGET_SECONDS / shards
+    if measured <= ceiling:
+        return
+
+    banner = "TEST-TIME BUDGET EXCEEDED - THIS IS NOT A TEST FAILURE"
+    reporter.write_sep("=", banner, red=True, bold=True)
+    reporter.write_line(
+        f"Every test above may have passed. This shard spent {measured:.6g}s of "
+        f"test time against a ceiling of {ceiling:.6g}s "
+        f"({TEST_TIME_BUDGET_SECONDS:.0f}s for the whole suite / {shards} shards)."
+    )
+    reporter.write_line(
+        "The suite got slower, it did not break. Reuse an existing "
+        "module-scoped environment instead of standing up a Server per test "
+        "(CLAUDE.md, 'Tests: reuse the environment, don't rebuild it'), or "
+        "raise TEST_TIME_BUDGET_SECONDS in tests/conftest.py deliberately and "
+        "put the measurement that justifies it in the commit message."
+    )
+    reporter.write_sep("=", banner, red=True, bold=True)
+    if session.exitstatus == 0:
+        # Never downgrade a real failure, an interrupt or an internal error:
+        # those are more informative than a budget breach.
+        session.exitstatus = 1
+
+
+@pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
-    """Release native model/session resources before interpreter teardown."""
+    """Release native model/session resources before interpreter teardown.
+
+    ``trylast`` so any other session-finish work runs before the budget check
+    below. The phase reports it measures are filed during the run rather than
+    at teardown, so its input is complete either way.
+    """
+    _enforce_test_time_budget(session)
+
     try:
         # Drain optional CPU spillover tagger if one was created by tag tasks.
         TagTask.release_idle_cpu_spillover_engine(force=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,11 +55,12 @@ _PER_TEST_OVERHEAD_SECONDS = 0.005
 #
 # Baseline: the last green develop run before this landed (Actions run
 # 31307604252, N=8) summed to 6662 s of test time, worst shard 1005 s, mean
-# 833 s. 12000 s total is 1.8x the measured total and 1500 s per shard is 1.5x
-# the worst shard, so runner noise and an out-of-date balance map cannot trip
-# it. It still fires at roughly half the drift back to the 2844 s/shard the
-# gate had reached before the #796 wave, which is the regression it exists to
-# catch.
+# 833 s. Only the WORST shard can trip, so the margin that matters is
+# 1500 / 1005 = 1.49x, and at that run's 1.21 imbalance the gate goes red at a
+# total near 9900 s rather than at 12000 s. That is still far above runner
+# noise and above what a stale balance map can shift, and it fires at roughly
+# half the drift back to the 2844 s/shard the gate had reached before the #796
+# wave, which is the regression it exists to catch.
 TEST_TIME_BUDGET_SECONDS = 12000.0
 
 
@@ -427,6 +428,12 @@ def _enforce_test_time_budget(session) -> None:
     spec = session.config.getoption("--ci-shard")
     if not spec:
         return
+    if session.exitstatus != 0:
+        # Already red for a better reason. Printing "this is not a test
+        # failure" directly above a real FAILURES section is triage
+        # misdirection, and the breach will still be there on the next green
+        # run, so say nothing rather than something false.
+        return
     reporter = session.config.pluginmanager.get_plugin("terminalreporter")
     if reporter is None:
         # No terminal reporter (-p no:terminal): nothing accumulated the phase
@@ -455,22 +462,21 @@ def _enforce_test_time_budget(session) -> None:
         "put the measurement that justifies it in the commit message."
     )
     reporter.write_sep("=", banner, red=True, bold=True)
-    if session.exitstatus == 0:
-        # Never downgrade a real failure, an interrupt or an internal error:
-        # those are more informative than a budget breach.
-        session.exitstatus = 1
+    session.exitstatus = 1
 
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
     """Release native model/session resources before interpreter teardown.
 
-    ``trylast`` so any other session-finish work runs before the budget check
-    below. The phase reports it measures are filed during the run rather than
-    at teardown, so its input is complete either way.
-    """
-    _enforce_test_time_budget(session)
+    ``trylast`` so any other session-finish work runs before this one. The
+    phase reports the budget check measures are filed during the run rather
+    than at teardown, so its input is complete wherever it sits.
 
+    The budget check runs *last*, after the native handles are released: if it
+    ever raises, the release below has already happened, rather than the
+    session dropping into interpreter teardown still holding models.
+    """
     try:
         # Drain optional CPU spillover tagger if one was created by tag tasks.
         TagTask.release_idle_cpu_spillover_engine(force=True)
@@ -492,3 +498,5 @@ def pytest_sessionfinish(session, exitstatus):
         pass
 
     gc.collect()
+
+    _enforce_test_time_budget(session)

--- a/tests/test_ci_shards.py
+++ b/tests/test_ci_shards.py
@@ -1413,12 +1413,16 @@ def test_test_time_budget_fires_on_over_budget_input():
         "The budget applied to an unsharded run"
     )
 
-    # A real failure, an interrupt or an internal error is more informative
-    # than a budget breach, so the check may escalate from 0 and nothing else.
+    # A run that is already red is red for a better reason. The check must not
+    # downgrade that status, and must not print "this is not a test failure"
+    # directly above a real FAILURES section, which is triage misdirection.
     interrupted = _BudgetStubReporter([ceiling * 99])
     session = _BudgetStubSession(interrupted, "1/4", exitstatus=2)
     shard_conftest._enforce_test_time_budget(session)
     assert session.exitstatus == 2, "The budget downgraded a worse exit status"
+    assert interrupted.lines == [], (
+        f"The budget banner claimed nothing failed on a red run: {interrupted.lines}"
+    )
 
 
 def test_test_time_budget_actually_turns_a_green_run_red():

--- a/tests/test_ci_shards.py
+++ b/tests/test_ci_shards.py
@@ -243,6 +243,54 @@ DEFERRED_FROM_GATE = frozenset(
     }
 )
 
+# Gated files the committed durations map has never timed. Same shape and same
+# job as DEFERRED_FROM_GATE: half of a partition, written down rather than
+# tolerated, so the hole is a decision instead of a silent gap. Repo-relative
+# paths here rather than bare names, because the gate also runs a subdirectory.
+#
+# This exists because the balance guardrail below used to build its node list
+# from the map's own keys, which made it structurally blind to exactly these
+# files: it reported a perfect 1.000 ratio while 27 of 118 gated files (23%)
+# were absent from the data it was grading. Refreshing the map with
+# scripts/record_test_durations.py is what empties this list, and emptying it
+# is the intended direction of travel.
+#
+# The list is self-cleaning in both directions. A newly gated file that nobody
+# recorded fails the guardrail, and so does an entry here that the map has
+# since learned about, so it cannot rot into a stale allowlist the way the
+# blindness it documents did.
+UNRECORDED_IN_DURATIONS_MAP = frozenset(
+    {
+        "tests/multi_project_authz/test_generic_field_reader_allowlist.py",
+        "tests/test_adapter_attachment.py",
+        "tests/test_adapter_header.py",
+        "tests/test_aitoolkit_run.py",
+        "tests/test_authz_library_pin.py",
+        "tests/test_checkpoint_hash_finder.py",
+        "tests/test_comfyui_pixlstash_saver.py",
+        "tests/test_hub_bootstrap.py",
+        "tests/test_hub_engine.py",
+        "tests/test_hub_model_shelf_schema.py",
+        "tests/test_hub_registry.py",
+        "tests/test_identity_storage_guardrail.py",
+        "tests/test_libraries_routes.py",
+        "tests/test_library_backup.py",
+        "tests/test_library_generation_coordinator.py",
+        "tests/test_library_settings.py",
+        "tests/test_library_switch.py",
+        "tests/test_model_file_classification.py",
+        "tests/test_model_folder_scanner.py",
+        "tests/test_model_shelf_fixtures.py",
+        "tests/test_model_shelf_library_fixture.py",
+        "tests/test_model_shelf_scan_invariants.py",
+        "tests/test_model_unload_race.py",
+        "tests/test_path_containment.py",
+        "tests/test_pending_score_invalidation.py",
+        "tests/test_share_link_library_pin.py",
+        "tests/test_tag_task.py",
+    }
+)
+
 
 @pytest.fixture(scope="module")
 def workflow() -> dict:
@@ -1199,9 +1247,44 @@ def test_recorded_durations_actually_balance_the_gate(workflow):
     show the difference in kind, and it is the *balanced* side that carries the
     assertion. If a single test ever grows past a shard's share this fails, and
     it should: no assignment can balance that, and the fix is the test.
+
+    The node list comes from the gate's own file list, never from the map's
+    keys. Grading the map on the tests it happens to contain is a tautology: it
+    reported 1.000 while 27 of 118 gated files were absent, and every test in
+    those files was being placed by round-robin fallback rather than by the
+    balance this claims to prove. Whatever the map does not know is either an
+    acknowledged entry in ``UNRECORDED_IN_DURATIONS_MAP`` or a failure here.
     """
     durations = _load_recorded_durations(DURATIONS_PATH)
-    nodeids = sorted(durations)
+    gated = _gated_files(workflow)
+    recorded_files = {nodeid.split("::", 1)[0] for nodeid in durations}
+
+    unlisted = sorted(gated - recorded_files - UNRECORDED_IN_DURATIONS_MAP)
+    assert not unlisted, (
+        f"These gated test files have no recorded durations: {unlisted}. Every "
+        "test in them is placed by round-robin fallback, so this balance "
+        "assertion says nothing about them. Refresh the map with "
+        "scripts/record_test_durations.py, or add them to "
+        "UNRECORDED_IN_DURATIONS_MAP."
+    )
+
+    recorded_now = sorted(UNRECORDED_IN_DURATIONS_MAP & recorded_files)
+    assert not recorded_now, (
+        f"UNRECORDED_IN_DURATIONS_MAP names files the map now times: "
+        f"{recorded_now}. Drop them from the list so it keeps naming the real "
+        "hole rather than an imagined one."
+    )
+
+    ungated = sorted(UNRECORDED_IN_DURATIONS_MAP - gated)
+    assert not ungated, (
+        f"UNRECORDED_IN_DURATIONS_MAP names files the gate does not run: "
+        f"{ungated}. Remove them; only gated files can be missing from the "
+        "data that balances the gate."
+    )
+
+    nodeids = sorted(
+        nodeid for nodeid in durations if nodeid.split("::", 1)[0] in gated
+    )
     total = len(_shard_matrix(workflow["jobs"][_GATE_JOB]))
 
     assignment = _time_balanced_shard_assignment(nodeids, total, durations)
@@ -1239,6 +1322,136 @@ def test_negligible_tests_do_not_all_land_on_one_shard():
 
     assert max(counts) <= 2 * min(counts), (
         f"Zero-cost tests piled onto one shard instead of being dealt: {counts}"
+    )
+
+
+class _BudgetStubReporter:
+    """The three pieces of the terminal reporter the budget check touches."""
+
+    def __init__(self, durations: list[float]):
+        self.stats = {"passed": [_BudgetStubReport(value) for value in durations]}
+        self.lines: list[str] = []
+
+    def write_sep(self, _sep, title, **_kwargs):
+        self.lines.append(title)
+
+    def write_line(self, line, **_kwargs):
+        self.lines.append(line)
+
+
+class _BudgetStubReport:
+    def __init__(self, duration: float):
+        self.duration = duration
+
+
+class _BudgetStubSession:
+    """A session whose exit status the budget check is allowed to change."""
+
+    def __init__(self, reporter, shard_spec, exitstatus=0):
+        self.exitstatus = exitstatus
+        self.config = _BudgetStubConfig(reporter, shard_spec)
+
+
+class _BudgetStubConfig:
+    def __init__(self, reporter, shard_spec):
+        self._shard_spec = shard_spec
+        self.pluginmanager = _BudgetStubPluginManager(reporter)
+
+    def getoption(self, name):
+        assert name == "--ci-shard", f"Unexpected option read: {name}"
+        return self._shard_spec
+
+
+class _BudgetStubPluginManager:
+    def __init__(self, reporter):
+        self._reporter = reporter
+
+    def get_plugin(self, name):
+        assert name == "terminalreporter", f"Unexpected plugin read: {name}"
+        return self._reporter
+
+
+def test_test_time_budget_fires_on_over_budget_input():
+    """The ceiling trips on synthetic time, and stays quiet under it.
+
+    Both directions on purpose: a budget that can only be observed to fire is
+    no better evidenced than one that never fires, and a guard permanently red
+    gets muted within a week.
+    """
+    ceiling = shard_conftest.TEST_TIME_BUDGET_SECONDS / 4
+
+    over = _BudgetStubReporter([ceiling * 0.6, ceiling * 0.6])
+    session = _BudgetStubSession(over, "1/4")
+    shard_conftest._enforce_test_time_budget(session)
+    assert session.exitstatus == 1, "Over-budget shard did not go red"
+    assert any("TEST-TIME BUDGET EXCEEDED" in line for line in over.lines), (
+        f"No budget banner was printed: {over.lines}"
+    )
+    assert any("NOT A TEST FAILURE" in line for line in over.lines), (
+        "The banner must be unmistakable from a failing test"
+    )
+
+    under = _BudgetStubReporter([ceiling * 0.6, ceiling * 0.3])
+    session = _BudgetStubSession(under, "1/4")
+    shard_conftest._enforce_test_time_budget(session)
+    assert session.exitstatus == 0, "Under-budget shard was failed anyway"
+    assert under.lines == [], f"Under-budget shard printed a banner: {under.lines}"
+
+    # The ceiling is one total-suite constant divided by the shard count, so
+    # the same measured time is fine at N=4 and a breach at N=16.
+    resharded = _BudgetStubReporter([ceiling * 0.6, ceiling * 0.3])
+    session = _BudgetStubSession(resharded, "1/16")
+    shard_conftest._enforce_test_time_budget(session)
+    assert session.exitstatus == 1, "A reshard silently kept the old ceiling"
+
+    # Not sharding at all means not measuring: a local partial run collects a
+    # fraction of the suite and must never be judged against a shard's share.
+    local = _BudgetStubReporter([ceiling * 99])
+    session = _BudgetStubSession(local, None)
+    shard_conftest._enforce_test_time_budget(session)
+    assert session.exitstatus == 0 and local.lines == [], (
+        "The budget applied to an unsharded run"
+    )
+
+    # A real failure, an interrupt or an internal error is more informative
+    # than a budget breach, so the check may escalate from 0 and nothing else.
+    interrupted = _BudgetStubReporter([ceiling * 99])
+    session = _BudgetStubSession(interrupted, "1/4", exitstatus=2)
+    shard_conftest._enforce_test_time_budget(session)
+    assert session.exitstatus == 2, "The budget downgraded a worse exit status"
+
+
+def test_test_time_budget_actually_turns_a_green_run_red():
+    """End to end: a passing shard over its ceiling exits non-zero.
+
+    The stub test above proves the arithmetic; this proves the wiring, which is
+    where the previous guardrails in this repo failed. It runs the real hook,
+    against the real terminal reporter's stats, in a real pytest process, and
+    the only synthetic part is the shard count: ``1/100000000`` puts the
+    ceiling at 0.12 ms, which any real test exceeds.
+
+    ``1 passed`` is asserted as well as the exit code, because a renamed target
+    would make pytest exit non-zero for "no tests ran" and this would pass for
+    the wrong reason.
+    """
+    target = (
+        "tests/test_ci_shards.py::test_nonsense_duration_values_are_dropped_not_trusted"
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", target, "--ci-shard=1/100000000"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+
+    assert "1 passed" in output, f"The target test did not run:\n{output}"
+    assert result.returncode != 0, (
+        f"A shard over its test-time ceiling still exited 0:\n{output}"
+    )
+    assert "TEST-TIME BUDGET EXCEEDED" in output, (
+        f"No budget banner in the failing run:\n{output}"
     )
 
 

--- a/tests/test_ci_shards.py
+++ b/tests/test_ci_shards.py
@@ -250,7 +250,7 @@ DEFERRED_FROM_GATE = frozenset(
 #
 # This exists because the balance guardrail below used to build its node list
 # from the map's own keys, which made it structurally blind to exactly these
-# files: it reported a perfect 1.000 ratio while 27 of 118 gated files (23%)
+# files: it reported a perfect 1.000 ratio while 28 of 119 gated files (24%)
 # were absent from the data it was grading. Refreshing the map with
 # scripts/record_test_durations.py is what empties this list, and emptying it
 # is the intended direction of travel.
@@ -280,6 +280,7 @@ UNRECORDED_IN_DURATIONS_MAP = frozenset(
         "tests/test_library_switch.py",
         "tests/test_model_file_classification.py",
         "tests/test_model_folder_scanner.py",
+        "tests/test_model_shelf_api.py",
         "tests/test_model_shelf_fixtures.py",
         "tests/test_model_shelf_library_fixture.py",
         "tests/test_model_shelf_scan_invariants.py",
@@ -1250,7 +1251,7 @@ def test_recorded_durations_actually_balance_the_gate(workflow):
 
     The node list comes from the gate's own file list, never from the map's
     keys. Grading the map on the tests it happens to contain is a tautology: it
-    reported 1.000 while 27 of 118 gated files were absent, and every test in
+    reported 1.000 while 28 of 119 gated files were absent, and every test in
     those files was being placed by round-robin fallback rather than by the
     balance this claims to prove. Whatever the map does not know is either an
     acknowledged entry in ``UNRECORDED_IN_DURATIONS_MAP`` or a failure here.


### PR DESCRIPTION
The #796 retrospective found the root cause of the 47 min/shard gate was not
capacity: it was documented intent that stopped matching reality, with nothing
checking the drift. Three of the seven findings were guardrails that checked
less than they claimed. This adds one guard that would have caught the
regression early, and fixes one that currently cannot fail for the reason it
exists.

## A. A self-measured ceiling on gated test time

`tests/conftest.py` grows `TEST_TIME_BUDGET_SECONDS = 12000.0` and a check that
runs at session finish. It is measured from **this run's own per-test report
durations**, never from `tests/ci_test_durations.json`: that map is stale
between refactors by design, so a guard reading it would be checking its own
input, which is exactly the bug fixed in part B.

- Only active under `--ci-shard`, so a local partial run never trips it.
- One total-suite constant divided by the shard count the run was actually
  given, so a reshard cannot silently move the effective bar.
- Signal, not a block. This repo has no required status checks on purpose, so
  the banner is deliberately unmistakable from a test failure:

```
==== TEST-TIME BUDGET EXCEEDED - THIS IS NOT A TEST FAILURE ====
Every test above may have passed. This shard spent 1743s of test time against
a ceiling of 1500s (12000s for the whole suite / 8 shards).
The suite got slower, it did not break. ...
```

- On a run that is already red it prints nothing and touches nothing. A real
  failure is a better reason to be red, and "this is not a test failure"
  directly above a FAILURES section is triage misdirection.

### Where 12000 came from

The last green develop run before this branch (Actions run `31307604252`,
N=8), summed from its own `--durations` output:

| shard | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | total |
|---|---|---|---|---|---|---|---|---|---|
| test seconds | 1005 | 770 | 859 | 753 | 840 | 916 | 792 | 728 | **6662** |

Only the worst shard can trip, so the margin that matters is
`1500 / 1005 = 1.49x`, and at that run's 1.21 imbalance the gate goes red near a
9900 s total rather than at 12000 s. That is far above runner noise and above
what a stale balance map can shift, and it still fires at roughly half the drift
back to the 2844 s/shard the gate had reached before #796, which is the
regression it exists to catch.

### Proof it fires

Two tests, because the repo has now had three guardrails that quietly checked
nothing:

- `test_test_time_budget_fires_on_over_budget_input` covers the arithmetic in
  both directions: over budget goes red with the banner, under budget is
  silent, the same measured time is fine at N=4 and a breach at N=16, an
  unsharded run is exempt, and an already-red exit status is neither
  downgraded nor banner-ed.
- `test_test_time_budget_actually_turns_a_green_run_red` is end to end: a real
  pytest subprocess, the real hook, the real terminal reporter's stats. The
  only synthetic part is the shard count, `1/100000000`, which puts the ceiling
  at 0.12 ms. Observed: `1 passed` and exit 1 with the banner.

## B. The balance guardrail was blind to a quarter of the gate

`test_recorded_durations_actually_balance_the_gate` built its node list as
`nodeids = sorted(durations)`, i.e. from the map's own keys. It reported a
perfect 1.000 balance ratio while being structurally blind to every gated file
absent from the map. Measured: **28 of 119 gated files (24%) have no recorded
durations**, and every test in them is placed by round-robin fallback rather
than by the balance the test claims to prove. The map's `recorded_from` is a
local run on 2026-08-04, which also predates the fixture wave, so the converted
files are overstated.

The node list now comes from the gate's file list in `.github/workflows/ci.yml`.
The 28 known-missing files are written down in `UNRECORDED_IN_DURATIONS_MAP`,
the same shape and same job as the existing `DEFERRED_FROM_GATE`: half of a
partition, not documentation. It self-cleans in three directions, all three
mutation-tested:

| mutation | result |
|---|---|
| drop an entry (simulates a newly gated, unrecorded file) | fails, names it |
| list a file the map now times | fails, tells you to remove it |
| list a file the gate does not run | fails |

A listed file still runs in the gate; it is only absent from the timing data,
so this is not a coverage hole. Refreshing the map with
`scripts/record_test_durations.py` empties the list, and that is a follow-up
chore, not part of this PR.

The guard immediately earned its keep: `tests/test_model_shelf_api.py` was
gated on develop while this branch was in review, with no recorded durations,
and the rebase went red until it was listed.

## C. A rule merged in #818 was wrong

`.github/copilot-instructions.md` told everyone to wipe tables under
`PRAGMA defer_foreign_keys = ON`. Two PRs disproved it: with pysqlite a PRAGMA
issued before any DML runs in autocommit, so the deferral is gone by the time
the DELETEs open their own transaction, and #822 measured it reading back `0`.
The reliable fix is ordering the reset, parents before children, which needs no
PRAGMA at all. The surviving half of the original warning stays: never
`PRAGMA foreign_keys` off/on, because a delete that raises in between leaves
enforcement off on that pooled connection. Whichever approach is chosen, it
must be demonstrated rather than assumed.

Two more items earned the hard way go in the same section:

- **Anchor a mutation check.** `AUTHZ_GATE_ENFORCING = True` appears twice in
  `pixlstash/authz/gate.py`, once inside the module docstring. A
  first-occurrence replace mutates prose, changes no behaviour, and produces a
  green that reads as "this assertion is dead". Two agents hit this in one day.
- **Assert the route resolves before trusting an authz negative.** Those paths
  are guarded by the READ-token middleware as well as the gate, and the
  middleware runs ahead of routing, so a request to a renamed or nonexistent
  route 403s identically to an in-scope refusal.

## Verification

- `tests/test_ci_shards.py`: 135 passed.
- Positive control: a real `--ci-shard 1/8` run exits 0 with no banner.
- Red-run control: a failing test over budget exits 1, prints no banner, and
  keeps its FAILURES section.
- `ruff format` and `ruff check` clean.
- `chief-security-officer` reviewed as an independent adversarial reviewer
  (the author did not certify this): APPROVE WITH CONDITIONS, no release
  blockers, then re-reviewed the fixes and returned APPROVE with no
  conditions. Both conditions were closed before push, and
  the recommendation about the stated headroom is folded into the constant's
  comment. `.github/workflows/ci.yml` is deliberately untouched, so there is no
  permissions, secrets or action-pin surface.

Follow-up, deliberately not in this PR: regenerate
`tests/ci_test_durations.json`, which empties `UNRECORDED_IN_DURATIONS_MAP`.
