### PR TITLE
Stop the WorkPlanner thread dying quietly

### DIFF
--- a/docs/regular-tests.md
+++ b/docs/regular-tests.md
@@ -116,7 +116,7 @@ shrinks as automated coverage grows.
 | dragging files over the grid raises the import overlay; leaving clears it | A synthetic DataTransfer with a real JPEG File dispatched on the grid scroll wrapper raises the "Drop files here to import" overlay; dragleave clears it | ✅ |
 
 > ⚠️ **Drop → import completes is NOT automatable in this harness:**
-> `POST /pictures/import` returns 400 "Face worker is not running" and the e2e
+> `POST /pictures/import` returns 400 "Cannot import: …" (no face worker) and the e2e
 > backend boots with `disable_background_workers: true`. The import-completion
 > half of legacy §2 stays in the manual plan (Import & background processing)
 > until the harness grows a worker-enabled mode or a test hook.

--- a/pixlstash/routes/pictures/_import.py
+++ b/pixlstash/routes/pictures/_import.py
@@ -330,10 +330,13 @@ def register_routes(router, server):
         _MAX_ZIP_ENTRIES = 50_000  # max files inside a zip
         _MAX_ZIP_DECOMPRESSED_BYTES = 50 * 1024**3  # 50 GB total decompressed
 
-        if not server.vault.is_worker_running(TaskType.FACE_EXTRACTION):
+        face_worker_problem = server.vault.worker_unavailable_reason(
+            TaskType.FACE_EXTRACTION
+        )
+        if face_worker_problem:
             raise HTTPException(
                 status_code=400,
-                detail="Face worker is not running. Start it before import.",
+                detail=f"Cannot import: {face_worker_problem}.",
             )
 
         # The same fail-fast the staging path runs. Without it a project id that
@@ -1493,10 +1496,13 @@ def register_routes(router, server):
         staged_files: list[dict] = session["staged_files"]
         if not staged_files:
             raise HTTPException(status_code=400, detail="No staged files to import")
-        if not server.vault.is_worker_running(TaskType.FACE_EXTRACTION):
+        face_worker_problem = server.vault.worker_unavailable_reason(
+            TaskType.FACE_EXTRACTION
+        )
+        if face_worker_problem:
             raise HTTPException(
                 status_code=400,
-                detail="Face worker is not running. Start it before import.",
+                detail=f"Cannot import: {face_worker_problem}.",
             )
 
         # Re-validate the drop target at handoff (it may have been deleted/locked

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -1254,8 +1254,36 @@ class Vault:
         return future
 
     def is_worker_running(self, worker_type: TaskType) -> bool:
-        """Check if a specific worker is running."""
-        return bool(self._work_planner and self._work_planner.is_running())
+        """Whether *worker_type* will actually be scheduled right now.
+
+        Both conditions matter and used to be conflated: the planner thread has
+        to be alive, and a finder for this task type has to still be registered
+        with it. Ignoring the argument meant a dead planner and a detached
+        finder produced the same answer, and callers reported whichever symptom
+        they happened to name.
+        """
+        if not self._work_planner or not self._work_planner.is_running():
+            return False
+        return self._work_planner.has_finder(worker_type)
+
+    def worker_unavailable_reason(self, worker_type: TaskType) -> str | None:
+        """Why *worker_type* is not schedulable, or None when it is.
+
+        Callers that refuse a request need to say which of the two conditions
+        failed; "the worker is not running" reads as a configuration choice and
+        has sent every investigation of a dead planner thread down the wrong
+        path.
+        """
+        if not self._work_planner:
+            return "the background work planner was never started"
+        if not self._work_planner.is_running():
+            return (
+                "the background work planner thread is not alive (it was "
+                "stopped, or it died); restart the server"
+            )
+        if not self._work_planner.has_finder(worker_type):
+            return f"no {worker_type} finder is registered with the work planner"
+        return None
 
     def _is_worker_active(self, worker_type: TaskType) -> bool:
         if not self._work_planner or not self._work_planner.is_running():

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -16,6 +16,9 @@ class WorkPlanner:
     MIN_INTERVAL_S = 0.05
     MAX_INTERVAL_S = 10.0
     BACKOFF_FACTOR = 1.8
+    # How long stop() waits for the loop thread, and how long start() waits for
+    # a previous thread that is still winding down.
+    STOP_JOIN_TIMEOUT_S = 5.0
 
     @staticmethod
     def work_finders(
@@ -184,28 +187,90 @@ class WorkPlanner:
         # to run and confirmed it has nothing to do.
         self._finder_exhausted: dict[str, bool] = {}
         self._lock = threading.Lock()
+        # Serialises start()/stop() so a restart cannot interleave with a
+        # shutdown that is still joining the outgoing thread.
+        self._lifecycle_lock = threading.RLock()
 
     def start(self):
-        if self._thread is not None and self._thread.is_alive():
-            return
-        self._stop.clear()
-        self._wake.clear()
-        self._thread = threading.Thread(
-            target=self._run, name="WorkPlanner", daemon=True
-        )
-        self._thread.start()
-        logger.debug("WorkPlanner started with %s finders.", len(self._task_finders))
+        with self._lifecycle_lock:
+            previous = self._thread
+            if previous is not None and previous.is_alive():
+                if not self._stop.is_set():
+                    return
+                # A thread that is alive with _stop set is winding down from an
+                # earlier stop() whose bounded join expired. Returning here
+                # would leave _stop set and, once that thread notices it and
+                # exits, the planner permanently dead with is_running() having
+                # answered True at the moment it was asked. Wait it out instead.
+                logger.info(
+                    "WorkPlanner start() found the previous thread still "
+                    "shutting down; waiting for it before restarting."
+                )
+                previous.join(timeout=self.STOP_JOIN_TIMEOUT_S)
+                if previous.is_alive():
+                    raise RuntimeError(
+                        "WorkPlanner cannot restart: the previous loop thread "
+                        f"is still alive {self.STOP_JOIN_TIMEOUT_S}s after "
+                        "stop(). A finder is blocked; starting a second loop "
+                        "would double-submit work."
+                    )
+            self._stop.clear()
+            self._wake.clear()
+            self._thread = threading.Thread(
+                target=self._run, name="WorkPlanner", daemon=True
+            )
+            self._thread.start()
+        with self._lock:
+            finder_count = len(self._task_finders)
+        logger.debug("WorkPlanner started with %s finders.", finder_count)
 
     def stop(self):
-        self._stop.set()
-        self._wake.set()
-        if self._thread is not None:
-            self._thread.join(timeout=5)
-            if self._thread.is_alive():
-                logger.warning("WorkPlanner did not stop within timeout.")
+        with self._lifecycle_lock:
+            self._stop.set()
+            self._wake.set()
+            if self._thread is not None:
+                self._thread.join(timeout=self.STOP_JOIN_TIMEOUT_S)
+                if self._thread.is_alive():
+                    logger.warning("WorkPlanner did not stop within timeout.")
 
     def is_running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
+
+    def has_finder(self, task_type: "TaskType") -> bool:
+        """Whether a finder for *task_type* is still registered with the loop."""
+        with self._lock:
+            name = self._finder_name_by_task_type.get(task_type)
+            return bool(name) and name in self._task_finders_by_name
+
+    def detach_finders(self, task_types) -> set:
+        """Unregister the finders for *task_types* and return their names.
+
+        Supported replacement for reaching into `_task_finders` from a test
+        fixture: the planner keeps the finder set in three structures, all of
+        which have to stay consistent, and mutating them from another thread
+        used to race the loop's own read. Detached finders are marked exhausted
+        so a finder that `depends_on()` one of them is not blocked for ever
+        waiting for a report that will never come again.
+        """
+        removed = set()
+        with self._lock:
+            for task_type in task_types:
+                name = self._finder_name_by_task_type.pop(task_type, None)
+                if not name:
+                    continue
+                finder = self._task_finders_by_name.pop(name, None)
+                if finder is None:
+                    continue
+                self._task_finders = [f for f in self._task_finders if f is not finder]
+                self._finder_exhausted[name] = True
+                removed.add(name)
+            self._finder_order_idx = 0
+        return removed
+
+    def registered_finder_names(self) -> set:
+        """Names of the finders the loop will currently visit."""
+        with self._lock:
+            return set(self._task_finders_by_name)
 
     def inflight_count(self, finder_name: str) -> int:
         if not finder_name:
@@ -235,7 +300,8 @@ class WorkPlanner:
                     "GPU may be idle until next finder cycle.",
                     finder_name,
                 )
-            finder = self._task_finders_by_name.get(finder_name)
+            with self._lock:
+                finder = self._task_finders_by_name.get(finder_name)
             if finder is not None:
                 try:
                     finder.on_task_complete(task, error)
@@ -258,7 +324,20 @@ class WorkPlanner:
 
     def _run(self):
         while not self._stop.is_set():
-            submitted = self._run_finders_once()
+            try:
+                submitted = self._run_finders_once()
+            except Exception:
+                # Without this the exception unwinds the thread and the planner
+                # is simply gone: nothing schedules work again, is_running()
+                # answers False and every dependent caller reports its own
+                # unrelated symptom. Log it and keep cycling; the backoff below
+                # keeps a persistently failing cycle from spinning.
+                logger.exception(
+                    "WorkPlanner cycle raised; the planner keeps running. "
+                    "Finders registered: %s",
+                    sorted(self.registered_finder_names()),
+                )
+                submitted = False
 
             if submitted:
                 self._interval_s = self.MIN_INTERVAL_S
@@ -274,14 +353,23 @@ class WorkPlanner:
         logger.info("WorkPlanner stopped.")
 
     def _run_finders_once(self) -> bool:
-        if not self._task_finders:
+        # One immutable snapshot per cycle. The finder set is mutated from other
+        # threads (detach_finders), and indexing the live list against a length
+        # captured a moment earlier throws IndexError, which used to unwind the
+        # loop thread outright. A snapshot is taken rather than holding the lock
+        # across the loop because find_task() does database and filesystem work
+        # and must not block on_task_complete() for the length of it.
+        with self._lock:
+            finders = list(self._task_finders)
+            order_idx = self._finder_order_idx
+        if not finders:
             return False
 
         submitted_any = False
-        finder_count = len(self._task_finders)
+        finder_count = len(finders)
         for offset in range(finder_count):
-            idx = (self._finder_order_idx + offset) % finder_count
-            finder = self._task_finders[idx]
+            idx = (order_idx + offset) % finder_count
+            finder = finders[idx]
             finder_name = finder.finder_name()
             max_inflight = max(1, int(finder.max_inflight_tasks()))
 

--- a/tests/multi_project_authz/shared_env.py
+++ b/tests/multi_project_authz/shared_env.py
@@ -129,83 +129,34 @@ _PICTURE_BASELINE_COLUMNS = (
 _MISSING_PROJECT_PROBES = ("99999999", "NoSuchProjectHere")
 
 
-def _wait_for_planner_thread_to_exit(planner, timeout_s=60.0):
-    """Block until *planner*'s worker thread is really gone after ``stop()``.
-
-    ``WorkPlanner.stop()`` sets ``_stop``, joins with a **5 s timeout** and then
-    only *logs a warning* if the thread outlived it (``work_planner.py``). Both
-    things the caller does next are unsafe against that survivor, and neither
-    fails loudly:
-
-    * mutating ``_task_finders`` races the live ``_run_finders_once`` loop, which
-      indexes that list against a length it captured a moment earlier;
-    * ``start()`` returns early when ``_thread.is_alive()`` — *before* it reaches
-      ``self._stop.clear()``. The old thread then notices ``_stop`` and exits, so
-      the planner is left dead with ``_stop`` set for the rest of the module, and
-      ``is_running()`` was True at the moment it was asserted. The symptom
-      surfaces several tests later as a 503 from the staging-import endpoint,
-      which refuses while the workers are down.
-
-    So: wait for the thread to actually die, and fail here rather than let either
-    of those happen. A finder pass that is genuinely slow gets the extra time; a
-    hung one produces a message that names the cause.
-    """
-    deadline = time.time() + timeout_s
-    while planner.is_running() and time.time() < deadline:
-        time.sleep(0.1)
-    assert not planner.is_running(), (
-        f"the WorkPlanner thread was still alive {timeout_s}s after stop(). "
-        f"Editing its finder lists now would race the live loop, and start() "
-        f"would return early without clearing _stop, leaving the planner dead "
-        f"for the rest of the module and the staging-import tests answering 503"
-    )
-
-
 def _detach_volatile_finders(server):
     """Take `_VOLATILE_TASK_TYPES` out of the running WorkPlanner.
 
     The planner itself keeps running — the staging-import endpoint refuses while
-    the workers are down, and three tests here import — so this removes finders
-    rather than stopping the scheduler. `WorkPlanner.__init__` copies the finder
-    mapping into three of its own structures, so all three have to be pruned;
-    each removed finder is also marked exhausted so a dependent finder is not
-    left waiting forever for one that will never report again.
+    the face worker is down, and three tests here import — so this removes
+    finders rather than stopping the scheduler. `WorkPlanner.detach_finders`
+    edits the planner's three finder structures under the planner's own lock and
+    marks each removed finder exhausted, so a finder that `depends_on()` one of
+    them is not left waiting for a report that will never come.
+
+    This used to stop the planner, wait out its thread by hand and start it
+    again, because editing `_task_finders` under a live loop threw IndexError
+    there and killed the planner outright. That is fixed in the planner itself,
+    so the stop/wait/restart dance is gone.
     """
     planner = server.vault._work_planner
     finders = server.vault._planner_work_finders
-    names = set()
     for task_type in _VOLATILE_TASK_TYPES:
-        finder = finders.pop(task_type, None)
-        assert finder is not None, (
+        assert finders.pop(task_type, None) is not None, (
             f"{task_type} is not registered any more; this module's seeded rows "
             f"are only stable because it is detached — re-check the new finder set"
         )
-        names.add(finder.finder_name())
-
-    # Stop the scheduler before shortening its list. `_run_finders_once` reads
-    # `_task_finders[idx]` against a length it captured a moment earlier, so
-    # swapping the list under a live thread throws IndexError there and kills
-    # the planner outright — observed, not theoretical.
-    planner.stop()
-    _wait_for_planner_thread_to_exit(planner)
-    for task_type in _VOLATILE_TASK_TYPES:
-        planner._finder_name_by_task_type.pop(task_type, None)
-    planner._task_finders = [
-        finder for finder in planner._task_finders if finder.finder_name() not in names
-    ]
-    for name in names:
-        planner._task_finders_by_name.pop(name, None)
-        # A detached finder never reports "nothing to do" again, and a finder
-        # that depends_on() it would otherwise block for ever.
-        planner._finder_exhausted[name] = True
-    planner._finder_order_idx = 0
-    planner.start()
-    # The old thread is provably gone by now, so this is a *new* thread with
-    # `_stop` cleared, not the previous one still winding down.
-    assert planner.is_running() and not planner._stop.is_set(), (
-        "the WorkPlanner did not restart after detaching finders; the import "
+    removed = planner.detach_finders(_VOLATILE_TASK_TYPES)
+    assert planner.is_running(), (
+        "the WorkPlanner is not running after detaching finders; the import "
         "tests in this module need a live worker"
     )
+    return removed
 
 
 def _picture_baseline(server, picture_ids):

--- a/tests/test_picture_mutation_scope.py
+++ b/tests/test_picture_mutation_scope.py
@@ -145,8 +145,9 @@ def _quiesce_background_work(server):
     code against hand-made objects — so every finder goes, not a curated
     subset. The planner thread itself keeps running (a route that wakes it must
     still find it alive) and so does the task runner, so routes that submit
-    work directly are unaffected. Stopping the planner around the removal keeps
-    ``_run_finders_once`` from indexing a list that is shrinking underneath it.
+    work directly are unaffected. ``detach_finders`` edits the planner's finder
+    structures under the planner's own lock, so the loop no longer has to be
+    stopped around the removal.
 
     Waiting the pipeline out per test instead was measured slower than the
     per-test servers this replaces (PR #814), which is why it is switched off
@@ -156,14 +157,10 @@ def _quiesce_background_work(server):
     re-check before every test that they are still gone.
     """
     planner = server.vault._work_planner
-    planner.stop()
-    removed = set()
-    for task_type in list(server.vault._planner_work_finders):
-        finder = server.vault._planner_work_finders.pop(task_type)
-        planner._task_finders.remove(finder)
-        planner._task_finders_by_name.pop(finder.finder_name(), None)
-        removed.add(finder.finder_name())
-    planner.start()
+    task_types = list(server.vault._planner_work_finders)
+    for task_type in task_types:
+        server.vault._planner_work_finders.pop(task_type)
+    removed = planner.detach_finders(task_types)
 
     # Work already queued or running when the finders went is still ours to
     # wait for: it would otherwise write into the first test's freshly reset
@@ -299,10 +296,7 @@ def fresh_state(_shared_env):
     shared = _shared_env
     _reset_library(shared)
 
-    running = {
-        finder.finder_name()
-        for finder in shared.server.vault._work_planner._task_finders
-    }
+    running = shared.server.vault._work_planner.registered_finder_names()
     assert running.isdisjoint(shared.disabled_finders), (
         "a background finder that rewrites this module's fixture data is "
         f"running again: {sorted(running & shared.disabled_finders)}"

--- a/tests/test_reviews_api.py
+++ b/tests/test_reviews_api.py
@@ -71,22 +71,19 @@ def _disable_conflicting_backfill(server):
     reason twice.
 
     Only these finders go, and the planner keeps running: the import endpoint
-    refuses outright while the workers are down ("Face worker is not running")
-    and every fixture here imports pictures. Waiting the pipeline out instead
+    refuses outright while the face worker is down and every fixture here
+    imports pictures. Waiting the pipeline out instead
     (``tests.utils.wait_likeness_settled``, or a narrower poll on the columns)
     was tried and measured slower than the per-test servers this replaces.
 
     Returns the names of the finders it removed, so ``reset_library`` can
     re-check before every test that they are still gone.
     """
-    planner = server.vault._work_planner
-    removed = set()
     for task_type in _CONFLICTING_FINDERS:
-        finder = server.vault._planner_work_finders.pop(task_type)
-        planner._task_finders.remove(finder)
-        planner._task_finders_by_name.pop(finder.finder_name(), None)
-        removed.add(finder.finder_name())
-    return removed
+        server.vault._planner_work_finders.pop(task_type)
+    # detach_finders() edits the planner's finder structures under its own lock,
+    # so this is safe against the loop thread that is running right now.
+    return server.vault._work_planner.detach_finders(_CONFLICTING_FINDERS)
 
 
 def _tables_to_wipe(server):
@@ -189,7 +186,7 @@ def reset_library(env):
     # (which reviews, which pictures) rather than on counts or status codes,
     # because a review that failed to clear and a review that was refused look
     # identical from a status code.
-    running = {f.finder_name() for f in server.vault._work_planner._task_finders}
+    running = server.vault._work_planner.registered_finder_names()
     assert running.isdisjoint(env.disabled_finders), (
         "a backfill finder that rewrites this module's fixture data is running "
         f"again: {sorted(running & env.disabled_finders)}"

--- a/tests/test_work_planner.py
+++ b/tests/test_work_planner.py
@@ -1,3 +1,9 @@
+import time
+
+import pytest
+
+from pixlstash.tasks import TaskType
+from pixlstash.vault import Vault
 from pixlstash.work_planner import WorkPlanner
 
 
@@ -88,6 +94,256 @@ def test_runner_stop_race_is_quiet_during_planner_shutdown():
     assert planner._run_finders_once() is False
     assert planner.inflight_count("TestFinder") == 0
     assert planner._finder_by_task_id == {}
+
+
+class _IdleFinder:
+    """A finder that never has work, so the loop just cycles over it."""
+
+    def __init__(self, name: str, find_delay_s: float = 0.0):
+        self._name = name
+        self._find_delay_s = find_delay_s
+
+    def finder_name(self) -> str:
+        return self._name
+
+    def max_inflight_tasks(self) -> int:
+        return 1
+
+    def depends_on(self) -> list:
+        return []
+
+    def find_task(self):
+        if self._find_delay_s:
+            time.sleep(self._find_delay_s)
+        return None
+
+    def on_task_complete(self, task, error):
+        return None
+
+    def on_all_tasks_complete(self):
+        return None
+
+
+class _NullRunner:
+    def submit(self, task):
+        return getattr(task, "id", None)
+
+
+def _stopped(planner):
+    planner._stop.set()
+    planner._wake.set()
+    if planner._thread is not None:
+        planner._thread.join(timeout=10)
+
+
+def test_finder_removed_mid_cycle_does_not_kill_the_loop():
+    """The finder list may shrink while ``_run_finders_once`` is walking it.
+
+    Module fixtures detach backfill finders from a live planner. The loop used
+    to capture ``len(self._task_finders)`` and then index the live list, so a
+    removal in between raised ``IndexError`` inside the planner thread, which
+    died with no report — and every later import answered "Face worker is not
+    running", naming a condition that was not the problem.
+    """
+    victim = _IdleFinder("Victim")
+    planner = WorkPlanner(task_runner=_NullRunner(), task_finders=[])
+
+    def shrink_then_report():
+        planner._task_finders.remove(victim)
+        return None
+
+    shrinker = _IdleFinder("Shrinker")
+    shrinker.find_task = shrink_then_report
+    planner._task_finders = [shrinker, victim]
+
+    assert planner._run_finders_once() is False
+
+
+def test_planner_thread_survives_concurrent_finder_mutation(caplog):
+    """The live loop and a mutating fixture must not race to an IndexError.
+
+    Asserts on the cycle staying clean, not only on the thread staying up: the
+    top-level guard in ``_run`` would otherwise absorb the IndexError and hide
+    the fact that whole finder passes are being lost to it.
+    """
+    # The small find_task() delay is load-bearing: it releases the GIL inside
+    # the cycle, which is what lets the mutating thread land between the loop's
+    # length read and its index. Real finders do database work there.
+    finders = [_IdleFinder(f"F{i}", find_delay_s=0.001) for i in range(6)]
+    planner = WorkPlanner(task_runner=_NullRunner(), task_finders=list(finders))
+    planner.MIN_INTERVAL_S = 0.0
+    planner.MAX_INTERVAL_S = 0.0
+
+    deaths = []
+    real_run = planner._run
+
+    def watched_run():
+        try:
+            real_run()
+        except BaseException as exc:  # noqa: BLE001 - the point of the test
+            deaths.append(exc)
+            raise
+
+    planner._run = watched_run
+    planner.start()
+    try:
+        # Deliberately the unlocked in-place edit the existing module fixtures
+        # perform, so the loop stays safe against callers that have not moved to
+        # detach_finders() yet.
+        victim = finders[-1]
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and planner.is_running():
+            planner._task_finders.remove(victim)
+            planner._task_finders.append(victim)
+        assert planner.is_running(), f"planner thread died: {deaths}"
+        assert deaths == []
+        assert "WorkPlanner cycle raised" not in caplog.text, (
+            "the loop raised while the finder list was being edited"
+        )
+    finally:
+        _stopped(planner)
+
+
+def test_a_raising_finder_does_not_silently_kill_the_planner(caplog):
+    """A cycle that raises must be reported and the loop must keep running."""
+
+    class _ExplodingFinder(_IdleFinder):
+        def find_task(self):
+            raise RuntimeError("finder blew up")
+
+    planner = WorkPlanner(
+        task_runner=_NullRunner(), task_finders=[_ExplodingFinder("Boom")]
+    )
+    planner.MIN_INTERVAL_S = 0.01
+    planner.MAX_INTERVAL_S = 0.01
+    planner.start()
+    try:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and "finder blew up" not in caplog.text:
+            time.sleep(0.05)
+        assert planner.is_running(), "the planner thread died on a finder exception"
+        assert "finder blew up" in caplog.text, "the failure was never reported"
+    finally:
+        _stopped(planner)
+
+
+def test_restart_after_a_slow_stop_leaves_the_planner_alive():
+    """``start()`` must not hand back a planner that is about to go dead.
+
+    ``stop()`` joins with a bounded timeout and only logs when the thread
+    outlives it. ``start()`` used to return early on ``is_alive()`` *before*
+    clearing ``_stop``, so the survivor exited a moment later and left the
+    planner permanently dead with ``is_running()`` having answered True at the
+    instant it was asserted.
+    """
+    slow = _IdleFinder("Slow", find_delay_s=1.0)
+    planner = WorkPlanner(task_runner=_NullRunner(), task_finders=[slow])
+    planner.STOP_JOIN_TIMEOUT_S = 0.2
+    planner.start()
+    try:
+        time.sleep(0.05)
+        planner.stop()
+        assert planner.is_running(), (
+            "this test needs a stop() whose join times out; the finder returned "
+            "too quickly to reproduce the race"
+        )
+
+        planner.STOP_JOIN_TIMEOUT_S = 10.0
+        planner.start()
+        assert not planner._stop.is_set()
+        assert planner.is_running()
+
+        time.sleep(1.5)
+        assert planner.is_running(), (
+            "the planner went dead after the outgoing thread finished winding down"
+        )
+    finally:
+        _stopped(planner)
+
+
+def test_start_refuses_to_run_two_loops_over_a_wedged_thread():
+    """A finder that never returns must fail loudly, not double-schedule."""
+    wedged = _IdleFinder("Wedged", find_delay_s=30.0)
+    planner = WorkPlanner(task_runner=_NullRunner(), task_finders=[wedged])
+    planner.STOP_JOIN_TIMEOUT_S = 0.2
+    planner.start()
+    try:
+        time.sleep(0.05)
+        planner.stop()
+        with pytest.raises(RuntimeError, match="cannot restart"):
+            planner.start()
+    finally:
+        _stopped(planner)
+
+
+def test_detach_finders_prunes_every_structure_and_marks_exhausted():
+    """The supported replacement for reaching into the planner's private lists."""
+    face = _IdleFinder("FaceFinder")
+    tagger = _IdleFinder("TagFinder")
+    planner = WorkPlanner(
+        task_runner=_NullRunner(),
+        task_finders={
+            TaskType.FACE_EXTRACTION: face,
+            TaskType.TAGGER: tagger,
+        },
+    )
+
+    assert planner.has_finder(TaskType.TAGGER)
+    removed = planner.detach_finders([TaskType.TAGGER])
+
+    assert removed == {"TagFinder"}
+    assert planner.registered_finder_names() == {"FaceFinder"}
+    assert planner._task_finders == [face]
+    assert not planner.has_finder(TaskType.TAGGER)
+    assert planner.has_finder(TaskType.FACE_EXTRACTION)
+    # A detached finder never reports "nothing to do" again, so anything that
+    # depends_on() it would block for ever unless it counts as exhausted.
+    assert planner._finder_exhausted["TagFinder"] is True
+    assert planner.detach_finders([TaskType.TAGGER]) == set(), "detach is idempotent"
+
+
+class _VaultWorkerProbe:
+    """Just the two Vault methods under test, over a planner we control.
+
+    Building a real ``Vault`` costs a Server; these two methods only read the
+    planner, so binding them to a stub keeps the check in this fast module.
+    """
+
+    is_worker_running = Vault.is_worker_running
+    worker_unavailable_reason = Vault.worker_unavailable_reason
+
+    def __init__(self, work_planner):
+        self._work_planner = work_planner
+
+
+def test_is_worker_running_answers_per_worker_type():
+    """It used to ignore its argument, so a detached finder read as healthy."""
+    planner = WorkPlanner(
+        task_runner=_NullRunner(),
+        task_finders={
+            TaskType.FACE_EXTRACTION: _IdleFinder("FaceFinder"),
+            TaskType.TAGGER: _IdleFinder("TagFinder"),
+        },
+    )
+    vault = _VaultWorkerProbe(planner)
+    planner.start()
+    try:
+        assert vault.is_worker_running(TaskType.FACE_EXTRACTION)
+        assert vault.worker_unavailable_reason(TaskType.FACE_EXTRACTION) is None
+
+        planner.detach_finders([TaskType.TAGGER])
+        # The planner is still alive, so the old implementation said yes here.
+        assert not vault.is_worker_running(TaskType.TAGGER)
+        assert "TAGGER" in str(vault.worker_unavailable_reason(TaskType.TAGGER))
+        assert vault.is_worker_running(TaskType.FACE_EXTRACTION), (
+            "detaching one finder must not refuse the others"
+        )
+    finally:
+        _stopped(planner)
+
+    # A dead planner and a detached finder must not read the same any more.
+    assert not vault.is_worker_running(TaskType.FACE_EXTRACTION)
+    assert "not alive" in vault.worker_unavailable_reason(TaskType.FACE_EXTRACTION)
 
 
 class _StubDatabase:


### PR DESCRIPTION
Three defects in `WorkPlanner`'s thread-safety and lifecycle. They all surfaced
as the same misleading 400 from import — "Face worker is not running" — which is
why this is one PR rather than three.

## Defect 1 — `_task_finders` read unlocked

`_run_finders_once` captured `len(self._task_finders)` and then indexed the
**live** list, so a fixture detaching a finder from another thread produced
`IndexError` inside the planner thread, which died with no report.

**Reproduced before the fix** (6 finders, one thread cycling, one thread
removing/re-adding a finder):

```
=== DEFECT 1: unlocked _task_finders read ===
planner thread died: IndexError: list index out of range
planner thread alive after mutation loop: False
```

**Chose a per-cycle snapshot, not a held lock.** `find_task()` does database and
filesystem work; holding `_lock` across the loop would block `on_task_complete()`
and `inflight_count()` for the length of a finder pass. The snapshot is a `list()`
copy so it is also safe against callers that still mutate the list in place.

Audited every access: `_task_finders` at `__init__`, `start()`'s log line, and the
three loop reads; `_task_finders_by_name` at `__init__` and `on_task_complete`
(now locked). All non-`__init__` reads are under `_lock`.

Also added `detach_finders()` / `has_finder()` / `registered_finder_names()` as
the supported mutation API, and migrated the three fixtures that were reaching
into the private lists (`test_reviews_api`, `test_picture_mutation_scope`,
`multi_project_authz/shared_env`). That deletes the hand-rolled
`_wait_for_planner_thread_to_exit` ritual entirely.

## Defect 2 — `is_worker_running` ignored its argument

It now answers per worker type (planner alive **and** a finder registered for
that type), mirroring `_is_worker_active`. Callers checked: only
`routes/pictures/_import.py:333` and `:1499`, both `FACE_EXTRACTION`. No suite
detaches `FACE_EXTRACTION` and then imports (`test_picture_mutation_scope`
detaches everything, but its only upload runs before the detach), so nothing
newly refuses.

The message is fixed too, via a new `Vault.worker_unavailable_reason()`: the
route now says *which* condition failed instead of naming a configuration
choice that was never the problem.

## Defect 3 — the restart race

`stop()` joins with a bounded timeout and only logs if the thread survives;
`start()` returned early on `is_alive()` **before** `_stop.clear()`, so a slow
survivor exited a moment later and left the planner permanently dead.

**Reproduced before the fix** (a finder blocking past the join):

```
stop() returned after 5.0s, thread alive=True
immediately after start(): running=True stop_set=True
after the old thread finished: running=False stop_set=True
```

**`stop()`'s semantics are unchanged** — still best-effort, still bounded, still
warns. The whole fix is in `start()`, which now waits the survivor out and raises
if it is still wedged after another join. Production callers of the pair:

| caller | effect |
|---|---|
| `vault.py:337` / `vault.py:598` | start-once / shutdown; unaffected |
| `services/restore/full_restore.py:374` / `:736` | **real production instance of this bug** — full restore stops the planner, swaps the database, and restarts it in a `finally`. A finder mid-query when the swap began could easily outlive the 5 s join, and the vault came back from restore with a dead planner |
| `tests/test_server.py:326` / `:366` | shared-server wipe; now waits instead of restarting into a corpse |

The `RuntimeError` on a genuinely wedged thread is deliberate: it is louder than
returning a planner that will be dead a second later, and starting a second loop
would double-submit work.

## No silent deaths

`_run` now has a top-level guard that logs the exception with the registered
finder set and keeps cycling. This was the through-line of all three defects: a
dead planner thread and a downstream caller reporting an unrelated symptom.

## Verification

Every fix mutation-tested (reverted, confirmed red):

| mutation | result |
|---|---|
| snapshot reverted | `IndexError: list index out of range`; both tests red 3/3 |
| `start()` restart fix reverted | `assert not planner._stop.is_set()` → `assert not True`; `DID NOT RAISE RuntimeError` |
| `_run` guard reverted | `assert planner.is_running()` → `assert False` |
| `detach_finders` exhausted marking reverted | red |
| `is_worker_running` back to ignoring its arg | `assert not is_worker_running(TaskType.TAGGER)` → `assert not True` |

Suites: `tests/test_work_planner.py` 15/15; `test_reviews_api.py` +
`test_picture_mutation_scope.py` + `multi_project_authz/` 129/129;
`test_restore.py` + `test_server.py` 118/118. `test_reviews_api.py` looped 12x.

No new test file, so no `ci.yml` change — the new tests go into the existing
`tests/test_work_planner.py`, which is already gated.