### PR TITLE
A dropped task is not a failed task

### DIFF
--- a/pixlstash/tasks/missing_checkpoint_hash_finder.py
+++ b/pixlstash/tasks/missing_checkpoint_hash_finder.py
@@ -6,6 +6,7 @@ import os
 
 from pixlstash.hub.db import HubDatabase
 from pixlstash.pixl_logging import get_logger
+from pixlstash.task_runner import TaskCancelledError
 from pixlstash.tasks.base_task_finder import BaseTaskFinder
 from pixlstash.tasks.checkpoint_hash_task import CheckpointHashTask
 
@@ -85,8 +86,22 @@ class MissingCheckpointHashFinder(BaseTaskFinder):
         return CheckpointHashTask(hub=self._hub, checkpoints=batch)
 
     def on_task_complete(self, task, error) -> None:
-        """Record which rows must not be handed out again this session."""
+        """Record which rows must not be handed out again this session.
+
+        A cancelled task never ran, so its rows are released and left alone:
+        deferring them would strand checkpoints over a plain planner stop or a
+        queue drain (every restore does both) and log it as a hashing failure.
+        """
         ids = (getattr(task, "params", None) or {}).get("checkpoint_ids") or []
+        if isinstance(error, TaskCancelledError):
+            logger.debug(
+                "Checkpoint hash task for %s was cancelled before it ran: %s. "
+                "Those rows stay eligible.",
+                ids,
+                error,
+            )
+            self._handed_out.difference_update(ids)
+            return
         if error is not None:
             logger.warning(
                 "Checkpoint hashing failed for %s: %s. Deferring those rows for "

--- a/pixlstash/tasks/missing_snapshot_identity_scrub_finder.py
+++ b/pixlstash/tasks/missing_snapshot_identity_scrub_finder.py
@@ -3,6 +3,7 @@ from sqlmodel import Session, select
 
 from pixlstash.db_models import Snapshot
 from pixlstash.pixl_logging import get_logger
+from pixlstash.task_runner import TaskCancelledError
 from pixlstash.tasks.base_task_finder import BaseTaskFinder
 from pixlstash.tasks.snapshot_identity_scrub_task import SnapshotIdentityScrubTask
 
@@ -75,9 +76,20 @@ class MissingSnapshotIdentityScrubFinder(BaseTaskFinder):
         produced hundreds of failing tasks per minute in testing. Skipping it
         for the rest of the process keeps the remaining archives draining, and a
         restart retries it once more.
+
+        A cancelled task never got that far. The claims are released and the
+        archive stays eligible, so a planner stop or a queue drain does not skip
+        it for the rest of the process.
         """
         super().on_task_complete(task, error)
         if error is None:
+            return
+        if isinstance(error, TaskCancelledError):
+            logger.debug(
+                "MissingSnapshotIdentityScrubFinder: scrub task cancelled before "
+                "it ran (%s). The archive stays eligible.",
+                error,
+            )
             return
         snapshot_id = (getattr(task, "params", None) or {}).get("snapshot_id")
         if snapshot_id is None:

--- a/pixlstash/work_planner.py
+++ b/pixlstash/work_planner.py
@@ -2,6 +2,7 @@ import threading
 from typing import TYPE_CHECKING
 
 from pixlstash.pixl_logging import get_logger
+from pixlstash.task_runner import TaskCancelledError
 
 if TYPE_CHECKING:
     from pixlstash.tasks.task_type import TaskType
@@ -567,6 +568,12 @@ class WorkPlanner:
         dropped between finding and submitting leaks its claims for the life of
         the process and those pictures can never be selected again.
 
+        The error is a ``TaskCancelledError`` rather than a bare
+        ``RuntimeError`` because a finder that records permanent state on
+        failure must be able to tell "this work was attempted and failed" from
+        "this work never ran". The task did not run here, so deferring its rows
+        for the rest of the session would strand them over a plain shutdown.
+
         Args:
             finder: The finder that produced *task* and holds its claims.
             task: The task that will not be submitted.
@@ -574,7 +581,7 @@ class WorkPlanner:
         """
         task_id = getattr(task, "id", None)
         finder_name = finder.finder_name()
-        error = RuntimeError(
+        error = TaskCancelledError(
             f"Task {task_id} was dropped before submission: {reason}",
         )
         released = True

--- a/tests/test_checkpoint_hash_finder.py
+++ b/tests/test_checkpoint_hash_finder.py
@@ -19,8 +19,10 @@ import os
 import pytest
 
 from pixlstash.hub.db import HubDatabase
+from pixlstash.task_runner import TaskRunner
 from pixlstash.tasks.checkpoint_hash_task import CheckpointHashTask
 from pixlstash.tasks.missing_checkpoint_hash_finder import MissingCheckpointHashFinder
+from pixlstash.work_planner import WorkPlanner
 
 
 @pytest.fixture
@@ -357,3 +359,57 @@ class TestFinder:
         finder.on_task_complete(task, RuntimeError("hub went away"))
 
         assert finder.find_task() is None
+
+    def test_a_planner_stop_leaves_the_batch_eligible(self, hub, tmp_path):
+        # A task the planner found but never submitted did not fail, it never
+        # ran. Releasing its claims is right; deferring its rows for the rest of
+        # the session is not, and Vault.stop() takes this path on every restore.
+        checkpoint_id = register(hub, write_model(tmp_path / "a.safetensors"))
+        finder = MissingCheckpointHashFinder(hub)
+        planner = WorkPlanner(task_runner=_NeverSubmits(), task_finders=[finder])
+        real_find_task = finder.find_task
+
+        def find_then_stop():
+            task = real_find_task()
+            planner._stop.set()
+            return task
+
+        finder.find_task = find_then_stop
+        assert planner._run_finders_once() is False
+        finder.find_task = real_find_task
+
+        assert finder._handed_out == set(), "the claim was not released"
+        assert finder._deferred == set(), "a task that never ran was deferred"
+        again = finder.find_task()
+        assert again is not None
+        assert again.params["checkpoint_ids"] == [checkpoint_id]
+
+    def test_a_task_cancelled_off_the_queue_leaves_the_batch_eligible(
+        self, hub, tmp_path
+    ):
+        # The common path: Vault.stop() and every full restore drain the queues.
+        checkpoint_id = register(hub, write_model(tmp_path / "a.safetensors"))
+        finder = MissingCheckpointHashFinder(hub)
+        # No workers are started, so the task can only leave through the drain.
+        runner = TaskRunner(name="checkpoint-cancel-test", num_workers=1)
+        planner = WorkPlanner(task_runner=runner, task_finders=[finder])
+        runner.add_task_complete_callback(planner.on_task_complete)
+
+        try:
+            assert planner._run_finders_once() is True
+            assert runner.cancel_pending_tasks() == 1
+
+            assert finder._handed_out == set(), "the claim was not released"
+            assert finder._deferred == set(), "a cancelled task was deferred"
+            again = finder.find_task()
+            assert again is not None
+            assert again.params["checkpoint_ids"] == [checkpoint_id]
+        finally:
+            runner.stop()
+
+
+class _NeverSubmits:
+    """A runner stand-in for the stop-before-submit path, which never calls it."""
+
+    def submit(self, task):
+        raise AssertionError("the planner submitted a task after it had stopped")

--- a/tests/test_work_planner.py
+++ b/tests/test_work_planner.py
@@ -771,6 +771,34 @@ def test_snapshot_identity_finder_stops_reissuing_a_failing_archive(tmp_path):
     finder.on_task_complete(second, None)
 
 
+def test_snapshot_identity_finder_reissues_an_archive_that_was_only_cancelled(tmp_path):
+    """A cancelled scrub never ran, so the archive must stay eligible.
+
+    Vault.stop() stops the planner and drains the queues, so both cancel paths
+    are ordinary shutdown, not a rare race. Treating them as a scrub failure
+    skipped the archive for the rest of the process and logged that it could not
+    be scrubbed, which is a lie about data still carrying portable identity.
+    """
+    from pixlstash.task_runner import TaskCancelledError
+    from pixlstash.tasks.missing_snapshot_identity_scrub_finder import (
+        MissingSnapshotIdentityScrubFinder,
+    )
+
+    vault = _vault_with_snapshots(tmp_path, [(1, False)])
+    finder = MissingSnapshotIdentityScrubFinder(
+        database=_StubDatabase(vault, str(tmp_path))
+    )
+
+    first = finder.find_task()
+    assert first.params["snapshot_id"] == 1
+    finder.on_task_complete(first, TaskCancelledError("drained from the queue"))
+
+    assert finder._failed == set(), "a task that never ran was recorded as failed"
+    again = finder.find_task()
+    assert again is not None
+    assert again.params["snapshot_id"] == 1
+
+
 def test_snapshot_identity_task_marks_a_missing_archive_done(tmp_path):
     """A dangling registration has no bytes at rest, so nothing can leak."""
     import sqlite3


### PR DESCRIPTION
Surfaced by a Copilot review comment on #859.

## The regression

#850 made the completion callbacks fire on paths where a task never ran, so finders release their claimed ids. That was the right fix for a real leak, but it passes a non-None error on those paths, and two finders treat any non-None error as "this work failed, never hand it out again this session":

- `MissingCheckpointHashFinder.on_task_complete` puts the ids in `_deferred`, which `find_task()` excludes for the life of the process.
- `MissingSnapshotIdentityScrubFinder.on_task_complete` puts the snapshot in `_failed`, same effect.

Two paths reach them with a task that never ran:

- `WorkPlanner._release_unsubmitted()`, from the planner stopping before it could submit and from `submit()` raising.
- `TaskRunner.cancel_pending_tasks()` / `stop()`'s drain, which fires `_cancel_queued_task` with a `TaskCancelledError`.

`Vault.stop()` and every full restore stop the planner and drain the queues, so this is an ordinary shutdown path, not a rare race. The symptom is checkpoints that silently never get a sha256 until the process restarts, with a log line claiming hashing failed.

## The fix

One central distinction rather than a per-finder workaround. `TaskCancelledError` already means "cancelled before it had a chance to complete", which is exactly both paths, so `_release_unsubmitted` raises that type instead of a bare `RuntimeError` (same message) and both stateful finders return early for it, after releasing what they hold. The claim release from #850 still happens on every path.

## Both directions

Negative (a task that never ran must stay eligible):

- `test_a_planner_stop_leaves_the_batch_eligible`
- `test_a_task_cancelled_off_the_queue_leaves_the_batch_eligible`
- `test_snapshot_identity_finder_reissues_an_archive_that_was_only_cancelled`

Positive (a genuine failure must still record permanent state, or the spin the scrub finder's docstring describes comes back):

- `test_a_failed_task_defers_its_whole_batch`, existing, still green
- `test_snapshot_identity_finder_stops_reissuing_a_failing_archive`, existing, still green
- `test_the_batch_is_released_once_its_result_is_in`, existing, still green

Each new test was proved able to fail by reverting one line of the fix at a time: restoring the bare `RuntimeError` reddens the planner-stop test; removing the checkpoint finder's cancelled branch reddens both checkpoint tests; removing the scrub finder's reddens the scrub test. All restored, suite green.

## Other consumers of `error is not None`

`Vault._on_task_completed` bails out on any error and records nothing, so it is unaffected. `BaseTaskFinder.on_task_complete` ignores the error entirely. No other finder overrides the callback.

Both test files are already in the backend gate's file list, so `ci.yml` needs no change.