### PR TITLE
Select the shelf the way a file manager does

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1500,12 +1500,41 @@ re-ticking the box brings it back rather than making the reader select it again.
 `pruneSelection` runs after every fetch and drops ids the shelf no longer holds,
 or a forgotten model would be counted by the bar for the life of the tab.
 
-**The checkbox goes in column 1, where the reserved glyph slot already was**, so
-ticking a row moves nothing. It is labelled with the row's own name: 1,800
-controls announcing "checkbox" is the same as none of them announcing anything.
-This is also the one rule F3 changed — the row itself is still not a focus stop,
-but its checkbox is, which is exactly what the old "rows carry no verb" comment
-anticipated.
+**Selection is the file manager's, not a checkbox's.** Plain click replaces the
+selection with the row clicked, Ctrl/Cmd+click toggles one, Shift+click takes the
+contiguous run from the anchor and **replaces** rather than merges — the same
+three gestures, and the same replace rule, as `ImageGrid.handleImageCardClick`.
+Replacing is what makes a mis-aimed range one click to correct instead of two.
+The anchor is held apart from the selection (`anchorId`, mirroring
+`useMultiSelect`'s `lastSelectedImageId`) precisely because a range replaces
+what was there: it could not be recovered from the selection afterwards.
+
+The shelf shipped a per-row checkbox first and it was the wrong call — a second
+selection dialect on the one list in the app that most looks like a file
+manager. The tick that remains in column 1 is a *mark*, not a control.
+
+**The range spans the DRAWN order, de-duplicated.** `orderedRowIds` walks
+`shownGroups` and skips collapsed groups, because banding re-orders groups and a
+range measured against an order the reader cannot see would select a run they
+did not point at. A model drawn under two folders appears once in that sequence,
+since the range is over models and models are what the verbs act on.
+
+**The rows are a multi-select listbox with a roving tabindex.** Removing the
+checkbox removed the only focus stop a row had, so the row takes the role
+instead: `role="listbox"` + `aria-multiselectable` on the `<ul>`,
+`role="option"` + `aria-selected` on each row, and exactly one row at
+`tabindex="0"` — seeded to the first drawn row, or a roving tabindex with
+nothing at 0 makes the whole list unreachable by Tab. That is the same "1,800
+tab stops is a trap" rule as before, now solved by roving rather than by having
+no stop at all. The listbox role is legitimate here and was refused in
+`ModelFoldersDialog` for the mirror-image reason: these rows hold no interactive
+controls, and a control inside `role="option"` is unreachable.
+
+Arrows move the stop **without** selecting, so a reader can walk the list
+without arming a verb against every row they pass; Space and Enter pick;
+Shift+arrow extends from the anchor, the keyboard's Shift+click; Escape clears.
+A click that lands while text is selected inside the row is ignored, or dragging
+across a name to copy it would collapse the selection on mouseup.
 
 **`ShelfSelectionBar.vue` emits; `ModelShelf.vue` acts.** Every button is an
 emit, so both confirmations live in one place instead of half in the bar and

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1524,7 +1524,17 @@ checkbox removed the only focus stop a row had, so the row takes the role
 instead: `role="listbox"` + `aria-multiselectable` on the `<ul>`,
 `role="option"` + `aria-selected` on each row, and exactly one row at
 `tabindex="0"` — seeded to the first drawn row, or a roving tabindex with
-nothing at 0 makes the whole list unreachable by Tab. That is the same "1,800
+nothing at 0 makes the whole list unreachable by Tab.
+
+**Focus is keyed per DRAWN ROW (`rowKey`), selection per MODEL (`id`), and the
+two lists are not the same.** Under folder grouping a model with copies in two
+folders is drawn twice, and both draws are places the cursor can be — but the
+verbs write the model, so the range de-duplicates. Keying focus by model id
+instead put `tabindex="0"` on every draw of the same model at once, which is two
+focusable options for one listbox position, and made the arrows read the first
+draw's index whichever draw the cursor was on. `rowKey` is assigned on **both**
+branches of `groups`, including the ungrouped default, where it was previously
+absent and left the list's `v-for` key `undefined` for every row. That is the same "1,800
 tab stops is a trap" rule as before, now solved by roving rather than by having
 no stop at all. The listbox role is legitimate here and was refused in
 `ModelFoldersDialog` for the mirror-image reason: these rows hold no interactive
@@ -1533,8 +1543,11 @@ controls, and a control inside `role="option"` is unreachable.
 Arrows move the stop **without** selecting, so a reader can walk the list
 without arming a verb against every row they pass; Space and Enter pick;
 Shift+arrow extends from the anchor, the keyboard's Shift+click; Escape clears.
-A click that lands while text is selected inside the row is ignored, or dragging
-across a name to copy it would collapse the selection on mouseup.
+A click that ends a text drag **inside that row** is ignored, or dragging across
+a name to copy it would collapse the selection on mouseup. Scoped to the clicked
+row: asking only whether any text is selected anywhere would make the entire
+list unclickable for as long as the reader had a selection elsewhere on the
+page.
 
 **`ShelfSelectionBar.vue` emits; `ModelShelf.vue` acts.** Every button is an
 emit, so both confirmations live in one place instead of half in the bar and

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -235,11 +235,21 @@ describe("keyboard", () => {
     wrapper.unmount();
   });
 
-  it("leaves rows out of the tab order while they have no verb", async () => {
-    // 1,800 empty tab stops is a trap. Roving focus arrives with the first
-    // thing a focused row can do (F2/F4).
-    const wrapper = await mountShelf([adapter()]);
-    expect(wrapper.find(".shelf-row").attributes("tabindex")).toBeUndefined();
+  it("gives the rows ONE tab stop between them, not 1,800", async () => {
+    // The rule that used to read "rows are not focus stops" — 1,800 empty stops
+    // is a trap. F3 gave a row something to do, so it is now a roving tabindex
+    // rather than no tabindex: exactly one row is reachable by Tab and the
+    // arrows move which one.
+    const wrapper = await mountShelf([
+      adapter({ id: 1 }),
+      adapter({ id: 2 }),
+      adapter({ id: 3 }),
+    ]);
+    const stops = wrapper
+      .findAll(".shelf-row")
+      .map((r) => r.attributes("tabindex"));
+    expect(stops.filter((t) => t === "0")).toHaveLength(1);
+    expect(stops.filter((t) => t === "-1")).toHaveLength(2);
     expect(wrapper.find(".shelf").attributes("tabindex")).toBe("-1");
   });
 });
@@ -295,15 +305,15 @@ describe("group headers", () => {
     expect(textOf(wrapper.find(".shelf-group-btn"))).toContain("2 models");
   });
 
-  it("is a real button and leaves the rows out of the tab order", async () => {
-    // Rows carry no verb, so the headers are the only stops in the list, which
-    // is what makes Tab a group-to-group move without inventing a shortcut.
+  it("is a real button, so Tab still moves group to group", async () => {
+    // The header stays a stop of its own. It shared that job with nothing while
+    // rows carried no verb; now it shares it with the list's single roving
+    // stop, which is one Tab press away rather than 1,800.
     const wrapper = await mountShelf([adapter({ base_model: "sdxl" })]);
     useModelShelfStore().setView({ groupBy: "base_model" });
     await wrapper.vm.$nextTick();
     expect(wrapper.find(".shelf-group-btn").element.tagName).toBe("BUTTON");
     expect(wrapper.find(".shelf-group-heading").element.tagName).toBe("H3");
-    expect(wrapper.find(".shelf-row").attributes("tabindex")).toBeUndefined();
   });
 
   it("sets a folder path in the path variant, never uppercased", async () => {
@@ -383,7 +393,9 @@ describe("the Sort split-button", () => {
 });
 
 describe("selecting rows", () => {
-  it("ticks by model, so one file selected in two folders is one selection", async () => {
+  const rowAt = (wrapper, i) => wrapper.findAll(".shelf-row")[i];
+
+  it("selects by model, so one file drawn in two folders is one selection", async () => {
     // Under folder grouping a model with copies in two folders is DRAWN twice.
     // The verbs write the model, so a per-row selection would let the same file
     // be half selected and ask the reader to hold a distinction the data has
@@ -399,31 +411,133 @@ describe("selecting rows", () => {
     useModelShelfStore().setView({ groupBy: "folder" });
     await wrapper.vm.$nextTick();
 
-    const boxes = wrapper.findAll(".shelf-row-pick input");
-    expect(boxes).toHaveLength(2);
-    await boxes[0].trigger("change");
+    expect(wrapper.findAll(".shelf-row")).toHaveLength(2);
+    await rowAt(wrapper, 0).trigger("click");
     await wrapper.vm.$nextTick();
 
     expect(useModelShelfStore().selectedRows).toHaveLength(1);
     expect(wrapper.findAll(".shelf-row--selected")).toHaveLength(2);
   });
 
+  it("replaces the selection on a plain click", async () => {
+    // The file-manager rule, and the one a checkbox got wrong: a bare click is
+    // not a toggle, it starts again.
+    const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    const store = useModelShelfStore();
+    await rowAt(wrapper, 0).trigger("click");
+    await rowAt(wrapper, 1).trigger("click");
+    expect([...store.selectedIds]).toEqual([2]);
+  });
+
+  it("toggles one row on Ctrl+click and leaves the rest alone", async () => {
+    const wrapper = await mountShelf([
+      adapter({ id: 1 }),
+      adapter({ id: 2 }),
+      adapter({ id: 3 }),
+    ]);
+    const store = useModelShelfStore();
+    await rowAt(wrapper, 0).trigger("click");
+    await rowAt(wrapper, 2).trigger("click", { ctrlKey: true });
+    expect([...store.selectedIds].sort()).toEqual([1, 3]);
+
+    await rowAt(wrapper, 2).trigger("click", { ctrlKey: true });
+    expect([...store.selectedIds]).toEqual([1]);
+  });
+
+  it("takes the range from the anchor on Shift+click, and replaces", async () => {
+    // Replace rather than merge, exactly as the grid does: it is what makes a
+    // mis-aimed range one click to correct instead of two.
+    const wrapper = await mountShelf([
+      adapter({ id: 1 }),
+      adapter({ id: 2 }),
+      adapter({ id: 3 }),
+      adapter({ id: 4 }),
+    ]);
+    const store = useModelShelfStore();
+    await rowAt(wrapper, 1).trigger("click");
+    await rowAt(wrapper, 3).trigger("click", { shiftKey: true });
+    expect([...store.selectedIds].sort()).toEqual([2, 3, 4]);
+
+    // The anchor stays put, so shrinking the range back measures from the same
+    // end rather than from wherever the last click landed.
+    await rowAt(wrapper, 2).trigger("click", { shiftKey: true });
+    expect([...store.selectedIds].sort()).toEqual([2, 3]);
+  });
+
+  it("ranges upward as readily as downward", async () => {
+    const wrapper = await mountShelf([
+      adapter({ id: 1 }),
+      adapter({ id: 2 }),
+      adapter({ id: 3 }),
+    ]);
+    const store = useModelShelfStore();
+    await rowAt(wrapper, 2).trigger("click");
+    await rowAt(wrapper, 0).trigger("click", { shiftKey: true });
+    expect([...store.selectedIds].sort()).toEqual([1, 2, 3]);
+  });
+
+  it("is a multi-select listbox, and says which rows are selected", async () => {
+    // The role is what tells a screen reader this list is selectable at all;
+    // it replaced the per-row checkbox that used to carry that meaning.
+    const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    const list = wrapper.find("ul.shelf-list");
+    expect(list.attributes("role")).toBe("listbox");
+    expect(list.attributes("aria-multiselectable")).toBe("true");
+
+    await rowAt(wrapper, 0).trigger("click");
+    await wrapper.vm.$nextTick();
+    expect(rowAt(wrapper, 0).attributes("aria-selected")).toBe("true");
+    expect(rowAt(wrapper, 1).attributes("aria-selected")).toBe("false");
+  });
+
+  it("keeps exactly one tab stop, seeded so the list is reachable", async () => {
+    // A roving tabindex with nothing at 0 makes the whole list unreachable by
+    // Tab, which is the failure this seeding exists to prevent.
+    const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    const stops = wrapper
+      .findAll(".shelf-row")
+      .map((r) => r.attributes("tabindex"));
+    expect(stops).toEqual(["0", "-1"]);
+  });
+
+  it("moves the tab stop on an arrow without selecting anything", async () => {
+    // Walking 1,800 rows must not arm a verb against every one passed.
+    const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    const store = useModelShelfStore();
+    await rowAt(wrapper, 0).trigger("keydown", { key: "ArrowDown" });
+    await wrapper.vm.$nextTick();
+
+    expect(store.selectedRows).toHaveLength(0);
+    expect(
+      wrapper.findAll(".shelf-row").map((r) => r.attributes("tabindex")),
+    ).toEqual(["-1", "0"]);
+  });
+
+  it("extends with Shift+arrow and clears with Escape", async () => {
+    const wrapper = await mountShelf([
+      adapter({ id: 1 }),
+      adapter({ id: 2 }),
+      adapter({ id: 3 }),
+    ]);
+    const store = useModelShelfStore();
+    await rowAt(wrapper, 0).trigger("keydown", { key: " " });
+    await rowAt(wrapper, 0).trigger("keydown", {
+      key: "ArrowDown",
+      shiftKey: true,
+    });
+    expect([...store.selectedIds].sort()).toEqual([1, 2]);
+
+    await rowAt(wrapper, 0).trigger("keydown", { key: "Escape" });
+    expect(store.selectedRows).toHaveLength(0);
+  });
+
   it("shows no selection bar until something is selected", async () => {
     const wrapper = await mountShelf([adapter()]);
     expect(wrapper.find(".shelf-selbar").exists()).toBe(false);
 
-    await wrapper.find(".shelf-row-pick input").trigger("change");
+    await rowAt(wrapper, 0).trigger("click");
     await wrapper.vm.$nextTick();
     expect(textOf(wrapper.find(".shelf-selbar"))).toContain("1 model selected");
-  });
-
-  it("names the row in the checkbox, not just 'checkbox'", async () => {
-    // 1,800 controls all announcing "checkbox" is the same as none of them
-    // announcing anything.
-    const wrapper = await mountShelf([adapter({ display_name: "Clementine" })]);
-    expect(wrapper.find(".shelf-row-pick input").attributes("aria-label")).toBe(
-      "Select Clementine",
-    );
   });
 
   it("drops a selected model that the shelf no longer holds", async () => {
@@ -431,9 +545,8 @@ describe("selecting rows", () => {
     // verb posts an id the server has to refuse.
     const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
     const store = useModelShelfStore();
-    for (const box of wrapper.findAll(".shelf-row-pick input")) {
-      await box.trigger("change");
-    }
+    await rowAt(wrapper, 0).trigger("click");
+    await rowAt(wrapper, 1).trigger("click", { ctrlKey: true });
     expect(store.selectedRows).toHaveLength(2);
 
     listAdapters.mockResolvedValue([adapter({ id: 1 })]);
@@ -553,7 +666,7 @@ describe("the group header's reserved column", () => {
 });
 
 describe("selection and drive bands together", () => {
-  it("ticks a row that sits under a band, and bands do not become rows", async () => {
+  it("selects a row that sits under a band, and bands do not become rows", async () => {
     // The seam this merge created: F2 renders `shownGroups` (banded) where F1
     // rendered `store.groups`, and F3 puts a checkbox inside the row loop. If
     // `bandGroups` ever dropped `rows` on its way through, the list would draw
@@ -585,13 +698,15 @@ describe("selection and drive bands together", () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.find(".shelf-band-heading").exists()).toBe(true);
-    const boxes = wrapper.findAll(".shelf-row-pick input");
-    expect(boxes).toHaveLength(1);
+    const rows = wrapper.findAll(".shelf-row");
+    expect(rows).toHaveLength(1);
 
-    await boxes[0].trigger("change");
+    await rows[0].trigger("click");
     await wrapper.vm.$nextTick();
     expect(textOf(wrapper.find(".shelf-selbar"))).toContain("1 model selected");
-    // The band is a header, not a row: it must not have acquired a checkbox.
-    expect(wrapper.find(".shelf-band-heading input").exists()).toBe(false);
+    // The band is a header, not a row: it must not have become selectable.
+    expect(wrapper.find(".shelf-band-heading").attributes("role")).not.toBe(
+      "option",
+    );
   });
 });

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -710,3 +710,111 @@ describe("selection and drive bands together", () => {
     );
   });
 });
+
+describe("focus under folder grouping, where a model is drawn twice", () => {
+  const twiceDrawn = () =>
+    adapter({
+      id: 1,
+      locations: [
+        { state: "present", folder_id: 1, folder_path: "/a", relpath: "x" },
+        { state: "present", folder_id: 2, folder_path: "/b", relpath: "x" },
+      ],
+    });
+
+  async function mountGrouped(rows) {
+    const wrapper = await mountShelf(rows);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "alpha" });
+    await wrapper.vm.$nextTick();
+    return wrapper;
+  }
+
+  it("still keeps exactly one tab stop across both draws", async () => {
+    // Keyed by model id, BOTH draws satisfied `row.id === rovingRowId` and both
+    // carried tabindex="0" — two focusable options for one listbox position.
+    const wrapper = await mountGrouped([twiceDrawn()]);
+    const stops = wrapper
+      .findAll(".shelf-row")
+      .map((r) => r.attributes("tabindex"));
+    expect(stops).toHaveLength(2);
+    expect(stops.filter((t) => t === "0")).toHaveLength(1);
+  });
+
+  it("moves the stop to the second draw, not back to the first", async () => {
+    // The bug the id-keying hid: `indexOf(row.id)` returned the FIRST draw's
+    // index whichever draw the cursor was on, so ArrowDown from the second draw
+    // moved to the second draw again.
+    const wrapper = await mountGrouped([twiceDrawn()]);
+    await wrapper.findAll(".shelf-row")[0].trigger("keydown", {
+      key: "ArrowDown",
+    });
+    await wrapper.vm.$nextTick();
+
+    const stops = wrapper
+      .findAll(".shelf-row")
+      .map((r) => r.attributes("tabindex"));
+    expect(stops).toEqual(["-1", "0"]);
+  });
+
+  it("gives every drawn row a key, including in the ungrouped default", async () => {
+    // `rowKey` was set only where a model can be drawn twice, so in the default
+    // view the list's v-for key — and everything else keyed per drawn row — was
+    // undefined for every row.
+    const flat = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    const keys = flat
+      .findAll(".shelf-row")
+      .map((r) => r.attributes("data-row-key"));
+    expect(keys).toEqual(["1", "2"]);
+
+    const grouped = await mountGrouped([twiceDrawn()]);
+    const groupedKeys = grouped
+      .findAll(".shelf-row")
+      .map((r) => r.attributes("data-row-key"));
+    expect(new Set(groupedKeys).size).toBe(2);
+  });
+
+  it("selects the model, so both of its draws light up", async () => {
+    // Focus is per drawn row; selection stays per model. Clicking one draw
+    // selects the model, and the other draw of it must show as selected too.
+    const wrapper = await mountGrouped([twiceDrawn()]);
+    await wrapper.findAll(".shelf-row")[0].trigger("click");
+    await wrapper.vm.$nextTick();
+
+    expect(useModelShelfStore().selectedRows).toHaveLength(1);
+    expect(wrapper.findAll(".shelf-row--selected")).toHaveLength(2);
+  });
+});
+
+describe("a click that ends a text drag", () => {
+  it("is ignored only when the text was dragged inside that row", async () => {
+    // Asking whether ANY text is selected anywhere made the whole list
+    // unclickable for as long as the reader had a selection elsewhere.
+    const wrapper = await mountShelf([adapter({ id: 1 }), adapter({ id: 2 })]);
+    const store = useModelShelfStore();
+    const rows = wrapper.findAll(".shelf-row");
+
+    // A live selection anchored OUTSIDE the row must not block the click.
+    const outside = document.createElement("p");
+    outside.textContent = "selected somewhere else";
+    document.body.appendChild(outside);
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+      anchorNode: outside,
+      toString: () => "selected somewhere else",
+    });
+
+    await rows[0].trigger("click");
+    expect([...store.selectedIds]).toEqual([1]);
+
+    // Anchored INSIDE the clicked row, it is a drag and must be ignored.
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+      anchorNode: rows[1].element.firstChild,
+      toString: () => "a name",
+    });
+    await rows[1].trigger("click");
+    expect([...store.selectedIds]).toEqual([1]);
+
+    window.getSelection.mockRestore();
+    outside.remove();
+  });
+});

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -271,10 +271,19 @@
             </button>
           </h3>
 
+          <!-- `role="listbox"` with `aria-multiselectable`, which is what the
+               rows became when the checkbox left: a list you select from with
+               click, Ctrl+click and Shift+click IS a multi-select listbox, and
+               the role is what tells a screen reader that. It is legitimate
+               here and was not in `ModelFoldersDialog` for the same reason in
+               reverse — these rows hold no interactive controls, and a control
+               inside `role="option"` is unreachable. -->
           <ul
             v-if="!grouped || !store.isCollapsed(group.key)"
             class="shelf-list"
-            role="list"
+            role="listbox"
+            aria-multiselectable="true"
+            :aria-label="grouped ? group.label : 'Models'"
           >
             <li
               v-for="row in group.rows"
@@ -282,19 +291,23 @@
               class="ps-row shelf-row"
               :class="{ 'shelf-row--selected': store.isSelected(row.id) }"
               :title="rowTitle(row)"
+              role="option"
+              :aria-selected="store.isSelected(row.id)"
+              :tabindex="row.id === rovingRowId ? 0 : -1"
+              :data-row-id="row.id"
+              @click="pickRow(row, $event)"
+              @keydown="onRowKeydown(row, $event)"
+              @focus="focusedRowId = row.id"
             >
-              <!-- Column 1 was a reserved empty slot while a row carried no
-                   verb. It carries one now, so the checkbox goes where the
-                   space already was and no column moves. Labelled by the row's
-                   own name, because "checkbox" repeated 1,800 times tells a
-                   screen reader nothing about which file it is on. -->
+              <!-- Column 1 stays the reserved glyph slot. The selection shows
+                   as the row's own wash and a tick here, not as a checkbox: a
+                   checkbox is a second, contradictory way to select in a list
+                   whose click already selects, and it was the shelf teaching a
+                   dialect the rest of the app does not speak. -->
               <span class="ps-row-glyph shelf-row-pick">
-                <input
-                  type="checkbox"
-                  :checked="store.isSelected(row.id)"
-                  :aria-label="`Select ${row.name.text}`"
-                  @change="store.toggleSelected(row.id)"
-                />
+                <v-icon v-if="store.isSelected(row.id)" size="16"
+                  >mdi-check</v-icon
+                >
               </span>
               <span class="shelf-row-kind">
                 <v-icon size="16">{{ KIND_ICON[row.file_kind] }}</v-icon>
@@ -447,6 +460,95 @@ const ALGO_LABEL = {
   dora: "DoRA",
   oft: "OFT",
 };
+
+/**
+ * The ids in the order the list DRAWS them, which is what a Shift-range spans.
+ *
+ * Not `store.groups`: banding re-orders the groups, and a range that measured
+ * against an order the reader cannot see would select a run they did not point
+ * at. Under folder grouping a model drawn in two folders appears twice, so the
+ * sequence is de-duplicated — the range is over models, which is what the
+ * verbs act on.
+ */
+const orderedRowIds = computed(() => {
+  const seen = new Set();
+  for (const group of shownGroups.value) {
+    if (grouped.value && store.isCollapsed(group.key)) continue;
+    for (const row of group.rows) seen.add(row.id);
+  }
+  return [...seen];
+});
+
+/**
+ * Which row owns the list's single tab stop.
+ *
+ * Roving, and it falls back to the first drawn row: with no row at `tabindex=0`
+ * the whole list is unreachable by Tab, which is the failure mode a roving
+ * tabindex introduces if nothing seeds it.
+ */
+const focusedRowId = ref(null);
+const rovingRowId = computed(
+  () => focusedRowId.value ?? orderedRowIds.value[0] ?? null,
+);
+
+/**
+ * Click, Ctrl+click, Shift+click — the grid's own three gestures.
+ *
+ * A text selection inside the row is not a pick: dragging across a name to
+ * copy it would otherwise collapse the selection to that one row on mouseup.
+ */
+function pickRow(row, event) {
+  if (window.getSelection?.()?.toString()) return;
+  focusedRowId.value = row.id;
+  store.selectFromClick(
+    row.id,
+    { ctrl: event.ctrlKey || event.metaKey, shift: event.shiftKey },
+    orderedRowIds.value,
+  );
+}
+
+/**
+ * The keyboard half of the same three gestures.
+ *
+ * Arrow keys move the tab stop without selecting, which is the roving-focus
+ * contract: a reader can walk 1,800 rows without arming a verb against every
+ * one they pass. Space and Enter pick; Shift+arrow extends from the anchor,
+ * the keyboard's Shift+click. Escape clears, so there is always a way out that
+ * does not involve finding the bar.
+ */
+function onRowKeydown(row, event) {
+  const order = orderedRowIds.value;
+  const index = order.indexOf(row.id);
+  const step = { ArrowDown: 1, ArrowUp: -1 }[event.key];
+  if (step !== undefined) {
+    const next = order[index + step];
+    if (next === undefined) return;
+    event.preventDefault();
+    focusedRowId.value = next;
+    if (event.shiftKey) {
+      store.selectFromClick(next, { shift: true }, order);
+    }
+    nextTick(() => {
+      rootEl.value
+        ?.querySelector(`[data-row-id="${next}"]`)
+        ?.focus({ preventScroll: false });
+    });
+    return;
+  }
+  if (event.key === " " || event.key === "Enter") {
+    event.preventDefault();
+    store.selectFromClick(
+      row.id,
+      { ctrl: event.key === " " || event.ctrlKey || event.metaKey },
+      order,
+    );
+    return;
+  }
+  if (event.key === "Escape" && store.selectedRows.length) {
+    event.preventDefault();
+    store.clearSelection();
+  }
+}
 
 /** "1 model" / "12 models", so no line ever reads "1 models". */
 function modelCount(n) {
@@ -656,11 +758,16 @@ watch(
   justify-content: center;
 }
 
-.shelf-row-pick input {
-  width: 16px;
-  height: 16px;
-  accent-color: rgb(var(--v-theme-primary));
+/* The row is the control, so it takes the pointer and the focus ring. The ring
+   is inset rather than an outline: the rows sit flush against each other and an
+   outer ring would be clipped by the neighbour above. */
+.shelf-row {
   cursor: pointer;
+}
+
+.shelf-row:focus-visible {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: -2px;
 }
 
 /* A wash, not a border: a 1px outline on a selected row shifts every glyph in

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -293,11 +293,11 @@
               :title="rowTitle(row)"
               role="option"
               :aria-selected="store.isSelected(row.id)"
-              :tabindex="row.id === rovingRowId ? 0 : -1"
-              :data-row-id="row.id"
+              :tabindex="row.rowKey === rovingRowKey ? 0 : -1"
+              :data-row-key="row.rowKey"
               @click="pickRow(row, $event)"
               @keydown="onRowKeydown(row, $event)"
-              @focus="focusedRowId = row.id"
+              @focus="focusedRowKey = row.rowKey"
             >
               <!-- Column 1 stays the reserved glyph slot. The selection shows
                    as the row's own wash and a tick here, not as a checkbox: a
@@ -462,44 +462,68 @@ const ALGO_LABEL = {
 };
 
 /**
- * The ids in the order the list DRAWS them, which is what a Shift-range spans.
+ * Every drawn row, in order, as `{key, id}`.
  *
- * Not `store.groups`: banding re-orders the groups, and a range that measured
+ * TWO orders come out of this and they are not the same list, which is the
+ * whole point. Focus moves over RENDERED ROWS: under folder grouping a model
+ * with copies in two folders is drawn twice, and both draws are places the
+ * cursor can be. Selection is over MODELS: the verbs write the model, so the
+ * range de-duplicates.
+ *
+ * Keying focus by `row.id` instead put `tabindex="0"` on every draw of the
+ * same model at once, gave `querySelector` the first duplicate whichever one
+ * was focused, and made `indexOf` return the first draw's index when the
+ * cursor was on the second.
+ *
+ * Not `store.groups`: banding re-orders the groups, and a range measured
  * against an order the reader cannot see would select a run they did not point
- * at. Under folder grouping a model drawn in two folders appears twice, so the
- * sequence is de-duplicated — the range is over models, which is what the
- * verbs act on.
+ * at.
  */
-const orderedRowIds = computed(() => {
-  const seen = new Set();
+const drawnRows = computed(() => {
+  const rows = [];
   for (const group of shownGroups.value) {
     if (grouped.value && store.isCollapsed(group.key)) continue;
-    for (const row of group.rows) seen.add(row.id);
+    for (const row of group.rows) rows.push({ key: row.rowKey, id: row.id });
   }
-  return [...seen];
+  return rows;
 });
 
+/** Model ids in drawn order, de-duplicated: what a Shift-range spans. */
+const orderedRowIds = computed(() => [
+  ...new Set(drawnRows.value.map((row) => row.id)),
+]);
+
 /**
- * Which row owns the list's single tab stop.
+ * Which drawn row owns the list's single tab stop.
  *
  * Roving, and it falls back to the first drawn row: with no row at `tabindex=0`
  * the whole list is unreachable by Tab, which is the failure mode a roving
  * tabindex introduces if nothing seeds it.
  */
-const focusedRowId = ref(null);
-const rovingRowId = computed(
-  () => focusedRowId.value ?? orderedRowIds.value[0] ?? null,
+const focusedRowKey = ref(null);
+const rovingRowKey = computed(
+  () => focusedRowKey.value ?? drawnRows.value[0]?.key ?? null,
 );
 
 /**
  * Click, Ctrl+click, Shift+click — the grid's own three gestures.
  *
- * A text selection inside the row is not a pick: dragging across a name to
- * copy it would otherwise collapse the selection to that one row on mouseup.
+ * A drag across THIS row's text is not a pick: releasing it would otherwise
+ * collapse the selection to that one row. Scoped to the row the click landed
+ * in — asking only whether any text is selected anywhere would make the whole
+ * list unclickable for as long as the reader had a selection somewhere else on
+ * the page, which is a far bigger rule than the one intended.
  */
 function pickRow(row, event) {
-  if (window.getSelection?.()?.toString()) return;
-  focusedRowId.value = row.id;
+  const selection = window.getSelection?.();
+  if (
+    selection &&
+    !selection.isCollapsed &&
+    event.currentTarget?.contains?.(selection.anchorNode)
+  ) {
+    return;
+  }
+  focusedRowKey.value = row.rowKey;
   store.selectFromClick(
     row.id,
     { ctrl: event.ctrlKey || event.metaKey, shift: event.shiftKey },
@@ -516,23 +540,37 @@ function pickRow(row, event) {
  * the keyboard's Shift+click. Escape clears, so there is always a way out that
  * does not involve finding the bar.
  */
+/**
+ * Move real focus to a drawn row by its key.
+ *
+ * Matched by reading `dataset` rather than building an attribute selector: a
+ * row key carries a folder path, so it can hold quotes, brackets and
+ * backslashes, and `CSS.escape` is not defined in jsdom — a selector here would
+ * be both fragile and untestable.
+ */
+function focusDrawnRow(key) {
+  for (const el of rootEl.value?.querySelectorAll("[data-row-key]") || []) {
+    if (el.dataset.rowKey === key) {
+      el.focus({ preventScroll: false });
+      return;
+    }
+  }
+}
+
 function onRowKeydown(row, event) {
-  const order = orderedRowIds.value;
-  const index = order.indexOf(row.id);
+  const drawn = drawnRows.value;
+  const index = drawn.findIndex((drawnRow) => drawnRow.key === row.rowKey);
   const step = { ArrowDown: 1, ArrowUp: -1 }[event.key];
   if (step !== undefined) {
-    const next = order[index + step];
+    const next = drawn[index + step];
     if (next === undefined) return;
     event.preventDefault();
-    focusedRowId.value = next;
+    // The cursor moves over DRAWN rows; the range it extends is over models.
+    focusedRowKey.value = next.key;
     if (event.shiftKey) {
-      store.selectFromClick(next, { shift: true }, order);
+      store.selectFromClick(next.id, { shift: true }, orderedRowIds.value);
     }
-    nextTick(() => {
-      rootEl.value
-        ?.querySelector(`[data-row-id="${next}"]`)
-        ?.focus({ preventScroll: false });
-    });
+    nextTick(() => focusDrawnRow(next.key));
     return;
   }
   if (event.key === " " || event.key === "Enter") {
@@ -540,7 +578,7 @@ function onRowKeydown(row, event) {
     store.selectFromClick(
       row.id,
       { ctrl: event.key === " " || event.ctrlKey || event.metaKey },
-      order,
+      orderedRowIds.value,
     );
     return;
   }

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -543,7 +543,18 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
         compareOn(a, b, view.sortKey, view.sortDirection) || a.id - b.id,
     );
     if (axis === "none") {
-      return [{ key: "", label: "", labelKind: "name", rows: sorted }];
+      // `rowKey` on this branch too. It was only set where a model can be drawn
+      // more than once, which left every row in the DEFAULT view without one:
+      // the list's `v-for` key was `undefined` for all of them, and so was
+      // anything else keyed per drawn row.
+      return [
+        {
+          key: "",
+          label: "",
+          labelKind: "name",
+          rows: sorted.map((row) => ({ ...row, rowKey: String(row.id) })),
+        },
+      ];
     }
 
     const byKey = new Map();

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -687,15 +687,24 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
     visibleRows.value.filter((row) => selectedIds.value.has(row.id)),
   );
 
+  /**
+   * The model a Shift-range measures from: the last one picked deliberately.
+   *
+   * Held apart from the selection itself, exactly as `lastSelectedImageId` is
+   * in `useMultiSelect`: a range replaces the selection, so the anchor cannot
+   * be recovered from what is selected afterwards.
+   */
+  const anchorId = ref(null);
+
   function isSelected(id) {
     return selectedIds.value.has(id);
   }
 
   /**
-   * Add or remove one model.
+   * Add or remove one model, and make it the anchor.
    *
    * A new Set rather than a mutation: Vue does not track `Set.add`, so the
-   * bar's count and every row's tick would go stale until something else
+   * bar's count and every row's mark would go stale until something else
    * happened to re-render.
    */
   function toggleSelected(id) {
@@ -703,15 +712,55 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
     if (next.has(id)) next.delete(id);
     else next.add(id);
     selectedIds.value = next;
+    anchorId.value = id;
+  }
+
+  /**
+   * Select from a click, the way a file manager does.
+   *
+   * The same three gestures `ImageGrid.handleImageCardClick` already teaches,
+   * and deliberately the same rules rather than a shelf dialect: a plain click
+   * REPLACES the selection with the row clicked, Ctrl/Cmd+click toggles one
+   * without disturbing the rest, and Shift+click takes the contiguous run from
+   * the anchor to the row clicked and replaces the selection with it (it does
+   * not merge, which is what makes a mis-aimed range one click to correct).
+   *
+   * @param {number} id - the model clicked.
+   * @param {Object} [modifiers] - `ctrl` and `shift` off the event.
+   * @param {Array<number>} [order] - model ids in the order the list DRAWS
+   *   them, which is the caller's business: banding re-orders groups, so the
+   *   store's own `groups` order is not what the reader sees. Omitted, a range
+   *   falls back to selecting the one row, which is what a range with nothing
+   *   to measure against means.
+   */
+  function selectFromClick(id, { ctrl = false, shift = false } = {}, order) {
+    if (ctrl) {
+      toggleSelected(id);
+      return;
+    }
+    const sequence = Array.isArray(order) ? order : [];
+    const from = sequence.indexOf(anchorId.value);
+    const to = sequence.indexOf(id);
+    if (shift && from >= 0 && to >= 0) {
+      const [start, end] = from <= to ? [from, to] : [to, from];
+      // The anchor stays where it was: dragging a range out and back with
+      // repeated Shift+clicks has to measure from the same end each time.
+      selectedIds.value = new Set(sequence.slice(start, end + 1));
+      return;
+    }
+    selectedIds.value = new Set([id]);
+    anchorId.value = id;
   }
 
   /** Select every model the current filters show, ungrouped duplicates and all. */
   function selectVisible() {
     selectedIds.value = new Set(visibleRows.value.map((row) => row.id));
+    anchorId.value = visibleRows.value[0]?.id ?? null;
   }
 
   function clearSelection() {
     if (selectedIds.value.size) selectedIds.value = new Set();
+    anchorId.value = null;
   }
 
   /**
@@ -808,6 +857,7 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
     epoch += 1;
     rows.value = [];
     selectedIds.value = new Set();
+    anchorId.value = null;
     loaded.value = false;
     error.value = "";
     loading.value = false;
@@ -842,8 +892,10 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
     collapsed,
     selectedIds,
     selectedRows,
+    anchorId,
     isSelected,
     toggleSelected,
+    selectFromClick,
     selectVisible,
     clearSelection,
     editSelected,


### PR DESCRIPTION
Replaces the shelf's per-row checkbox with the app's own selection idiom, as
ruled 2026-08-10. #870 shipped the checkbox; this is that call corrected, on a
branch off `develop` because #870 merged while the work was in flight.

## The gestures

Plain click **replaces** the selection with the row clicked, Ctrl/Cmd+click
toggles one, Shift+click takes the contiguous run from the anchor and replaces
rather than merges — the same three, and the same replace rule, as
`ImageGrid.handleImageCardClick`. Replacing is what makes a mis-aimed range one
click to correct instead of two.

`anchorId` is held apart from the selection, mirroring `useMultiSelect`'s
`lastSelectedImageId`, precisely because a range replaces what was there: the
anchor could not be recovered from the selection afterwards. Shrinking a range
back therefore measures from the same end rather than from wherever the last
click landed.

## The range spans the drawn order

`orderedRowIds` walks `shownGroups` and skips collapsed groups. Not
`store.groups`: banding re-orders the groups, and a range measured against an
order the reader cannot see would select a run they never pointed at. A model
drawn under two folders appears once, since the range is over models and models
are what the verbs act on.

## Keyboard, because the checkbox was the only stop a row had

The rows become a multi-select listbox: `role="listbox"` +
`aria-multiselectable` on the `<ul>`, `role="option"` + `aria-selected` per row,
and exactly one row at `tabindex="0"`, **seeded to the first drawn row** — a
roving tabindex with nothing at 0 makes the whole list unreachable by Tab. That
is the same "1,800 tab stops is a trap" rule the old comment stated, now solved
by roving rather than by having no stop at all.

Arrows move the stop **without** selecting, so a reader can walk the list
without arming a verb against every row they pass; Space and Enter pick;
Shift+arrow extends from the anchor; Escape clears. A click that lands while
text is selected inside the row is ignored, or dragging across a name to copy it
would collapse the selection on mouseup.

The listbox role is legitimate here and was refused in `ModelFoldersDialog` for
the mirror-image reason: these rows hold no interactive controls, and a control
inside `role="option"` is unreachable.

## Two contracts this deliberately changes

Both had tests, and both are rewritten rather than deleted:

- *"leaves rows out of the tab order while they have no verb"* → the rows now
  have one, so it asserts exactly one stop among them instead of none.
- *"is a real button and leaves the rows out of the tab order"* → the group
  header is still its own stop; it just no longer has the list to itself.

## Verification

2,808 frontend tests, 12 new covering each gesture, the listbox semantics, the
roving stop and the keyboard. Mutation-checked: breaking the anchor lookup turns
the three range tests red. eslint and prettier clean.