### PR TITLE
Resolve and bound the path a model folder may be registered at

### DIFF
--- a/pixlstash/routes/model_folders.py
+++ b/pixlstash/routes/model_folders.py
@@ -48,7 +48,10 @@ from pixlstash.pixl_logging import get_logger
 from pixlstash.services.managed_model_store import MANAGED_KIND
 from pixlstash.services.model_folder_scanner import ModelFolderScanner
 from pixlstash.utils.host_path_utils import is_absolute_host_path, normalize_host_path
-from pixlstash.utils.reference_folder_validator import validate_reference_folder_path
+from pixlstash.utils.reference_folder_validator import (
+    validate_reference_folder_accessible,
+    validate_reference_folder_path,
+)
 
 logger = get_logger(__name__)
 
@@ -283,7 +286,21 @@ def create_router(server) -> APIRouter:
                 ),
             )
         path = os.path.normpath(payload.path)
+        # Lexical first, because it is the only check that can still see a
+        # relative path: realpath below would silently make one absolute against
+        # the server's cwd.
         error = validate_reference_folder_path(path)
+        if error:
+            raise HTTPException(status_code=400, detail=error)
+        # That check compares strings, so one symlink defeats it: ``~/models ->
+        # /etc`` passes, and the scan then walks /etc because os.walk follows the
+        # top-level link (followlinks=False only governs links found inside the
+        # tree). Resolve, re-run the blocklist on what the link actually points
+        # at, and store the resolved path so the row names the directory that
+        # gets walked. This is the second half of the check
+        # ``create_reference_folder`` runs and this route was missing.
+        path = os.path.realpath(path)
+        error = validate_reference_folder_accessible(path)
         if error:
             raise HTTPException(status_code=400, detail=error)
         host_path = _normalize_optional_host_path(payload.host_path)

--- a/pixlstash/routes/model_folders.py
+++ b/pixlstash/routes/model_folders.py
@@ -328,10 +328,13 @@ def create_router(server) -> APIRouter:
         error = validate_reference_folder_path(path)
         if error:
             raise HTTPException(status_code=400, detail=error)
-        # That check compares strings, so one symlink defeats it: ``~/models ->
-        # /etc`` passes, and the scan then walks /etc because os.walk follows the
-        # top-level link (followlinks=False only governs links found inside the
-        # tree). Resolve, re-run the blocklist on what the link actually points
+        # That check compares strings, so one symlink defeats it:
+        # ``/home/u/models-link -> /etc`` passes, and the scan then walks /etc
+        # because os.walk follows the top-level link (followlinks=False only
+        # governs links found inside the tree). The example is spelled absolute
+        # because the lexical check above has already refused anything else, and
+        # nothing here expands ``~``. Resolve, re-run the blocklist on what the
+        # link actually points
         # at, and store the resolved path so the row names the directory that
         # gets walked. This is the second half of the check
         # ``create_reference_folder`` runs and this route was missing.

--- a/pixlstash/routes/model_folders.py
+++ b/pixlstash/routes/model_folders.py
@@ -48,6 +48,7 @@ from pixlstash.pixl_logging import get_logger
 from pixlstash.services.managed_model_store import MANAGED_KIND
 from pixlstash.services.model_folder_scanner import ModelFolderScanner
 from pixlstash.utils.host_path_utils import is_absolute_host_path, normalize_host_path
+from pixlstash.utils.path_utils import path_is_within
 from pixlstash.utils.reference_folder_validator import (
     validate_reference_folder_accessible,
     validate_reference_folder_path,
@@ -213,6 +214,41 @@ def create_router(server) -> APIRouter:
             raise HTTPException(status_code=404, detail="Model folder not found.")
         return dict(row)
 
+    def _validate_folder_conflicts(path: str) -> None:
+        """Refuse a path that overlaps the vault or an already-registered folder.
+
+        Containment, not just equality, for the same reason
+        ``_validate_reference_folder_conflicts`` checks it: two roots over the
+        same files register a ``model_file`` row per root, which double-counts
+        every file in ``file_count`` and in a model's locations, and gives the
+        scanner N walks of the same bytes. ``/`` is refused here rather than by a
+        rule of its own, since it contains the vault by construction.
+
+        Args:
+            path: The resolved candidate path.
+
+        Raises:
+            HTTPException: 409 if the path overlaps something already registered.
+        """
+        image_root = getattr(server.vault, "image_root", "") or ""
+        if path_is_within(path, image_root) or path_is_within(image_root, path):
+            raise HTTPException(
+                status_code=409,
+                detail="Path overlaps the PixlStash data folder.",
+            )
+        for row in server.hub.fetchall("SELECT path FROM model_folder"):
+            other = str(row["path"])
+            if path_is_within(path, other):
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Path is inside a registered model folder: {other}",
+                )
+            if path_is_within(other, path):
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"A registered model folder is inside this path: {other}",
+                )
+
     def _file_counts() -> dict[int, int]:
         """Copies per folder, in one grouped query rather than one per folder."""
         rows = server.hub.fetchall(
@@ -318,6 +354,7 @@ def create_router(server) -> APIRouter:
             raise HTTPException(
                 status_code=409, detail="This folder is already registered."
             )
+        _validate_folder_conflicts(path)
         with server.hub.transaction() as conn:
             cursor = conn.execute(
                 "INSERT INTO model_folder (path, kind, owner, movable, host_path, "

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -640,13 +640,17 @@ def test_a_system_directory_is_refused(shelf_env):
 
 def test_a_symlink_into_a_system_directory_is_refused(shelf_env, tmp_path):
     """The blocklist is a string comparison, so it has to run on the resolved
-    path: ``~/models -> /etc`` passes the lexical check, and the scan then walks
-    /etc because ``os.walk`` follows the *top-level* link. ``GET /adapters`` is
-    reachable from any network location, so the walk's filenames leave the host.
+    path: ``/home/u/models-link -> /etc`` passes the lexical check, and the scan
+    then walks /etc because ``os.walk`` follows the *top-level* link. ``GET
+    /adapters`` is reachable from any network location, so the walk's filenames
+    leave the host.
     """
     assert_real_route(shelf_env.server.api, "POST", f"{API}/model-folders")
     link = tmp_path / "models-link"
-    link.symlink_to("/etc")
+    try:
+        link.symlink_to("/etc", target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available here")
 
     r = shelf_env.owner.post(f"{API}/model-folders", json={"path": str(link)})
     assert r.status_code == 400, r.text
@@ -670,7 +674,10 @@ def test_a_symlink_to_an_allowed_folder_registers_at_its_resolved_path(
     real = tmp_path / "real-loras"
     real.mkdir()
     link = tmp_path / "linked-loras"
-    link.symlink_to(real)
+    try:
+        link.symlink_to(real, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available here")
 
     r = shelf_env.owner.post(f"{API}/model-folders", json={"path": str(link)})
     assert r.status_code == 200, r.text

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -691,6 +691,64 @@ def test_a_path_that_is_not_a_directory_is_refused(shelf_env, tmp_path):
         assert "not a directory" in r.json()["detail"], r.text
 
 
+def test_the_filesystem_root_is_refused(shelf_env):
+    """``/`` is absolute, is no blocklist entry and is prefixed by none, so the
+    blocklist alone admits it — and a rescan of it then stats every file on every
+    mounted volume and SHA-256s every adapter on the machine, with a server
+    restart as the only off switch. It is refused for containing the vault."""
+    assert_real_route(shelf_env.server.api, "POST", f"{API}/model-folders")
+    r = shelf_env.owner.post(f"{API}/model-folders", json={"path": "/"})
+    assert r.status_code == 409, r.text
+    assert "PixlStash data folder" in r.json()["detail"], r.text
+
+
+def test_the_vault_data_folder_is_refused(shelf_env):
+    r = shelf_env.owner.post(
+        f"{API}/model-folders", json={"path": shelf_env.server.vault.image_root}
+    )
+    assert r.status_code == 409, r.text
+    assert "PixlStash data folder" in r.json()["detail"], r.text
+
+
+def test_a_folder_overlapping_a_registered_one_is_refused_in_both_directions(
+    shelf_env, tmp_path
+):
+    """Two roots over the same files give every file a ``model_file`` row per
+    root: double-counted in ``file_count`` and in a model's locations, and walked
+    twice by the scanner. Nesting is refused whichever way round it arrives."""
+    parent = _new_folder_path(str(tmp_path), "nest")
+    child = _new_folder_path(parent, "inner")
+    grandparent = str(tmp_path)
+
+    assert (
+        shelf_env.owner.post(f"{API}/model-folders", json={"path": parent}).status_code
+        == 200
+    )
+
+    r = shelf_env.owner.post(f"{API}/model-folders", json={"path": child})
+    assert r.status_code == 409, r.text
+    assert "inside a registered model folder" in r.json()["detail"], r.text
+
+    r = shelf_env.owner.post(f"{API}/model-folders", json={"path": grandparent})
+    assert r.status_code == 409, r.text
+    assert "is inside this path" in r.json()["detail"], r.text
+
+
+def test_a_folder_beside_a_registered_one_still_registers(shelf_env, tmp_path):
+    """The positive control for the containment rule: siblings do not overlap,
+    and refusing them would be its own regression."""
+    assert (
+        shelf_env.owner.post(
+            f"{API}/model-folders", json={"path": _new_folder_path(str(tmp_path), "a")}
+        ).status_code
+        == 200
+    )
+    r = shelf_env.owner.post(
+        f"{API}/model-folders", json={"path": _new_folder_path(str(tmp_path), "b")}
+    )
+    assert r.status_code == 200, r.text
+
+
 def test_folder_list_counts_copies_and_reports_the_seeded_folder(shelf_env):
     r = shelf_env.owner.get(f"{API}/model-folders")
     assert r.status_code == 200, r.text

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -638,6 +638,59 @@ def test_a_system_directory_is_refused(shelf_env):
     assert r.status_code == 400, r.text
 
 
+def test_a_symlink_into_a_system_directory_is_refused(shelf_env, tmp_path):
+    """The blocklist is a string comparison, so it has to run on the resolved
+    path: ``~/models -> /etc`` passes the lexical check, and the scan then walks
+    /etc because ``os.walk`` follows the *top-level* link. ``GET /adapters`` is
+    reachable from any network location, so the walk's filenames leave the host.
+    """
+    assert_real_route(shelf_env.server.api, "POST", f"{API}/model-folders")
+    link = tmp_path / "models-link"
+    link.symlink_to("/etc")
+
+    r = shelf_env.owner.post(f"{API}/model-folders", json={"path": str(link)})
+    assert r.status_code == 400, r.text
+    # The refusal must be the blocklist's, not an incidental 4xx: a generic
+    # failure here would leave the bypass open the moment the incident changed.
+    assert "restricted system directory" in r.json()["detail"], r.text
+    registered = {
+        row["path"]
+        for row in shelf_env.owner.get(f"{API}/model-folders").json()["folders"]
+    }
+    assert registered == {"/models/loras"}, registered
+
+
+def test_a_symlink_to_an_allowed_folder_registers_at_its_resolved_path(
+    shelf_env, tmp_path
+):
+    """The positive direction: resolving must refuse system directories without
+    refusing a symlinked model folder, which is an ordinary way to keep adapters
+    on a second drive. The row stores the resolved path, so it names the
+    directory the scanner actually walks."""
+    real = tmp_path / "real-loras"
+    real.mkdir()
+    link = tmp_path / "linked-loras"
+    link.symlink_to(real)
+
+    r = shelf_env.owner.post(f"{API}/model-folders", json={"path": str(link)})
+    assert r.status_code == 200, r.text
+    assert r.json()["path"] == os.path.realpath(str(real))
+
+    r = shelf_env.owner.post(f"{API}/model-folders/{r.json()['id']}/rescan")
+    assert r.status_code == 202, r.text
+
+
+def test_a_path_that_is_not_a_directory_is_refused(shelf_env, tmp_path):
+    """An existing directory or nothing: a file or a missing path registers a
+    folder that can only ever scan as unreachable."""
+    a_file = tmp_path / "adapter.safetensors"
+    a_file.write_bytes(b"not a folder")
+    for candidate in (str(a_file), str(tmp_path / "does-not-exist")):
+        r = shelf_env.owner.post(f"{API}/model-folders", json={"path": candidate})
+        assert r.status_code == 400, f"{candidate}: {r.status_code} {r.text}"
+        assert "not a directory" in r.json()["detail"], r.text
+
+
 def test_folder_list_counts_copies_and_reports_the_seeded_folder(shelf_env):
     r = shelf_env.owner.get(f"{API}/model-folders")
     assert r.status_code == 200, r.text


### PR DESCRIPTION
Two trust-boundary defects in `POST /model-folders`, from the adversarial review of today's merges (F9, F13). Both are the same file and the same boundary, so one PR, two commits.

## F9 (MEDIUM): the system-directory blocklist was bypassable by one symlink

`create_model_folder` ran only the lexical `validate_reference_folder_path`. `create_reference_folder`, the route this one's docstring says it copies, also runs `validate_reference_folder_accessible`, which `realpath`s and re-runs the blocklist on the resolved path. This route had the first half and not the second.

A `LOCAL_OWNER_ONLY` caller (loopback, LAN, or a Tailscale peer) could point `~/models-link` at `/etc`, register it, and rescan: `os.path.isdir` follows symlinks and `os.walk` follows the top-level link, since `followlinks=False` only governs links found inside the tree. `GET /adapters` is `OWNER_ONLY` and reachable from any network location, so the filenames left the host. Blast radius is filename enumeration, not file contents.

Fix: keep the lexical check first (it is the only one that can still see a relative path, since `realpath` would make one absolute against the server's cwd), then `realpath` and run the accessible check on the result, and store the resolved path so the row names the directory the scanner walks.

## F13 (MEDIUM-LOW): nothing bounded what could be registered

`/` is absolute, is no blocklist entry and is prefixed by none, so it registered. There was no `isdir` check and no containment check. `POST /` then rescan gave a daemon thread stat'ing every file on every mounted volume and SHA-256ing every `.safetensors` on the machine, with a server restart as the only off switch. Overlapping roots also give each file a `model_file` row per root, double-counting it in `file_count` and in a model's locations.

Fix: the `isdir`/readable half comes free with the F9 call. Containment is a new `_validate_folder_conflicts` that refuses a path overlapping the vault `image_root` or any registered `model_folder` row, in both directions, using the existing `path_utils.path_is_within` rather than a second implementation of containment. The managed store is a `model_folder` row, so it is covered by that loop. `/` needs no rule of its own: it contains the vault by construction.

`_validate_reference_folder_conflicts` itself does not generalise. It is a closure over the vault `Session` and queries the `ReferenceFolder` table; model folders are hub rows read with plain SQL. The containment predicate is shared, the query is not.

## Skipped

- **A cancel route for a running scan.** Nice-to-have per the brief, and it needs a route plus a schema, so it stays out of this diff. With `/` and overlapping roots refused and a non-directory refused, the remaining unbounded case is an owner deliberately registering something like `/home`, which is the owner's call at this tier.
- **A cap on folder count.** Containment already makes N overlapping roots impossible, which was the amplification the finding named.

## Behaviour change worth flagging

Registering a path that is not an existing readable directory is now `400` instead of silently creating a row that can only ever scan as unreachable. This includes Docker, where the reference-folder block defers the check to a `pending_mount` status that model folders have no column for.

## Verification

`tests/test_model_shelf_api.py` (already gated, and its module-scoped server already has everything these need, so no new file and no `ci.yml` change).

Negative and positive on both findings: symlink-to-`/etc` refused vs symlink-to-a-real-folder registered at its resolved path and rescanning; `/`, the vault root and both nesting directions refused vs a sibling folder accepted; a file and a missing path refused. Every negative asserts the status code and the error detail, and the two that hardcode the URL call `assert_real_route` first, so a renamed route fails loudly instead of passing on a middleware 403.

Red-then-green, run serially:

- Replacing `error = validate_reference_folder_accessible(path)` with `error = None`: `test_a_symlink_into_a_system_directory_is_refused` and `test_a_path_that_is_not_a_directory_is_refused` fail (the symlink registers, `/etc` gets a row). Restored, both green.
- Deleting the `_validate_folder_conflicts(path)` call: the `/`, vault-root and overlapping tests fail and the sibling positive stays green. Restored, all green.

Full runs: `tests/test_model_shelf_api.py` 87 passed; the seven other model-shelf and hub suites 159 passed; `test_architecture_guardrails.py`, `test_ci_shards.py`, `test_path_containment.py` 188 passed. No route path or signature changed, so `ROUTE_POLICIES` and the coverage matrix are untouched and the guardrail confirms it. `ruff format` and `ruff check pixlstash` clean.

No per-handler authz check was added; the gate still owns authorization.
