### PR TITLE
Keep the planner sweeping when a finder raises

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -824,6 +824,12 @@ Snapshot: id, kind, created_at, relative_path,
 - **`TaskRunner`** — executes tasks from CPU and GPU queues. CPU queue is multi-threaded (`NUM_WORKERS` per `worker_config.py`); GPU queue is serialised to avoid CUDA contention.
 - **`WorkPlanner`** — polls each finder, respects `*_MAX_INFLIGHT` limits, applies adaptive backoff when no work is found.
 
+**Release is unconditional.** A task's claimed picture ids and its in-flight slot are given back only by the `TaskRunner` completion callbacks, so *every* path that ends a task fires them, not just the worker's `finally`: `TaskRunner._cancel_queued_task` is the single cancel path (used by `cancel_pending_tasks()`, `stop()`'s drain and the worker's post-stop dequeue) and passes a `TaskCancelledError`, and `WorkPlanner._release_unsubmitted` hands back a task the planner found but decided not to submit. Anything that skips this wedges the finder at max in-flight for the life of the process and makes the claimed pictures permanently un-selectable — `start()` does not heal it.
+
+**A raising finder costs only its own turn.** The planner catches per finder, not per cycle, so one failing `find_task()` is logged and skipped while the rest of the sweep continues; only shutdown abandons a cycle.
+
+**`on_all_tasks_complete()` fires from either edge.** "Exhausted and idle" can be entered by the last task completing *or* by the finder reporting no more work, whichever happens second. `WorkPlanner._claim_drain` is armed on submit and claimed under `_lock` by whichever edge sees the condition first, so the drain (a GPU session teardown for `MissingTagFinder`) is announced exactly once per burst and is not announced over a task that has just been taken.
+
 ### Registered tasks
 
 | Task | Queue | Finder | Purpose |

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -10,6 +10,14 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+class _PlannerStopping(Exception):
+    """Raised inside a finder's turn when shutdown began part-way through it.
+
+    Distinguishes "abandon the whole cycle" from the finder failures the cycle
+    is meant to survive, which are logged and skipped so the sweep continues.
+    """
+
+
 class WorkPlanner:
     """Central planner that discovers tasks through registered task finders."""
 
@@ -186,6 +194,12 @@ class WorkPlanner:
         # dependent finders are blocked until the finder has been given a chance
         # to run and confirmed it has nothing to do.
         self._finder_exhausted: dict[str, bool] = {}
+        # Armed when a finder's task is submitted, disarmed by whichever edge
+        # first sees the finder both exhausted and idle. Without it,
+        # on_all_tasks_complete() was announced only from the task-completion
+        # edge and was missed entirely whenever the last task finished before
+        # the finder reported that it had run out of work.
+        self._all_done_pending: dict[str, bool] = {}
         self._lock = threading.Lock()
         # Serialises start()/stop() so a restart cannot interleave with a
         # shutdown that is still joining the outgoing thread.
@@ -251,11 +265,16 @@ class WorkPlanner:
         used to race the loop's own read. Detached finders are marked exhausted
         so a finder that `depends_on()` one of them is not blocked for ever
         waiting for a report that will never come again.
+
+        The `_finder_name_by_task_type` entry is deliberately kept: it is how
+        `depends_on()` resolves a TaskType to the name `_finder_exhausted` is
+        keyed by. Popping it made the exhausted flag written below unreachable,
+        so the dependent finder blocked for ever anyway.
         """
         removed = set()
         with self._lock:
             for task_type in task_types:
-                name = self._finder_name_by_task_type.pop(task_type, None)
+                name = self._finder_name_by_task_type.get(task_type)
                 if not name:
                     continue
                 finder = self._task_finders_by_name.pop(name, None)
@@ -283,7 +302,6 @@ class WorkPlanner:
 
     def on_task_complete(self, task, error):
         finder_name = None
-        all_done = False
         with self._lock:
             finder_name = self._finder_by_task_id.pop(getattr(task, "id", None), None)
             if finder_name:
@@ -291,7 +309,6 @@ class WorkPlanner:
                 new_inflight = max(0, inflight_count - 1)
                 self._inflight_by_finder[finder_name] = new_inflight
                 is_exhausted = self._finder_exhausted.get(finder_name, False)
-                all_done = new_inflight == 0 and is_exhausted
         if finder_name:
             _GPU_FINDERS = {"MissingTagFinder", "MissingFaceExtractionFinder"}
             if new_inflight == 0 and not is_exhausted and finder_name in _GPU_FINDERS:
@@ -311,15 +328,14 @@ class WorkPlanner:
                         finder_name,
                         exc,
                     )
-                if all_done:
-                    try:
-                        finder.on_all_tasks_complete()
-                    except Exception as exc:
-                        logger.warning(
-                            "Finder all-complete callback failed for %s: %s",
-                            finder_name,
-                            exc,
-                        )
+                # Re-read the state under the lock rather than trusting the
+                # value computed at the top: releasing the claims above is what
+                # makes this finder's pictures selectable again, so the loop
+                # thread can have taken a new task in between and the drain
+                # callback (a GPU session teardown for MissingTagFinder) would
+                # land on it.
+                if self._claim_drain(finder_name):
+                    self._notify_all_tasks_complete(finder, finder_name)
         self._wake.set()
 
     def _run(self):
@@ -370,98 +386,164 @@ class WorkPlanner:
         for offset in range(finder_count):
             idx = (order_idx + offset) % finder_count
             finder = finders[idx]
-            finder_name = finder.finder_name()
-            max_inflight = max(1, int(finder.max_inflight_tasks()))
+            try:
+                submitted_any = self._sweep_finder(
+                    finder, idx, finder_count, submitted_any
+                )
+            except _PlannerStopping:
+                return submitted_any
+            except Exception:
+                # A finder that raises must cost only its own turn. Catching
+                # this around the whole cycle instead abandoned the rest of the
+                # sweep, and _finder_order_idx advances only on a successful
+                # submit or in the tail below, so it stayed parked on the raiser
+                # and every finder behind it stopped being swept for the life of
+                # the process while is_running() went on reporting healthy.
+                logger.exception(
+                    "WorkPlanner finder %s raised; skipping it for this cycle "
+                    "and continuing with the rest.",
+                    type(finder).__name__,
+                )
 
-            blocking_finders = finder.depends_on()
-            if blocking_finders:
+        if not submitted_any:
+            with self._lock:
+                self._finder_order_idx = (self._finder_order_idx + 1) % finder_count
+        return submitted_any
+
+    def _sweep_finder(
+        self, finder, idx: int, finder_count: int, submitted_any: bool
+    ) -> bool:
+        """Give one finder its turn and return the updated *submitted_any*.
+
+        Raises:
+            _PlannerStopping: Shutdown began mid-turn; the caller must abandon
+                the whole cycle rather than move on to the next finder.
+        """
+        finder_name = finder.finder_name()
+        max_inflight = max(1, int(finder.max_inflight_tasks()))
+
+        blocking_finders = finder.depends_on()
+        if blocking_finders:
+            with self._lock:
                 blocking_names = [
                     self._finder_name_by_task_type.get(tt, str(tt))
                     for tt in blocking_finders
                 ]
-                with self._lock:
-                    if any(
-                        self._inflight_by_finder.get(name, 0) > 0
-                        or not self._finder_exhausted.get(name, False)
-                        for name in blocking_names
-                    ):
-                        continue
-
-            # Fill all available inflight slots for this finder in one pass so
-            # that fast-completing tasks (e.g. custom tagger at ~100ms) don't
-            # leave the GPU idle while the planner sleeps MIN_INTERVAL_S between
-            # cycles.  Previously, a single submit + return True meant inflight
-            # was always 1 regardless of max_inflight.
-            while True:
-                with self._lock:
-                    inflight_count = int(self._inflight_by_finder.get(finder_name, 0))
-                if inflight_count >= max_inflight:
-                    break
-
-                task = finder.find_task()
-                if task is None:
-                    with self._lock:
-                        self._finder_exhausted[finder_name] = True
-                    break
-                # A finder may block in database or filesystem work long enough
-                # for stop()'s bounded join to return. Do not submit the task it
-                # found after shutdown has begun and the runner may already be
-                # stopped by Vault.stop().
-                if self._stop.is_set():
-                    self._release_unsubmitted(
-                        finder, task, "the planner stopped before it could submit"
-                    )
+                if any(
+                    self._inflight_by_finder.get(name, 0) > 0
+                    or not self._finder_exhausted.get(name, False)
+                    for name in blocking_names
+                ):
                     return submitted_any
 
-                task_id = getattr(task, "id", None)
+        # Fill all available inflight slots for this finder in one pass so
+        # that fast-completing tasks (e.g. custom tagger at ~100ms) don't
+        # leave the GPU idle while the planner sleeps MIN_INTERVAL_S between
+        # cycles.  Previously, a single submit + return True meant inflight
+        # was always 1 regardless of max_inflight.
+        while True:
+            with self._lock:
+                inflight_count = int(self._inflight_by_finder.get(finder_name, 0))
+            if inflight_count >= max_inflight:
+                break
+
+            task = finder.find_task()
+            if task is None:
+                with self._lock:
+                    self._finder_exhausted[finder_name] = True
+                # The other edge into "exhausted and idle". When the last task
+                # completed before the finder ran out of work, the completion
+                # edge saw exhausted=False and nobody ever announced the drain,
+                # so the GPU arena stayed held until a later full cycle.
+                if self._claim_drain(finder_name):
+                    self._notify_all_tasks_complete(finder, finder_name)
+                break
+            # A finder may block in database or filesystem work long enough
+            # for stop()'s bounded join to return. Do not submit the task it
+            # found after shutdown has begun and the runner may already be
+            # stopped by Vault.stop().
+            if self._stop.is_set():
+                self._release_unsubmitted(
+                    finder, task, "the planner stopped before it could submit"
+                )
+                raise _PlannerStopping
+
+            task_id = getattr(task, "id", None)
+            with self._lock:
+                current_inflight = int(self._inflight_by_finder.get(finder_name, 0))
+                self._inflight_by_finder[finder_name] = current_inflight + 1
+                self._finder_exhausted[finder_name] = False
+                self._all_done_pending[finder_name] = True
+                if task_id:
+                    self._finder_by_task_id[task_id] = finder_name
+
+            try:
+                submitted_task_id = self._task_runner.submit(task)
+            except Exception as submit_exc:
                 with self._lock:
                     current_inflight = int(self._inflight_by_finder.get(finder_name, 0))
-                    self._inflight_by_finder[finder_name] = current_inflight + 1
-                    self._finder_exhausted[finder_name] = False
-                    if task_id:
-                        self._finder_by_task_id[task_id] = finder_name
-
-                try:
-                    submitted_task_id = self._task_runner.submit(task)
-                except Exception as submit_exc:
-                    with self._lock:
-                        current_inflight = int(
-                            self._inflight_by_finder.get(finder_name, 0)
-                        )
-                        self._inflight_by_finder[finder_name] = max(
-                            0,
-                            current_inflight - 1,
-                        )
-                        if task_id:
-                            self._finder_by_task_id.pop(task_id, None)
-                    self._release_unsubmitted(
-                        finder, task, f"submit() raised: {submit_exc}"
+                    self._inflight_by_finder[finder_name] = max(
+                        0,
+                        current_inflight - 1,
                     )
-                    # Close the remaining race between the stop check above and
-                    # TaskRunner.submit(). A stopped runner is expected during
-                    # vault teardown; any submission failure while still live
-                    # remains a real error and is re-raised.
-                    if self._stop.is_set():
-                        return submitted_any
-                    raise
-
-                if submitted_task_id and submitted_task_id != task_id:
-                    with self._lock:
-                        if task_id:
-                            self._finder_by_task_id.pop(task_id, None)
-                        self._finder_by_task_id[submitted_task_id] = finder_name
-
-                self._finder_order_idx = (idx + 1) % finder_count
-                logger.debug(
-                    "WorkPlanner submitted task id=%s via finder=%s",
-                    submitted_task_id,
-                    finder_name,
+                    if task_id:
+                        self._finder_by_task_id.pop(task_id, None)
+                self._release_unsubmitted(
+                    finder, task, f"submit() raised: {submit_exc}"
                 )
-                submitted_any = True
+                # Close the remaining race between the stop check above and
+                # TaskRunner.submit(). A stopped runner is expected during
+                # vault teardown; any submission failure while still live
+                # remains a real error and is re-raised.
+                if self._stop.is_set():
+                    raise _PlannerStopping from submit_exc
+                raise
 
-        if not submitted_any:
-            self._finder_order_idx = (self._finder_order_idx + 1) % finder_count
+            if submitted_task_id and submitted_task_id != task_id:
+                with self._lock:
+                    if task_id:
+                        self._finder_by_task_id.pop(task_id, None)
+                    self._finder_by_task_id[submitted_task_id] = finder_name
+
+            with self._lock:
+                self._finder_order_idx = (idx + 1) % finder_count
+            logger.debug(
+                "WorkPlanner submitted task id=%s via finder=%s",
+                submitted_task_id,
+                finder_name,
+            )
+            submitted_any = True
+
         return submitted_any
+
+    def _claim_drain(self, finder_name: str) -> bool:
+        """Whether this caller owns the finder's ``on_all_tasks_complete()`` call.
+
+        True at most once per burst of work: armed when a task is submitted,
+        and claimed by whichever of the two edges -- the last task completing,
+        or the finder reporting no more work -- first observes the finder both
+        exhausted and idle. The whole decision is made under ``_lock`` so the
+        two edges cannot both fire it.
+        """
+        with self._lock:
+            if not self._all_done_pending.get(finder_name, False):
+                return False
+            if int(self._inflight_by_finder.get(finder_name, 0)) != 0:
+                return False
+            if not self._finder_exhausted.get(finder_name, False):
+                return False
+            self._all_done_pending[finder_name] = False
+            return True
+
+    def _notify_all_tasks_complete(self, finder, finder_name: str):
+        try:
+            finder.on_all_tasks_complete()
+        except Exception as exc:
+            logger.warning(
+                "Finder all-complete callback failed for %s: %s",
+                finder_name,
+                exc,
+            )
 
     def _release_unsubmitted(self, finder, task, reason: str):
         """Hand a task the planner will never submit back to its finder.

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -473,6 +473,13 @@ class WorkPlanner:
                 current_inflight = int(self._inflight_by_finder.get(finder_name, 0))
                 self._inflight_by_finder[finder_name] = current_inflight + 1
                 self._finder_exhausted[finder_name] = False
+                # Armed *before* submit, because a runner that completes the
+                # task synchronously calls back before submit() returns and the
+                # flag has to be visible by then. Captured so the failure path
+                # can put it back: see the rollback below.
+                previous_all_done_pending = self._all_done_pending.get(
+                    finder_name, False
+                )
                 self._all_done_pending[finder_name] = True
                 if task_id:
                     self._finder_by_task_id[task_id] = finder_name
@@ -486,6 +493,13 @@ class WorkPlanner:
                         0,
                         current_inflight - 1,
                     )
+                    # Disarm, or leave it as it was. Nothing was submitted, so
+                    # this burst never earned an `on_all_tasks_complete()`; a
+                    # flag left armed here is claimed later by the first
+                    # `find_task() -> None`, firing the callback for work that
+                    # never ran. Restoring rather than clearing keeps a burst
+                    # that was already legitimately armed by an earlier task.
+                    self._all_done_pending[finder_name] = previous_all_done_pending
                     if task_id:
                         self._finder_by_task_id.pop(task_id, None)
                 self._release_unsubmitted(

--- a/tests/test_work_planner.py
+++ b/tests/test_work_planner.py
@@ -831,3 +831,40 @@ def test_snapshot_scrub_progress_is_counted_in_archives_not_pictures(tmp_path):
 
     assert (total, remaining) == (5, 3)
     assert max(total - remaining, 0) == 2, "two archives are genuinely done"
+
+
+class _SubmitRaisesRunner:
+    """A runner whose ``submit()`` always fails, with the planner still live."""
+
+    def submit(self, task):
+        raise RuntimeError("runner refused the task")
+
+
+def test_a_failed_submit_does_not_arm_the_drain_for_work_that_never_ran():
+    """`on_all_tasks_complete()` is a burst-ended signal, not a cycle-ended one.
+
+    `_all_done_pending` is armed *before* `submit()`, because a runner that
+    completes synchronously calls back before `submit()` returns. That arming
+    has to be undone when the submit fails: nothing ran, so the burst never
+    earned its callback. Left armed, the flag is claimed by the next
+    `find_task() -> None` — the finder reports no work, in-flight is zero,
+    exhausted is true — and the drain fires for a task that was never submitted.
+    For the tagger that means tearing down a CUDA arena that was never built.
+    """
+    finder = _OneShotFinder()
+    drained = []
+    finder.on_all_tasks_complete = lambda: drained.append("drained")
+    planner = WorkPlanner(task_runner=_SubmitRaisesRunner(), task_finders=[finder])
+
+    # The sweep catches the finder's failure and carries on -- that is this
+    # PR's subject -- so nothing propagates here.
+    planner._run_finders_once()
+
+    assert planner._all_done_pending.get("TestFinder", False) is False, (
+        "a failed submit left the drain armed"
+    )
+
+    # The next sweep finds no work. Nothing was ever submitted, so nothing is
+    # owed a completion callback.
+    assert planner._run_finders_once() is False
+    assert drained == [], f"drain fired for work that never ran: {drained}"

--- a/tests/test_work_planner.py
+++ b/tests/test_work_planner.py
@@ -225,24 +225,47 @@ def test_planner_thread_survives_concurrent_finder_mutation(caplog):
 
 
 def test_a_raising_finder_does_not_silently_kill_the_planner(caplog):
-    """A cycle that raises must be reported and the loop must keep running."""
+    """A raising finder must be reported, and cost only its own turn.
+
+    Three finders, not one: a single-finder planner cannot see the real damage.
+    ``_finder_order_idx`` advances only on a successful submit or in the
+    ``not submitted_any`` tail, so catching the exception around the whole cycle
+    parked the order index on the raiser and every finder behind it stopped
+    being swept for the life of the process, while ``is_running()`` went on
+    answering True.
+    """
+    swept = []
 
     class _ExplodingFinder(_IdleFinder):
         def find_task(self):
+            swept.append(self.finder_name())
             raise RuntimeError("finder blew up")
 
+    class _SweptFinder(_IdleFinder):
+        def find_task(self):
+            swept.append(self.finder_name())
+            return None
+
     planner = WorkPlanner(
-        task_runner=_NullRunner(), task_finders=[_ExplodingFinder("Boom")]
+        task_runner=_NullRunner(),
+        task_finders=[
+            _ExplodingFinder("Boom"),
+            _SweptFinder("Behind1"),
+            _SweptFinder("Behind2"),
+        ],
     )
     planner.MIN_INTERVAL_S = 0.01
     planner.MAX_INTERVAL_S = 0.01
     planner.start()
     try:
         deadline = time.monotonic() + 5.0
-        while time.monotonic() < deadline and "finder blew up" not in caplog.text:
+        while time.monotonic() < deadline and not {"Behind1", "Behind2"} <= set(swept):
             time.sleep(0.05)
         assert planner.is_running(), "the planner thread died on a finder exception"
         assert "finder blew up" in caplog.text, "the failure was never reported"
+        assert {"Behind1", "Behind2"} <= set(swept), (
+            f"the finders behind the raiser were never swept: {sorted(set(swept))}"
+        )
     finally:
         _stopped(planner)
 
@@ -320,6 +343,130 @@ def test_detach_finders_prunes_every_structure_and_marks_exhausted():
     # depends_on() it would block for ever unless it counts as exhausted.
     assert planner._finder_exhausted["TagFinder"] is True
     assert planner.detach_finders([TaskType.TAGGER]) == set(), "detach is idempotent"
+
+
+def test_a_dependent_finder_unblocks_when_its_blocker_is_detached():
+    """The outcome the exhausted-marking promises, not just the flag being written.
+
+    ``detach_finders`` used to pop the TaskType to name mapping before writing
+    ``_finder_exhausted[name]``, so ``depends_on()`` resolution fell through to
+    its ``str(task_type)`` default, never found the flag, and blocked the
+    dependent finder for ever.
+    """
+
+    class _DependentFinder(_IdleFinder):
+        def depends_on(self) -> list:
+            return [TaskType.TAGGER]
+
+    swept = []
+    tagger = _IdleFinder("TagFinder")
+    dependent = _DependentFinder("DependentFinder")
+    dependent.find_task = lambda: swept.append("DependentFinder") and None
+
+    planner = WorkPlanner(
+        task_runner=_NullRunner(),
+        task_finders={
+            TaskType.TAGGER: tagger,
+            TaskType.DESCRIPTION: dependent,
+        },
+    )
+
+    # A blocker with work in flight blocks its dependent.
+    planner._inflight_by_finder["TagFinder"] = 1
+    assert planner._run_finders_once() is False
+    assert swept == [], "the dependent ran while its blocker still had work"
+
+    assert planner.detach_finders([TaskType.TAGGER]) == {"TagFinder"}
+    planner._inflight_by_finder["TagFinder"] = 0
+
+    assert planner._run_finders_once() is False
+    assert swept == ["DependentFinder"], (
+        "the dependent stayed blocked on a finder that will never report again"
+    )
+
+
+class _TwoSlotOneTaskFinder(_OneShotFinder):
+    """One task, two in-flight slots, so one cycle both submits and runs dry."""
+
+    def max_inflight_tasks(self) -> int:
+        return 2
+
+
+def test_the_drain_fires_when_the_last_task_finishes_before_the_finder_runs_dry():
+    """``on_all_tasks_complete()`` must not depend on which edge comes first.
+
+    ``exhausted`` is set only when ``find_task()`` returns None, which is after
+    the in-flight count reaches zero whenever the last task completes quickly.
+    The completion edge then computed ``all_done`` as ``(0 == 0) and False`` and
+    the drain was missed entirely, so the tagger's CUDA arena stayed held.
+    """
+    runner = _FastCompleteRunner()
+    finder = _OneShotFinder()
+    drained = []
+    finder.on_all_tasks_complete = lambda: drained.append("drained")
+    planner = WorkPlanner(task_runner=runner, task_finders=[finder])
+    # Complete the task inside submit(), so in-flight hits zero while the finder
+    # has not yet reported that it is out of work.
+    runner.on_submit = lambda task: planner.on_task_complete(task, None)
+
+    assert planner._run_finders_once() is True
+    assert drained == ["drained"], "the drain was missed on this edge ordering"
+
+    assert planner._run_finders_once() is False
+    assert drained == ["drained"], "the drain fired more than once per burst"
+
+
+def test_the_drain_still_fires_on_the_last_task_completing():
+    """Positive control for the other edge ordering, which already worked."""
+    runner = _FastCompleteRunner()
+    finder = _TwoSlotOneTaskFinder()
+    drained = []
+    finder.on_all_tasks_complete = lambda: drained.append("drained")
+    planner = WorkPlanner(task_runner=runner, task_finders=[finder])
+    submitted_tasks = []
+    runner.on_submit = submitted_tasks.append
+
+    # The spare slot lets the same cycle submit the one task and then see the
+    # finder run dry, so exhausted is set while the task is still in flight.
+    assert planner._run_finders_once() is True
+    assert drained == [], "the drain fired while a task was still in flight"
+
+    planner.on_task_complete(submitted_tasks[0], None)
+    assert drained == ["drained"], "the drain was missed on the completion edge"
+
+
+def test_the_drain_is_skipped_when_a_new_task_lands_while_the_claims_release():
+    """Releasing the claims is what lets the loop thread take the next task.
+
+    ``all_done`` was computed at the top of ``on_task_complete``, the lock was
+    dropped, the finder released its claims, and only then was
+    ``on_all_tasks_complete()`` called. For MissingTagFinder that is a GPU
+    session teardown, and it landed on the task the loop thread had taken in
+    between.
+    """
+    runner = _FastCompleteRunner()
+    finder = _TwoSlotOneTaskFinder()
+    drained = []
+    finder.on_all_tasks_complete = lambda: drained.append("drained")
+    planner = WorkPlanner(task_runner=runner, task_finders=[finder])
+    submitted_tasks = []
+    runner.on_submit = submitted_tasks.append
+
+    assert planner._run_finders_once() is True
+    assert drained == []
+
+    def take_a_new_task_while_releasing(task, error):
+        # Exactly the bookkeeping the loop thread does when it submits, run in
+        # the window the re-validation exists to cover.
+        with planner._lock:
+            planner._inflight_by_finder["TestFinder"] = 1
+            planner._finder_exhausted["TestFinder"] = False
+            planner._all_done_pending["TestFinder"] = True
+
+    finder.on_task_complete = take_a_new_task_while_releasing
+
+    planner.on_task_complete(submitted_tasks[0], None)
+    assert drained == [], "the drain tore the engine down under a live task"
 
 
 class _ClaimedTask(BaseTask):


### PR DESCRIPTION
Stacked on #850. Closes review findings F6, F8, F12, F30 and F31 from
`develop-2026-08-09`.

## F6 (HIGH) a raising finder starved every finder behind it

#844 wrapped the whole cycle in `except Exception`. `_finder_order_idx` advances
only on a successful submit or in the `not submitted_any` tail, so an exception
out of `_run_finders_once()` skipped both and the sweep restarted on the raiser
next time. With finders `[A, B, C]` and `A.find_task()` raising persistently, B
and C never ran again for the process lifetime while `is_running()` reported
healthy.

A finder's turn now lives in `_sweep_finder()` and is caught individually: the
raiser is logged with its class name and skipped, the sweep continues. A
dedicated `_PlannerStopping` keeps "abandon the whole cycle because shutdown
began" distinguishable from "this finder failed", which is what the two
`return submitted_any` early exits meant. `_run`'s cycle-level catch stays as a
last-resort net for anything outside a finder's turn.

`test_a_raising_finder_does_not_silently_kill_the_planner` now registers three
finders, since a one-finder planner cannot see this at all.

## F8 (MEDIUM) `detach_finders()`'s exhausted-marking was unreachable

It popped `_finder_name_by_task_type[task_type]` and then wrote
`_finder_exhausted[name]`. `depends_on()` resolution reads
`_finder_name_by_task_type.get(tt, str(tt))`, so with the entry gone it looked up
`_finder_exhausted["TaskType.TAGGER"]`, found `False`, and blocked the dependent
finder for ever, which is exactly what the docstring promises to prevent.

The mapping is now kept (`get`, not `pop`); `has_finder()` and detach
idempotency both key off `_task_finders_by_name`, which is still pruned. The
one `_finder_name_by_task_type` read left outside `_lock` moved inside the
adjacent locked block.

New test asserts a **surviving dependent finder actually unblocks**, not just
that the flag was written.

## F12 + F30 the drain callback

`on_all_tasks_complete()` is `unload_tagger_session()` for `MissingTagFinder`.
Two defects, one cause: the "exhausted and idle" condition was evaluated once,
at the top of `on_task_complete`, on one of the two edges that can enter it.

- **F12**: the lock was released, the claims were released (which is precisely
  what makes this finder's pictures selectable again), and only then was the
  callback made, so the loop thread could take a new `TagTask` in between and
  the teardown landed on it.
- **F30**: `exhausted` is set only when `find_task()` returns None. If the last
  task completed first, `all_done` was `(0 == 0) and False` and the drain was
  missed entirely, the `[PIPELINE_STALL]` warning fired, and the arena stayed
  held until a later full drain cycle.

`_claim_drain(finder_name)` is armed when a task is submitted and claimed under
`_lock` by whichever edge -- the last completion, or the finder running dry --
first observes the finder exhausted and idle. Both call sites go through it, so
the drain fires exactly once per burst of work, from either ordering, and never
over a task that has just been taken. Arming on submit also means an
always-idle finder is never sent a drain it did not earn.

Confirming the brief's question: the F12 re-validation alone does **not** cover
F30. Re-reading the state at the completion edge still sees `exhausted=False`
there; F30 needed the second edge to be able to fire at all.

## F31 (LOW) `_finder_order_idx` written outside `_lock`

Both writes are now under `_lock`, so a loop-thread write can no longer clobber
`detach_finders()`'s deliberate reset with a pre-detach index.

## Tests

Four new tests plus the extended F6 one, all in the already-gated
`tests/test_work_planner.py`.

**Mutation evidence**, run in three rounds because the mutations interact:

| Revert | Red |
|---|---|
| per-finder handler re-raises (catch back at cycle level) | `test_a_raising_finder_does_not_silently_kill_the_planner` |
| `get` back to `pop` in `detach_finders` | `test_a_dependent_finder_unblocks_when_its_blocker_is_detached` |
| drop the exhausted-edge `_claim_drain` call | `test_the_drain_fires_when_the_last_task_finishes_before_the_finder_runs_dry` |
| `_claim_drain` stops re-validating in-flight/exhausted | `test_the_drain_still_fires_on_the_last_task_completing`, `test_the_drain_is_skipped_when_a_new_task_lands_while_the_claims_release` |

Each round left the other tests green. All reverted; 23 pass.

## Not fixed, deliberately

The `[PIPELINE_STALL]` warning still fires when the last task completes before
the finder runs dry. It is a heuristic log line and the condition it reports
(the GPU is idle until the next finder cycle) is true when it fires; the
misleading part was the missed drain, which is fixed. Changing the warning's
predicate is a separate judgement call, not a root cause.

`ruff format` + `ruff check pixlstash` clean.
`tests/test_work_planner.py tests/test_reviews_api.py tests/test_operation_log.py tests/test_restore.py tests/test_picture_mutation_scope.py`: 251 passed.