### PR TITLE
Unbreak the durations-map guardrail on develop

### DIFF
--- a/tests/test_ci_shards.py
+++ b/tests/test_ci_shards.py
@@ -249,18 +249,25 @@ DEFERRED_FROM_GATE = frozenset(
 # tolerated, so the hole is a decision instead of a silent gap. Repo-relative
 # paths here rather than bare names, because the gate also runs a subdirectory.
 #
-# EMPTY, which is the intended end state. It held 28 of 119 gated files (24%)
-# when the balance guardrail below still built its node list from the map's own
-# keys and was therefore structurally blind to exactly those files, reporting a
-# perfect 1.000 ratio over data that did not contain a quarter of the gate.
-# Regenerating the map from a real gate run recorded all 119, so there is
-# nothing left to acknowledge.
+# Empty is the intended end state. It held 28 of 119 gated files (24%) when the
+# balance guardrail below still built its node list from the map's own keys and
+# was therefore structurally blind to exactly those files, reporting a perfect
+# 1.000 ratio over data that did not contain a quarter of the gate. Regenerating
+# the map from a real gate run recorded all 119.
+#
+# One has since come back. #832 gated test_security_supported_versions.py, and
+# #838 regenerated the map from a CI run at `develop @ a66d8b99`, which predates
+# it. Each PR was green against a base that did not yet contain the other, and
+# they merged out of order, so the gate has run red on develop ever since. The
+# next durations refresh records the file and this entry then has to come out.
 #
 # Leave the mechanism in place. The list is self-cleaning in both directions: a
 # newly gated file that nobody recorded fails the guardrail until it is listed
 # here, and an entry the map has since learned about fails it until it is
 # removed. Both halves have to exist for either to work.
-UNRECORDED_IN_DURATIONS_MAP: frozenset[str] = frozenset()
+UNRECORDED_IN_DURATIONS_MAP: frozenset[str] = frozenset(
+    {"tests/test_security_supported_versions.py"}
+)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## The bug

`tests/test_ci_shards.py::test_recorded_durations_actually_balance_the_gate` is
red on `develop` right now, so one of the eight `backend` shards fails on every
PR for a reason unrelated to that PR. Seven green shards make it read as flaky
noise.

`tests/test_security_supported_versions.py` was gated by #832. #838 regenerated
`tests/ci_test_durations.json` from CI run 31312307563 at `develop @ a66d8b99`,
which predates the gating. `UNRECORDED_IN_DURATIONS_MAP` was `frozenset()`, so
the gated-but-untimed file had nothing to acknowledge it.

Root cause of the class is a stale base, not the map: #832 (93a2ca4f) and #838
(f9ac55dd) were each green against a base that did not yet contain the other,
and merged out of order. Neither PR's gate could see the combination it created.

## The fix

Add the one path to `UNRECORDED_IN_DURATIONS_MAP` with the reason. This is the
designed escape hatch: the two guardrails beside it already assert the set names
only files the gate runs and only files the map does not yet time, so the entry
fails loudly once the next durations refresh records the file.

No map regeneration, no shard-count change.

## Not done: pinning `record-test-durations.yml` to the harvested SHA

Checked and deliberately skipped. The harvested SHA here is `a66d8b99`, which is
seven first-parent merges *older* than the gating commit, so pinning the
checkout to it would move the pre-push guardrail backwards and make it blinder,
not sharper. The workflow also resolves the run SHA in step 3, after the
checkout in step 1, so this is not a one-line `ref:` addition. If we want to
close the class, "Require branches to be up to date before merging" on `develop`
is the lever.

## Verification

Before (guardrail reverted):

```
E  AssertionError: These gated test files have no recorded durations:
   ['tests/test_security_supported_versions.py']. ...
1 failed in 0.15s
```

After:

```
$ ~/.venv/bin/python -m pytest -q tests/test_ci_shards.py --fast-captions --force-cpu
135 passed in 40.47s
```

`ruff format` and `ruff check` clean.
