### PR TITLE
F1a: the model shelf lists what is on this machine

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -126,7 +126,7 @@ frontend/src/
 └── components/
     ├── TitleBar.vue             # Shared library chrome plus Electron title bar: active-library entry point, breadcrumb, window controls, update alert
     ├── WordmarkLogo.vue         # "PixlStash" brand wordmark in the Tiny5 pixel font (two-tone via --wordmark-accent)
-    ├── views/       # Full-page / full-screen UI surfaces: ImageGrid, ImageOverlay + extracted OverlayTagsPanel/OverlayDescriptionPanel/OverlayMetadataPanel/OverlayFilmstrip, ReviewSessionsOverlay, DuplicateQueue, LoginScreen
+    ├── views/       # Full-page / full-screen UI surfaces: ImageGrid, ImageOverlay + extracted OverlayTagsPanel/OverlayDescriptionPanel/OverlayMetadataPanel/OverlayFilmstrip, ReviewSessionsOverlay, DuplicateQueue, ModelShelf, LoginScreen
     ├── panels/      # Large structural panels that form the app shell: SideBar, Toolbar + extracted TbTagPanel/TbComfyPanel/TbExportPanel/TbImportPanel/GbFilterPanel/UndoControl, SelectionBar, SelectionMenu, StatsSidebar, ProjectFiles, …
     ├── reviews/     # Tag-review surfaces (see below)
     │   ├── ReviewSessionView.vue      # One open review session: header, rail, and card queue
@@ -1280,6 +1280,56 @@ While the lightbox overlay is open, the user's own in-overlay edits (and any oth
 3. **On close, reconcile in place (no pill).** `ImageGrid.closeOverlay()` applies the deferred work directly: it swaps in any `pendingGridImages` and, when `pendingOverlayGridRefresh` / `pendingTagFilterRefresh` is set, runs `debouncedFetchAllGridImages()`. So the now-non-matching picture leaves the grid and any re-sort applies as a direct in-place refresh — never as a pill flashing on exit.
 
 `grid.isOverlayOpen` / `grid.markOverlayDeferredRefresh` are exposed by `ImageGrid` (Tier-3 imperative API) and forwarded to `useGridRealtimeSync` through `App.vue`'s `gridApi`. Tested in `useGridRealtimeSync.test.js` (both directions: deferred while open, pill still raised when closed).
+
+---
+
+### 9.1a The model shelf destination
+
+`/models` mounts `ModelShelf.vue` in place of `ImageGrid` (`App.vue`,
+`isModelsView`), on exactly the `/duplicates` pattern: a route rather than a
+selection, because the shelf lists **files on this machine** — LoRAs, other
+adapters and checkpoints found by the scanner — and no picture selection can
+express that. Like Duplicates it is excluded from `selectionOwnsHighlight` in
+`SideBar.vue`, or the underlying picture selection would light a second active
+destination in the rail.
+
+Four rules come from measurement against real adapter folders and are easy to
+undo by accident:
+
+- **A blank cell is the failure mode, not an edge case.** 37% of real adapters
+  carry no title, no base model and no trigger word at all. So the name falls
+  back through `display_name` → a name derived from the filename → the filename
+  itself (`utils/modelShelf.js`), and the metadata line always renders its
+  kind, its base model *or* the words "Base model not set", and its size.
+- **The derived name is computed at render, never stored.** That is what keeps
+  `display_name IS NULL` an exact "nobody has named this" queue on the backend
+  and stops a guess being mistaken for a choice. `deriveModelName` mirrors
+  `pixlstash/utils/model_utils.py`; `cleanAssetName` beneath it must not drift,
+  because its Python original feeds stored sentence embeddings.
+- **The derived name is marked by type, never by opacity.** `--font-mono` at
+  `--weight-regular` and full strength: §3 gives the mono face to file paths,
+  and a filename-derived name is one. Rank is never opacity
+  (`visual-language.md` §5.1) and a third of the rows faded would be a column
+  of ghosts. A font swap is silent to a screen reader, so the row also carries
+  a `visually-hidden` qualifier.
+- **`unknown` is never rendered as a checkpoint.** `file_kind='unknown'` is a
+  first-class stored value with its own glyph and the word "Unclassified". It
+  is in neither list by default and is fetched only from the *adapters* block
+  under `?file_kind=unknown`.
+
+Rows are built on the shared row system (`SideBar.global.css`, §5.1) through
+the neutral `.ps-row` / `.ps-row-glyph` aliases, so the shelf consumes those
+rules rather than keeping a second copy of them. Column 1 is reserved and empty
+until grouping fills it. Rows are **not** focus stops while they carry no verb:
+1,800 empty tab stops would be a trap, so the shelf root takes `tabindex="-1"`
+and receives focus on entry, and roving focus arrives with the first thing a
+focused row can do. The sidebar's Models entry is a real `<button>` with
+`aria-current`; the three older fixed destinations are still clickable `div`s,
+which is a filed gap rather than a pattern to copy.
+
+Windowing is `content-visibility: auto` with `contain-intrinsic-size` on the
+row rather than a virtual scroller: the browser skips layout and paint outside
+the viewport, which is what 1,800 rows need, in two declarations.
 
 ---
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -54,6 +54,7 @@ import RestoreConfirmDialog from "./components/widgets/RestoreConfirmDialog.vue"
 import TelemetryConsentDialog from "./components/dialogs/TelemetryConsentDialog.vue";
 import ImageGrid from "./components/views/ImageGrid.vue";
 import DuplicateQueue from "./components/views/DuplicateQueue.vue";
+import ModelShelf from "./components/views/ModelShelf.vue";
 import ReviewSessionsOverlay from "./components/views/ReviewSessionsOverlay.vue";
 import StatsSidebar from "./components/panels/StatsSidebar.vue";
 import ThumbnailUpgradeBanner from "./components/panels/ThumbnailUpgradeBanner.vue";
@@ -135,6 +136,8 @@ const error = ref(null);
 // route back into the stores is useViewStore's job, not this one's.
 const {
   isDuplicatesView,
+  isModelsView,
+  handleSelectModels,
   handleSelectCharacter,
   handleSelectSet,
   handleSelectFolder,
@@ -531,6 +534,7 @@ defineExpose({
             @view-project="handleViewProject"
             @select-character="handleSelectCharacter"
             @select-duplicates="handleSelectDuplicates"
+            @select-models="handleSelectModels"
             @select-set="handleSelectSet"
             @select-folder="handleSelectFolder"
             @images-assigned-to-character="handleImagesAssignedToCharacter"
@@ -598,6 +602,11 @@ defineExpose({
                 v-if="isDuplicatesView"
                 @open-settings="openSettingsDialog"
               />
+              <!-- The model shelf lists files on this machine rather than
+                   pictures in the library, so like Duplicates it replaces the
+                   grid instead of floating over it, and the grid stays
+                   unmounted while it is open. -->
+              <ModelShelf v-else-if="isModelsView" />
               <ImageGrid
                 v-else
                 ref="gridContainer"

--- a/frontend/src/api/modelShelf.js
+++ b/frontend/src/api/modelShelf.js
@@ -1,0 +1,60 @@
+// Model shelf resource — /adapters and /checkpoints.
+//
+// Two route blocks, one table (see `pixlstash/routes/model_shelf.py`). They
+// converge on the same query filtered by `file_kind`; the blocks stay apart
+// because their addressing differs. Three consequences the caller must honour:
+//
+//   * `attachments` come back ON THE LIST as well as on the detail, so the
+//     shelf never fetches them a row at a time.
+//   * `file_kind='unknown'` is first-class. It is in neither list by default
+//     and surfaces here under `listAdapters({ fileKind: "unknown" })`.
+//     `/checkpoints` never returns one, and asking it for one is a 400.
+//   * A null `base_model` is explicit, not absent: `UNASSIGNED` selects the
+//     rows that record none, exactly as the project filter spells it.
+
+import { apiClient } from "../utils/apiClient";
+import { unwrap } from "../utils/unwrap";
+
+/** The sentinel the API uses for "records no base model". */
+export const BASE_MODEL_UNASSIGNED = "UNASSIGNED";
+
+/**
+ * List adapters (or the unclassified files) on the shelf.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.fileKind="adapter"] - `adapter` or `unknown`.
+ *   Checkpoints have their own route; anything else is a 400.
+ * @param {string} [options.baseModel] - exact match, or `UNASSIGNED` for the
+ *   rows that record none. Omit for all.
+ * @param {string} [options.kind] - adapter algorithm, e.g. `lora` or `lokr`.
+ * @param {string} [options.q] - substring of name, filename or trigger words.
+ * @returns {Promise<Array<Object>>} the `adapters` array of the response body.
+ */
+export async function listAdapters({ fileKind, baseModel, kind, q } = {}) {
+  const params = {};
+  if (fileKind) params.file_kind = fileKind;
+  if (baseModel) params.base_model = baseModel;
+  if (kind) params.kind = kind;
+  if (q) params.q = q;
+  const body = await unwrap(apiClient.get("/adapters", { params }));
+  return Array.isArray(body?.adapters) ? body.adapters : [];
+}
+
+/**
+ * List checkpoints on the shelf.
+ *
+ * `sha256` is null until `MissingCheckpointHashFinder` has read the file, so
+ * `id` is the identifier to hold on to for these rows.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.baseModel] - exact match, or `UNASSIGNED`.
+ * @param {string} [options.q] - substring of the display name or filename.
+ * @returns {Promise<Array<Object>>} the `checkpoints` array of the body.
+ */
+export async function listCheckpoints({ baseModel, q } = {}) {
+  const params = {};
+  if (baseModel) params.base_model = baseModel;
+  if (q) params.q = q;
+  const body = await unwrap(apiClient.get("/checkpoints", { params }));
+  return Array.isArray(body?.checkpoints) ? body.checkpoints : [];
+}

--- a/frontend/src/components/panels/SideBar.css
+++ b/frontend/src/components/panels/SideBar.css
@@ -2426,3 +2426,19 @@ button.sidebar-ctx-item:disabled:hover {
 .relocate-actions {
   padding: 10px 16px 14px;
 }
+
+/* A fixed destination rendered as a real button rather than a clickable div,
+   so it is reachable by Tab. It carries the row classes and needs only the
+   defaults a <button> does not inherit: full width, left-aligned text, and the
+   UI font. The three older destinations are still divs; making them buttons is
+   the same four-line change and is filed, not forgotten. */
+.sidebar-destination-btn {
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  font-size: var(--text-sm);
+}
+
+.sidebar-collapsed-item.sidebar-destination-btn {
+  text-align: center;
+}

--- a/frontend/src/components/panels/SideBar.global.css
+++ b/frontend/src/components/panels/SideBar.global.css
@@ -10,7 +10,10 @@
    same family, and a scoped rule in SideBar.css cannot cross a component
    boundary. It used to keep its own copy, which had drifted to a different
    padding and a missing base rail; that is the drift this placement prevents.
-   Every selector here is `sidebar-`-prefixed, so global scope is contained.
+   Every selector here is `sidebar-` or `ps-row`-prefixed, so global scope is
+   contained. `.ps-row` is the neutral alias: the model shelf renders rows of
+   this family outside the rail, and a private copy there is exactly the drift
+   this placement prevents. It is an ALIAS, never a second declaration.
 
    Two invariants do the work:
 
@@ -30,7 +33,8 @@
 .sidebar-project-tree-subheader,
 .sidebar-folder-row,
 .sidebar-folder-section-header,
-.sidebar-section-header {
+.sidebar-section-header,
+.ps-row {
   box-sizing: border-box;
   padding-left: calc(var(--space-3) + var(--depth, 0) * var(--indent-step));
   padding-right: var(--sidebar-right-edge, 8px);
@@ -44,7 +48,8 @@
    remove the box and the row jumps. This replaces an inline `:style` ternary in
    SideBar.vue and an `[style*="display: none"]` attribute-selector hack, which
    were two different local patches for this one missing rule. */
-.sidebar-row-glyph {
+.sidebar-row-glyph,
+.ps-row-glyph {
   flex: none;
   display: inline-flex;
   align-items: center;
@@ -57,7 +62,8 @@
   margin-right: var(--space-2);
 }
 
-.sidebar-row-glyph--empty {
+.sidebar-row-glyph--empty,
+.ps-row-glyph--empty {
   visibility: hidden;
 }
 

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -154,6 +154,7 @@ const hasFolderFilter = computed(
 // Duplicates is addressed by route name, not by a selection sentinel: it shows
 // no pictures, so there is no selection to express.
 const isDuplicatesView = computed(() => route.name === "duplicates");
+const isModelsView = computed(() => route.name === "models");
 
 // A shared library keeps the duplicate affordances VISIBLE and inert rather
 // than hiding them: a read-only visitor should still see that the feature
@@ -171,6 +172,7 @@ const props = defineProps({
 
 const emit = defineEmits([
   "select-duplicates",
+  "select-models",
   "select-character",
   "select-set",
   "import-finished",
@@ -2489,14 +2491,15 @@ function isCountSelected(id) {
 
 /**
  * Whether a selection-driven row may render as active at all. The Duplicates
- * view is addressed by ROUTE, not by the selection system, so while it is open
+ * view and the model shelf are addressed by ROUTE, not by the selection
+ * system, so while either is open
  * the underlying selection (kept so back-navigation restores it) must yield
  * the highlight — otherwise the sidebar shows two active destinations. A live
  * folder filter suppresses the same rows for the same reason, so the two
  * guards travel together.
  */
 const selectionOwnsHighlight = computed(
-  () => !hasFolderFilter.value && !isDuplicatesView.value,
+  () => !hasFolderFilter.value && !isDuplicatesView.value && !isModelsView.value,
 );
 
 const isAllPicturesRowActive = computed(() => {
@@ -4944,6 +4947,21 @@ defineExpose({
             </div>
           </div>
 
+          <!-- The shelf's dock mirror. Same <button> reasoning as the
+               expanded row. -->
+          <div :class="['sidebar-collapsed-row', { active: isModelsView }]">
+            <button
+              type="button"
+              class="sidebar-collapsed-item sidebar-destination-btn"
+              :class="{ active: isModelsView }"
+              :aria-current="isModelsView ? 'page' : undefined"
+              title="Models"
+              @click="emit('select-models')"
+            >
+              <v-icon>mdi-layers-outline</v-icon>
+            </button>
+          </div>
+
           <!-- Scrap Heap at bottom of dock. The flex spacer above it fills most
                of the dock's blank space; its right-clicks bubble to the list's
                catch-all handler, so it needs no handler of its own. -->
@@ -5391,6 +5409,26 @@ defineExpose({
                   title="There are duplicates to review"
                 ></span>
               </div>
+            </div>
+
+            <!-- The shelf is a destination, not a filter: it lists the LoRAs
+                 and checkpoints on this machine, which no picture view can
+                 express. A <button>, unlike the rows above it, because a new
+                 destination must not be born unreachable by keyboard; the
+                 other three are filed to follow. -->
+            <div class="sidebar-all-pictures-row">
+              <button
+                type="button"
+                class="sidebar-list-item sidebar-destination-btn"
+                :class="{ active: isModelsView }"
+                :aria-current="isModelsView ? 'page' : undefined"
+                @click="emit('select-models')"
+              >
+                <span class="sidebar-list-icon sidebar-list-icon--toplevel"
+                  ><v-icon size="18">mdi-layers-outline</v-icon></span
+                >
+                <span class="sidebar-list-label">Models</span>
+              </button>
             </div>
 
             <div v-if="!isReadOnly" class="sidebar-all-pictures-row">

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -1,0 +1,143 @@
+// The shelf's reading surface.
+//
+// The three assertions worth having are the ones that guard the measured data
+// realities: a third of real adapters have no title, no base model and no
+// trigger, so a row must never render a blank; a derived name must stay
+// distinguishable from a chosen one; and `unknown` must never read as a
+// checkpoint.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+const listAdapters = vi.fn();
+const listCheckpoints = vi.fn();
+
+vi.mock("../../api/modelShelf", () => ({
+  BASE_MODEL_UNASSIGNED: "UNASSIGNED",
+  listAdapters: (...args) => listAdapters(...args),
+  listCheckpoints: (...args) => listCheckpoints(...args),
+}));
+
+import ModelShelf from "./ModelShelf.vue";
+
+const globalOpts = { global: { stubs: { "v-icon": true } } };
+
+/** The shape `/adapters` really returns, taken from a fixture probe. */
+function adapter(overrides = {}) {
+  return {
+    id: 1,
+    sha256: "a".repeat(64),
+    file_kind: "adapter",
+    kind: "lora",
+    display_name: "Cyanwood Style",
+    filename: "Cyanwood_Style_000000250.safetensors",
+    base_model: "flux.1-dev",
+    file_size: 358733183,
+    locations: [{ state: "present", folder_path: "/m", relpath: "a.st" }],
+    attachments: [],
+    ...overrides,
+  };
+}
+
+async function mountShelf(rows, checkpoints = []) {
+  listAdapters.mockResolvedValue(rows);
+  listCheckpoints.mockResolvedValue(checkpoints);
+  const wrapper = mount(ModelShelf, globalOpts);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await wrapper.vm.$nextTick();
+  return wrapper;
+}
+
+/** Text with runs of whitespace collapsed, so wrapping is not asserted. */
+function textOf(el) {
+  return el.text().replace(/\s+/g, " ");
+}
+
+beforeEach(() => {
+  listAdapters.mockReset();
+  listCheckpoints.mockReset();
+});
+
+describe("a row with nothing in its header", () => {
+  it("shows a name derived from the filename, never a blank", async () => {
+    const wrapper = await mountShelf([
+      adapter({
+        display_name: null,
+        base_model: null,
+        filename: "Foxglove_Char_000000250.safetensors",
+      }),
+    ]);
+    const row = wrapper.find(".shelf-row");
+    expect(row.find(".shelf-row-name").text()).toContain("Foxglove Char");
+    // Every slot on the metadata line renders something: the kind is derived
+    // from `file_kind` and is the guaranteed anchor when all else is null.
+    const slots = row.findAll(".shelf-row-meta > span").map((s) => s.text());
+    expect(slots).toEqual(["LoRA", "Base model not set", "342.1 MB"]);
+  });
+
+  it("marks the derived name by type, not by fading it", async () => {
+    // Rank is size, weight and tracking, never opacity (§5.1) — and 37% of
+    // rows faded would be a column of ghosts rather than a signal.
+    const wrapper = await mountShelf([
+      adapter({ id: 1, display_name: null }),
+      adapter({ id: 2, display_name: "Clementine" }),
+    ]);
+    const names = wrapper.findAll(".shelf-row-name");
+    expect(names[0].classes()).toContain("shelf-row-name--derived");
+    expect(names[1].classes()).not.toContain("shelf-row-name--derived");
+    // ...and the mark is announced, because a font swap is silent.
+    expect(names[0].text()).toContain("name taken from the filename");
+  });
+});
+
+describe("file kinds", () => {
+  it("never renders an unclassified file as a checkpoint", async () => {
+    const wrapper = await mountShelf([
+      adapter({ file_kind: "unknown", kind: null, display_name: "aurora" }),
+    ]);
+    const meta = textOf(wrapper.find(".shelf-row-meta"));
+    expect(meta).toContain("Unclassified");
+    expect(meta).not.toContain("Checkpoint");
+  });
+
+  it("names a checkpoint as one, having no algorithm to name", async () => {
+    const wrapper = await mountShelf(
+      [],
+      [adapter({ file_kind: "checkpoint", kind: null })],
+    );
+    expect(textOf(wrapper.find(".shelf-row-meta"))).toContain("Checkpoint");
+  });
+});
+
+describe("location state", () => {
+  it("keeps 'we could not look' visually apart from 'it is not there'", async () => {
+    const wrapper = await mountShelf([
+      adapter({ id: 1, locations: [{ state: "missing" }] }),
+      adapter({ id: 2, locations: [{ state: "unreachable" }] }),
+      adapter({ id: 3 }),
+    ]);
+    const slots = wrapper.findAll(".shelf-row-loc");
+    expect(slots[0].classes()).toContain("shelf-row-loc--missing");
+    expect(slots[1].classes()).toContain("shelf-row-loc--unreachable");
+    // Present reserves its slot and shows nothing, so no row ever shifts.
+    expect(slots[2].classes()).toContain("shelf-row-loc--present");
+  });
+});
+
+describe("empty states", () => {
+  it("says where PixlStash looks when the shelf is empty", async () => {
+    const wrapper = await mountShelf([]);
+    const state = textOf(wrapper.find(".shelf-state"));
+    expect(state).toContain("No models found");
+    expect(state).toContain("model folders registered on this machine");
+  });
+});
+
+describe("keyboard", () => {
+  it("leaves rows out of the tab order while they have no verb", async () => {
+    // 1,800 empty tab stops is a trap. Roving focus arrives with the first
+    // thing a focused row can do (F2/F4).
+    const wrapper = await mountShelf([adapter()]);
+    expect(wrapper.find(".shelf-row").attributes("tabindex")).toBeUndefined();
+    expect(wrapper.find(".shelf").attributes("tabindex")).toBe("-1");
+  });
+});

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -1,0 +1,332 @@
+<template>
+  <div
+    ref="rootEl"
+    class="shelf"
+    tabindex="-1"
+    aria-label="Model shelf"
+    aria-describedby="shelf-help"
+  >
+    <p id="shelf-help" class="visually-hidden">
+      Every adapter and checkpoint PixlStash has found on this machine. A name
+      in a monospaced face was taken from the filename, because nobody has named
+      that file yet.
+    </p>
+
+    <div class="shelf-toolbar">
+      <span class="shelf-title">Models</span>
+      <span class="shelf-sub">{{ countLabel }}</span>
+    </div>
+
+    <div class="shelf-body">
+      <p v-if="loading" class="shelf-state">Reading the shelf…</p>
+      <p v-else-if="error" class="shelf-state" role="alert">{{ error }}</p>
+      <div v-else-if="!rows.length" class="shelf-state">
+        <p>No models found.</p>
+        <p>
+          PixlStash lists what it finds in the model folders registered on this
+          machine. Register one to fill the shelf.
+        </p>
+      </div>
+
+      <!-- Rows are not focus stops: they carry no verb and no selection, so
+           1,800 empty tab stops would be a trap. Roving focus arrives with the
+           first thing a focused row can do. -->
+      <ul v-else class="shelf-list" role="list">
+        <li
+          v-for="row in rows"
+          :key="row.id"
+          class="ps-row shelf-row"
+          :title="rowTitle(row)"
+        >
+          <span class="ps-row-glyph ps-row-glyph--empty"></span>
+          <span class="shelf-row-kind">
+            <v-icon size="16">{{ KIND_ICON[row.file_kind] }}</v-icon>
+          </span>
+          <span class="shelf-row-label">
+            <span
+              class="shelf-row-name"
+              :class="{ 'shelf-row-name--derived': row.name.derived }"
+              >{{ row.name.text
+              }}<span v-if="row.name.derived" class="visually-hidden">
+                (name taken from the filename)</span
+              ></span
+            >
+            <span class="shelf-row-meta">
+              <span>{{ kindLabel(row) }}</span>
+              <span>{{ row.base_model || "Base model not set" }}</span>
+              <span v-if="row.file_size" class="shelf-row-size">{{
+                formatModelSize(row.file_size)
+              }}</span>
+            </span>
+          </span>
+          <span
+            class="shelf-row-loc"
+            :class="`shelf-row-loc--${row.locState}`"
+            :title="LOC_TITLE[row.locState]"
+          >
+            <v-icon size="16">{{ LOC_ICON[row.locState] }}</v-icon>
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, onMounted, ref } from "vue";
+import { listAdapters, listCheckpoints } from "../../api/modelShelf";
+import { errorDetail } from "../../utils/apiError";
+import { formatModelSize, locationState, modelName } from "../../utils/modelShelf";
+
+const rootEl = ref(null);
+const models = ref([]);
+const loading = ref(false);
+const error = ref("");
+
+// A closed vocabulary gets a glyph, an open one a word. `unknown` gets a plain
+// file rather than a question mark (an unclassified file is a fact about our
+// parser, not the user's mistake) and never the checkpoint cube.
+const KIND_ICON = {
+  adapter: "mdi-layers-outline",
+  checkpoint: "mdi-cube-outline",
+  unknown: "mdi-file-outline",
+};
+
+// `missing` is a fact (the folder was readable, the file was not in it);
+// `unreachable` is the absence of one (we could not look). Only the fact wears
+// a status colour — claiming a hue for "we do not know" would assert knowledge
+// we do not have. `present` reserves its slot and shows nothing.
+const LOC_ICON = {
+  present: "mdi-check",
+  missing: "mdi-file-remove-outline",
+  unreachable: "mdi-help-circle-outline",
+  forgotten: "mdi-folder-off-outline",
+};
+
+const LOC_TITLE = {
+  present: "",
+  missing: "The file is not where it was",
+  unreachable: "Could not check this location",
+  forgotten: "Every registered copy has been forgotten",
+};
+
+// Trainers spell these however they like; the shelf spells them one way.
+const ALGO_LABEL = {
+  lora: "LoRA",
+  lokr: "LoKr",
+  loha: "LoHa",
+  dora: "DoRA",
+  oft: "OFT",
+};
+
+/** The rows as the list renders them: name resolved, locations reduced. */
+const rows = computed(() =>
+  models.value.map((row) => ({
+    ...row,
+    name: modelName(row),
+    locState: locationState(row.locations),
+  })),
+);
+
+const countLabel = computed(() => {
+  const n = rows.value.length;
+  return `${n.toLocaleString()} ${n === 1 ? "model" : "models"}`;
+});
+
+/** The always-present anchor of the metadata line, whatever else is null. */
+function kindLabel(row) {
+  if (row.file_kind === "checkpoint") return "Checkpoint";
+  if (row.file_kind === "unknown") return "Unclassified";
+  const kind = String(row.kind || "").toLowerCase();
+  return ALGO_LABEL[kind] || kind || "Adapter";
+}
+
+/** Filename and folder live in the tooltip; the row shows the name. */
+function rowTitle(row) {
+  const where = (row.locations || [])
+    .map((loc) => `${loc.folder_path}/${loc.relpath}`)
+    .join("\n");
+  return [row.filename, where].filter(Boolean).join("\n");
+}
+
+/**
+ * Load the shelf: two requests, never one per row, because the list already
+ * carries each copy's location and who uses the model. Unclassified files are
+ * in neither — `unknown` is first-class, gets its own filter with the `Show`
+ * panel, and is never folded into either bucket.
+ */
+async function fetchRows() {
+  loading.value = true;
+  error.value = "";
+  try {
+    const [adapters, checkpoints] = await Promise.all([
+      listAdapters(),
+      listCheckpoints(),
+    ]);
+    models.value = [...adapters, ...checkpoints];
+  } catch (err) {
+    error.value = errorDetail(err) || err?.message || String(err);
+    models.value = [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(async () => {
+  await fetchRows();
+  // Tab out of the sidebar lands in the shelf, the same contract the duplicate
+  // queue has.
+  await nextTick();
+  rootEl.value?.focus();
+});
+</script>
+
+<style scoped>
+.shelf {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: rgb(var(--v-theme-background));
+  color: rgb(var(--v-theme-on-background));
+  outline: none;
+}
+
+.shelf-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  height: var(--bar-height);
+  padding: 0 var(--space-5);
+  border-bottom: 1px solid rgb(var(--v-theme-divider));
+  flex-shrink: 0;
+}
+
+.shelf-title {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+}
+
+.shelf-sub {
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-background), 0.7);
+  font-variant-numeric: tabular-nums;
+}
+
+.shelf-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.shelf-state {
+  padding: var(--space-7) var(--space-5);
+  font-size: var(--text-sm);
+  color: rgba(var(--v-theme-on-background), 0.7);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-4);
+  max-width: 60ch;
+}
+
+.shelf-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* The box, the rail and the indent come from the shared row system
+   (SideBar.global.css, visual-language.md §5.1) via `.ps-row`; only the
+   columns and the vertical rhythm are the shelf's own. Column 1 stays
+   reserved and empty: grouping fills it, and a column that appears later
+   would move every label sideways. */
+.shelf-row {
+  display: grid;
+  grid-template-columns:
+    var(--gutter-glyph)
+    var(--entity-thumb)
+    minmax(0, 1fr)
+    auto;
+  align-items: center;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+  padding-bottom: var(--space-2);
+  transition: background var(--dur-1) var(--ease-standard);
+  /* Native windowing: the browser skips layout and paint for rows outside the
+     viewport, which is what 1,800 rows need and is two lines rather than a
+     virtual scroller. The size hint is only the first guess — `auto` makes the
+     browser remember each row's real height after it has painted once. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto calc(var(--entity-thumb) + var(--space-5));
+}
+
+.shelf-row:hover {
+  background: var(--hover-wash);
+}
+
+.shelf-row-kind {
+  display: inline-flex;
+  justify-content: center;
+  color: rgba(var(--v-theme-on-background), 0.7);
+}
+
+.shelf-row-label {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.shelf-row-name {
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The unnamed third. Mono at regular weight, at FULL strength: §3 gives the
+   mono face to file paths, and a filename-derived name is one — so this says
+   what the string is rather than demoting it. Rank is never opacity (§5.1),
+   and 37% of rows faded would be a column of ghosts. */
+.shelf-row-name--derived {
+  font-family: var(--font-mono);
+  font-weight: var(--weight-regular);
+}
+
+.shelf-row-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-xs);
+  /* 0.7, not 0.6: at 12px the lower alpha measures 4.07:1 on the light canvas
+     and misses the 4.5:1 floor. */
+  color: rgba(var(--v-theme-on-background), 0.7);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shelf-row-size {
+  font-variant-numeric: tabular-nums;
+}
+
+.shelf-row-loc {
+  display: inline-flex;
+  width: var(--gutter-glyph);
+  margin-left: var(--space-3);
+}
+
+.shelf-row-loc--present {
+  visibility: hidden;
+}
+
+.shelf-row-loc--missing,
+.shelf-row-loc--forgotten {
+  color: rgb(var(--v-theme-error));
+}
+
+.shelf-row-loc--unreachable {
+  color: rgba(var(--v-theme-on-background), 0.7);
+}
+</style>

--- a/frontend/src/composables/useAppNavigation.js
+++ b/frontend/src/composables/useAppNavigation.js
@@ -346,6 +346,15 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
   // the selection store: it shows no pictures, so it has no selection to express.
   const isDuplicatesView = computed(() => route.name === "duplicates");
 
+  // Same reasoning for the model shelf: it lists files on this machine, not
+  // pictures in the library, so it is a route rather than a selection.
+  const isModelsView = computed(() => route.name === "models");
+
+  /** Open the model shelf. */
+  function handleSelectModels() {
+    pushAppRoute({ name: "models" });
+  }
+
   /**
    * Open the duplicate triage queue, optionally scoped to one collection object.
    *
@@ -373,6 +382,8 @@ export function useAppNavigation({ onClearSearch, onNavigated } = {}) {
 
   return {
     isDuplicatesView,
+    isModelsView,
+    handleSelectModels,
     handleSelectCharacter,
     handleSelectSet,
     handleSelectFolder,

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -19,6 +19,7 @@ import App from "../App.vue";
 //   /scrapheap                              → Scrapheap
 //   /duplicates                             → Duplicate triage queue
 //   /duplicates?scope=set&scope_id=12       → …scoped to one collection object
+//   /models                                 → Model shelf (adapters/checkpoints)
 //   /ref-folder/:id                         → Reference folder view (id = numeric)
 //   /import-folder/:id                      → Import folder view (id = numeric)
 //
@@ -40,6 +41,7 @@ const routes = [
   { path: "/project/:projectId/set/:id", name: "project-set", component: App },
   { path: "/scrapheap", name: "scrapheap", component: App },
   { path: "/duplicates", name: "duplicates", component: App },
+  { path: "/models", name: "models", component: App },
   { path: "/ref-folder/:id", name: "ref-folder", component: App },
   { path: "/import-folder/:id", name: "import-folder", component: App },
   // Catch-all: redirect unknown paths to home

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -1,0 +1,120 @@
+// Model-shelf row helpers: the name fallback chain, size, and location state.
+//
+// 37% of real adapters carry no title, no base model and no trigger word at
+// all, so none of this is edge-case handling — it is what most of the column
+// renders. Two rules follow from that and are load-bearing:
+//
+//   * The derived name is computed HERE, at render, never stored. That is what
+//     keeps `display_name IS NULL` an exact "nobody has named this" queue on
+//     the backend and stops a guess being mistaken for a choice.
+//   * A missing value is still rendered. "Base model not set" occupies the same
+//     slot in the same type as a real value; a blank cell is the failure mode.
+
+/** Trailing tokens that record where in a training run a file was saved.
+ *
+ * Mirrors `_TRAINING_SUFFIX_RE` in `pixlstash/utils/model_utils.py`. The
+ * bare-digit rule needs five digits on purpose: ai-toolkit zero-pads its step
+ * counts, so `000002750` goes while the `2` in `portrait mix v2` stays.
+ */
+const TRAINING_SUFFIX_RE = /^(?:step\d+|epoch\d+|\d+ep|\d{5,})$/i;
+
+/**
+ * Strip the extension and turn separators into spaces.
+ *
+ * Mirrors `clean_asset_name`, which must not change: its output is baked into
+ * stored sentence embeddings. Anything the shelf wants on top goes in
+ * {@link deriveModelName}.
+ *
+ * @param {string} filename - file name or path.
+ * @returns {string}
+ */
+export function cleanAssetName(filename) {
+  const base = String(filename || "").split(/[\\/]/).pop();
+  const stem = base.replace(/\.[^.]+$/, "");
+  return stem.replace(/[_-]/g, " ").trim();
+}
+
+/**
+ * Derive a display name for a file that never said what it is called.
+ *
+ * Mirrors `derive_model_name`: drops trailing training bookkeeping, because
+ * the step is parsed into its own field and repeating it turns six checkpoints
+ * of one run into six unrelated-looking rows.
+ *
+ * @param {string} filename - file name or path.
+ * @returns {string} a human-readable name, or `""` when nothing survives.
+ */
+export function deriveModelName(filename) {
+  const tokens = cleanAssetName(filename).split(/\s+/).filter(Boolean);
+  while (tokens.length && TRAINING_SUFFIX_RE.test(tokens[tokens.length - 1])) {
+    tokens.pop();
+  }
+  return tokens.join(" ");
+}
+
+/**
+ * Resolve what a row is called, and whether anybody chose it.
+ *
+ * The chain is: the name the user gave, else one derived from the filename,
+ * else the filename itself. `derived` is what the row uses to mark the name as
+ * a fact about the file rather than a title someone wrote.
+ *
+ * @param {Object} model - a row from `/adapters` or `/checkpoints`.
+ * @returns {{text: string, derived: boolean}}
+ */
+export function modelName(model) {
+  const given = String(model?.display_name || "").trim();
+  if (given) return { text: given, derived: false };
+  const filename = String(model?.filename || "").trim();
+  const derived = deriveModelName(filename);
+  if (derived) return { text: derived, derived: true };
+  // Nothing survived the strip (a file called `000002750.safetensors`). The
+  // raw filename is the only honest thing left to show.
+  return { text: filename || "no name in file", derived: true };
+}
+
+const SIZE_UNITS = ["B", "KB", "MB", "GB", "TB"];
+
+/**
+ * Format a byte count for the size column.
+ *
+ * Deliberately its own function rather than the two `formatBytes` copies in
+ * `ProjectFiles.vue` and `ImageImporter.vue`: both are local, and the first
+ * tops out at MB, which understates a 4.3 GB adapter by three orders.
+ *
+ * @param {number|null|undefined} bytes
+ * @returns {string} e.g. `179.4 MB`, or `""` when the size is unknown.
+ */
+export function formatModelSize(bytes) {
+  // `Number(null)` is 0, so the null check has to come first or a row with no
+  // recorded size claims to be empty.
+  if (bytes === null || bytes === undefined || bytes === "") return "";
+  const n = Number(bytes);
+  if (!Number.isFinite(n) || n < 0) return "";
+  let value = n;
+  let unit = 0;
+  while (value >= 1024 && unit < SIZE_UNITS.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const digits = unit === 0 ? 0 : 1;
+  return `${value.toFixed(digits)} ${SIZE_UNITS[unit]}`;
+}
+
+/**
+ * Reduce a row's copies to the one state worth reporting.
+ *
+ * `missing` is a fact (the folder was readable and the file was not in it);
+ * `unreachable` is the absence of one (we could not look). They must not read
+ * the same, and one present copy makes both moot — the file is usable.
+ *
+ * @param {Array<Object>} locations - the row's `locations` array.
+ * @returns {"present"|"missing"|"unreachable"|"forgotten"}
+ */
+export function locationState(locations) {
+  const list = Array.isArray(locations) ? locations : [];
+  if (!list.length) return "forgotten";
+  if (list.some((loc) => loc?.state === "present")) return "present";
+  if (list.some((loc) => loc?.state === "unreachable")) return "unreachable";
+  return "missing";
+}

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -1,0 +1,112 @@
+// The name fallback chain, size and location reduction the shelf row is built
+// on. The name cases are the ones that matter: 37% of real adapters carry no
+// title at all, so the "derived" branch is the common path, not the fallback.
+
+import { describe, it, expect } from "vitest";
+import {
+  cleanAssetName,
+  deriveModelName,
+  formatModelSize,
+  locationState,
+  modelName,
+} from "./modelShelf";
+
+describe("cleanAssetName", () => {
+  it("matches the Python it mirrors", () => {
+    // Parity with `clean_asset_name`, whose output is baked into stored
+    // embeddings and therefore may not drift.
+    expect(cleanAssetName("z_image_turbo_bf16.safetensors")).toBe(
+      "z image turbo bf16",
+    );
+    expect(cleanAssetName("/a/b/portrait-mix.safetensors")).toBe(
+      "portrait mix",
+    );
+  });
+});
+
+describe("deriveModelName", () => {
+  it("drops the training bookkeeping, keeps a version suffix", () => {
+    // The three doctest cases from `derive_model_name`. The bare-digit rule
+    // needs five digits so `000002750` goes and the `2` in `v2` stays;
+    // dropping that distinction merges six checkpoints of one run into six
+    // unrelated-looking rows, or renames every `v2` file.
+    expect(deriveModelName("JimmyCarr_000002750.safetensors")).toBe(
+      "JimmyCarr",
+    );
+    expect(deriveModelName("ohwx_woman-step00004500.safetensors")).toBe(
+      "ohwx woman",
+    );
+    expect(deriveModelName("portrait_mix_v2.safetensors")).toBe(
+      "portrait mix v2",
+    );
+  });
+
+  it("returns nothing when nothing survives the strip", () => {
+    expect(deriveModelName("000002750.safetensors")).toBe("");
+  });
+});
+
+describe("modelName", () => {
+  it("prefers the name somebody gave it, and says nobody did", () => {
+    expect(modelName({ display_name: "Clementine", filename: "x.st" })).toEqual(
+      { text: "Clementine", derived: false },
+    );
+  });
+
+  it("derives from the filename and marks it derived", () => {
+    // The mark is the whole point: a guess must stay distinguishable from a
+    // choice, because `display_name IS NULL` is the backend's work queue.
+    expect(
+      modelName({ display_name: null, filename: "Foxglove_Char_000000250.safetensors" }),
+    ).toEqual({ text: "Foxglove Char", derived: true });
+  });
+
+  it("falls back to the raw filename rather than to a blank", () => {
+    expect(modelName({ filename: "000002750.safetensors" })).toEqual({
+      text: "000002750.safetensors",
+      derived: true,
+    });
+  });
+
+  it("never returns an empty string", () => {
+    expect(modelName({}).text).not.toBe("");
+  });
+});
+
+describe("formatModelSize", () => {
+  it("scales past MB", () => {
+    // The two local `formatBytes` copies in the app top out at MB, which
+    // understates a 4.3 GB adapter by three orders.
+    expect(formatModelSize(179426130)).toBe("171.1 MB");
+    expect(formatModelSize(4.3 * 1024 ** 3)).toBe("4.3 GB");
+    expect(formatModelSize(512)).toBe("512 B");
+  });
+
+  it("says nothing rather than zero when the size is unknown", () => {
+    expect(formatModelSize(null)).toBe("");
+    expect(formatModelSize(undefined)).toBe("");
+  });
+});
+
+describe("locationState", () => {
+  it("treats one present copy as healthy", () => {
+    expect(
+      locationState([{ state: "missing" }, { state: "present" }]),
+    ).toBe("present");
+  });
+
+  it("keeps 'we could not look' apart from 'it is not there'", () => {
+    // `missing` is a fact and may be acted on; `unreachable` is the absence of
+    // one and must never be recorded as a deletion.
+    expect(locationState([{ state: "unreachable" }])).toBe("unreachable");
+    expect(locationState([{ state: "missing" }])).toBe("missing");
+    expect(
+      locationState([{ state: "missing" }, { state: "unreachable" }]),
+    ).toBe("unreachable");
+  });
+
+  it("reports no copies at all as its own state", () => {
+    expect(locationState([])).toBe("forgotten");
+    expect(locationState(undefined)).toBe("forgotten");
+  });
+});


### PR DESCRIPTION
First half of **F1** of the model shelf. `/models` becomes a destination like `/duplicates`, listing every adapter and checkpoint the scanner has found. Built against the generated fixtures (`scripts/generate_model_shelf_fixtures.py`, 1,800 adapters), not invented data.

**Split, and why.** F1 as specced (row, list, `Show` multi-select `.tbm` panel, Flat view, persisted config) is ~1,080 source lines, well over the 600 cap. The seam is the `Show` panel: this PR is the destination and the row, and the filter panel plus the store that holds its persisted selection follow in a stacked PR against this branch. Each half is a usable increment.

### The three measured data realities

- **37% of real adapters carry no title, no base model and no trigger word.** Verified on the full fixture set: 1,801 rows, **0 blank names, 0 blank sizes, 650 derived names (36.1%)**. The name falls back `display_name` → derived from the filename → the filename; the metadata line always renders kind, base-model-or-"Base model not set", and size.
- **A null base model is explicit.** It renders as the words `Base model not set` in the same slot and the same type as a real value — never an em-dash, never a blank. The `base_model=UNASSIGNED` filter that carries it lands with the `Show` panel.
- **`unknown` never renders as a checkpoint.** It has its own glyph and the word `Unclassified`, and is fetched only from the adapters block under `?file_kind=unknown` — which means it is in neither list here, by design, until `Show` can ask for it.

### Design and UX rulings applied

`lead-designer` and `ui-ux-expert` were both consulted. Zero new design tokens were needed.

- The derived name is marked by **type, not opacity**: `--font-mono` at `--weight-regular`, full strength. Rank is never opacity (§5.1) and a third of the rows faded would be a column of ghosts. A font swap is silent to a screen reader, so the row carries a `visually-hidden` qualifier too.
- Rows sit on P2's shipped row system through neutral `.ps-row` / `.ps-row-glyph` **aliases** added to `SideBar.global.css` — an alias, never a second declaration, because two copies of a row style drift and the copy is where the rail bug survives. Column 1 stays reserved and empty until grouping fills it.
- `missing` wears `error`; `unreachable` stays neutral. "We could not look" is not a status, and giving it a hue would claim knowledge we do not have. `present` reserves its slot and shows nothing, so no row shifts.

### Accessibility

- The sidebar's **Models entry is a real `<button>` with `aria-current`**. The three older fixed destinations are clickable `div`s and unreachable by keyboard; copying that would ship a fifth inaccessible destination. Fixing the other three is a separate change, filed, not done here.
- The shelf root takes `tabindex="-1"` + `aria-describedby` and receives focus on entry, so Tab out of the sidebar lands in the list (`DuplicateQueue`'s contract).
- **Rows are deliberately not focus stops** while they carry no verb: 1,800 empty tab stops is a trap. Roving focus arrives with the first thing a focused row can do.

### Performance

`content-visibility: auto` + `contain-intrinsic-size` on the row rather than a virtual scroller — two declarations for what 1,800 rows need.

### Checks

- `npm run build` — clean.
- `npm test` — 155 files, 2,692 tests, all passing.
- `npm run lint` — 0 errors (1 pre-existing warning in `AppDialog.test.js`).
- Diff grepped for hex literals, `rgba(0,0,0,…)`, emoji and raw `px`: none in the new source. The only length is `1px` hairline borders, the codebase-wide convention.
- 600 source lines (tests and docs excluded).

### Deferred

`Show` panel, persisted filter selection and the filter-driven empty states → the stacked follow-up. Groupings, drive bands, capacity meters and sort → F2. The five verbs, selection bar and receipts (and with them the attachment count, which is assignment's own information) → F3. Drag and drop → F4. Stacks → F5. ai-toolkit import → F6.