### PR TITLE
Import an ai-toolkit run onto the shelf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,7 @@ jobs:
           tests/test_model_file_classification.py
           tests/test_model_folder_scanner.py
           tests/test_model_move.py
+          tests/test_model_run_import.py
           tests/test_model_shelf_api.py
           tests/test_model_shelf_fixtures.py
           tests/test_model_shelf_library_fixture.py

--- a/docs/authz-coverage-matrix.md
+++ b/docs/authz-coverage-matrix.md
@@ -563,6 +563,13 @@ and the declarations themselves are pinned by
 | GET | `/api/v1/model-moves` | **local_owner_only** |  | §16.3 progress for the in-flight or last move: host paths, per-file relpaths and outcomes. Deliberately **not** the shelf's `owner_only` read tier — the only way this data exists is a POST that only a local owner can issue, so a lower tier here would hand the operation's filenames to a caller barred from every route that could produce them. No object data beyond what the same-tier POST already named |
 | DELETE | `/api/v1/model-moves` | **local_owner_only** |  | §16.3 cancels an in-flight host-filesystem move. Halting the owner's own file operation is the same authority as starting it, so it carries the same tier. Stops the queue between files; nothing already moved is rolled back, which is the ruling (shelf plan §7: no undo for shelf operations) |
 
+### model_imports.py (added 2026-08-09 — model shelf B7; §16.3 host-capability, whole block)
+
+| Method | Effective path | Policy | id_param / body_ids | Rationale (current enforcement) |
+|---|---|---|---|---|
+| GET | `/api/v1/model-folders/{folder_id}/runs` | **local_owner_only** |  | §16.3 walks a registered ai-toolkit output root and reads every run folder and `config.yaml` under it — the same host-filesystem authority as `model-folders/{folder_id}/rescan` and `reference-folders/detect-sidecars`. Reads only: nothing is hashed, copied, moved or written, which is what lets the whole card grid be drawn before the user commits to anything. Owner + loopback/LAN/Tailscale, or remote owner iff `allow_remote_host_ops=true` (§16.3.1) |
+| POST | `/api/v1/model-imports` | **local_owner_only** |  | §16.3 copies a run's checkpoints into a registered host folder and, when the source folder carries `delete_after_import`, unlinks them from the output root — the same authority as `POST /model-moves`. The run is named, never pathed: the body gives a registered `source` folder id and a run *name*, and the server joins them with `resolve_path_within`, so a name resolving outside the registered root is a 400 rather than a read. Owner + loopback/LAN/Tailscale, or remote owner iff `allow_remote_host_ops=true` (§16.3.1) |
+
 ### other
 
 | Method | Effective path | Policy | id_param / body_ids | Rationale (current enforcement) |

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -510,6 +510,8 @@ Public guest scoring and shared-link endpoints.
 | PATCH  | /api/v1/model-folders/{folder_id}                                             | model_shelf     | Update a registered model folder                           |
 | DELETE | /api/v1/model-folders/{folder_id}                                             | model_shelf     | Forget a registered model folder                           |
 | POST   | /api/v1/model-folders/{folder_id}/rescan                                      | model_shelf     | Rescan a registered model folder                           |
+| GET    | /api/v1/model-folders/{folder_id}/runs                                        | model_shelf     | List the training runs in an ai-toolkit output folder      |
+| POST   | /api/v1/model-imports                                                         | model_shelf     | Import a training run onto the shelf                       |
 | GET    | /api/v1/model-moves                                                           | model_shelf     | How the current or last model move is going                |
 | POST   | /api/v1/model-moves                                                           | model_shelf     | Move model files into another registered folder            |
 | DELETE | /api/v1/model-moves                                                           | model_shelf     | Cancel the running model move                              |
@@ -1636,7 +1638,11 @@ The authz refactor (§16.2) moved this class off `require_user_id` and onto decl
 
     **Path containment applies here and did not apply to B4 or B5** (§13, #776): B4 walks and B5 registers, and reads are deliberately never contained; B7 is the write/delete path. Every destination is resolved with `resolve_path_within` against the **destination** `model_folder.path` and every source against its **own** `model_folder.path`, so a `model_file.relpath` that a faulty scan, a restored hub or a bug put in the table cannot make the mover write outside a registered folder or unlink outside one. Containment is on the `open(…, "wb")` and the `os.unlink`, never on the read.
 
-    Arithmetic, not judgement — pinned by `tests/test_authz_host_capability_16_3.py::test_host_capability_tier_split_is_21_local_5_loopback`.
+    Arithmetic, not judgement.
+
+  - **Updated 2026-08-09 (third change the same day) — the locality total is now `28 = 23 local + 5 loopback`.** Re-derived from `ROUTE_POLICIES`. The shelf's **ai-toolkit import** block (shelf plan B7) adds **+2 `local_owner_only`**: `GET /api/v1/model-folders/{folder_id}/runs` and `POST /api/v1/model-imports`. The listing walks a registered output root and reads every run folder and `config.yaml` under it, which is `model-folders/{folder_id}/rescan`'s authority exactly; the import writes files into one registered folder and, when the source folder carries `delete_after_import`, unlinks them from the output root, which is `POST /model-moves`' authority exactly. **Neither takes a host path**: the import names a registered `source` folder id and a run *name*, and the server joins them with `resolve_path_within`, so a run name resolving outside the registered root is refused rather than read. They are on the locality tier for the authority they exercise, not for an input they accept.
+
+    Arithmetic, not judgement — pinned by `tests/test_authz_host_capability_16_3.py::test_host_capability_tier_split_is_23_local_5_loopback`.
 
     **Scope of that guarantee (do not over-read it).** Loopback enforcement inherits the pre-existing proxy caveat in CSO Condition 2 below, shared with the other four loopback routes: a reverse proxy that sets no `X-Forwarded-For`, or passes an inbound one through, can make a remote caller resolve to loopback. So the correct claim is that safety depends on the flag being off **or** the proxy being configured correctly — *not* that it stops depending on the flag entirely. Container port-mapping is **not** a bypass (Docker bridge / slirp present `172.17.x` / `10.0.2.x`, which are not loopback).
 

--- a/pixlstash/authz/registry.py
+++ b/pixlstash/authz/registry.py
@@ -383,6 +383,19 @@ ROUTE_POLICIES: dict[tuple[str, str], RoutePolicy] = {
         _LOCAL,
         justification="§16.3 cancels an in-flight host-filesystem move; halting the owner's own file operation is the same authority as starting it; owner + loopback/LAN/Tailscale, or remote owner iff allow_remote_host_ops=true (§16.3.1)",
     ),
+    # ── model_imports.py (shelf plan B7; §16.3 host-capability) ────────────
+    # The listing walks a registered output root; the import writes into one
+    # registered folder and may unlink from another. Neither takes a host path:
+    # the import names a run *inside* a registered folder and the server joins
+    # and contains it.
+    ("GET", "/api/v1/model-folders/{folder_id}/runs"): RoutePolicy(
+        _LOCAL,
+        justification="§16.3 walks a registered ai-toolkit output root and reads every run folder and config under it — the same authority as model-folders/{folder_id}/rescan and reference-folders/detect-sidecars; owner + loopback/LAN/Tailscale, or remote owner iff allow_remote_host_ops=true (§16.3.1)",
+    ),
+    ("POST", "/api/v1/model-imports"): RoutePolicy(
+        _LOCAL,
+        justification="§16.3 copies a run's files into a registered host folder and, when the source folder carries delete_after_import, unlinks them from the output root — the same filesystem authority as POST /model-moves; owner + loopback/LAN/Tailscale, or remote owner iff allow_remote_host_ops=true (§16.3.1)",
+    ),
     # ── filesystem.py (§16.3 host-capability; Step-3 → LOCAL_OWNER_ONLY) ─────
     ("GET", "/api/v1/filesystem/browse"): RoutePolicy(
         _LOCAL,

--- a/pixlstash/routes/model_imports.py
+++ b/pixlstash/routes/model_imports.py
@@ -1,0 +1,348 @@
+"""Look at what a training run produced, then take it onto the shelf.
+
+Two routes, and the split between them is the whole point: **listing a run costs
+nothing and changes nothing.** ``GET /model-folders/{id}/runs`` reads filenames
+and one ``config.yaml`` per run — it does not hash, copy, move or write anything,
+so the card grid can be drawn for an entire output root before the user has
+decided about any of it. That property is what keeps face recognition and
+hashing out of the browsing path, and it must not be eroded by adding "just one"
+cheap-looking computation here.
+
+``POST /model-imports`` is the committing half, and it runs the same ordering as
+a move because it *is* a move with a row created rather than repointed: copy →
+verify by SHA-256 → register the row and commit → then unlink. The unlink only
+happens at all when the source folder carries ``delete_after_import``.
+
+**A run is addressed by name, not by path.** The body names a registered
+``source`` folder and a run *inside* it, and the server joins them, so no host
+path is ever taken from the caller. The join is contained: a run name that
+resolves outside its registered output root is refused rather than read.
+
+Authorization: both routes are `LOCAL_OWNER_ONLY`, declared in
+``pixlstash/authz/registry.py``. The listing walks a registered host path and
+reads every run under it, which is the same authority as
+``model-folders/{id}/rescan``; the import writes files into one registered folder
+and may unlink them from another, which is the ``model-moves`` authority.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Optional
+
+from fastapi import APIRouter, Body, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, Field
+
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services.model_mover import MoveRefused
+from pixlstash.services.run_importer import RunImporter
+from pixlstash.utils.aitoolkit_run import read_output_root
+from pixlstash.utils.path_utils import resolve_path_within
+
+logger = get_logger(__name__)
+
+SOURCE_FOLDER_KIND = "source"
+
+# One import at a time, for the same reason as one move at a time: both are
+# I/O-bound on one disk and both space-check the destination up front.
+_importing = threading.Lock()
+
+
+class RunSample(BaseModel):
+    """One preview image ai-toolkit rendered during the run."""
+
+    model_config = ConfigDict(extra="allow")
+
+    filename: str = Field(description="The sample's filename inside `samples/`.")
+    step: int = Field(description="Training step it was rendered at.")
+    index: int = Field(description="Which prompt, in the order ai-toolkit rendered.")
+
+
+class RunCheckpoint(BaseModel):
+    """One saved adapter file from the run."""
+
+    model_config = ConfigDict(extra="allow")
+
+    filename: str = Field(description="Filename inside the run folder.")
+    step: Optional[int] = Field(
+        default=None,
+        description=(
+            "Training step, or null for the bare final file that carries no step "
+            "in its name. A run with no bare final has an **unconfirmed cover**: "
+            "the highest step is the best available answer, not a certain one."
+        ),
+    )
+    size: Optional[int] = Field(default=None, description="Bytes on disk.")
+
+
+class RunResponse(BaseModel):
+    """One training run, described without importing, hashing or moving it."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(description="The run folder's own name.")
+    checkpoints: list[RunCheckpoint] = Field(default_factory=list)
+    samples: list[RunSample] = Field(
+        default_factory=list,
+        description="Previews, so a step can be judged before it is imported.",
+    )
+    base_model: Optional[str] = Field(
+        default=None,
+        description="`name_or_path` from the run's `config.yaml`, verbatim.",
+    )
+    trigger_words: list[str] = Field(default_factory=list)
+    rank: Optional[int] = Field(
+        default=None, description="`linear` from the config, when it records one."
+    )
+    config_error: Optional[str] = Field(
+        default=None,
+        description=(
+            "Why the config could not be read. The run is still importable "
+            "without it: steps and samples come from filenames."
+        ),
+    )
+
+
+class RunListResponse(BaseModel):
+    """Body of ``GET /model-folders/{folder_id}/runs``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    runs: list[RunResponse]
+
+
+class ImportRequest(BaseModel):
+    """Body of ``POST /model-imports``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_folder_id: int = Field(
+        description="A registered `source` folder — an ai-toolkit output root."
+    )
+    run_name: str = Field(
+        description=(
+            "A run inside that folder, as `GET .../runs` named it. A name, never "
+            "a path: the server joins it to the registered root and refuses "
+            "anything that resolves outside."
+        )
+    )
+    destination_folder_id: int = Field(
+        description="A registered folder the shelf catalogues. Never a `source` one."
+    )
+    steps: Optional[list[Optional[int]]] = Field(
+        default=None,
+        description=(
+            "Which checkpoints to take, by step, with `null` for the bare final. "
+            "Omit for the whole run."
+        ),
+    )
+
+
+class ImportedFile(BaseModel):
+    """What happened to one checkpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    filename: str
+    step: Optional[int] = None
+    status: str = Field(description="`imported`, `failed`, or `cancelled`.")
+    model_id: Optional[int] = Field(
+        default=None, description="The hub `model.id` the file landed on."
+    )
+    detail: Optional[str] = Field(default=None, description="Why, when it failed.")
+
+
+class ImportResponse(BaseModel):
+    """Body of ``POST /model-imports``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    run_name: str
+    stack_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "The `adapter_stack` the run's steps landed in, so the whole run "
+            "reads as one shelf row with an expandable step strip."
+        ),
+    )
+    deleted_source: bool = Field(
+        description=(
+            "Whether the run's own files were removed after each row was "
+            "committed. Follows the source folder's `delete_after_import`; the "
+            "unlink is always the last step, never the first."
+        )
+    )
+    files: list[ImportedFile] = Field(default_factory=list)
+
+
+def _to_run_response(run) -> RunResponse:
+    return RunResponse(
+        name=run.name,
+        checkpoints=[
+            RunCheckpoint(
+                filename=checkpoint.filename,
+                step=checkpoint.step,
+                size=_size_of(checkpoint.path),
+            )
+            for checkpoint in run.checkpoints
+        ],
+        samples=[
+            RunSample(filename=sample.filename, step=sample.step, index=sample.index)
+            for sample in run.samples
+        ],
+        base_model=run.base_model,
+        trigger_words=list(run.trigger_words),
+        rank=run.rank,
+        config_error=run.config_error,
+    )
+
+
+def _size_of(path: str) -> Optional[int]:
+    try:
+        return os.path.getsize(path)
+    except OSError as exc:
+        logger.warning(
+            "Could not stat run checkpoint %s: %s. Reporting it with no size "
+            "rather than dropping it from the run.",
+            path,
+            exc,
+        )
+        return None
+
+
+def create_router(server) -> APIRouter:
+    """Create the ai-toolkit import router.
+
+    Args:
+        server: The Server instance, for ``hub`` (the shelf tables) and ``auth``.
+
+    Returns:
+        The configured router.
+    """
+    router = APIRouter()
+
+    def _source_folder(folder_id: int) -> dict:
+        row = server.hub.fetchone(
+            "SELECT id, path, kind, delete_after_import FROM model_folder WHERE id = ?",
+            (folder_id,),
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Model folder not found.")
+        if row["kind"] != SOURCE_FOLDER_KIND:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "That folder is catalogued in place, not taken from. Only a "
+                    "`source` folder holds importable runs."
+                ),
+            )
+        return dict(row)
+
+    @router.get(
+        "/model-folders/{folder_id}/runs",
+        summary="List the training runs in an ai-toolkit output folder",
+        description=(
+            "Describes every run under a registered `source` folder: its steps, "
+            "its previews, and what its config says it was trained against. "
+            "**Nothing is hashed, copied, moved or written** — the whole card "
+            "grid can be drawn before the user decides about any of it."
+        ),
+        tags=["model_shelf"],
+        response_model=RunListResponse,
+    )
+    def list_runs(folder_id: int, request: Request):
+        server.auth.ensure_secure_when_required(request)
+        folder = _source_folder(folder_id)
+        try:
+            runs = read_output_root(folder["path"])
+        except (NotADirectoryError, OSError) as exc:
+            logger.warning(
+                "Could not list ai-toolkit output root %s (folder id=%s): %s",
+                folder["path"],
+                folder_id,
+                exc,
+            )
+            raise HTTPException(
+                status_code=409,
+                detail=f"Could not read {folder['path']}: {exc}",
+            ) from exc
+        return RunListResponse(runs=[_to_run_response(run) for run in runs])
+
+    @router.post(
+        "/model-imports",
+        summary="Import a training run onto the shelf",
+        description=(
+            "Copies the selected checkpoints into a folder the shelf catalogues "
+            "and registers them as one stack. Per file the order is copy, verify "
+            "by SHA-256, register the row and commit, and only then unlink — so "
+            "an interruption leaves a duplicate, never a row naming a file that "
+            "is gone. The run's own files are removed only when the source "
+            "folder carries `delete_after_import`."
+        ),
+        tags=["model_shelf"],
+        response_model=ImportResponse,
+    )
+    def import_run(request: Request, payload: ImportRequest = Body(...)):
+        server.auth.ensure_secure_when_required(request)
+        folder = _source_folder(payload.source_folder_id)
+        try:
+            # A name, joined to the registered root and contained: the caller
+            # never supplies a host path, and `../..` in a run name reads a
+            # folder nobody registered.
+            run_dir = resolve_path_within(folder["path"], payload.run_name)
+        except ValueError as exc:
+            logger.error(
+                "Refusing to import %r from %s: it resolves outside the "
+                "registered output root (%s).",
+                payload.run_name,
+                folder["path"],
+                exc,
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=f"{payload.run_name!r} is not a run inside that folder.",
+            ) from exc
+
+        delete_source = bool(folder["delete_after_import"])
+        if not _importing.acquire(blocking=False):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "An import is already running. Two at once would race for "
+                    "the free space each of them checked."
+                ),
+            )
+        try:
+            report = RunImporter(server.hub).import_run(
+                run_dir,
+                payload.destination_folder_id,
+                steps=payload.steps,
+                delete_source=delete_source,
+            )
+        except NotADirectoryError as exc:
+            raise HTTPException(
+                status_code=404, detail=f"No run named {payload.run_name!r}."
+            ) from exc
+        except MoveRefused as exc:
+            raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+        finally:
+            _importing.release()
+
+        return ImportResponse(
+            run_name=report.run_name,
+            stack_id=report.stack_id,
+            deleted_source=delete_source,
+            files=[
+                ImportedFile(
+                    filename=outcome.filename,
+                    step=outcome.step,
+                    status=outcome.status,
+                    model_id=outcome.model_id,
+                    detail=outcome.detail,
+                )
+                for outcome in report.outcomes
+            ],
+        )
+
+    return router

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -92,6 +92,7 @@ from pixlstash.routes.import_folders import (
 from pixlstash.routes.filesystem import create_router as create_filesystem_router
 from pixlstash.routes.libraries import create_router as create_libraries_router
 from pixlstash.routes.model_folders import create_router as create_model_folders_router
+from pixlstash.routes.model_imports import create_router as create_model_imports_router
 from pixlstash.routes.model_moves import create_router as create_model_moves_router
 from pixlstash.routes.model_shelf import create_router as create_model_shelf_router
 from pixlstash.routes.guest_scores import create_router as create_guest_scores_router
@@ -1463,6 +1464,11 @@ class Server(
         )
         self.api.include_router(
             create_model_moves_router(self),
+            prefix=API_V1_PREFIX,
+            dependencies=gate,
+        )
+        self.api.include_router(
+            create_model_imports_router(self),
             prefix=API_V1_PREFIX,
             dependencies=gate,
         )

--- a/pixlstash/services/model_mover.py
+++ b/pixlstash/services/model_mover.py
@@ -175,7 +175,7 @@ def same_device(source_path: str, destination_dir: str) -> bool:
     return os.stat(source_path).st_dev == os.stat(destination_dir).st_dev
 
 
-def _copy_and_digest(source_path: str, destination_path: str) -> str:
+def copy_and_digest(source_path: str, destination_path: str) -> str:
     """Copy the file and return the SHA-256 of the bytes that were *read*.
 
     One pass. Hashing the source in a separate read would double the cost of a
@@ -196,12 +196,70 @@ def _copy_and_digest(source_path: str, destination_path: str) -> str:
     return digest.hexdigest()
 
 
-def _digest(path: str) -> str:
+def file_digest(path: str) -> str:
     digest = hashlib.sha256()
     with open(path, "rb") as handle:
         while chunk := handle.read(_COPY_CHUNK_BYTES):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def unlink_source(source_path: str) -> None:
+    """The last step of a move or an import, and only ever the last step.
+
+    Its own function so the crash-window test has a seam to interrupt exactly
+    here — between a durable commit and the removal that commit authorises —
+    without patching ``os.unlink`` for the whole process.
+    """
+    os.unlink(source_path)
+
+
+def discard_partial(partial: str) -> None:
+    """Remove a copy that never verified. Never raises: the caller is already
+    reporting a failure and a cleanup error must not replace it."""
+    try:
+        os.unlink(partial)
+    except FileNotFoundError:
+        # The copy never got as far as creating it. Nothing to clean up.
+        logger.debug("No partial copy at %s to discard.", partial)
+    except OSError as exc:
+        logger.warning(
+            "Could not remove the partial copy %s: %s. It is inert — no row "
+            "names it and the scanner ignores it — but it is occupying disk.",
+            partial,
+            exc,
+        )
+
+
+def require_space(destination_path: str, bytes_to_copy: int) -> None:
+    """Check free space **before the first byte**, for the whole batch.
+
+    Per file would fill the disk and fail on file 1,500 of 1,806, having
+    already moved 1,499 — and there is no undo.
+    """
+    if bytes_to_copy <= 0:
+        return
+    try:
+        free = shutil.disk_usage(destination_path).free
+    except OSError as exc:
+        logger.error(
+            "Could not read free space on %s: %s. Refusing the move rather "
+            "than starting a copy that may not fit.",
+            destination_path,
+            exc,
+        )
+        raise MoveRefused(
+            f"Could not read free space on {destination_path}.",
+            status_code=507,
+        ) from exc
+    required = int(bytes_to_copy * _SPACE_HEADROOM)
+    if required > free:
+        raise MoveRefused(
+            f"Not enough space in {destination_path}: the move needs "
+            f"{required / 1024**3:.2f} GB including 10 % headroom and "
+            f"{free / 1024**3:.2f} GB is free. Nothing was moved.",
+            status_code=507,
+        )
 
 
 class ModelMover:
@@ -278,7 +336,7 @@ class ModelMover:
             moves.append(move)
 
         bytes_to_copy = sum(move.size for move in moves if not move.same_device)
-        self._require_space(destination_path, bytes_to_copy)
+        require_space(destination_path, bytes_to_copy)
         logger.info(
             "Planned a move of %d file(s) into %s: %d byte(s) to copy, %d rename(s).",
             len(moves),
@@ -338,6 +396,12 @@ class ModelMover:
         # Flattened to the basename: dropping a file onto a folder means "put it
         # in that folder", not "recreate three levels of somebody else's tree in
         # it". A collision is refused below, never silently overwritten.
+        #
+        # The containment that follows is therefore a sanitizer rather than the
+        # live guard — ``basename`` has already made an escape unreachable. The
+        # reachable containment on this path is the *source* one above, which
+        # governs the unlink and does have a test. This one stays because it
+        # becomes load-bearing the day the destination stops being flattened.
         destination_relpath = os.path.basename(relpath)
         try:
             resolved_destination = resolve_path_within(
@@ -409,37 +473,6 @@ class ModelMover:
             raise MoveRefused(
                 f"{destination_relpath} is registered to another model in the "
                 "destination folder. Rescan that folder first."
-            )
-
-    @staticmethod
-    def _require_space(destination_path: str, bytes_to_copy: int) -> None:
-        """Check free space **before the first byte**, for the whole batch.
-
-        Per file would fill the disk and fail on file 1,500 of 1,806, having
-        already moved 1,499 — and there is no undo.
-        """
-        if bytes_to_copy <= 0:
-            return
-        try:
-            free = shutil.disk_usage(destination_path).free
-        except OSError as exc:
-            logger.error(
-                "Could not read free space on %s: %s. Refusing the move rather "
-                "than starting a copy that may not fit.",
-                destination_path,
-                exc,
-            )
-            raise MoveRefused(
-                f"Could not read free space on {destination_path}.",
-                status_code=507,
-            ) from exc
-        required = int(bytes_to_copy * _SPACE_HEADROOM)
-        if required > free:
-            raise MoveRefused(
-                f"Not enough space in {destination_path}: the move needs "
-                f"{required / 1024**3:.2f} GB including 10 % headroom and "
-                f"{free / 1024**3:.2f} GB is free. Nothing was moved.",
-                status_code=507,
             )
 
     # -- execution --------------------------------------------------------
@@ -535,11 +568,11 @@ class ModelMover:
         """The invariant, in the only order that has no dangling-row window."""
         partial = move.destination_path + PARTIAL_SUFFIX
         try:
-            written = _copy_and_digest(move.source_path, partial)
+            written = copy_and_digest(move.source_path, partial)
             # Read the destination back. The source digest above proves what left;
             # only re-reading proves what arrived, which is the entire point of
             # verifying a copy rather than trusting the write.
-            arrived = _digest(partial)
+            arrived = file_digest(partial)
             if arrived != written:
                 raise OSError(
                     f"Copy of {move.source_path} verified as {arrived} but "
@@ -557,7 +590,7 @@ class ModelMover:
                 )
             os.replace(partial, move.destination_path)
         except OSError:
-            self._discard_partial(partial)
+            discard_partial(partial)
             raise
 
         # Durable before the unlink, and *only* then the unlink.
@@ -566,33 +599,8 @@ class ModelMover:
             return MoveOutcome(
                 move.source_folder_id, move.source_relpath, STATUS_COPIED
             )
-        self._unlink_source(move.source_path)
+        unlink_source(move.source_path)
         return MoveOutcome(move.source_folder_id, move.source_relpath, STATUS_MOVED)
-
-    @staticmethod
-    def _unlink_source(source_path: str) -> None:
-        """The last step, and only ever the last step.
-
-        Its own method so the crash-window test has a seam to interrupt exactly
-        here — between a durable commit and the removal it authorises — without
-        patching ``os.unlink`` for the whole process.
-        """
-        os.unlink(source_path)
-
-    @staticmethod
-    def _discard_partial(partial: str) -> None:
-        try:
-            os.unlink(partial)
-        except FileNotFoundError:
-            # The copy never got as far as creating it. Nothing to clean up.
-            logger.debug("No partial copy at %s to discard.", partial)
-        except OSError as exc:
-            logger.warning(
-                "Could not remove the partial copy %s: %s. It is inert — no row "
-                "names it and the scanner ignores it — but it is occupying disk.",
-                partial,
-                exc,
-            )
 
     def _repoint(
         self, move: PlannedMove, plan: MovePlan, *, delete_source: bool = True

--- a/pixlstash/services/run_importer.py
+++ b/pixlstash/services/run_importer.py
@@ -1,0 +1,429 @@
+"""Bring an ai-toolkit run onto the shelf, one checkpoint at a time.
+
+A ``kind='source'`` folder is an ai-toolkit output root: the scanner never
+catalogues it, because a run's steps are working output rather than a library of
+models. Importing is how a run's files stop being working output — they are
+brought into a folder the shelf *does* catalogue, and become ``model`` rows with
+a stack over them so the whole run reads as one shelf row with an expandable step
+strip.
+
+**The move invariant applies unchanged**, because an import is a move with one
+extra step: copy → verify by SHA-256 → register the row and commit → then unlink.
+The helpers are :mod:`pixlstash.services.model_mover`'s, not copies of them, so
+there is one implementation of the ordering and one place to get it wrong. The
+only difference is which row is written: a move *repoints* an existing
+``model_file``, an import *creates* the ``model`` and the ``model_file`` together,
+because the source was never catalogued and so has no row to repoint.
+
+``delete_after_import`` on the source folder decides whether the last step runs.
+Off (the default) the run's files stay where the trainer left them and the shelf
+holds a second copy; on, the run folder is emptied of the files that were taken.
+Either way the unlink is last, so an interruption leaves a duplicate.
+
+**Provenance is ``trained``, not ``external``.** Every other row on the shelf was
+found on disk by the scanner and says so; a run PixlStash imported from a trainer
+it can read is the one case where the shelf knows where the file came from.
+
+An interrupted import can leave an ``adapter_stack`` row with no members. It is
+inert — nothing reads a stack except through a ``model.stack_id`` pointing at it —
+so it is left rather than cleaned up by a rollback the rest of this module
+deliberately does not have.
+
+The stack mirrors ``PictureStack`` exactly, so nothing new is invented for
+presentation: ``stack_position`` 0 is the cover and is the **final** checkpoint
+when the run has a bare no-step file, or the highest step when it does not.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+from pixlstash.hub.db import HubDatabase
+from pixlstash.pixl_logging import get_logger
+from pixlstash.services.model_folder_scanner import STATE_PRESENT
+from pixlstash.services.model_mover import (
+    PARTIAL_SUFFIX,
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    MoveRefused,
+    copy_and_digest,
+    discard_partial,
+    file_digest,
+    require_space,
+    unlink_source,
+)
+from pixlstash.utils.adapter_header import FILE_ADAPTER, describe_adapter
+from pixlstash.utils.path_utils import resolve_path_within
+from pixlstash.utils.aitoolkit_run import Checkpoint, read_run
+
+logger = get_logger(__name__)
+
+# What an imported file's ``model.provenance`` says. The one value the scanner
+# never writes: it only ever finds files somebody else put there.
+PROVENANCE_TRAINED = "trained"
+
+STATUS_IMPORTED = "imported"
+
+
+@dataclass
+class ImportOutcome:
+    """What happened to one checkpoint of the run."""
+
+    filename: str
+    step: Optional[int]
+    status: str
+    model_id: Optional[int] = None
+    detail: Optional[str] = None
+
+
+@dataclass
+class ImportReport:
+    """What happened to the run."""
+
+    run_name: str
+    stack_id: Optional[int] = None
+    outcomes: list[ImportOutcome] = field(default_factory=list)
+    cancelled: bool = False
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _cover_first(checkpoints: list[Checkpoint]) -> list[Checkpoint]:
+    """Order a run's files so ``stack_position`` 0 is the right cover.
+
+    The bare no-step file is what the trainer wrote last and is the one a user
+    means by "the LoRA", so it leads. Without one — the run the fixtures call
+    *the unconfirmed cover* — the highest step is the best available answer, and
+    the rest follow newest first so expanding the strip reads backwards in time.
+    """
+    finals = [c for c in checkpoints if c.is_final]
+    stepped = sorted(
+        (c for c in checkpoints if not c.is_final),
+        key=lambda c: c.step or 0,
+        reverse=True,
+    )
+    return finals + stepped
+
+
+class RunImporter:
+    """Copy a run's checkpoints into a catalogued folder and register them."""
+
+    def __init__(self, hub: HubDatabase) -> None:
+        """Bind the importer to an open hub.
+
+        Args:
+            hub: The hub database. Only the model-shelf tables are touched.
+        """
+        self._hub = hub
+
+    def import_run(
+        self,
+        run_dir: str,
+        destination_folder_id: int,
+        *,
+        steps: Optional[list[Optional[int]]] = None,
+        delete_source: bool = False,
+        should_cancel: Optional[Callable[[], bool]] = None,
+        on_progress: Optional[Callable[[ImportOutcome], None]] = None,
+    ) -> ImportReport:
+        """Import the selected checkpoints of one run.
+
+        Args:
+            run_dir: The run folder, i.e. a child of a registered ``source``
+                folder. Contained against that folder by the caller.
+            destination_folder_id: A registered folder the shelf catalogues.
+            steps: Which checkpoints to take, by step, with ``None`` meaning the
+                bare final. Omit for every checkpoint in the run.
+            delete_source: Whether to unlink each file after its row is durably
+                committed. Comes from the source folder's
+                ``delete_after_import``; the unlink is always last.
+            should_cancel: Consulted between files. Nothing is rolled back.
+            on_progress: Called with each :class:`ImportOutcome`.
+
+        Returns:
+            An :class:`ImportReport`, with the stack the run landed in.
+
+        Raises:
+            MoveRefused: The destination is unusable, the run holds nothing to
+                import, a filename collides, or the copy would not fit. Nothing
+                has been written when this is raised.
+        """
+        destination = self._destination(destination_folder_id)
+        run = read_run(run_dir)
+        wanted = self._select(run.checkpoints, steps)
+        if not wanted:
+            raise MoveRefused(
+                f"{run.name} has no checkpoint to import"
+                + (f" at step(s) {steps}." if steps else "."),
+                status_code=404,
+            )
+
+        targets = self._resolve_targets(wanted, destination, destination_folder_id)
+        require_space(destination, sum(os.path.getsize(c.path) for c in wanted))
+
+        report = ImportReport(run_name=run.name)
+        report.stack_id = self._create_stack(run.name)
+        for position, checkpoint in enumerate(_cover_first(wanted)):
+            if should_cancel is not None and should_cancel():
+                report.cancelled = True
+                report.outcomes.append(
+                    ImportOutcome(
+                        checkpoint.filename, checkpoint.step, STATUS_CANCELLED
+                    )
+                )
+                continue
+            outcome = self._import_one(
+                checkpoint,
+                targets[checkpoint.path],
+                run=run,
+                stack_id=report.stack_id,
+                position=position,
+                destination_folder_id=destination_folder_id,
+                delete_source=delete_source,
+            )
+            report.outcomes.append(outcome)
+            if on_progress is not None:
+                on_progress(outcome)
+
+        logger.info(
+            "Imported %s into folder %s: %d file(s), stack %s%s.",
+            run.name,
+            destination_folder_id,
+            sum(1 for o in report.outcomes if o.status == STATUS_IMPORTED),
+            report.stack_id,
+            " (cancelled)" if report.cancelled else "",
+        )
+        return report
+
+    # -- planning ---------------------------------------------------------
+
+    def _destination(self, destination_folder_id: int) -> str:
+        row = self._hub.fetchone(
+            "SELECT path, kind FROM model_folder WHERE id = ?",
+            (destination_folder_id,),
+        )
+        if row is None:
+            raise MoveRefused("No such destination folder.", status_code=404)
+        if row["kind"] == "source":
+            raise MoveRefused(
+                "A source folder is where runs are taken from, never a place to "
+                "import them into."
+            )
+        if not os.path.isdir(row["path"]):
+            raise MoveRefused(
+                f"Destination folder {row['path']} is not a readable directory "
+                "right now, so nothing was imported.",
+                status_code=409,
+            )
+        return row["path"]
+
+    @staticmethod
+    def _select(
+        checkpoints: list[Checkpoint], steps: Optional[list[Optional[int]]]
+    ) -> list[Checkpoint]:
+        if steps is None:
+            return list(checkpoints)
+        wanted = set(steps)
+        return [c for c in checkpoints if c.step in wanted]
+
+    def _resolve_targets(
+        self,
+        checkpoints: list[Checkpoint],
+        destination: str,
+        destination_folder_id: int,
+    ) -> dict[str, str]:
+        """Contain and collision-check every destination before the first byte.
+
+        Same rule as the mover: refuse the batch rather than import half a run
+        and stop, because there is no undo for shelf operations.
+        """
+        targets: dict[str, str] = {}
+        for checkpoint in checkpoints:
+            relpath = os.path.basename(checkpoint.filename)
+            try:
+                # Containment (#776) on the write path. ``basename`` above has
+                # already flattened the name, and ``aitoolkit_run`` only ever
+                # produces ``scandir`` entry names, so today nothing can reach
+                # this check — it is a sanitizer, not the live guard. It stays
+                # because it becomes load-bearing the moment a second producer
+                # supplies a relpath, and because ``os.path.join`` silently
+                # discards the base for an absolute component.
+                target = resolve_path_within(destination, relpath)
+            except ValueError as exc:
+                raise MoveRefused(
+                    f"{relpath!r} would be written outside the destination folder."
+                ) from exc
+            if target in targets.values():
+                raise MoveRefused(
+                    f"Two files in {os.path.dirname(checkpoint.path)} would both "
+                    f"land on {relpath!r}."
+                )
+            if os.path.exists(target):
+                raise MoveRefused(
+                    f"{relpath} already exists in the destination folder. "
+                    "Nothing was imported."
+                )
+            if self._hub.fetchone(
+                "SELECT 1 FROM model_file WHERE model_folder_id = ? AND relpath = ?",
+                (destination_folder_id, relpath),
+            ):
+                raise MoveRefused(
+                    f"{relpath} is already registered in the destination folder. "
+                    "Rescan it first."
+                )
+            targets[checkpoint.path] = target
+        return targets
+
+    def _create_stack(self, name: str) -> int:
+        now = _utcnow()
+        with self._hub.transaction() as conn:
+            return int(
+                conn.execute(
+                    "INSERT INTO adapter_stack (name, created_at, updated_at) "
+                    "VALUES (?, ?, ?)",
+                    (name, now, now),
+                ).lastrowid
+            )
+
+    # -- one file ---------------------------------------------------------
+
+    def _import_one(
+        self,
+        checkpoint: Checkpoint,
+        target: str,
+        *,
+        run,
+        stack_id: int,
+        position: int,
+        destination_folder_id: int,
+        delete_source: bool,
+    ) -> ImportOutcome:
+        """copy → verify → register and commit → then unlink. No other order."""
+        partial = target + PARTIAL_SUFFIX
+        try:
+            written = copy_and_digest(checkpoint.path, partial)
+            if file_digest(partial) != written:
+                raise OSError(
+                    f"Copy of {checkpoint.path} did not verify; the copy was "
+                    "discarded and the original is untouched."
+                )
+            os.replace(partial, target)
+        except OSError as exc:
+            discard_partial(partial)
+            logger.error(
+                "Importing %s into %s failed: %s. The run's file is untouched.",
+                checkpoint.path,
+                target,
+                exc,
+                exc_info=True,
+            )
+            return ImportOutcome(
+                checkpoint.filename, checkpoint.step, STATUS_FAILED, detail=str(exc)
+            )
+
+        model_id = self._register(
+            target,
+            written,
+            checkpoint=checkpoint,
+            run=run,
+            stack_id=stack_id,
+            position=position,
+            destination_folder_id=destination_folder_id,
+        )
+        if delete_source:
+            unlink_source(checkpoint.path)
+        return ImportOutcome(
+            checkpoint.filename, checkpoint.step, STATUS_IMPORTED, model_id=model_id
+        )
+
+    def _register(
+        self,
+        target: str,
+        digest: str,
+        *,
+        checkpoint: Checkpoint,
+        run,
+        stack_id: int,
+        position: int,
+        destination_folder_id: int,
+    ) -> int:
+        """Write the content row and the location row in one transaction.
+
+        The header is parsed from the *destination* copy, which is the one the
+        row will name. ``ON CONFLICT(sha256)`` because a run imported twice, or a
+        file already on the shelf from somewhere else, is one model with two
+        locations — the shelf's whole content/location split. On that path the
+        curation already on the row is kept and only the run facts are filled in.
+
+        The run's own config supplies what the header often does not: 37 % of
+        real adapters record no base model at all, and ai-toolkit's
+        ``config.yaml`` names it exactly.
+        """
+        info = describe_adapter(target)
+        size = os.path.getsize(target)
+        mtime = os.stat(target).st_mtime_ns
+        now = _utcnow()
+        base_model = (info.base_model if info else None) or run.base_model
+        triggers = (info.trigger_words if info else None) or run.trigger_words
+        with self._hub.transaction() as conn:
+            conn.execute(
+                "INSERT INTO model (file_kind, kind, sha256, display_name, "
+                "filename, base_model, trigger_words, provenance, training_step, "
+                "param_count, file_size, stack_id, stack_position, run_key, "
+                "created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(sha256) DO UPDATE SET "
+                "display_name = COALESCE(model.display_name, excluded.display_name), "
+                "base_model = COALESCE(model.base_model, excluded.base_model), "
+                "trigger_words = COALESCE(model.trigger_words, excluded.trigger_words), "
+                "training_step = COALESCE(model.training_step, excluded.training_step), "
+                "stack_id = COALESCE(model.stack_id, excluded.stack_id), "
+                "stack_position = COALESCE(model.stack_position, excluded.stack_position), "
+                "run_key = COALESCE(model.run_key, excluded.run_key), "
+                "file_size = excluded.file_size",
+                (
+                    # An adapter, always: a training run's output is what it
+                    # trained, and the CHECK constraints demand a kind with it.
+                    FILE_ADAPTER,
+                    (info.kind if info else None) or "unknown",
+                    digest,
+                    run.name,
+                    os.path.basename(target),
+                    base_model,
+                    json.dumps(triggers) if triggers else None,
+                    PROVENANCE_TRAINED,
+                    checkpoint.step,
+                    info.param_count if info else None,
+                    size,
+                    stack_id,
+                    position,
+                    run.name,
+                    now,
+                ),
+            )
+            model_id = int(
+                conn.execute(
+                    "SELECT id FROM model WHERE sha256 = ?", (digest,)
+                ).fetchone()[0]
+            )
+            conn.execute(
+                "INSERT INTO model_file (model_id, model_folder_id, relpath, "
+                "state, seen_at, file_mtime) VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(model_folder_id, relpath) DO UPDATE SET "
+                "model_id = excluded.model_id, state = excluded.state, "
+                "seen_at = excluded.seen_at, file_mtime = excluded.file_mtime",
+                (
+                    model_id,
+                    destination_folder_id,
+                    os.path.basename(target),
+                    STATE_PRESENT,
+                    now,
+                    mtime,
+                ),
+            )
+        return model_id

--- a/tests/test_authz_host_capability_16_3.py
+++ b/tests/test_authz_host_capability_16_3.py
@@ -148,10 +148,10 @@ def test_loopback_owner_only_is_justification_required():
     assert ok == []
 
 
-def test_host_capability_tier_split_is_21_local_5_loopback():
+def test_host_capability_tier_split_is_23_local_5_loopback():
     """The loopback tier is the 4 host-shell GUI-spawn routes plus the e2e test
-    hook; the filesystem/folder routes stay LOCAL_OWNER_ONLY. 26 routes carry a
-    locality tier = 21 local + 5 loopback.
+    hook; the filesystem/folder routes stay LOCAL_OWNER_ONLY. 28 routes carry a
+    locality tier = 23 local + 5 loopback.
 
     History, so a future change to this number arrives with its reason: 16 = 13 +
     3 originally; 17 = 13 + 4 after CSO Condition 1 folded in
@@ -177,6 +177,14 @@ def test_host_capability_tier_split_is_21_local_5_loopback():
     that could produce them. The DELETE is the POST's authority from the other
     end.
 
+    28 = 23 + 5 later still, when the shelf's **ai-toolkit import** block joined
+    it: ``GET /model-folders/{folder_id}/runs`` and ``POST /model-imports``.
+    The listing walks a registered output root, which is ``rescan``'s authority;
+    the import writes into one registered folder and may unlink from the output
+    root, which is ``POST /model-moves``' authority. Neither takes a host path —
+    the import names a registered folder id and a run *name* — so they are on
+    this tier for what they do, not for what they accept.
+
     Arithmetic, not judgement."""
     loopback = {
         key
@@ -190,7 +198,7 @@ def test_host_capability_tier_split_is_21_local_5_loopback():
     }
     assert loopback == _LOOPBACK_ROUTE_KEYS, loopback
     assert len(loopback) == 5, sorted(loopback)
-    assert len(local) == 21, sorted(local)
+    assert len(local) == 23, sorted(local)
 
 
 # ===========================================================================

--- a/tests/test_model_move.py
+++ b/tests/test_model_move.py
@@ -205,11 +205,9 @@ def test_crash_after_the_commit_and_before_the_unlink_leaves_a_duplicate(
     the dangling row the shelf must never produce.
     """
     monkeypatch.setattr(
-        ModelMover,
-        "_unlink_source",
-        staticmethod(
-            lambda *args: (_ for _ in ()).throw(Crash("killed after the commit"))
-        ),
+        mover_module,
+        "unlink_source",
+        lambda *args: (_ for _ in ()).throw(Crash("killed after the commit")),
     )
     mover = ModelMover(two_folders["hub"])
     plan = mover.plan(
@@ -236,10 +234,10 @@ def test_the_steps_happen_in_the_only_safe_order(
     they interrupt; this one observes the whole sequence."""
     events: list[str] = []
 
-    original_copy = mover_module._copy_and_digest
-    original_digest = mover_module._digest
+    original_copy = mover_module.copy_and_digest
+    original_digest = mover_module.file_digest
     original_repoint = ModelMover._repoint
-    original_unlink = ModelMover._unlink_source
+    original_unlink = mover_module.unlink_source
 
     def traced_copy(source, destination):
         events.append("copy")
@@ -257,10 +255,10 @@ def test_the_steps_happen_in_the_only_safe_order(
         events.append("unlink")
         return original_unlink(path)
 
-    monkeypatch.setattr(mover_module, "_copy_and_digest", traced_copy)
-    monkeypatch.setattr(mover_module, "_digest", traced_digest)
+    monkeypatch.setattr(mover_module, "copy_and_digest", traced_copy)
+    monkeypatch.setattr(mover_module, "file_digest", traced_digest)
     monkeypatch.setattr(ModelMover, "_repoint", traced_repoint)
-    monkeypatch.setattr(ModelMover, "_unlink_source", staticmethod(traced_unlink))
+    monkeypatch.setattr(mover_module, "unlink_source", traced_unlink)
 
     mover = ModelMover(two_folders["hub"])
     plan = mover.plan(
@@ -329,9 +327,8 @@ def test_a_copy_that_does_not_verify_leaves_the_original_alone(
 ):
     """A bad write must cost the copy, never the original. The failure is
     reported per file and the source is still exactly where the row says."""
-    monkeypatch.setattr(
-        mover_module, "_digest", lambda path: "0" * 64
-    )  # the destination reads back as something else entirely
+    # The destination reads back as something else entirely.
+    monkeypatch.setattr(mover_module, "file_digest", lambda path: "0" * 64)
     mover = ModelMover(two_folders["hub"])
     report = mover.execute(
         mover.plan(

--- a/tests/test_model_run_import.py
+++ b/tests/test_model_run_import.py
@@ -1,0 +1,391 @@
+"""Importing an ai-toolkit run onto the shelf (shelf plan B7).
+
+An import is a move with the row created rather than repointed, so it runs the
+same ordering — copy → verify by SHA-256 → register and commit → then unlink —
+and the same crash window applies. The two interruption tests here are the
+import's half of the acceptance bar; the move's half is in
+``tests/test_model_move.py``, and both use the same ``BaseException`` trick so no
+error handler tidies up what a killed process would have left.
+
+What is specific to import and asserted here:
+
+* **the listing changes nothing.** ``read_output_root`` costs filenames and one
+  config per run, and the card grid is drawn from it before the user decides
+  about anything. A test pins that no bytes are hashed and no row appears.
+* **``delete_after_import`` decides only whether the last step runs.** Off, the
+  run keeps its files and the shelf holds a second copy; on, the run's file goes
+  — after the row is committed, never before.
+* **provenance is ``trained``**, the one value the scanner never writes.
+* **one stack per run**, cover first: the bare final leads, and a run with no
+  bare final falls back to its highest step (the fixtures' "unconfirmed cover").
+
+Environment: no ``Server``; a hub plus tmp directories. The route half lives in
+the warm ``tests/test_model_shelf_api.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import struct
+
+import pytest
+
+from pixlstash.hub.db import HubDatabase
+from pixlstash.services import model_mover as mover_module
+from pixlstash.services import run_importer as importer_module
+from pixlstash.services.model_mover import MoveRefused
+from pixlstash.services.run_importer import (
+    PROVENANCE_TRAINED,
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_IMPORTED,
+    RunImporter,
+)
+
+
+class Crash(BaseException):
+    """A process death. See the note in ``tests/test_model_move.py``."""
+
+
+@pytest.fixture
+def hub(tmp_path):
+    database = HubDatabase(str(tmp_path / "hub.db"))
+    yield database
+    database.close()
+
+
+def _tensor(shape):
+    return {"dtype": "F16", "shape": list(shape), "data_offsets": [0, 0]}
+
+
+def write_adapter(path, *, name=None, seed=b""):
+    """A header-only safetensors with LoRA markers, so it parses as an adapter."""
+    header = {f"blocks.{i}.lora_A.weight": _tensor([8, 16]) for i in range(2)}
+    header["blocks.0.lora_B.weight"] = _tensor([16, 8])
+    metadata = {"format": "pt"}
+    if name:
+        metadata["ss_output_name"] = name
+    header["__metadata__"] = metadata
+    blob = json.dumps(header).encode("utf-8")
+    # The seed goes in the payload, so two steps of one run are two different
+    # files. Without it every step would hash identically and `model.sha256`
+    # being UNIQUE would collapse the whole run into one row.
+    with open(path, "wb") as handle:
+        handle.write(struct.pack("<Q", len(blob)) + blob + seed)
+    return str(path)
+
+
+@pytest.fixture
+def run_folder(tmp_path):
+    """One ai-toolkit run: two steps, a bare final, a sample, and a config."""
+    output_root = tmp_path / "output"
+    run_dir = output_root / "Clementine"
+    (run_dir / "samples").mkdir(parents=True)
+    write_adapter(run_dir / "Clementine_000000250.safetensors", seed=b"step250")
+    write_adapter(run_dir / "Clementine_000000500.safetensors", seed=b"step500")
+    write_adapter(run_dir / "Clementine.safetensors", seed=b"final")
+    (run_dir / "samples" / "1712345678901__000000500_0.jpg").write_bytes(b"jpeg")
+    (run_dir / "config.yaml").write_text(
+        "config:\n"
+        "  process:\n"
+        "    - model:\n"
+        "        name_or_path: black-forest-labs/FLUX.1-dev\n"
+        "      trigger_word: clemntn\n"
+        "      network:\n"
+        "        linear: 32\n"
+    )
+    return output_root, run_dir
+
+
+@pytest.fixture
+def shelf(hub, tmp_path, run_folder):
+    """A registered source folder, a registered destination, and a run in it."""
+    output_root, run_dir = run_folder
+    destination_dir = tmp_path / "loras"
+    destination_dir.mkdir()
+    with hub.transaction() as conn:
+        source_id = int(
+            conn.execute(
+                "INSERT INTO model_folder (path, kind, owner, movable, "
+                "delete_after_import, created_at) VALUES (?, 'source', "
+                "'ai-toolkit', 'external', 0, '2026-08-09T00:00:00+00:00')",
+                (str(output_root),),
+            ).lastrowid
+        )
+        destination_id = int(
+            conn.execute(
+                "INSERT INTO model_folder (path, kind, movable, created_at) "
+                "VALUES (?, 'user', 'per_item', '2026-08-09T00:00:00+00:00')",
+                (str(destination_dir),),
+            ).lastrowid
+        )
+    return {
+        "hub": hub,
+        "output_root": output_root,
+        "run_dir": run_dir,
+        "destination_dir": destination_dir,
+        "source_id": source_id,
+        "destination_id": destination_id,
+    }
+
+
+def models(hub):
+    return {row["filename"]: row for row in hub.fetchall("SELECT * FROM model")}
+
+
+def assert_no_dangling_rows(hub):
+    dangling = [
+        os.path.join(row["path"], row["relpath"])
+        for row in hub.fetchall(
+            "SELECT f.path, mf.relpath FROM model_file mf "
+            "JOIN model_folder f ON f.id = mf.model_folder_id"
+        )
+        if not os.path.exists(os.path.join(row["path"], row["relpath"]))
+    ]
+    assert not dangling, f"model_file row(s) name files that do not exist: {dangling}"
+
+
+# ===========================================================================
+# The crash windows — the same invariant as a move
+# ===========================================================================
+
+
+def test_crash_after_the_copy_and_before_the_register_leaves_no_row(shelf, monkeypatch):
+    """Window 1. The bytes are at the destination and nothing claims them.
+
+    The run still has its own copy, because the unlink is last and the register
+    never happened. Residue: an unregistered file the destination folder's next
+    scan picks up as a normal adapter. Not a dangling row — there is no row.
+    """
+    monkeypatch.setattr(
+        RunImporter,
+        "_register",
+        lambda *args, **kwargs: (_ for _ in ()).throw(Crash("killed after the copy")),
+    )
+    with pytest.raises(Crash):
+        RunImporter(shelf["hub"]).import_run(
+            str(shelf["run_dir"]), shelf["destination_id"], delete_source=True
+        )
+
+    assert os.path.exists(shelf["run_dir"] / "Clementine.safetensors"), (
+        "the run's file was unlinked before its row was committed"
+    )
+    assert os.path.exists(shelf["destination_dir"] / "Clementine.safetensors")
+    assert models(shelf["hub"]) == {}
+    assert_no_dangling_rows(shelf["hub"])
+
+
+def test_crash_after_the_register_and_before_the_unlink_leaves_a_duplicate(
+    shelf, monkeypatch
+):
+    """Window 2. The bytes are at both paths and the row names the destination.
+
+    Reverse the register and the unlink and this becomes a committed row naming
+    a file that was deleted before anything recorded where its copy went.
+    """
+    # Patched on the importer, not on the mover: ``run_importer`` binds the
+    # helper by name at import time, so the mover's global is the wrong seam.
+    monkeypatch.setattr(
+        importer_module,
+        "unlink_source",
+        lambda *args: (_ for _ in ()).throw(Crash("killed after the commit")),
+    )
+    with pytest.raises(Crash):
+        RunImporter(shelf["hub"]).import_run(
+            str(shelf["run_dir"]), shelf["destination_id"], delete_source=True
+        )
+
+    assert os.path.exists(shelf["run_dir"] / "Clementine.safetensors")
+    assert os.path.exists(shelf["destination_dir"] / "Clementine.safetensors")
+    rows = models(shelf["hub"])
+    assert "Clementine.safetensors" in rows
+    assert_no_dangling_rows(shelf["hub"])
+
+
+def test_a_copy_that_does_not_verify_registers_nothing(shelf, monkeypatch):
+    monkeypatch.setattr(importer_module, "file_digest", lambda path: "0" * 64)
+    report = RunImporter(shelf["hub"]).import_run(
+        str(shelf["run_dir"]), shelf["destination_id"], delete_source=True
+    )
+
+    assert {outcome.status for outcome in report.outcomes} == {STATUS_FAILED}
+    assert models(shelf["hub"]) == {}
+    assert os.path.exists(shelf["run_dir"] / "Clementine.safetensors")
+    assert sorted(os.listdir(shelf["destination_dir"])) == []
+
+
+# ===========================================================================
+# What an import produces
+# ===========================================================================
+
+
+def test_a_run_lands_as_one_stack_with_the_final_as_its_cover(shelf):
+    report = RunImporter(shelf["hub"]).import_run(
+        str(shelf["run_dir"]), shelf["destination_id"]
+    )
+
+    assert [outcome.status for outcome in report.outcomes] == [STATUS_IMPORTED] * 3
+    rows = models(shelf["hub"])
+    assert set(rows) == {
+        "Clementine.safetensors",
+        "Clementine_000000500.safetensors",
+        "Clementine_000000250.safetensors",
+    }
+    assert {row["stack_id"] for row in rows.values()} == {report.stack_id}
+    # Cover first: the bare final is what a user means by "the LoRA".
+    assert rows["Clementine.safetensors"]["stack_position"] == 0
+    assert rows["Clementine_000000500.safetensors"]["stack_position"] == 1
+    assert rows["Clementine_000000250.safetensors"]["stack_position"] == 2
+    assert rows["Clementine_000000500.safetensors"]["training_step"] == 500
+    assert rows["Clementine.safetensors"]["training_step"] is None
+    assert_no_dangling_rows(shelf["hub"])
+
+
+def test_an_import_records_trained_provenance_and_the_config_base_model(shelf):
+    """``trained`` is the one provenance the scanner never writes, and the run's
+    config names a base model the header does not carry — 37 % of real adapters
+    record none at all."""
+    RunImporter(shelf["hub"]).import_run(str(shelf["run_dir"]), shelf["destination_id"])
+    row = models(shelf["hub"])["Clementine.safetensors"]
+    assert row["provenance"] == PROVENANCE_TRAINED
+    assert row["base_model"] == "black-forest-labs/FLUX.1-dev"
+    assert json.loads(row["trigger_words"]) == ["clemntn"]
+    assert row["run_key"] == "Clementine"
+    assert row["file_kind"] == "adapter"
+
+
+def test_delete_after_import_off_keeps_the_run_and_makes_a_second_copy(shelf):
+    """The default. The run stays where the trainer left it; the shelf holds a
+    copy. Two paths, and only one of them registered — which is fine, because the
+    output root is never catalogued."""
+    RunImporter(shelf["hub"]).import_run(
+        str(shelf["run_dir"]), shelf["destination_id"], delete_source=False
+    )
+    assert os.path.exists(shelf["run_dir"] / "Clementine.safetensors")
+    assert os.path.exists(shelf["destination_dir"] / "Clementine.safetensors")
+
+
+def test_delete_after_import_on_empties_the_run(shelf):
+    RunImporter(shelf["hub"]).import_run(
+        str(shelf["run_dir"]), shelf["destination_id"], delete_source=True
+    )
+    assert not os.path.exists(shelf["run_dir"] / "Clementine.safetensors")
+    assert os.path.exists(shelf["destination_dir"] / "Clementine.safetensors")
+    assert_no_dangling_rows(shelf["hub"])
+
+
+def test_selecting_steps_takes_only_those(shelf):
+    report = RunImporter(shelf["hub"]).import_run(
+        str(shelf["run_dir"]), shelf["destination_id"], steps=[None, 500]
+    )
+    assert len(report.outcomes) == 2
+    assert set(models(shelf["hub"])) == {
+        "Clementine.safetensors",
+        "Clementine_000000500.safetensors",
+    }
+    assert os.path.exists(shelf["run_dir"] / "Clementine_000000250.safetensors")
+
+
+def test_a_run_with_no_bare_final_covers_with_its_highest_step(shelf):
+    """The fixtures' *unconfirmed cover*: nothing says which step the user meant,
+    so the newest is the best available answer rather than a certain one."""
+    os.unlink(shelf["run_dir"] / "Clementine.safetensors")
+    RunImporter(shelf["hub"]).import_run(str(shelf["run_dir"]), shelf["destination_id"])
+    rows = models(shelf["hub"])
+    assert rows["Clementine_000000500.safetensors"]["stack_position"] == 0
+    assert rows["Clementine_000000250.safetensors"]["stack_position"] == 1
+
+
+# ===========================================================================
+# Refused before the first byte
+# ===========================================================================
+
+
+def test_a_source_folder_is_never_an_import_destination(shelf):
+    with pytest.raises(MoveRefused, match="taken from"):
+        RunImporter(shelf["hub"]).import_run(str(shelf["run_dir"]), shelf["source_id"])
+
+
+def test_a_run_with_nothing_selected_is_refused(shelf):
+    with pytest.raises(MoveRefused, match="no checkpoint to import"):
+        RunImporter(shelf["hub"]).import_run(
+            str(shelf["run_dir"]), shelf["destination_id"], steps=[9999]
+        )
+    assert os.listdir(shelf["destination_dir"]) == []
+
+
+def test_a_name_already_in_the_destination_is_refused_before_anything_copies(shelf):
+    """Refused as a batch: importing two of three steps and stopping is a
+    half-done operation with no undo."""
+    write_adapter(shelf["destination_dir"] / "Clementine.safetensors", seed=b"other")
+    with pytest.raises(MoveRefused, match="already exists"):
+        RunImporter(shelf["hub"]).import_run(
+            str(shelf["run_dir"]), shelf["destination_id"]
+        )
+    assert os.listdir(shelf["destination_dir"]) == ["Clementine.safetensors"]
+    assert models(shelf["hub"]) == {}
+
+
+def test_space_is_checked_before_the_first_byte(shelf, monkeypatch):
+    import shutil
+
+    monkeypatch.setattr(
+        mover_module.shutil,
+        "disk_usage",
+        lambda path: shutil._ntuple_diskusage(total=1, used=1, free=1),
+    )
+    with pytest.raises(MoveRefused) as excinfo:
+        RunImporter(shelf["hub"]).import_run(
+            str(shelf["run_dir"]), shelf["destination_id"]
+        )
+    assert excinfo.value.status_code == 507
+    assert os.listdir(shelf["destination_dir"]) == []
+
+
+def test_cancel_stops_the_queue_and_rolls_nothing_back(shelf):
+    seen: list = []
+
+    report = RunImporter(shelf["hub"]).import_run(
+        str(shelf["run_dir"]),
+        shelf["destination_id"],
+        delete_source=True,
+        should_cancel=lambda: bool(seen),
+        on_progress=seen.append,
+    )
+
+    assert report.cancelled is True
+    assert [outcome.status for outcome in report.outcomes] == [
+        STATUS_IMPORTED,
+        STATUS_CANCELLED,
+        STATUS_CANCELLED,
+    ]
+    # Not rolled back.
+    assert os.path.exists(shelf["destination_dir"] / "Clementine.safetensors")
+    assert not os.path.exists(shelf["run_dir"] / "Clementine.safetensors")
+    assert os.path.exists(shelf["run_dir"] / "Clementine_000000500.safetensors")
+    assert_no_dangling_rows(shelf["hub"])
+
+
+# ===========================================================================
+# Listing a run costs nothing
+# ===========================================================================
+
+
+def test_listing_runs_hashes_nothing_and_writes_nothing(shelf, monkeypatch):
+    """The property the whole card grid rests on: an output root can be browsed
+    without importing, hashing or moving anything."""
+    from pixlstash.utils.aitoolkit_run import read_output_root
+
+    def refuse(*args, **kwargs):
+        raise AssertionError("listing a run must not hash anything")
+
+    monkeypatch.setattr(hashlib, "sha256", refuse)
+    runs = read_output_root(str(shelf["output_root"]))
+
+    assert [run.name for run in runs] == ["Clementine"]
+    assert len(runs[0].checkpoints) == 3
+    assert runs[0].base_model == "black-forest-labs/FLUX.1-dev"
+    assert models(shelf["hub"]) == {}
+    assert os.listdir(shelf["destination_dir"]) == []

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -1359,3 +1359,187 @@ def test_remote_owner_is_refused_on_every_move_route_naming_the_flag(shelf_env):
             f"{method} {path} denied without naming the setting that enables it: "
             f"{r.text}"
         )
+
+
+# ===========================================================================
+# ai-toolkit import (B7) — the route, and both authz directions
+# ===========================================================================
+
+_IMPORT_ROUTES = (
+    ("GET", f"{API}/model-folders/1/runs", {}),
+    (
+        "POST",
+        f"{API}/model-imports",
+        {
+            "json": {
+                "source_folder_id": 1,
+                "run_name": "Clementine",
+                "destination_folder_id": 1,
+            }
+        },
+    ),
+)
+
+
+def _write_run_adapter(path, seed):
+    """A header-only safetensors with LoRA markers and a distinguishing payload."""
+    import struct
+
+    header = {f"blocks.{i}.lora_A.weight": _TENSOR for i in range(2)}
+    header["blocks.0.lora_B.weight"] = _TENSOR
+    header["__metadata__"] = {"format": "pt"}
+    blob = json.dumps(header).encode()
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob + seed)
+
+
+_TENSOR = {"dtype": "F16", "shape": [8, 16], "data_offsets": [0, 0]}
+
+
+@pytest.fixture
+def import_folders(shelf_env, tmp_path):
+    """A registered ai-toolkit output root with one run, and a destination."""
+    output_root = tmp_path / "output"
+    run_dir = output_root / "Clementine"
+    run_dir.mkdir(parents=True)
+    _write_run_adapter(run_dir / "Clementine.safetensors", b"final")
+    _write_run_adapter(run_dir / "Clementine_000000500.safetensors", b"step500")
+    destination_dir = tmp_path / "loras"
+    destination_dir.mkdir()
+
+    with shelf_env.server.hub.transaction() as conn:
+        source_id = int(
+            conn.execute(
+                "INSERT INTO model_folder (path, kind, owner, movable, "
+                "delete_after_import, created_at) VALUES (?, 'source', "
+                "'ai-toolkit', 'external', 0, '2026-08-09T00:00:00Z')",
+                (str(output_root),),
+            ).lastrowid
+        )
+        destination_id = int(
+            conn.execute(
+                "INSERT INTO model_folder (path, kind, movable, created_at) "
+                "VALUES (?, 'user', 'per_item', '2026-08-09T00:00:00Z')",
+                (str(destination_dir),),
+            ).lastrowid
+        )
+    return SimpleNamespace(
+        output_root=output_root,
+        run_dir=run_dir,
+        destination_dir=destination_dir,
+        source_id=source_id,
+        destination_id=destination_id,
+    )
+
+
+def test_every_import_route_is_declared_local_owner_only():
+    for method, path in (
+        ("GET", "/api/v1/model-folders/{folder_id}/runs"),
+        ("POST", "/api/v1/model-imports"),
+    ):
+        declared = ROUTE_POLICIES.get((method, path))
+        assert declared is not None, f"({method}, {path}) has no ROUTE_POLICIES entry"
+        assert declared.policy is AccessPolicy.LOCAL_OWNER_ONLY, (
+            f"{method} {path} declares {declared.policy}, not LOCAL_OWNER_ONLY"
+        )
+        assert declared.justification, f"{method} {path} is on the tier with no reason"
+
+
+def test_listing_runs_describes_them_without_importing_anything(
+    shelf_env, import_folders
+):
+    r = shelf_env.owner.get(f"{API}/model-folders/{import_folders.source_id}/runs")
+    assert r.status_code == 200, r.text
+    runs = r.json()["runs"]
+    assert [run["name"] for run in runs] == ["Clementine"]
+    assert len(runs[0]["checkpoints"]) == 2
+    # Nothing was taken: the card grid is drawn before any decision.
+    assert list(import_folders.destination_dir.iterdir()) == []
+    assert shelf_env.owner.get(f"{API}/adapters").json()["adapters"] != []
+
+
+def test_a_folder_that_is_catalogued_in_place_holds_no_runs(shelf_env, import_folders):
+    """A `user` folder is a library of models, not a place runs are taken from."""
+    r = shelf_env.owner.get(f"{API}/model-folders/{import_folders.destination_id}/runs")
+    assert r.status_code == 400, r.text
+
+
+def test_importing_a_run_registers_it_as_one_stack(shelf_env, import_folders):
+    r = shelf_env.owner.post(
+        f"{API}/model-imports",
+        json={
+            "source_folder_id": import_folders.source_id,
+            "run_name": "Clementine",
+            "destination_folder_id": import_folders.destination_id,
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert [f["status"] for f in body["files"]] == ["imported", "imported"]
+    assert body["deleted_source"] is False
+    assert body["stack_id"] is not None
+
+    # delete_after_import is off, so the run keeps its own copy.
+    assert (import_folders.run_dir / "Clementine.safetensors").exists()
+    assert (import_folders.destination_dir / "Clementine.safetensors").exists()
+
+    rows = {
+        row["filename"]: row
+        for row in shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+    }
+    cover = rows["Clementine.safetensors"]
+    assert cover["provenance"] == "trained"
+    assert cover["stack_position"] == 0
+    assert cover["member_count"] == 2
+
+
+def test_a_run_name_that_escapes_the_output_root_is_refused(shelf_env, import_folders):
+    """The body names a run, never a path. A name that resolves outside the
+    registered root is refused rather than read."""
+    r = shelf_env.owner.post(
+        f"{API}/model-imports",
+        json={
+            "source_folder_id": import_folders.source_id,
+            "run_name": "../../etc",
+            "destination_folder_id": import_folders.destination_id,
+        },
+    )
+    assert r.status_code == 400, r.text
+    assert list(import_folders.destination_dir.iterdir()) == []
+
+
+def test_import_routes_refuse_every_share_token(shelf_env):
+    for description, restriction in (
+        ("import scoped probe", {"resource_type": "character", "resource_id": 1}),
+        ("import unscoped probe", {}),
+    ):
+        token = _mint(shelf_env.owner, description, **restriction)
+        client = _bearer(shelf_env.server, token)
+        assert client.get(f"{API}/pictures").status_code == 200, (
+            f"{description} is dead; the refusals below would prove nothing"
+        )
+        for method, path, kwargs in _IMPORT_ROUTES:
+            assert_real_route(shelf_env.server.api, method, path)
+            r = client.request(method, path, **kwargs)
+            assert r.status_code == 403, (
+                f"{description} reached {method} {path}: {r.status_code} {r.text}"
+            )
+
+
+def test_local_owner_reaches_every_import_route(shelf_env):
+    for method, path, kwargs in _IMPORT_ROUTES:
+        for headers in ({}, _xff("192.168.1.9"), _xff("100.64.0.5")):
+            r = shelf_env.owner.request(method, path, headers=headers, **kwargs)
+            assert "restricted to local" not in r.text, (
+                f"{method} {path} from {headers or 'loopback'} was refused as "
+                f"non-local: {r.status_code} {r.text}"
+            )
+
+
+def test_remote_owner_is_refused_on_every_import_route_naming_the_flag(shelf_env):
+    for method, path, kwargs in _IMPORT_ROUTES:
+        r = shelf_env.owner.request(method, path, headers=_xff("8.8.8.8"), **kwargs)
+        assert r.status_code == 403, f"{method} {path}: {r.status_code} {r.text}"
+        assert "allow_remote_host_ops" in r.text, (
+            f"{method} {path} denied without naming the setting that enables it: "
+            f"{r.text}"
+        )


### PR DESCRIPTION
**B7, part 4 of 6 — the "import" half.** Base: #842. **Do not merge before the CSO sign-off.**

`RunImporter` plus two routes: `GET /api/v1/model-folders/{folder_id}/runs` and
`POST /api/v1/model-imports`.

**An import is a move with the row created rather than repointed**, so it runs
the same ordering — copy → verify by SHA-256 → register and commit → then
unlink — using **the mover's own helpers**, not copies of them. That is why this
PR also promotes `copy_and_digest` / `file_digest` / `unlink_source` /
`discard_partial` / `require_space` from `ModelMover` privates to module
functions in `model_mover.py`: a second caller reaching through a class is the
coupling that eventually produces a second implementation of the ordering.
Net behaviour change: none, and #841's tests are re-pointed at the new seams.

`tests/test_model_run_import.py` interrupts both windows again, for the import's
shape: crash after the copy and before the register (bytes at the destination,
no row claims them, the run keeps its own copy — no dangling row because there is
no row); crash after the register and before the unlink (bytes at both paths, the
row names the destination).

`delete_after_import` on the source folder decides only whether the last step
runs. Off (the default), the run keeps its files and the shelf holds a second
copy. Provenance is `trained`, the one value the scanner never writes. One
`adapter_stack` per run, cover first: the bare final leads, and a run without one
falls back to its highest step (the fixtures' "unconfirmed cover").

**Listing costs nothing and changes nothing** — a test pins that no bytes are
hashed and no row appears. That is what keeps the F6 card grid drawable for a
whole output root before any decision, and it is the property that must not be
eroded by adding one cheap-looking computation.

### Policy chosen (both `LOCAL_OWNER_ONLY`)

- `GET .../runs` — walks a registered output root and reads every run folder and
  `config.yaml` under it. Same authority as `model-folders/{id}/rescan` and
  `reference-folders/detect-sidecars`.
- `POST /model-imports` — writes into one registered folder and may unlink from
  the output root. Same authority as `POST /model-moves`.

**Neither takes a host path.** The import names a registered `source` folder id
and a run **name**, and the server joins them with `resolve_path_within`, so a
run name resolving outside the registered root is a 400 rather than a read.
They are on this tier for the authority they exercise, not for an input they
accept. `ROUTE_POLICIES` + coverage-matrix rows are in this PR; the §16.3 tally
goes to **`28 = 23 local + 5 loopback`**.

### Containment

The destination for each checkpoint resolves against the destination
`model_folder.path`; the run directory resolves against the registered output
root, and **that one is the live guard** (`../../etc` as a run name is refused,
mutation-tested). The per-file destination containment is a sanitizer, since the
filename is `basename()`-flattened first — the comment says so.

**Mutation-tested:** unlink before the register (both crash tests red);
verification skipped; run-name containment dropped; space checked after the copy;
cover ordering ignoring the bare final.

### Known residue, deliberately not "fixed"

An interrupted import can leave an `adapter_stack` row with no members. It is
inert (nothing reads a stack except through a `model.stack_id` pointing at it)
and cleaning it up would need the rollback this module deliberately does not
have. Documented in the module docstring.
