### PR TITLE
Sort the shelf in the list query, aggregates and all

### DIFF
--- a/pixlstash/routes/model_shelf.py
+++ b/pixlstash/routes/model_shelf.py
@@ -27,11 +27,11 @@ explicit sentinel ``base_model=UNASSIGNED``.
 
 The queries themselves live in
 :mod:`pixlstash.services.model_shelf_service`, including the hub/vault seam the
-``character_id`` / ``set_id`` filter has to cross. Sorting by ``added_at`` /
-``file_mtime`` and by the stack aggregates is B7's half of the shelf; the list is
-ordered by ``model.id`` here, and locations and attachments each arrive in a
-single whole-page query, so adding those aggregates is a change to one SELECT
-rather than the unpicking of an N+1.
+``character_id`` / ``set_id`` filter has to cross. Locations and attachments each
+arrive in a single whole-page query, and B7's sorting went into that same one
+SELECT: ``member_count`` / ``total_size`` / ``newest_member_at`` for a stack and
+the newest ``file_mtime`` across a model's present copies are joined in, never
+looked up per row.
 
 Authorization is declared, never inline: every route here is ``OWNER_ONLY`` in
 ``pixlstash/authz/registry.py`` and takes the **default** library pin
@@ -41,7 +41,7 @@ branch). See ``docs/backend_architecture.md`` §16.1.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import APIRouter, Body, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
@@ -49,6 +49,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from pixlstash.db_models.adapter_attachment import ENTITY_CHARACTER, ENTITY_SET
 from pixlstash.pixl_logging import get_logger
 from pixlstash.services.model_shelf_service import (
+    DEFAULT_DIRECTION,
+    DEFAULT_SORT,
     ENTITY_TYPES,
     UnknownAttachmentEntityError,
     attached_hashes,
@@ -66,6 +68,13 @@ logger = get_logger(__name__)
 # its own block because it is not addressable by hash, and folding it in here
 # would be the "unknown renders as checkpoint" defect in the other direction.
 ADAPTER_BLOCK_FILE_KINDS = (FILE_ADAPTER, FILE_UNKNOWN)
+
+# Constrained here rather than validated in the handler, so an unknown key is a
+# 422 from FastAPI and never reaches the SQL builder. The values are the five
+# ruled sort keys; keep them in step with ``model_shelf_service.SORT_KEYS``,
+# which a test pins.
+SortKey = Literal["added_at", "file_mtime", "name", "size", "base_model"]
+SortDirection = Literal["asc", "desc"]
 
 
 class ModelLocation(BaseModel):
@@ -154,6 +163,38 @@ class ModelResponse(BaseModel):
     added_at: Optional[str] = Field(
         default=None, description="``model.created_at`` — when the shelf first saw it."
     )
+    newest_file_mtime: Optional[int] = Field(
+        default=None,
+        description=(
+            "Newest ``st_mtime_ns`` across this model's **present** copies, which "
+            "is what the `file_modified` sort orders on. Null when no copy is "
+            "present, so the row sorts last in either direction."
+        ),
+    )
+    member_count: Optional[int] = Field(
+        default=None,
+        description=(
+            "How many models share this row's ``stack_id``. Null for a model "
+            "that stands alone. Computed in the list query, not per row."
+        ),
+    )
+    total_size: Optional[int] = Field(
+        default=None,
+        description=(
+            "Sum of ``file_size`` over every member of this row's stack. This is "
+            "what the shelf displays and what `size` sorts on for a stacked row, "
+            "because the cover alone understates a six-step run by about six "
+            "times, in the column the shelf exists to answer. Null when the row "
+            "is not stacked; its own ``file_size`` is then both."
+        ),
+    )
+    newest_member_at: Optional[str] = Field(
+        default=None,
+        description=(
+            "Newest ``created_at`` across the stack's members: a stack's date is "
+            "its newest member's, never its cover's. Null when not stacked."
+        ),
+    )
     locations: list[ModelLocation] = Field(
         default_factory=list,
         description="Every registered copy. Empty means every copy was forgotten.",
@@ -217,6 +258,10 @@ def _to_response(
         stack_position=row["stack_position"],
         run_key=row["run_key"],
         added_at=row["created_at"],
+        newest_file_mtime=row["newest_file_mtime"],
+        member_count=row["member_count"],
+        total_size=row["total_size"],
+        newest_member_at=row["newest_member_at"],
         locations=[ModelLocation(**loc) for loc in locations.get(int(row["id"]), [])],
         attachments=[
             ModelAttachment(**att) for att in attachments.get(row["sha256"] or "", [])
@@ -244,6 +289,8 @@ def create_router(server) -> APIRouter:
         q: Optional[str],
         character_id: Optional[int],
         set_id: Optional[int],
+        sort: str = DEFAULT_SORT,
+        direction: str = DEFAULT_DIRECTION,
     ) -> list[ModelResponse]:
         """The shared body of both list routes: three queries, whatever the size."""
         if character_id is not None and set_id is not None:
@@ -252,7 +299,13 @@ def create_router(server) -> APIRouter:
             )
 
         rows = fetch_models(
-            server.hub, file_kinds, base_model=base_model, kind=kind, q=q
+            server.hub,
+            file_kinds,
+            base_model=base_model,
+            kind=kind,
+            q=q,
+            sort=sort,
+            direction=direction,
         )
 
         if character_id is not None or set_id is not None:
@@ -313,6 +366,19 @@ def create_router(server) -> APIRouter:
             None,
             description="Substring of the display name, filename or trigger words.",
         ),
+        sort: SortKey = Query(
+            DEFAULT_SORT,
+            description=(
+                "`added_at` (default), `file_mtime`, `name`, `size` or "
+                "`base_model`. A stacked row sorts by its stack's total size and "
+                "its newest member's date, which is what it displays. Rows with "
+                "no value for the key sort last in both directions."
+            ),
+        ),
+        direction: SortDirection = Query(
+            DEFAULT_DIRECTION,
+            description="`desc` (default, newest/largest first) or `asc`.",
+        ),
     ):
         server.auth.ensure_secure_when_required(request)
         if file_kind not in ADAPTER_BLOCK_FILE_KINDS:
@@ -331,6 +397,8 @@ def create_router(server) -> APIRouter:
                 q=q,
                 character_id=character_id,
                 set_id=set_id,
+                sort=sort,
+                direction=direction,
             )
         )
 
@@ -381,6 +449,10 @@ def create_router(server) -> APIRouter:
         q: Optional[str] = Query(
             None, description="Substring of the display name or filename."
         ),
+        sort: SortKey = Query(DEFAULT_SORT, description="Same five keys as /adapters."),
+        direction: SortDirection = Query(
+            DEFAULT_DIRECTION, description="`desc` (default) or `asc`."
+        ),
     ):
         server.auth.ensure_secure_when_required(request)
         return CheckpointListResponse(
@@ -391,6 +463,8 @@ def create_router(server) -> APIRouter:
                 q=q,
                 character_id=None,
                 set_id=None,
+                sort=sort,
+                direction=direction,
             )
         )
 

--- a/pixlstash/services/model_shelf_service.py
+++ b/pixlstash/services/model_shelf_service.py
@@ -8,10 +8,16 @@ foreign key and no SQL join can cross the two, so a filter that mixes them is tw
 queries intersected in Python — and, importantly, *two* queries no matter how
 many rows come back.
 
-Everything here is shaped so the B7 sorting work is a change to one SELECT rather
+Everything here is shaped so the sorting work is a change to one SELECT rather
 than the unpicking of an N+1: the list is one hub query, the locations for the
 whole page are one more, and the attachments for the whole page are one vault
 query. Nothing is fetched per row.
+
+**Sorting (B7) kept that promise.** A stack's size is the sum of its members and
+its date is the newest member's, and a row must never sort by a number it does
+not display — so those aggregates are two ``LEFT JOIN``s onto grouped subqueries
+inside the *same* ``SELECT`` as the rows, not a lookup per row. 1,806 rows sorted
+by an aggregate is the N+1 this shape exists to prevent.
 
 Both list blocks — adapters and checkpoints — go through :func:`fetch_models`.
 There is one content table, so there is one query; ``file_kind`` is the only
@@ -89,6 +95,93 @@ MODEL_COLUMNS = (
     "created_at",
 )
 
+# Computed per row by the two aggregate joins below, never by a second query.
+AGGREGATE_COLUMNS = (
+    "member_count",
+    "total_size",
+    "newest_member_at",
+    "newest_file_mtime",
+)
+
+# A stack's numbers, one grouped pass over ``model``. The shelf shows a stack as
+# one row whose size is the sum of every member (a cover understates by ~6x in
+# the column the shelf exists to answer) and whose date is the newest member's.
+# Sorting never reorders members: ``stack_position`` is the cover and stays put.
+_STACK_JOIN = """
+LEFT JOIN (
+    SELECT stack_id,
+           COUNT(*)        AS member_count,
+           SUM(file_size)  AS total_size,
+           MAX(created_at) AS newest_member_at
+    FROM model
+    WHERE stack_id IS NOT NULL
+    GROUP BY stack_id
+) st ON st.stack_id = m.stack_id
+"""
+
+# "File modified" is a fact about a *copy*, and a model can have several. The
+# newest ``present`` one is the honest answer: a ``missing`` row's mtime is the
+# last thing we saw, not the last thing that happened.
+_LOCATION_JOIN = """
+LEFT JOIN (
+    SELECT model_id, MAX(file_mtime) AS newest_file_mtime
+    FROM model_file
+    WHERE state = 'present'
+    GROUP BY model_id
+) loc ON loc.model_id = m.id
+"""
+
+_SELECT_LIST = ", ".join(
+    [*(f"m.{name}" for name in MODEL_COLUMNS), *(f"{c}" for c in AGGREGATE_COLUMNS)]
+)
+
+_FROM = f"FROM model m{_STACK_JOIN}{_LOCATION_JOIN}"
+
+# The five sort keys ruled 2026-08-08. ``COALESCE`` on the stack aggregate is the
+# "a row never sorts by a number it does not display" rule in SQL: a stacked row
+# displays the stack's total, a standalone row displays its own.
+#
+# ``COLLATE NOCASE`` on the two text keys because "Name A to Z" that puts every
+# lowercase name after every uppercase one is not A to Z.
+SORT_KEYS = {
+    "added_at": "COALESCE(st.newest_member_at, m.created_at)",
+    "file_mtime": "loc.newest_file_mtime",
+    "name": "m.display_name COLLATE NOCASE",
+    "size": "COALESCE(st.total_size, m.file_size)",
+    "base_model": "m.base_model COLLATE NOCASE",
+}
+
+DEFAULT_SORT = "added_at"
+DEFAULT_DIRECTION = "desc"
+
+# Fixed and implicit, never a second control: a tie-break dropdown doubles the
+# state space of a control nobody has learned. Name A to Z, falling back to
+# filename when the primary key already *is* the name.
+_TIE_BREAK = "m.filename COLLATE NOCASE"
+_DEFAULT_TIE_BREAK = "m.display_name COLLATE NOCASE"
+
+
+def _order_by(sort: str, direction: str) -> str:
+    """Build the ``ORDER BY`` clause for one sort key and direction.
+
+    Nulls last in **both** directions, spelled ``(expr) IS NULL`` rather than
+    ``NULLS LAST`` so it does not depend on the host SQLite being 3.30+. It
+    governs hundreds of rows, not an edge case: 37 % of a measured real folder
+    records no base model and none of those files carries a name either, and a
+    user who flips the direction does not want 900 unnamed rows at the top.
+
+    ``m.id`` closes the clause so the order is total. Two rows that tie on the
+    key *and* the tie-break would otherwise come back in whatever order SQLite
+    chose that run, which is a paging bug waiting to be reported as a ghost.
+    """
+    expression = SORT_KEYS[sort]
+    descending = "DESC" if direction == "desc" else "ASC"
+    tie = _TIE_BREAK if sort == "name" else _DEFAULT_TIE_BREAK
+    return (
+        f"ORDER BY ({expression}) IS NULL, {expression} {descending}, "
+        f"({tie}) IS NULL, {tie} ASC, m.id ASC"
+    )
+
 
 def fetch_models(
     hub,
@@ -97,8 +190,15 @@ def fetch_models(
     base_model: Optional[str] = None,
     kind: Optional[str] = None,
     q: Optional[str] = None,
+    sort: str = DEFAULT_SORT,
+    direction: str = DEFAULT_DIRECTION,
 ) -> list[dict]:
-    """Return the shelf rows of the given ``file_kind``s, oldest id first.
+    """Return the shelf rows of the given ``file_kind``s, sorted.
+
+    One SELECT, whatever the filter and whatever the sort. The stack and
+    location aggregates are joined in, so sorting 1,806 rows by "total size of
+    the stack this row belongs to" costs one grouped scan rather than 1,806
+    lookups.
 
     Args:
         hub: The open :class:`~pixlstash.hub.db.HubDatabase`.
@@ -112,41 +212,53 @@ def fetch_models(
         q: Substring of the display name, filename or trigger words.
             Case-insensitive for ASCII, which is what SQLite's default LIKE
             gives, and wildcard-escaped.
+        sort: One of :data:`SORT_KEYS`. Defaults to newest-added first.
+        direction: ``asc`` or ``desc``. Nulls stay last in both.
 
     Returns:
-        One dict per row, keyed by :data:`MODEL_COLUMNS`.
+        One dict per row, keyed by :data:`MODEL_COLUMNS` plus
+        :data:`AGGREGATE_COLUMNS`.
+
+    Raises:
+        KeyError: *sort* is not a known key. The routes constrain it with a
+            ``Literal`` before it reaches here, so this is the programmer-error
+            path, not the request path.
     """
-    where = [f"file_kind IN ({','.join('?' * len(file_kinds))})"]
+    where = [f"m.file_kind IN ({','.join('?' * len(file_kinds))})"]
     params: list = list(file_kinds)
 
     if base_model is not None:
         if base_model == UNSET:
-            where.append("base_model IS NULL")
+            where.append("m.base_model IS NULL")
         else:
-            where.append("base_model = ?")
+            where.append("m.base_model = ?")
             params.append(base_model)
     if kind:
-        where.append("kind = ?")
+        where.append("m.kind = ?")
         params.append(kind)
     if q and q.strip():
         term = f"%{q.strip().translate(_LIKE_ESCAPE)}%"
         where.append(
-            "(display_name LIKE ? ESCAPE '\\' OR filename LIKE ? ESCAPE '\\' "
-            "OR trigger_words LIKE ? ESCAPE '\\')"
+            "(m.display_name LIKE ? ESCAPE '\\' OR m.filename LIKE ? ESCAPE '\\' "
+            "OR m.trigger_words LIKE ? ESCAPE '\\')"
         )
         params.extend([term, term, term])
 
     sql = (
-        f"SELECT {', '.join(MODEL_COLUMNS)} FROM model "
-        f"WHERE {' AND '.join(where)} ORDER BY id"
+        f"SELECT {_SELECT_LIST} {_FROM} "
+        f"WHERE {' AND '.join(where)} {_order_by(sort, direction)}"
     )
     return [dict(row) for row in hub.fetchall(sql, tuple(params))]
 
 
 def fetch_model_by_hash(hub, sha256: str) -> Optional[dict]:
-    """Return the one model row carrying *sha256*, or None."""
+    """Return the one model row carrying *sha256*, or None.
+
+    The same SELECT as the list, so the detail response carries the stack and
+    mtime aggregates too and the two shapes cannot drift apart.
+    """
     rows = hub.fetchall(
-        f"SELECT {', '.join(MODEL_COLUMNS)} FROM model WHERE sha256 = ?",
+        f"SELECT {_SELECT_LIST} {_FROM} WHERE m.sha256 = ?",
         (sha256,),
     )
     return dict(rows[0]) if rows else None

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -74,13 +74,78 @@ ADAPTER_NO_BASE_2 = _h("adapternobase2")
 UNKNOWN_HASH = _h("unknownfile")
 CHECKPOINT_HASHED = _h("checkpointhashed")
 
-# (sha256, file_kind, kind, display_name, filename, base_model)
+# The stack the sorting tests need. Two of the four adapters are one subject's
+# run, so "a row never sorts by a number it does not display" is assertable:
+# a stacked row must sort by the stack's total size and its newest member's
+# date, not by the cover's own.
+STACK_ID = 7
+
+# (sha256, file_kind, kind, display_name, filename, base_model, created_at,
+#  file_size, file_mtime, stack_position)
+#
+# Every sortable column is given a *different* order from every other, so a sort
+# that silently fell back to id order, or read the wrong column, cannot pass.
 _SEED_MODELS = (
-    (ADAPTER_WITH_BASE, "adapter", "lora", "Alice", "alice.safetensors", "SDXL 1.0"),
-    (ADAPTER_WITH_BASE_2, "adapter", "lokr", "Bob", "bob.safetensors", "Flux.1 dev"),
-    (ADAPTER_NO_BASE, "adapter", "lora", None, "sd_xl_noname.safetensors", None),
-    (ADAPTER_NO_BASE_2, "adapter", "lora", "Dana", "dana.safetensors", None),
-    (UNKNOWN_HASH, "unknown", None, None, "mystery.safetensors", None),
+    (
+        ADAPTER_WITH_BASE,
+        "adapter",
+        "lora",
+        "Alice",
+        "alice.safetensors",
+        "SDXL 1.0",
+        "2026-08-01T00:00:00Z",
+        1000,
+        11,
+        0,
+    ),
+    (
+        ADAPTER_WITH_BASE_2,
+        "adapter",
+        "lokr",
+        "Bob",
+        "bob.safetensors",
+        "Flux.1 dev",
+        "2026-08-02T00:00:00Z",
+        5000,
+        55,
+        None,
+    ),
+    (
+        ADAPTER_NO_BASE,
+        "adapter",
+        "lora",
+        None,
+        "sd_xl_noname.safetensors",
+        None,
+        "2026-08-03T00:00:00Z",
+        2000,
+        22,
+        None,
+    ),
+    (
+        ADAPTER_NO_BASE_2,
+        "adapter",
+        "lora",
+        "Dana",
+        "dana.safetensors",
+        None,
+        "2026-08-04T00:00:00Z",
+        3000,
+        44,
+        1,
+    ),
+    (
+        UNKNOWN_HASH,
+        "unknown",
+        None,
+        None,
+        "mystery.safetensors",
+        None,
+        "2026-08-05T00:00:00Z",
+        100,
+        5,
+        None,
+    ),
     (
         CHECKPOINT_HASHED,
         "checkpoint",
@@ -88,9 +153,24 @@ _SEED_MODELS = (
         "Base XL",
         "base_xl.safetensors",
         "SDXL 1.0",
+        "2026-08-06T00:00:00Z",
+        9000,
+        66,
+        None,
     ),
     # The one that has no hash yet: a 24 GB file the hash finder has not read.
-    (None, "checkpoint", None, None, "huge_unhashed.safetensors", None),
+    (
+        None,
+        "checkpoint",
+        None,
+        None,
+        "huge_unhashed.safetensors",
+        None,
+        "2026-08-07T00:00:00Z",
+        24000,
+        77,
+        None,
+    ),
 )
 
 
@@ -100,24 +180,53 @@ def _seed_hub(server) -> dict[str, int]:
         conn.execute("DELETE FROM model_file")
         conn.execute("DELETE FROM model")
         conn.execute("DELETE FROM model_folder")
+        conn.execute("DELETE FROM adapter_stack")
         conn.execute(
             "INSERT INTO model_folder (id, path, kind, movable, created_at) "
             "VALUES (1, '/models/loras', 'user', 'per_item', '2026-08-09T00:00:00Z')"
         )
+        conn.execute(
+            "INSERT INTO adapter_stack (id, name, created_at) "
+            "VALUES (?, 'Alice run', '2026-08-01T00:00:00Z')",
+            (STACK_ID,),
+        )
         ids: dict[str, int] = {}
-        for sha, file_kind, kind, display_name, filename, base_model in _SEED_MODELS:
+        for row in _SEED_MODELS:
+            (
+                sha,
+                file_kind,
+                kind,
+                display_name,
+                filename,
+                base_model,
+                created_at,
+                file_size,
+                file_mtime,
+                stack_position,
+            ) = row
             cursor = conn.execute(
                 "INSERT INTO model (file_kind, kind, sha256, display_name, filename, "
-                "base_model, provenance, file_size, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, 'external', 4096, '2026-08-09T00:00:00Z')",
-                (file_kind, kind, sha, display_name, filename, base_model),
+                "base_model, provenance, file_size, created_at, stack_id, "
+                "stack_position) VALUES (?, ?, ?, ?, ?, ?, 'external', ?, ?, ?, ?)",
+                (
+                    file_kind,
+                    kind,
+                    sha,
+                    display_name,
+                    filename,
+                    base_model,
+                    file_size,
+                    created_at,
+                    None if stack_position is None else STACK_ID,
+                    stack_position,
+                ),
             )
             model_id = int(cursor.lastrowid)
             ids[filename] = model_id
             conn.execute(
                 "INSERT INTO model_file (model_id, model_folder_id, relpath, state, "
-                "seen_at, file_mtime) VALUES (?, 1, ?, 'present', ?, 17)",
-                (model_id, filename, "2026-08-09T00:00:00Z"),
+                "seen_at, file_mtime) VALUES (?, 1, ?, 'present', ?, ?)",
+                (model_id, filename, "2026-08-09T00:00:00Z", file_mtime),
             )
     return ids
 
@@ -330,7 +439,7 @@ def test_adapter_detail_carries_locations(shelf_env):
             "folder_path": "/models/loras",
             "relpath": "alice.safetensors",
             "state": "present",
-            "file_mtime": 17,
+            "file_mtime": 11,
         }
     ]
     # An unknown is hashed on sight, so it is addressable here too.
@@ -846,3 +955,216 @@ def test_attachment_write_is_owner_only_in_both_directions(shelf_env):
         )
         r = client.put(_attachments_url(ADAPTER_WITH_BASE), json=[])
         assert r.status_code == 403, f"{description}: {r.status_code} {r.text}"
+
+
+# ===========================================================================
+# Sorting (B7) — the aggregates are in the list query, not per row
+# ===========================================================================
+
+
+def _order(shelf_env, **params) -> list[str]:
+    r = shelf_env.owner.get(f"{API}/adapters", params=params)
+    assert r.status_code == 200, r.text
+    return [row["filename"] for row in r.json()["adapters"]]
+
+
+def test_sort_keys_are_exactly_the_five_that_were_ruled():
+    """The route's ``Literal`` and the SQL builder's map are two spellings of
+    one decision. If they drift, an accepted query key builds no ORDER BY, or a
+    ruled key becomes a 422."""
+    from typing import get_args
+
+    from pixlstash.routes.model_shelf import SortKey
+    from pixlstash.services.model_shelf_service import SORT_KEYS
+
+    assert set(get_args(SortKey)) == set(SORT_KEYS)
+    assert set(SORT_KEYS) == {
+        "added_at",
+        "file_mtime",
+        "name",
+        "size",
+        "base_model",
+    }
+
+
+def test_default_sort_is_newest_added_first(shelf_env):
+    """Ruled default. Alice and Dana are one stack, so both carry the stack's
+    newest member date (Dana's, 08-04) and lead — Alice's own 08-01 would put her
+    last, which is exactly the per-row reading this must not do."""
+    assert _order(shelf_env) == [
+        "alice.safetensors",
+        "dana.safetensors",
+        "sd_xl_noname.safetensors",
+        "bob.safetensors",
+    ]
+
+
+def test_a_stacked_row_sorts_by_the_stack_total_not_the_cover(shelf_env):
+    """Size is the sum of all members and is displayed as such, because a cover
+    understates a run by about six times in the column the shelf exists to
+    answer. Alice's own file is the *smallest* of the four; her stack's total is
+    second largest, and that is where she must land."""
+    assert _order(shelf_env, sort="size") == [
+        "bob.safetensors",  # 5000, unstacked
+        "alice.safetensors",  # stack total 4000, own file 1000
+        "dana.safetensors",  # same stack, same total; tie-broken by name
+        "sd_xl_noname.safetensors",  # 2000
+    ]
+
+
+def test_stack_aggregates_are_on_the_row(shelf_env):
+    """The numbers the row displays come back with it, so the shelf never has to
+    ask a second question per row."""
+    rows = {
+        row["filename"]: row
+        for row in shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+    }
+    alice = rows["alice.safetensors"]
+    assert alice["stack_id"] == STACK_ID
+    assert alice["member_count"] == 2
+    assert alice["total_size"] == 4000
+    assert alice["newest_member_at"] == "2026-08-04T00:00:00Z"
+
+    standalone = rows["bob.safetensors"]
+    assert standalone["member_count"] is None
+    assert standalone["total_size"] is None
+    assert standalone["newest_member_at"] is None
+
+
+def test_nulls_sort_last_in_both_directions(shelf_env):
+    """Two of six rows in the design's own mock have no name and no base model,
+    and 37 % of a measured real folder records neither. A user who flips the
+    direction is not asking for 900 unnamed rows at the top."""
+    ascending = _order(shelf_env, sort="name", direction="asc")
+    descending = _order(shelf_env, sort="name", direction="desc")
+    assert ascending == [
+        "alice.safetensors",
+        "bob.safetensors",
+        "dana.safetensors",
+        "sd_xl_noname.safetensors",
+    ]
+    assert descending == [
+        "dana.safetensors",
+        "bob.safetensors",
+        "alice.safetensors",
+        "sd_xl_noname.safetensors",
+    ]
+    assert ascending[-1] == descending[-1] == "sd_xl_noname.safetensors"
+
+
+def test_file_modified_sorts_on_the_newest_present_copy(shelf_env):
+    """``file_mtime`` is per *copy*, and a model can have several. It is also the
+    one date that is NOT stack-aggregated: a stack's members were written at
+    different times and the row shows the newest of its own copies."""
+    assert _order(shelf_env, sort="file_mtime") == [
+        "bob.safetensors",  # 55
+        "dana.safetensors",  # 44
+        "sd_xl_noname.safetensors",  # 22
+        "alice.safetensors",  # 11
+    ]
+
+
+def test_a_missing_copy_contributes_no_modification_date(shelf_env):
+    """A ``missing`` row's mtime is the last thing we saw, not the last thing
+    that happened, so it must not answer "when was this modified". With no
+    present copy the row has no date and sorts last in either direction."""
+    with shelf_env.server.hub.transaction() as conn:
+        conn.execute(
+            "UPDATE model_file SET state = 'missing' WHERE relpath = 'bob.safetensors'"
+        )
+    rows = {
+        row["filename"]: row
+        for row in shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+    }
+    assert rows["bob.safetensors"]["newest_file_mtime"] is None
+    assert rows["dana.safetensors"]["newest_file_mtime"] == 44
+    for direction in ("asc", "desc"):
+        assert (
+            _order(shelf_env, sort="file_mtime", direction=direction)[-1]
+            == "bob.safetensors"
+        )
+
+
+def test_base_model_sort_puts_the_unrecorded_rows_last(shelf_env):
+    assert _order(shelf_env, sort="base_model", direction="asc") == [
+        "bob.safetensors",  # Flux.1 dev
+        "alice.safetensors",  # SDXL 1.0
+        "dana.safetensors",  # none; tie-broken by name, nulls last
+        "sd_xl_noname.safetensors",  # none, and no name either
+    ]
+
+
+def test_checkpoints_sort_too(shelf_env):
+    r = shelf_env.owner.get(f"{API}/checkpoints", params={"sort": "size"})
+    assert r.status_code == 200, r.text
+    assert [row["filename"] for row in r.json()["checkpoints"]] == [
+        "huge_unhashed.safetensors",
+        "base_xl.safetensors",
+    ]
+
+
+def test_an_unknown_sort_key_is_refused_before_it_reaches_the_sql(shelf_env):
+    r = shelf_env.owner.get(f"{API}/adapters", params={"sort": "id; DROP TABLE model"})
+    assert r.status_code == 422, r.text
+    assert shelf_env.owner.get(f"{API}/adapters").status_code == 200
+
+
+def test_sorting_by_an_aggregate_is_still_two_hub_queries(shelf_env):
+    """The claim B5 left standing and B7 had to keep: the list is one SELECT for
+    the rows and one for the locations, whatever the sort and *whatever the row
+    count*. 1,806 rows sorted by "the total size of the stack this row belongs
+    to" is otherwise the textbook N+1."""
+    server = shelf_env.server
+    calls: list[str] = []
+    original = server.hub.fetchall
+
+    def counting(sql, params=()):
+        calls.append(sql)
+        return original(sql, params)
+
+    server.hub.fetchall = counting
+    try:
+        assert (
+            shelf_env.owner.get(f"{API}/adapters", params={"sort": "size"}).status_code
+            == 200
+        )
+        with_four_rows = len(calls)
+
+        # Twenty more adapters, ten of them in a second stack.
+        calls.clear()
+        with server.hub.transaction() as conn:
+            conn.execute("INSERT INTO adapter_stack (id, name) VALUES (99, 'Bulk run')")
+            for index in range(20):
+                cursor = conn.execute(
+                    "INSERT INTO model (file_kind, kind, sha256, filename, "
+                    "provenance, file_size, created_at, stack_id, stack_position) "
+                    "VALUES ('adapter', 'lora', ?, ?, 'external', ?, ?, ?, ?)",
+                    (
+                        _h(f"bulk{index}z"),
+                        f"bulk_{index}.safetensors",
+                        1000 + index,
+                        f"2026-07-{index + 1:02d}T00:00:00Z",
+                        99 if index < 10 else None,
+                        index if index < 10 else None,
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO model_file (model_id, model_folder_id, relpath, "
+                    "state, seen_at, file_mtime) VALUES (?, 1, ?, 'present', ?, ?)",
+                    (
+                        int(cursor.lastrowid),
+                        f"bulk_{index}.safetensors",
+                        "2026-08-09T00:00:00Z",
+                        index,
+                    ),
+                )
+        calls.clear()
+        r = shelf_env.owner.get(f"{API}/adapters", params={"sort": "size"})
+        assert r.status_code == 200, r.text
+        assert len(r.json()["adapters"]) == 24
+        assert len(calls) == with_four_rows == 2, (
+            f"{len(calls)} hub queries for 24 rows vs {with_four_rows} for 4 — "
+            "the list has grown a per-row lookup"
+        )
+    finally:
+        server.hub.fetchall = original


### PR DESCRIPTION
**B7, part 1 of 6.** Base: `develop`. Do not merge before the CSO review of the stack.

Sorting's backend half. `added_at`, `file_mtime` and the stack aggregates
(`member_count` / `total_size` / `newest_member_at`) are computed **in the list
query** — two `LEFT JOIN`s onto grouped subqueries inside the same `SELECT` as
the rows, not a lookup per row. B5's claim that this would be a change to one
SELECT held up; the list is still one hub query for the rows plus one for the
locations, and `test_sorting_by_an_aggregate_is_still_two_hub_queries` proves it
by counting hub queries at 4 rows and at 24 and asserting the count did not move.

Five ruled sort keys, constrained by a `Literal` so an unknown key is a 422 and
never reaches the SQL builder. Nulls last in **both** directions, spelled
`(expr) IS NULL` rather than `NULLS LAST` so it does not need SQLite 3.30+.
Tie-break fixed and implicit (name A-Z, filename when the primary key is name),
closed with `m.id` so the order is total.

A stacked row sorts by what it *displays*: the stack's total size and its newest
member's date. `file_mtime` is deliberately not stack-aggregated and takes the
newest **present** copy — a `missing` row's mtime is the last thing we saw, not
the last thing that happened.

No new routes, so no `ROUTE_POLICIES` or coverage-matrix change.

**Mutation-tested** (each break makes the suite red, restore makes it green):
stacked rows sorting by their own size; nulls no longer forced last; a `missing`
copy supplying a modification date; locations fetched per row.
