### PR TITLE
Release claimed picture ids on every exit path

### DIFF
--- a/pixlstash/task_runner.py
+++ b/pixlstash/task_runner.py
@@ -400,17 +400,7 @@ class TaskRunner:
                     break
                 if isinstance(queued_task, _StopTask):
                     continue
-                try:
-                    queued_task.on_cancel()
-                except Exception as exc:
-                    logger.warning(
-                        "Task %s (%s) cancel hook failed: %s",
-                        queued_task.id,
-                        queued_task.type,
-                        exc,
-                    )
-                queued_task.status = TaskStatus.CANCELLED
-                queued_task.completed_at = datetime.now(UTC)
+                self._cancel_queued_task(queued_task, "drained from the queue")
                 cancelled += 1
         logger.debug(
             "TaskRunner %s: cancelled %d pending task(s).", self._name, cancelled
@@ -465,18 +455,7 @@ class TaskRunner:
                     break
                 if isinstance(queued_task, _StopTask):
                     continue
-                try:
-                    queued_task.on_cancel()
-                except Exception as exc:
-                    logger.warning(
-                        "Task %s (%s) cancel hook failed: %s",
-                        queued_task.id,
-                        queued_task.type,
-                        exc,
-                    )
-                queued_task.status = TaskStatus.CANCELLED
-                queued_task.completed_at = datetime.now(UTC)
-                queued_task._done_event.set()
+                self._cancel_queued_task(queued_task, "runner stopped")
 
         # Cancel tasks that are currently executing so their loops can exit early.
         with self._active_task_lock:
@@ -581,18 +560,7 @@ class TaskRunner:
                 continue
 
             if self._stop.is_set():
-                try:
-                    task.on_cancel()
-                except Exception as exc:
-                    logger.warning(
-                        "Task %s (%s) cancel hook failed after stop: %s",
-                        task.id,
-                        task.type,
-                        exc,
-                    )
-                task.status = TaskStatus.CANCELLED
-                task.completed_at = datetime.now(UTC)
-                task._done_event.set()
+                self._cancel_queued_task(task, "runner stopped before the task ran")
                 continue
 
             logger.debug(
@@ -706,17 +674,55 @@ class TaskRunner:
                     task.status,
                     elapsed_s,
                 )
-                callbacks = list(self._on_task_complete_callbacks)
-                for callback in callbacks:
-                    try:
-                        callback(task, error)
-                    except Exception as callback_exc:
-                        logger.warning(
-                            "Task completion callback failed for %s: %s",
-                            task.id,
-                            callback_exc,
-                        )
+                self._fire_task_complete_callbacks(task, error)
         logger.debug("TaskRunner %s stopped.", self._name)
+
+    def _fire_task_complete_callbacks(
+        self, task: BaseTask, error: Optional[BaseException]
+    ):
+        for callback in list(self._on_task_complete_callbacks):
+            try:
+                callback(task, error)
+            except Exception as callback_exc:
+                logger.warning(
+                    "Task completion callback failed for %s (%s): %s",
+                    task.id,
+                    task.type,
+                    callback_exc,
+                )
+
+    def _cancel_queued_task(self, task: BaseTask, reason: str):
+        """Cancel a task that will never run and release everything it holds.
+
+        The completion callbacks are the only path that gives a task's resources
+        back: ``BaseTaskFinder.on_task_complete`` discards its claimed picture
+        ids and ``WorkPlanner.on_task_complete`` frees its in-flight slot. They
+        used to fire only from the worker's ``finally``, so a task cancelled off
+        the queue kept both for the life of the process — the finder then sat at
+        max in-flight for ever, every finder that ``depends_on()`` it starved,
+        and the claimed pictures could never be selected again.
+
+        Args:
+            task: The task being cancelled; it has been taken off its queue.
+            reason: Why it was cancelled, for the log and the callback error.
+        """
+        try:
+            task.on_cancel()
+        except Exception as exc:
+            logger.warning(
+                "Task %s (%s) cancel hook failed (%s): %s",
+                task.id,
+                task.type,
+                reason,
+                exc,
+            )
+        task.status = TaskStatus.CANCELLED
+        task.completed_at = datetime.now(UTC)
+        task._done_event.set()
+        self._fire_task_complete_callbacks(
+            task,
+            TaskCancelledError(f"Task {task.id} ({task.type}) cancelled: {reason}"),
+        )
 
 
 class _StopTask(BaseTask):

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -481,19 +481,34 @@ class WorkPlanner:
         error = RuntimeError(
             f"Task {task_id} was dropped before submission: {reason}",
         )
+        released = True
         try:
             finder.on_task_complete(task, error)
         except Exception as exc:
+            released = False
             logger.warning(
                 "Finder %s failed to release the claims of dropped task %s: %s",
                 finder_name,
                 task_id,
                 exc,
             )
-        logger.debug(
-            "WorkPlanner dropped task id=%s from finder=%s and released its "
-            "claims (%s).",
-            task_id,
-            finder_name,
-            reason,
-        )
+        # Two messages, because one that always claimed the claims were released
+        # would be at its most misleading in the one failure this helper exists
+        # to surface: a finder whose `on_task_complete` raised still holds the
+        # ids, and those pictures are refused until the process restarts.
+        if released:
+            logger.debug(
+                "WorkPlanner dropped task id=%s from finder=%s and released its "
+                "claims (%s).",
+                task_id,
+                finder_name,
+                reason,
+            )
+        else:
+            logger.debug(
+                "WorkPlanner dropped task id=%s from finder=%s (%s); its claims "
+                "were NOT released — see the warning above.",
+                task_id,
+                finder_name,
+                reason,
+            )

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -408,6 +408,9 @@ class WorkPlanner:
                 # found after shutdown has begun and the runner may already be
                 # stopped by Vault.stop().
                 if self._stop.is_set():
+                    self._release_unsubmitted(
+                        finder, task, "the planner stopped before it could submit"
+                    )
                     return submitted_any
 
                 task_id = getattr(task, "id", None)
@@ -420,7 +423,7 @@ class WorkPlanner:
 
                 try:
                     submitted_task_id = self._task_runner.submit(task)
-                except Exception:
+                except Exception as submit_exc:
                     with self._lock:
                         current_inflight = int(
                             self._inflight_by_finder.get(finder_name, 0)
@@ -431,6 +434,9 @@ class WorkPlanner:
                         )
                         if task_id:
                             self._finder_by_task_id.pop(task_id, None)
+                    self._release_unsubmitted(
+                        finder, task, f"submit() raised: {submit_exc}"
+                    )
                     # Close the remaining race between the stop check above and
                     # TaskRunner.submit(). A stopped runner is expected during
                     # vault teardown; any submission failure while still live
@@ -456,3 +462,38 @@ class WorkPlanner:
         if not submitted_any:
             self._finder_order_idx = (self._finder_order_idx + 1) % finder_count
         return submitted_any
+
+    def _release_unsubmitted(self, finder, task, reason: str):
+        """Hand a task the planner will never submit back to its finder.
+
+        ``find_task()`` has already claimed the batch's picture ids and
+        ``on_task_complete()`` is the only thing that discards them, so a task
+        dropped between finding and submitting leaks its claims for the life of
+        the process and those pictures can never be selected again.
+
+        Args:
+            finder: The finder that produced *task* and holds its claims.
+            task: The task that will not be submitted.
+            reason: Why it was dropped, for the log and the finder's error.
+        """
+        task_id = getattr(task, "id", None)
+        finder_name = finder.finder_name()
+        error = RuntimeError(
+            f"Task {task_id} was dropped before submission: {reason}",
+        )
+        try:
+            finder.on_task_complete(task, error)
+        except Exception as exc:
+            logger.warning(
+                "Finder %s failed to release the claims of dropped task %s: %s",
+                finder_name,
+                task_id,
+                exc,
+            )
+        logger.debug(
+            "WorkPlanner dropped task id=%s from finder=%s and released its "
+            "claims (%s).",
+            task_id,
+            finder_name,
+            reason,
+        )

--- a/tests/test_work_planner.py
+++ b/tests/test_work_planner.py
@@ -1,9 +1,13 @@
 import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 
+from pixlstash.task_runner import TaskRunner
 from pixlstash.tasks import TaskType
+from pixlstash.tasks.base_task import BaseTask
+from pixlstash.tasks.base_task_finder import BaseTaskFinder
 from pixlstash.vault import Vault
 from pixlstash.work_planner import WorkPlanner
 
@@ -316,6 +320,147 @@ def test_detach_finders_prunes_every_structure_and_marks_exhausted():
     # depends_on() it would block for ever unless it counts as exhausted.
     assert planner._finder_exhausted["TagFinder"] is True
     assert planner.detach_finders([TaskType.TAGGER]) == set(), "detach is idempotent"
+
+
+class _ClaimedTask(BaseTask):
+    """A real task carrying the ``picture_ids`` the release path reads."""
+
+    def __init__(self, picture_ids):
+        super().__init__(task_type="ClaimedTask", params={"picture_ids": picture_ids})
+
+    def _run_task(self):
+        return None
+
+
+class _ClaimingFinder(BaseTaskFinder):
+    """A real finder, so the claim bookkeeping under test is the real one."""
+
+    def __init__(self, picture_ids):
+        super().__init__()
+        self._picture_ids = list(picture_ids)
+        self.last_task = None
+
+    def finder_name(self) -> str:
+        return "ClaimingFinder"
+
+    def find_task(self):
+        candidates = [SimpleNamespace(id=pid) for pid in self._picture_ids]
+        selected = self._filter_and_claim(candidates, len(candidates))
+        if not selected:
+            return None
+        self.last_task = _ClaimedTask([picture.id for picture in selected])
+        return self.last_task
+
+
+def test_a_task_cancelled_off_the_queue_releases_its_claims():
+    """A cancelled task must give back its slot and its picture ids.
+
+    ``cancel_pending_tasks()`` used to drain the queues without firing the
+    completion callbacks, which are the only path that discards claims and
+    decrements the in-flight count. One full restore therefore pinned the
+    tagger finder at max in-flight for the life of the process, starved every
+    finder that ``depends_on()`` it, and left the claimed pictures permanently
+    unselectable.
+    """
+    runner = TaskRunner(name="cancel-claims-test", num_workers=1)
+    finder = _ClaimingFinder([1, 2, 3])
+    planner = WorkPlanner(task_runner=runner, task_finders=[finder])
+    runner.add_task_complete_callback(planner.on_task_complete)
+
+    try:
+        # The workers are deliberately not started, so the task can only leave
+        # the queue through the cancel path.
+        assert planner._run_finders_once() is True
+        assert planner.inflight_count("ClaimingFinder") == 1
+        assert finder._claimed_picture_ids == {1, 2, 3}
+
+        assert runner.cancel_pending_tasks() == 1
+
+        assert finder._claimed_picture_ids == set()
+        assert planner.inflight_count("ClaimingFinder") == 0
+        assert planner._finder_by_task_id == {}
+
+        # And the finder can pick the same work up again.
+        assert planner._run_finders_once() is True
+        assert finder._claimed_picture_ids == {1, 2, 3}
+    finally:
+        runner.stop()
+
+
+def test_stop_between_find_and_submit_releases_the_claims():
+    """``find_task()`` claims before the planner decides not to submit."""
+    runner = _FastCompleteRunner()
+    finder = _ClaimingFinder([4, 5])
+    planner = WorkPlanner(task_runner=runner, task_finders=[finder])
+    submitted_tasks = []
+    runner.on_submit = submitted_tasks.append
+
+    real_find_task = finder.find_task
+
+    def find_then_stop():
+        task = real_find_task()
+        planner._stop.set()
+        return task
+
+    finder.find_task = find_then_stop
+
+    assert planner._run_finders_once() is False
+    assert submitted_tasks == []
+    assert planner.inflight_count("ClaimingFinder") == 0
+    assert finder._claimed_picture_ids == set()
+
+
+def test_a_failed_submit_releases_the_claims():
+    """The submit-raised handler unwound its own bookkeeping but not the claims."""
+    finder = _ClaimingFinder([6, 7])
+    planner = None
+
+    class _StoppingRunner:
+        def submit(self, task):
+            planner._stop.set()
+            raise RuntimeError("TaskRunner test is stopped.")
+
+    planner = WorkPlanner(task_runner=_StoppingRunner(), task_finders=[finder])
+
+    assert planner._run_finders_once() is False
+    assert planner.inflight_count("ClaimingFinder") == 0
+    assert planner._finder_by_task_id == {}
+    assert finder._claimed_picture_ids == set()
+
+
+def test_a_completed_task_releases_its_claims_exactly_once():
+    """The positive control: the happy path still releases, and only once."""
+    runner = TaskRunner(name="complete-claims-test", num_workers=1)
+    finder = _ClaimingFinder([8, 9])
+    releases = []
+    real_on_task_complete = finder.on_task_complete
+
+    def counting_on_task_complete(task, error):
+        releases.append((task.id, error))
+        real_on_task_complete(task, error)
+
+    finder.on_task_complete = counting_on_task_complete
+    planner = WorkPlanner(task_runner=runner, task_finders=[finder])
+    runner.add_task_complete_callback(planner.on_task_complete)
+    runner.start()
+    try:
+        assert planner._run_finders_once() is True
+        task = finder.last_task
+        assert task._done_event.wait(timeout=10.0), "the task never completed"
+        # The callbacks fire after the worker sets the done event.
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not releases:
+            time.sleep(0.01)
+
+        assert releases == [(task.id, None)], (
+            f"expected exactly one release with no error, got {releases}"
+        )
+        assert finder._claimed_picture_ids == set()
+        assert planner.inflight_count("ClaimingFinder") == 0
+    finally:
+        runner.stop()
+
+    assert releases == [(task.id, None)], "stop() released the task a second time"
 
 
 class _VaultWorkerProbe:


### PR DESCRIPTION
Closes review findings F2 (CRITICAL) and F7 (HIGH) from `develop-2026-08-09`.

## The bug class

`BaseTaskFinder.on_task_complete()` is the only thing that discards a task's
claimed picture ids, and `WorkPlanner.on_task_complete()` is the only thing
that frees its in-flight slot. Both hang off `TaskRunner`'s completion
callbacks, which fired **only** from the worker's `finally`. Every path where a
task never runs therefore leaked both, permanently.

**F2.** `cancel_pending_tasks()` drained the queues, called the no-op
`on_cancel()`, stamped CANCELLED and returned. One full restore
(`full_restore.py:378` stop + cancel) left `_inflight_by_finder["MissingTagFinder"]`
pinned at max for the life of the process; `start()` clears only `_stop` and
`_wake`, so the restart at :736 did not heal it. The four finders that
`depends_on(TaskType.TAGGER)` starved with it, and the claimed picture ids were
un-selectable in the restored library.

**F7.** Two planner paths dropped a task whose ids `_filter_and_claim` had
already claimed: the `if self._stop.is_set(): return` after a successful
`find_task()`, and the `submit()` raised handler (which unwound
`_inflight_by_finder` and `_finder_by_task_id` but not the claims).

## The fix

One cancel path in `TaskRunner`. `_cancel_queued_task(task, reason)` runs the
cancel hook, stamps CANCELLED, sets the done event and fires the completion
callbacks with a `TaskCancelledError`, so every registered finder's release path
runs exactly as it does for a failed task. It replaces the three hand-rolled
copies: `cancel_pending_tasks()`, `stop()`'s drain, and the post-stop branch in
the worker's dequeue loop (a third leak site the review did not name, same
class). `stop()`'s *active*-task loop is untouched, since those tasks reach the
worker `finally` on their own.

Both callbacks were checked against a task that never ran:
`Vault._on_task_completed` returns immediately on a non-None error, and
`WorkPlanner.on_task_complete` only does bookkeeping.

In the planner, `_release_unsubmitted(finder, task, reason)` hands a task that
will not be submitted back to its finder with an explanatory error, at both
early-return sites.

Side effect worth naming: `cancel_pending_tasks()` now sets `_done_event`, as
`stop()` always did, so a `submit_and_wait()` caller gets `TaskCancelledError`
instead of blocking to its timeout.

## Tests

Four new tests in the already-gated `tests/test_work_planner.py`, built on a
real `BaseTaskFinder` and a real `TaskRunner` so the claim bookkeeping under
test is the production one:

- a task cancelled off the queue releases its claims, drops to zero in-flight,
  and the finder submits the same work again;
- the stop-between-find-and-submit path leaves `_claimed_picture_ids` empty;
- the submit-raised path leaves `_claimed_picture_ids` empty;
- positive control: a normally-completing task releases exactly once, with no
  second release from `stop()`.

**Mutation evidence.** Three one-line reverts applied together (drop the
callback fan-out in `_cancel_queued_task`; drop each `_release_unsubmitted`
call) turned exactly the three matching tests red, one per mutation, with the
other 16 still green. Restored, and all 19 pass.

`ruff format` + `ruff check pixlstash` clean.
`tests/test_work_planner.py tests/test_reviews_api.py tests/test_picture_mutation_scope.py tests/test_restore.py`: 184 passed.