### PR TITLE
Give the checkpoint hash worker a progress row of its own

### DIFF
--- a/frontend/src/components/panels/StatsSidebar.vue
+++ b/frontend/src/components/panels/StatsSidebar.vue
@@ -512,6 +512,7 @@ const tmLabelMap = {
   missing_file_purge: "File cleanup",
   snapshot_identity_scrub: "Snapshot cleanup",
   planner_managed: "Planner task",
+  checkpoints_hashed: "Checkpoint Hash",
   text_score: "Text score",
   object_detection: "Object detection",
 };

--- a/pixlstash/tasks/missing_checkpoint_hash_finder.py
+++ b/pixlstash/tasks/missing_checkpoint_hash_finder.py
@@ -57,6 +57,32 @@ class MissingCheckpointHashFinder(BaseTaskFinder):
     def finder_name(self) -> str:
         return "MissingCheckpointHashFinder"
 
+    def progress(self) -> tuple[int, int]:
+        """``(models this worker owns, how many still await a hash)``.
+
+        The task manager needs a denominator that is the model shelf, not the
+        picture library, and a "remaining" that cannot disagree with the work
+        actually left. Both counts therefore come from one query over one row
+        set, and the pending count is the finder's own ``sha256 IS NULL``
+        predicate rather than a ``file_kind`` guess: a row this finder would
+        hand out must never be reported as nothing left to do.
+
+        Deferred rows still count as pending. They are work this session has
+        refused to retry, not work that finished, and hiding them would make a
+        broken path look like a completed one.
+        """
+        row = self._hub.fetchone(
+            "SELECT COUNT(*) AS total, "
+            "SUM(CASE WHEN m.sha256 IS NULL THEN 1 ELSE 0 END) AS pending "
+            "FROM model m "
+            "WHERE (m.sha256 IS NULL OR m.file_kind = 'checkpoint') "
+            "AND EXISTS (SELECT 1 FROM model_file mf "
+            "WHERE mf.model_id = m.id AND mf.state = 'present')"
+        )
+        if row is None:
+            return 0, 0
+        return int(row["total"] or 0), int(row["pending"] or 0)
+
     def find_task(self):
         skip = self._deferred | self._handed_out
         limit = CheckpointHashTask.BATCH_SIZE + len(skip)

--- a/pixlstash/vault.py
+++ b/pixlstash/vault.py
@@ -1496,6 +1496,17 @@ class Vault:
                     total = 0
                     missing = 0
                     worker_active_override = False
+            elif worker_type == TaskType.CHECKPOINT_HASH:
+                # The one worker here whose denominator is the model shelf and
+                # not the picture library. Left in the `planner_managed` default
+                # below it inherited the library's picture count as its own
+                # total and a hardcoded `missing = 0`, so reading tens of
+                # gigabytes off disk for minutes rendered as "N / N, nothing
+                # remaining, 0/s" on a row that still said running — which is
+                # what made a healthy long task look like a stuck one.
+                finder = self._planner_work_finders.get(TaskType.CHECKPOINT_HASH)
+                total, missing = finder.progress() if finder is not None else (0, 0)
+                label = "checkpoints_hashed"
             elif worker_type == TaskType.THUMBNAIL_GENERATION:
                 # Whole-frame bitmap regeneration (MissingThumbnailFinder). After
                 # the v1.8.0 upgrade this counts the entire library, which is what

--- a/tests/test_checkpoint_hash_finder.py
+++ b/tests/test_checkpoint_hash_finder.py
@@ -30,7 +30,9 @@ def hub(tmp_path):
     database.close()
 
 
-def register(hub, path, *, sha256=None, base_model=None, state="present"):
+def register(
+    hub, path, *, sha256=None, base_model=None, state="present", file_kind="checkpoint"
+):
     """Register one checkpoint the way a scan would: content row plus location."""
     path = str(path)
     folder, relpath = os.path.split(path)
@@ -51,10 +53,14 @@ def register(hub, path, *, sha256=None, base_model=None, state="present"):
         )
         model_id = int(
             conn.execute(
-                "INSERT INTO model (file_kind, filename, file_size, sha256, "
+                "INSERT INTO model (file_kind, kind, filename, file_size, sha256, "
                 "base_model, provenance, created_at) "
-                "VALUES ('checkpoint', ?, ?, ?, ?, 'external', 'now')",
+                "VALUES (?, ?, ?, ?, ?, ?, 'external', 'now')",
                 (
+                    file_kind,
+                    # The schema demands an algorithm for an adapter and forbids
+                    # guessing one for anything else.
+                    "lora" if file_kind == "adapter" else None,
                     relpath,
                     os.path.getsize(path) if os.path.exists(path) else None,
                     sha256,
@@ -357,3 +363,71 @@ class TestFinder:
         finder.on_task_complete(task, RuntimeError("hub went away"))
 
         assert finder.find_task() is None
+
+
+class TestProgress:
+    """What the task manager is fed while this worker is running.
+
+    Hashing 57 GB is genuinely minutes of disk-bound work, so the row is
+    legitimately active for a long time. It looked stuck rather than busy
+    because it reported no progress at all: the snapshot fell through to the
+    generic branch, which advertised the *picture library's* total and a
+    hardcoded zero remaining. "N / N, nothing left" on a row that says running
+    is the report a healthy long task must never produce.
+    """
+
+    def test_it_counts_the_shelf_and_not_the_picture_library(self, hub, tmp_path):
+        register(hub, write_model(tmp_path / "a.safetensors"))
+        register(hub, write_model(tmp_path / "b.safetensors", b"b"))
+        register(hub, write_model(tmp_path / "c.safetensors", b"c"), sha256="done")
+
+        assert MissingCheckpointHashFinder(hub).progress() == (3, 2)
+
+    def test_an_adapter_the_scan_already_hashed_is_not_in_the_denominator(
+        self, hub, tmp_path
+    ):
+        # Adapters are hashed inline by the scan and are never this worker's
+        # business. Counting them would park the bar at ~100% on any real LoRA
+        # folder, which is the same "nothing left to do" lie by another route.
+        register(hub, write_model(tmp_path / "a.safetensors"))
+        register(
+            hub,
+            write_model(tmp_path / "lora.safetensors", b"lora"),
+            sha256="hashed-by-the-scan",
+            file_kind="adapter",
+        )
+
+        assert MissingCheckpointHashFinder(hub).progress() == (1, 1)
+
+    def test_a_row_with_no_present_copy_is_not_counted(self, hub, tmp_path):
+        # find_task() skips it, so counting it would leave the bar permanently
+        # short of its total over a drive that is merely unplugged.
+        register(hub, write_model(tmp_path / "gone.safetensors"), state="unreachable")
+
+        assert MissingCheckpointHashFinder(hub).progress() == (0, 0)
+
+    def test_it_never_reports_nothing_left_while_a_batch_is_still_owed(
+        self, hub, tmp_path
+    ):
+        """The invariant that makes the number worth showing.
+
+        Whatever ``find_task`` would still hand out has to appear in the
+        remaining count, including rows deferred for the session: those are
+        work this process refuses to retry, not work that finished.
+        """
+        for index in range(3):
+            register(
+                hub, write_model(tmp_path / f"{index}.safetensors", bytes([index]))
+            )
+        finder = MissingCheckpointHashFinder(hub)
+
+        seen = []
+        while (task := finder.find_task()) is not None:
+            _total, pending = finder.progress()
+            seen.append(pending)
+            assert pending > 0, "progress said nothing was left while work was in hand"
+            task.run()
+            finder.on_task_complete(task, None)
+
+        assert seen, "the finder never handed anything out"
+        assert finder.progress() == (3, 0)

--- a/tests/test_workers_api.py
+++ b/tests/test_workers_api.py
@@ -73,6 +73,40 @@ def test_an_active_dedup_scan_never_reports_terminal_task_progress(monkeypatch):
         gc.collect()
 
 
+def test_checkpoint_hash_does_not_report_the_picture_library_as_its_progress(
+    monkeypatch,
+):
+    """The Checkpoint Hash row must not borrow the library's numbers.
+
+    It used to fall through to the generic `planner_managed` branch, which set
+    `missing = 0` and left `total` at the picture count. Reading tens of
+    gigabytes off disk then rendered as "N / N, 0 remaining, 0/s" on a row that
+    still said running, so a healthy long task read as a stuck one.
+
+    The picture count is forced to a sentinel rather than importing pictures:
+    an empty library makes the two branches indistinguishable, which is exactly
+    how this would pass while still broken.
+    """
+    temp_dir, _client, server = _setup()
+    try:
+        monkeypatch.setattr(
+            server.vault, "_count_total_pictures", lambda _session: 4242
+        )
+        workers = server.vault.get_worker_progress()
+        snapshot = workers[TaskType.CHECKPOINT_HASH.value]
+        assert snapshot["label"] == "checkpoints_hashed"
+        # The sentinel proves the branch ran: a picture-scoped worker shows it.
+        assert workers[TaskType.QUALITY.value]["total"] == 4242
+        # No hub registration in this fixture, so there is no shelf to count and
+        # the honest answer is zero — never the picture library's total.
+        assert snapshot["total"] == 0
+        assert snapshot["current"] == 0
+    finally:
+        server.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
 def test_version_endpoint_returns_200():
     temp_dir, client, server = _setup()
     try:


### PR DESCRIPTION
Two complaints about the Checkpoint Hash row in the task manager, from a real
scan of a 57 GB / 91-file folder. Reproduced both before touching anything;
they turned out to be two different things, and only one of them is mine.

## Reproduced

Against `develop` at `adddcc37`, i.e. **with #855 merged** — the sweep-starvation
regression is not involved.

**"It arrived late."** A poller sampling every 50 ms during a real
`ModelFolderScanner.scan_folder` over 91 files (6.11 GB) recorded **zero rows
visible to the finder at any point during the scan**; the first one appears only
after `scan_folder` returns. `_WRITE_BATCH = 200` in
`pixlstash/services/model_folder_scanner.py` means 91 files are one commit, at
the end, and the scan spends nearly all its time hashing adapters inline
(`_describe` calls `sha256_file` on every adapter). So the worker cannot start
before the scan is practically finished. **This is the scanner's commit cadence,
not the planner** — handed to the agent doing the scan-to-Task conversion rather
than edited here.

**"It overstayed."** Not an accounting bug. Driving the real `WorkPlanner` +
`TaskRunner` over 24 checkpoints and sampling `inflight_count` against the
runner's active-task set: the flag was on for 0.50 s, a task was genuinely
executing for 0.50 s of that, and it dropped to zero within one 50 ms sample of
the last row being hashed. **No in-flight leak; the duration is real work.**

## The actual defect: it reported nothing while doing it

`CHECKPOINT_HASH` had no branch in `Vault._build_worker_progress_snapshot`, so
it fell through to the generic tail: `missing = 0`, `label = "planner_managed"`,
and `total` left at the **picture library's** count. A multi-minute read of tens
of gigabytes therefore rendered as `N / N`, `0 remaining`, `0/s`, on a row that
still said running. The owner was reading the card correctly — it said there was
nothing left to do.

`MissingCheckpointHashFinder.progress()` now returns `(owned, pending)` from one
query over one row set, and the vault renders it. Pending is the finder's own
`sha256 IS NULL` predicate, not a `file_kind` guess, so a row `find_task` would
hand out can never be reported as done; deferred rows stay counted, because a
broken path is refused work, not finished work. Adapters the scan already hashed
stay out of the denominator, or the bar would park at ~100% on any LoRA folder.

Measured after the fix, same harness: `3/24 → 6/24 → 9/24 → … → 23/24`.

## Mutation-tested

Committed first, then each mutation reverted:

- remove the vault branch → `test_checkpoint_hash_does_not_report_the_picture_library_as_its_progress` fails (`'planner_managed' == 'checkpoints_hashed'`)
- force `pending` to 0 → all three `TestProgress` cases fail
- drop the `file_kind` restriction → `test_an_adapter_the_scan_already_hashed_is_not_in_the_denominator` fails

The API test forces the picture count to a sentinel and asserts a picture-scoped
worker still shows it: an empty library makes the two branches indistinguishable,
which is how this would pass while still broken.

Both test files are already gated, so no `ci.yml` change. 220 passed across
`test_checkpoint_hash_finder`, `test_workers_api`, `test_ci_shards`,
`test_model_folder_scanner`, `test_work_planner`. `ruff format` + `ruff check
pixlstash` clean.