### PR TITLE
Show registered folders that hold no models

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1405,6 +1405,13 @@ models is thirty-six headers. Under `Folder` the second level is spent on the
     folder", discriminated on `last_checked IS NULL` rather than on a zero count,
     because a folder nothing has walked has no count to be zero. Only one of the
     two states is the owner's to act on.
+  - **Absence from `groups` does not mean empty**, which is why the registry's
+    `file_count` decides and not the group list. `groups` is built from the
+    VISIBLE rows, so a folder full of adapters has no group at all while `Show`
+    is narrowed to checkpoints; synthesising an empty group there would print
+    "No models in this folder" over a folder holding ninety. A folder with
+    `file_count > 0` is skipped and stays absent from a filtered view, exactly
+    as every other filtered-out row does.
   - The note is a plain `<li>`, never a `role="option"`: there is no model there
     for a verb to write.
   - It applies under `Group by: Folder` only. A folder appearing while grouped by

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1394,6 +1394,24 @@ models is thirty-six headers. Under `Folder` the second level is spent on the
   arithmetic — the inner offset is the outer's measured height, which no token
   knows — and the band is a label with a meter rather than something worth
   pinning while the reader scans one folder. So there is still one sticky offset.
+- **A registered folder holding no models still gets a group.** Groups are built
+  from `model_file` rows, so a folder with nothing in it produces none — and the
+  managed store is exactly that on every fresh install, despite being the ruled
+  default destination for a drop or an import. A destination you cannot see is
+  not a destination. `withEmptyFolders` merges the registry into the folder
+  groups, which is why `ModelShelf.vue` now fetches the folder list on mount
+  rather than leaving `ModelFoldersDialog` as its only reader.
+  - It says **which** empty it is: "Not scanned yet" against "No models in this
+    folder", discriminated on `last_checked IS NULL` rather than on a zero count,
+    because a folder nothing has walked has no count to be zero. Only one of the
+    two states is the owner's to act on.
+  - The note is a plain `<li>`, never a `role="option"`: there is no model there
+    for a verb to write.
+  - It applies under `Group by: Folder` only. A folder appearing while grouped by
+    base model would be a category error.
+  - A shelf holding **no** models at all still shows its own empty state instead
+    of a list of empty folders, because "add the folder where you keep them" is
+    the better answer on a fresh install than an inventory of nothing.
 - **The band is named by the volume, not by the mount point.** A Linux mount
   point runs to `/media/glindkvist/102AB4B6757AF9A3` and crowds the header out,
   so the band shows `label` behind a disk glyph and keeps `mount_point` as its

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -24,9 +24,11 @@ vi.mock("../../api/modelShelf", () => ({
 // reset — which empties the shelf store MID-TEST and made an unrelated sort
 // assertion read the default view back.
 const listModelFolderDevices = vi.fn();
+const listModelFolders = vi.fn();
 vi.mock("../../api/modelFolders", async (importOriginal) => ({
   ...(await importOriginal()),
   listModelFolderDevices: (...args) => listModelFolderDevices(...args),
+  listModelFolders: (...args) => listModelFolders(...args),
 }));
 
 import ModelShelf from "./ModelShelf.vue";
@@ -89,6 +91,8 @@ beforeEach(() => {
   listCheckpoints.mockReset();
   listModelFolderDevices.mockReset();
   listModelFolderDevices.mockResolvedValue([]);
+  listModelFolders.mockReset();
+  listModelFolders.mockResolvedValue([]);
 });
 
 describe("a row with nothing in its header", () => {
@@ -816,5 +820,107 @@ describe("a click that ends a text drag", () => {
 
     window.getSelection.mockRestore();
     outside.remove();
+  });
+});
+
+describe("a registered folder holding no models", () => {
+  it("gets a group of its own, so the managed store is visible", async () => {
+    // It is ruled to always exist and to be the default destination for a drop
+    // or an import. A destination you cannot see is not a destination.
+    listModelFolders.mockResolvedValue([
+      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      { id: 2, path: "/models/store", last_checked: "2026-08-10T00:00:00Z" },
+    ]);
+    const wrapper = await mountShelf([
+      adapter({
+        locations: [
+          {
+            state: "present",
+            folder_id: 1,
+            folder_path: "/models/loras",
+            relpath: "a",
+          },
+        ],
+      }),
+    ]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "alpha" });
+    await wrapper.vm.$nextTick();
+
+    const labels = wrapper.findAll(".shelf-group-label").map((l) => l.text());
+    expect(labels).toContain("/models/store");
+    expect(textOf(wrapper.find(".shelf-empty-folder"))).toBe(
+      "No models in this folder.",
+    );
+  });
+
+  it("says it has not been looked in yet when it has not", async () => {
+    // "We have not looked" is the owner's to act on; "we looked and it is
+    // empty" is not, and a bare "0 models" says neither.
+    //
+    // A shelf with NO models at all renders its own empty state instead of the
+    // group list, which is the better answer there ("add a folder"), so the
+    // case asserted is the one the owner actually hits: models elsewhere, and
+    // one folder nothing has looked in.
+    listModelFolders.mockResolvedValue([
+      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      { id: 2, path: "/models/store", last_checked: null },
+    ]);
+    const wrapper = await mountShelf([
+      adapter({
+        locations: [
+          {
+            state: "present",
+            folder_id: 1,
+            folder_path: "/models/loras",
+            relpath: "a",
+          },
+        ],
+      }),
+    ]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "alpha" });
+    await wrapper.vm.$nextTick();
+
+    expect(textOf(wrapper.find(".shelf-empty-folder"))).toBe(
+      "Not scanned yet.",
+    );
+  });
+
+  it("stays out of the way on every other axis", async () => {
+    // The folder registry is a fact about folders. Grouping by base model and
+    // seeing a folder appear would be a category error.
+    listModelFolders.mockResolvedValue([
+      { id: 2, path: "/models/store", last_checked: null },
+    ]);
+    const wrapper = await mountShelf([adapter({ base_model: "sdxl" })]);
+    useModelShelfStore().setView({ groupBy: "base_model" });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".shelf-empty-folder").exists()).toBe(false);
+  });
+
+  it("is not selectable, having no model to act on", async () => {
+    // A verb armed against a folder would be a verb with nothing to write.
+    listModelFolders.mockResolvedValue([
+      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      { id: 2, path: "/models/store", last_checked: null },
+    ]);
+    const wrapper = await mountShelf([
+      adapter({
+        locations: [
+          {
+            state: "present",
+            folder_id: 1,
+            folder_path: "/models/loras",
+            relpath: "a",
+          },
+        ],
+      }),
+    ]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "alpha" });
+    await wrapper.vm.$nextTick();
+
+    const note = wrapper.find(".shelf-empty-folder");
+    expect(note.attributes("role")).toBeUndefined();
+    expect(note.attributes("tabindex")).toBeUndefined();
   });
 });

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -828,7 +828,12 @@ describe("a registered folder holding no models", () => {
     // It is ruled to always exist and to be the default destination for a drop
     // or an import. A destination you cannot see is not a destination.
     listModelFolders.mockResolvedValue([
-      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      {
+        id: 1,
+        path: "/models/loras",
+        last_checked: "2026-08-10T00:00:00Z",
+        file_count: 1,
+      },
       { id: 2, path: "/models/store", last_checked: "2026-08-10T00:00:00Z" },
     ]);
     const wrapper = await mountShelf([
@@ -862,7 +867,12 @@ describe("a registered folder holding no models", () => {
     // case asserted is the one the owner actually hits: models elsewhere, and
     // one folder nothing has looked in.
     listModelFolders.mockResolvedValue([
-      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      {
+        id: 1,
+        path: "/models/loras",
+        last_checked: "2026-08-10T00:00:00Z",
+        file_count: 1,
+      },
       { id: 2, path: "/models/store", last_checked: null },
     ]);
     const wrapper = await mountShelf([
@@ -901,7 +911,12 @@ describe("a registered folder holding no models", () => {
   it("is not selectable, having no model to act on", async () => {
     // A verb armed against a folder would be a verb with nothing to write.
     listModelFolders.mockResolvedValue([
-      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      {
+        id: 1,
+        path: "/models/loras",
+        last_checked: "2026-08-10T00:00:00Z",
+        file_count: 1,
+      },
       { id: 2, path: "/models/store", last_checked: null },
     ]);
     const wrapper = await mountShelf([

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -728,8 +728,13 @@ onMounted(() => {
   // slow or offline mount must not hold up the models. The folder list comes
   // with them now, because a folder holding nothing is only visible if the
   // shelf knows it is registered — the dialog used to be its only reader.
+  //
+  // NOT `quiet`: that suppresses the folder store's `loading`, and the folders
+  // dialog reads it. Opening the dialog while this first fetch is in flight
+  // would show an empty list with no "Reading the registered folders…" state.
+  // Unawaited already means it does not hold up the shelf.
   foldersStore.refreshDevices();
-  foldersStore.refresh({ quiet: true });
+  foldersStore.refresh();
 });
 
 // A credential change (logout, login, share token, restore) empties the store,

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -285,6 +285,13 @@
             aria-multiselectable="true"
             :aria-label="grouped ? group.label : 'Models'"
           >
+            <!-- Not a `role="option"`: there is nothing here to select. A
+                 registered folder with no models says which of the two states
+                 it is in, because "we have not looked yet" is the owner's to
+                 act on and "we looked and it is empty" is not. -->
+            <li v-if="!group.rows.length" class="shelf-empty-folder">
+              {{ EMPTY_FOLDER_NOTE[group.emptyReason] }}
+            </li>
             <li
               v-for="row in group.rows"
               :key="row.rowKey"
@@ -360,6 +367,7 @@ import { useModelFoldersStore } from "../../stores/useModelFoldersStore";
 import {
   bandGroups,
   bandUsage,
+  withEmptyFolders,
   formatModelSize,
   GROUP_BY_LABELS,
   SORT_LABELS,
@@ -588,6 +596,17 @@ function onRowKeydown(row, event) {
   }
 }
 
+/**
+ * What an empty folder group says, per reason.
+ *
+ * Never a bare "0 models": the count is already in the header, and the reader's
+ * question is whether the shelf has looked.
+ */
+const EMPTY_FOLDER_NOTE = {
+  unscanned: "Not scanned yet.",
+  empty: "No models in this folder.",
+};
+
 /** "1 model" / "12 models", so no line ever reads "1 models". */
 function modelCount(n) {
   return `${n.toLocaleString()} ${n === 1 ? "model" : "models"}`;
@@ -603,10 +622,14 @@ function modelCount(n) {
  * arrangement is still testable without a component.
  */
 const shownGroups = computed(() => {
-  if (store.view.groupBy !== "folder" || store.view.folderLayout !== "drive") {
-    return store.groups;
-  }
-  return bandGroups(store.groups, foldersStore.deviceByFolderId);
+  if (store.view.groupBy !== "folder") return store.groups;
+  // A registered folder holding nothing has no rows and therefore no group.
+  // The managed store is exactly that on a fresh install, and it is the ruled
+  // default destination for a drop or an import — which it cannot be while the
+  // owner has no way to see it.
+  const groups = withEmptyFolders(store.groups, foldersStore.folders);
+  if (store.view.folderLayout !== "drive") return groups;
+  return bandGroups(groups, foldersStore.deviceByFolderId);
 });
 
 function usage(band) {
@@ -702,8 +725,11 @@ onMounted(() => {
   rootEl.value?.focus();
   store.fetchRows();
   // Unawaited and never blocking the list: the drives decorate the bands, and a
-  // slow or offline mount must not hold up the models.
+  // slow or offline mount must not hold up the models. The folder list comes
+  // with them now, because a folder holding nothing is only visible if the
+  // shelf knows it is registered — the dialog used to be its only reader.
   foldersStore.refreshDevices();
+  foldersStore.refresh({ quiet: true });
 });
 
 // A credential change (logout, login, share token, restore) empties the store,

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -10,7 +10,12 @@ import {
 import { onSessionReset } from "../utils/apiClient";
 import { useNoticeStore } from "./useNoticeStore";
 import { errorDetail } from "../utils/apiError";
-import { locationState, modelName } from "../utils/modelShelf";
+import {
+  compareGroups,
+  locationState,
+  modelName,
+  UNSET_GROUP_KEY,
+} from "../utils/modelShelf";
 
 /** Where the `Show` selection is remembered between visits. */
 const FILTERS_KEY = "pixlstash:modelShelfFilters";
@@ -299,9 +304,6 @@ function storedCollapsed() {
   return collapsed;
 }
 
-/** The group a row with no value on the current axis falls into. */
-const UNSET_GROUP_KEY = "\u0000unset";
-
 /**
  * Every group a row belongs to on one axis, as `{key, label, labelKind}`.
  *
@@ -341,30 +343,6 @@ function groupsOf(row, axis) {
     labelKind: "path",
     location: loc,
   }));
-}
-
-/**
- * Order two groups.
- *
- * Alphabetical by label, with the "not set" group ALWAYS last, in both sort
- * directions. It is the absence of a value rather than a value, so it never
- * joins the alphabetical run and never swaps ends when the direction flips.
- * That is the same rule `baseModelOptions` already applies to the filter's
- * `UNASSIGNED` option, and it matters here because "not set" is not a tail: 37%
- * of real adapters record no base model, so it is one of the largest groups on
- * the shelf and putting it first would bury everything identifiable under it.
- *
- * The sort keys never reorder groups, only rows inside them. Switching to
- * "Largest first" moving every header out from under the reader would be a
- * different view, not a sorted one.
- */
-function compareGroups(a, b) {
-  if (a.key === UNSET_GROUP_KEY) return b.key === UNSET_GROUP_KEY ? 0 : 1;
-  if (b.key === UNSET_GROUP_KEY) return -1;
-  return a.label.localeCompare(b.label, undefined, {
-    numeric: true,
-    sensitivity: "base",
-  });
 }
 
 /** The three top-level type checkboxes, each one request and one row bucket. */

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -151,6 +151,73 @@ export function formatModelSize(bytes) {
   return `${value.toFixed(digits)} ${SIZE_UNITS[unit]}`;
 }
 
+/**
+ * The group a row with no value on the current axis falls into.
+ *
+ * Here rather than in the store because {@link compareGroups} needs it and the
+ * store imports this module, so the other direction would be a cycle.
+ */
+export const UNSET_GROUP_KEY = "\u0000unset";
+
+/**
+ * Order two groups.
+ *
+ * Alphabetical by label, with the "not set" group ALWAYS last, in both sort
+ * directions. It is the absence of a value rather than a value, so it never
+ * joins the alphabetical run and never swaps ends when the direction flips.
+ * That is the same rule `baseModelOptions` already applies to the filter's
+ * `UNASSIGNED` option, and it matters here because "not set" is not a tail: 37%
+ * of real adapters record no base model, so it is one of the largest groups on
+ * the shelf and putting it first would bury everything identifiable under it.
+ *
+ * The sort keys never reorder groups, only rows inside them. Switching to
+ * "Largest first" moving every header out from under the reader would be a
+ * different view, not a sorted one.
+ */
+export function compareGroups(a, b) {
+  if (a.key === UNSET_GROUP_KEY) return b.key === UNSET_GROUP_KEY ? 0 : 1;
+  if (b.key === UNSET_GROUP_KEY) return -1;
+  return a.label.localeCompare(b.label, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+/**
+ * Add a group for every registered folder that has none.
+ *
+ * Groups are built from `model_file` rows, so a folder holding nothing produces
+ * no group at all — and the managed store holds nothing on every fresh install,
+ * despite being the ruled default destination for a drop or an import. A
+ * destination you cannot see is not a destination.
+ *
+ * The empty group carries `emptyReason`, because "registered and empty" and
+ * "never scanned" are different facts and only one of them is the owner's to
+ * act on. `last_checked` is the discriminator rather than a zero count: a
+ * folder that has never been walked has no count to be zero.
+ *
+ * @param {Array<Object>} groups - the folder groups the rows produced.
+ * @param {Array<Object>} folders - rows from `GET /model-folders`.
+ * @returns {Array<Object>} groups plus the empties, in one sorted run.
+ */
+export function withEmptyFolders(groups, folders) {
+  const held = new Set(groups.map((group) => group.key));
+  const empties = [];
+  for (const folder of folders || []) {
+    const key = String(folder.path || folder.id || "");
+    if (!key || held.has(key)) continue;
+    empties.push({
+      key,
+      label: key,
+      labelKind: "path",
+      folderId: Number(folder.id),
+      emptyReason: folder.last_checked ? "empty" : "unscanned",
+      rows: [],
+    });
+  }
+  return empties.length ? [...groups, ...empties].sort(compareGroups) : groups;
+}
+
 /** What each folder layout is called, and the glyph that stands for it. */
 export const FOLDER_LAYOUT_LABELS = {
   drive: { label: "Drive, then folder", icon: "mdi-harddisk" },

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -193,8 +193,12 @@ export function compareGroups(a, b) {
  *
  * The empty group carries `emptyReason`, because "registered and empty" and
  * "never scanned" are different facts and only one of them is the owner's to
- * act on. `last_checked` is the discriminator rather than a zero count: a
- * folder that has never been walked has no count to be zero.
+ * act on. `last_checked` is the discriminator for that pair rather than a zero
+ * count: a folder that has never been walked has no count to be zero.
+ *
+ * `file_count` decides something else — whether the folder is empty at all.
+ * Absence from `groups` cannot answer that, because `groups` is built from the
+ * visible rows and a filter can empty a folder that is full.
  *
  * @param {Array<Object>} groups - the folder groups the rows produced.
  * @param {Array<Object>} folders - rows from `GET /model-folders`.
@@ -206,12 +210,21 @@ export function withEmptyFolders(groups, folders) {
   for (const folder of folders || []) {
     const key = String(folder.path || folder.id || "");
     if (!key || held.has(key)) continue;
+    // "Has no group" is NOT "is empty". `groups` is built from the VISIBLE
+    // rows, so a folder full of adapters has no group at all while Show is
+    // narrowed to checkpoints — and calling that folder empty would be a plain
+    // lie about the disk. The registry knows better: `file_count` counts the
+    // copies registered under the folder in any state, so a folder that holds
+    // something is skipped and simply stays absent from a filtered view, which
+    // is what every other filtered-out row does.
+    const unscanned = !folder.last_checked;
+    if (!unscanned && Number(folder.file_count) > 0) continue;
     empties.push({
       key,
       label: key,
       labelKind: "path",
       folderId: Number(folder.id),
-      emptyReason: folder.last_checked ? "empty" : "unscanned",
+      emptyReason: unscanned ? "unscanned" : "empty",
       rows: [],
     });
   }

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -260,6 +260,41 @@ describe("withEmptyFolders", () => {
     expect(arranged[1].folderId).toBe(2);
   });
 
+  it("does not call a folder empty just because a filter hid its models", () => {
+    // The failure this guards: `groups` is built from the VISIBLE rows, so a
+    // folder full of adapters has no group while Show is narrowed to
+    // checkpoints. Reading "no group" as "no models" would print "No models in
+    // this folder" over a folder holding ninety.
+    const arranged = withEmptyFolders(
+      [],
+      [
+        {
+          id: 1,
+          path: "/models/loras",
+          last_checked: "2026-08-10T00:00:00Z",
+          file_count: 91,
+        },
+        {
+          id: 2,
+          path: "/models/store",
+          last_checked: "2026-08-10T00:00:00Z",
+          file_count: 0,
+        },
+      ],
+    );
+    expect(arranged.map((g) => g.label)).toEqual(["/models/store"]);
+  });
+
+  it("still shows a folder nothing has looked in, whatever its count says", () => {
+    // `file_count` is 0 for an unscanned folder too, but the two are different
+    // facts and only this one is the owner's to act on.
+    const [only] = withEmptyFolders(
+      [],
+      [{ id: 1, path: "/models/new", last_checked: null, file_count: 0 }],
+    );
+    expect(only.emptyReason).toBe("unscanned");
+  });
+
   it("keeps 'never scanned' apart from 'scanned and empty'", () => {
     // Only one of the two is the owner's to act on, and `last_checked` is the
     // discriminator: a folder that has never been walked has no count to be

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import {
   bandGroups,
   bandUsage,
+  withEmptyFolders,
   cleanAssetName,
   deriveModelName,
   formatModelSize,
@@ -228,5 +229,67 @@ describe("bandUsage", () => {
       shelfBytes: 5000,
     });
     expect(usage.shelfPct).toBe(usage.usedPct);
+  });
+});
+
+describe("withEmptyFolders", () => {
+  const group = (path) => ({
+    key: path,
+    label: path,
+    labelKind: "path",
+    folderId: 1,
+    rows: [{ id: 1 }],
+  });
+
+  it("adds the registered folder that produced no group", () => {
+    // The managed store is exactly this on a fresh install: registered, ruled
+    // to be the default drop destination, and holding nothing — so it has no
+    // rows, no group, and no way to be seen.
+    const arranged = withEmptyFolders(
+      [group("/models/loras")],
+      [
+        { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+        { id: 2, path: "/models/store", last_checked: "2026-08-10T00:00:00Z" },
+      ],
+    );
+    expect(arranged.map((g) => g.label)).toEqual([
+      "/models/loras",
+      "/models/store",
+    ]);
+    expect(arranged[1].rows).toEqual([]);
+    expect(arranged[1].folderId).toBe(2);
+  });
+
+  it("keeps 'never scanned' apart from 'scanned and empty'", () => {
+    // Only one of the two is the owner's to act on, and `last_checked` is the
+    // discriminator: a folder that has never been walked has no count to be
+    // zero.
+    const [never, walked] = withEmptyFolders(
+      [],
+      [
+        { id: 1, path: "/a", last_checked: null },
+        { id: 2, path: "/b", last_checked: "2026-08-10T00:00:00Z" },
+      ],
+    );
+    expect(never.emptyReason).toBe("unscanned");
+    expect(walked.emptyReason).toBe("empty");
+  });
+
+  it("never duplicates a folder that already has rows", () => {
+    const arranged = withEmptyFolders(
+      [group("/models/loras")],
+      [{ id: 1, path: "/models/loras", last_checked: null }],
+    );
+    expect(arranged).toHaveLength(1);
+    expect(arranged[0].rows).toHaveLength(1);
+  });
+
+  it("returns the groups untouched when every folder has some", () => {
+    // Identity, not a copy: the caller bands this result, and a needless new
+    // array would invalidate every downstream computed on each keystroke.
+    const groups = [group("/models/loras")];
+    expect(withEmptyFolders(groups, [{ id: 1, path: "/models/loras" }])).toBe(
+      groups,
+    );
   });
 });


### PR DESCRIPTION
Plan item 4, and half of what the owner reported: *"neither does the Managed
folder itself"*. Stacked on #871 because both rework the same list markup;
merge #871 first and this rebases onto `develop`.

## The defect

Folder groups are built from `model_file` rows, so a registered folder holding
nothing produces **no group at all** — no header under `Group by: Folder`, no
band under `Drive, then folder`. Measured against the live hub: two registered
folders, one of them the managed store with 0 rows, and only one visible.

The managed store is ruled to always exist and to be the default destination for
a drop or an import. It cannot be either while the owner has no way to see it.

## The fix

`withEmptyFolders` merges the folder registry into the folder groups, sorted by
the same comparator the rows use. `ModelShelf.vue` now fetches the folder list
on mount; `ModelFoldersDialog` used to be its only reader.

- **It says which empty it is.** "Not scanned yet" against "No models in this
  folder", discriminated on `last_checked IS NULL` rather than on a zero count —
  a folder nothing has walked has no count to be zero. Only one of the two is
  the owner's to act on, and a bare "0 models" says neither.
- **The note is a plain `<li>`, never a `role="option"`.** There is no model
  there for a verb to write.
- **`Group by: Folder` only.** A folder appearing while grouped by base model
  would be a category error.

## One thing left deliberately alone

A shelf holding **no** models at all still shows its own empty state ("PixlStash
lists what it finds in the model folders registered on this machine. Add the
folder where you keep them.") rather than a list of empty folders. That is the
better answer on a fresh install, and two tests were rewritten when they assumed
otherwise — the case that matters is the one the owner hits: models elsewhere,
and a folder holding none.

## A refactor that came with it

`compareGroups` and `UNSET_GROUP_KEY` moved from `useModelShelfStore.js` into
`utils/modelShelf.js`. The store already imports that module, so the merge
helper could not have reused the comparator from the store without closing an
import cycle — and a second copy of "unset sorts last, in both directions" is
exactly the rule that drifts.

## Verification

2,816 frontend tests, 8 new (4 unit on the merge, 4 on the view).
Mutation-checked: dropping the merge turns three of the four view tests red.
eslint and prettier clean.