### PR TITLE
Give the shelf's empty-state buttons a fill

### DIFF
--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -147,7 +147,11 @@
            first two offer Reset. -->
       <div v-else-if="store.nothingSelected" class="shelf-state">
         <p>Nothing is selected in Show.</p>
-        <button class="tbm-action" type="button" @click="store.resetFilters()">
+        <button
+          class="tbm-action tbm-action--secondary"
+          type="button"
+          @click="store.resetFilters()"
+        >
           Reset filters
         </button>
       </div>
@@ -157,13 +161,21 @@
           PixlStash lists what it finds in the model folders registered on this
           machine. Add the folder where you keep them.
         </p>
-        <button class="tbm-action" type="button" @click="openFolders($event)">
+        <button
+          class="tbm-action tbm-action--primary"
+          type="button"
+          @click="openFolders($event)"
+        >
           Add a model folder
         </button>
       </div>
       <div v-else-if="!store.visibleRows.length" class="shelf-state">
         <p>No models match these filters.</p>
-        <button class="tbm-action" type="button" @click="store.resetFilters()">
+        <button
+          class="tbm-action tbm-action--secondary"
+          type="button"
+          @click="store.resetFilters()"
+        >
           Reset filters
         </button>
       </div>


### PR DESCRIPTION
The three empty-state buttons on the model shelf carried a bare `.tbm-action`.
That recipe sets layout and type only: the background and colour live on the
`--primary` / `--secondary` modifiers (`App.css:844-850`), so without one the
button renders as unfilled text. "Add a model folder" read as a link rather
than a button.

`--primary` for the one call to action, `--secondary` for the two Reset
filters, matching `Toolbar.vue:317` and `GbFilterPanel.vue:445`.

The four bare `.tbm-action` rows in `Toolbar.vue` are left alone: those are
`TbOverflowMenu` rows and are deliberately unfilled against the panel.

Prettier, eslint and the 284 view tests pass.