### PR TITLE
Generalise AddToEntityControl for hosts that are not pictures

### DIFF
--- a/frontend/src/components/panels/SelectionMenu.vue
+++ b/frontend/src/components/panels/SelectionMenu.vue
@@ -19,7 +19,7 @@
         ref="ateProjectRef"
         type="project"
         placement="right"
-        :picture-ids="selectedImageIds"
+        :subject-ids="selectedImageIds"
         :disabled="selectedCount === 0 || !!groupingLockReason"
         :title="groupingLockReason || undefined"
         :readonly="isReadOnly"
@@ -29,7 +29,7 @@
         ref="ateCharacterRef"
         type="character"
         placement="right"
-        :picture-ids="selectedImageIds"
+        :subject-ids="selectedImageIds"
         :disabled="selectedCount === 0 || !!groupingLockReason"
         :title="groupingLockReason || undefined"
         :readonly="isReadOnly"
@@ -40,7 +40,7 @@
         ref="ateSetRef"
         type="set"
         placement="right"
-        :picture-ids="selectedImageIds"
+        :subject-ids="selectedImageIds"
         :disabled="selectedCount === 0 || !!groupingLockReason"
         :title="groupingLockReason || undefined"
         :readonly="isReadOnly"
@@ -128,10 +128,7 @@
         @mouseenter="autoTagSubmenuOpen = true"
         @mouseleave="autoTagSubmenuOpen = false"
       >
-        <button
-          class="ctx-item"
-          :disabled="selectedCount === 0 || isReadOnly"
-        >
+        <button class="ctx-item" :disabled="selectedCount === 0 || isReadOnly">
           <v-icon class="ctx-icon" size="15">mdi-tag-outline</v-icon>
           Tag automatically
           <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
@@ -162,10 +159,7 @@
         @mouseenter="descriptionSubmenuOpen = true"
         @mouseleave="descriptionSubmenuOpen = false"
       >
-        <button
-          class="ctx-item"
-          :disabled="selectedCount === 0 || isReadOnly"
-        >
+        <button class="ctx-item" :disabled="selectedCount === 0 || isReadOnly">
           <v-icon class="ctx-icon" size="15">mdi-text-box-outline</v-icon>
           Generate description
           <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
@@ -224,10 +218,7 @@
         @mouseenter="restoreSubmenuOpen = true"
         @mouseleave="restoreSubmenuOpen = false"
       >
-        <button
-          class="ctx-item"
-          :disabled="selectedCount === 0 || isReadOnly"
-        >
+        <button class="ctx-item" :disabled="selectedCount === 0 || isReadOnly">
           <v-icon class="ctx-icon" size="15">mdi-restore</v-icon>
           Restore from snapshot
           <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>

--- a/frontend/src/components/panels/SelectionMenu.vue
+++ b/frontend/src/components/panels/SelectionMenu.vue
@@ -128,7 +128,10 @@
         @mouseenter="autoTagSubmenuOpen = true"
         @mouseleave="autoTagSubmenuOpen = false"
       >
-        <button class="ctx-item" :disabled="selectedCount === 0 || isReadOnly">
+        <button
+          class="ctx-item"
+          :disabled="selectedCount === 0 || isReadOnly"
+        >
           <v-icon class="ctx-icon" size="15">mdi-tag-outline</v-icon>
           Tag automatically
           <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
@@ -159,7 +162,10 @@
         @mouseenter="descriptionSubmenuOpen = true"
         @mouseleave="descriptionSubmenuOpen = false"
       >
-        <button class="ctx-item" :disabled="selectedCount === 0 || isReadOnly">
+        <button
+          class="ctx-item"
+          :disabled="selectedCount === 0 || isReadOnly"
+        >
           <v-icon class="ctx-icon" size="15">mdi-text-box-outline</v-icon>
           Generate description
           <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
@@ -218,7 +224,10 @@
         @mouseenter="restoreSubmenuOpen = true"
         @mouseleave="restoreSubmenuOpen = false"
       >
-        <button class="ctx-item" :disabled="selectedCount === 0 || isReadOnly">
+        <button
+          class="ctx-item"
+          :disabled="selectedCount === 0 || isReadOnly"
+        >
           <v-icon class="ctx-icon" size="15">mdi-restore</v-icon>
           Restore from snapshot
           <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>

--- a/frontend/src/components/views/ImageOverlay.vue
+++ b/frontend/src/components/views/ImageOverlay.vue
@@ -252,7 +252,7 @@
             type="set"
             ref="addToSetControlRef"
             :key="addToSetControlKey"
-            :picture-ids="[image.id]"
+            :subject-ids="[image.id]"
             :include-deleted-members="true"
             :force-dark="true"
             :disabled="!!stackGroupingLockReason"
@@ -264,7 +264,7 @@
           <AddToEntityControl
             v-if="image && !isReadOnly"
             type="project"
-            :picture-ids="[image.id]"
+            :subject-ids="[image.id]"
             :include-deleted-members="true"
             :expand-stacks="false"
             :force-dark="true"
@@ -703,13 +703,16 @@
                            popups as OS menus that ignore option colour. This
                            is the same menu language as the rest of the app
                            (AddToEntityControl's force-dark skin), in its
-                           single-select face mode. -->
+                           single-select face mode. Face mode picks one person
+                           for one face, so it has no subject list to compute a
+                           tri-state across and passes an empty one. -->
                       <div class="face-assign-person">
                         <AddToEntityControl
                           :ref="(el) => setFaceMenuRef(face.faceKey, el)"
                           type="face"
                           allow-create
                           float-menu
+                          :subject-ids="[]"
                           :force-dark="true"
                           :face-id="face.id"
                           :assigned-character-id="face.character_id"
@@ -807,7 +810,11 @@ import {
   safeDownloadName,
   setInternalDragPayload,
 } from "../../utils/media.js";
-import { API_BASE_URL, appendShareToken, isReadOnly } from "../../utils/apiClient";
+import {
+  API_BASE_URL,
+  appendShareToken,
+  isReadOnly,
+} from "../../utils/apiClient";
 import {
   getPictureMetadata,
   listPictureFaces,
@@ -1649,9 +1656,9 @@ function buildOverlayExpandedStackImages(stackId, fallbackItem, stackCount) {
     ordered.push(img);
   };
 
-  const orderedIds = sortStackMembers(
-    Array.from(imageById.values()),
-  ).map((img) => String(img.id));
+  const orderedIds = sortStackMembers(Array.from(imageById.values())).map(
+    (img) => String(img.id),
+  );
   for (const id of orderedIds) {
     addImage(imageById.get(String(id)));
   }
@@ -2041,7 +2048,8 @@ function showNextImage() {
  */
 function hasNativeCopyContext(target) {
   if (isTypingTarget(target)) return true;
-  const selection = typeof window === "undefined" ? null : window.getSelection?.();
+  const selection =
+    typeof window === "undefined" ? null : window.getSelection?.();
   return Boolean(selection && !selection.isCollapsed && selection.toString());
 }
 
@@ -4038,8 +4046,7 @@ function mediaActionInfo(target = null) {
 }
 
 function mediaActionError(err, fallback = "Please try again.") {
-  return (
-    errorDetail(err) || err?.message || String(err || fallback) );
+  return errorDetail(err) || err?.message || String(err || fallback);
 }
 
 function triggerMediaDownload(blob, filename) {
@@ -4111,14 +4118,18 @@ async function saveMediaAs(target = null) {
     if (desktop?.beginMediaSaveAs && desktop?.completeMediaSaveAs) {
       const choice = await desktop.beginMediaSaveAs(info.filename);
       if (choice?.canceled) return false;
-      if (!choice?.saveId) throw new Error("The desktop save dialog did not return a save request.");
+      if (!choice?.saveId)
+        throw new Error(
+          "The desktop save dialog did not return a save request.",
+        );
       try {
         const blob = await fetchOriginalMedia(info);
         const result = await desktop.completeMediaSaveAs(
           choice.saveId,
           await blob.arrayBuffer(),
         );
-        if (!result?.saved) throw new Error("The desktop app did not write the file.");
+        if (!result?.saved)
+          throw new Error("The desktop app did not write the file.");
       } catch (err) {
         await desktop.cancelMediaSaveAs?.(choice.saveId);
         throw err;
@@ -4179,8 +4190,7 @@ function copyAvailability() {
   if (!desktopCapable && !browserCapable) {
     return {
       available: false,
-      reason:
-        "This browser cannot copy image pixels. Save the media instead.",
+      reason: "This browser cannot copy image pixels. Save the media instead.",
     };
   }
   const video = isSupportedVideoFile(getOverlayFormat(image.value));
@@ -4235,7 +4245,8 @@ async function renderMediaPng(target = null) {
     );
   }
   const blob = await canvasToBlob(canvas, "image/png");
-  if (!blob) throw new Error("This browser could not encode the pixels as PNG.");
+  if (!blob)
+    throw new Error("This browser could not encode the pixels as PNG.");
   return blob;
 }
 
@@ -4254,7 +4265,8 @@ async function copyMedia(target = null) {
       const result = await window.pixlstashDesktop.copyPngToClipboard(
         await png.arrayBuffer(),
       );
-      if (!result?.copied) throw new Error("The desktop clipboard rejected the image.");
+      if (!result?.copied)
+        throw new Error("The desktop clipboard rejected the image.");
     } else {
       // Pass the pending PNG promise to ClipboardItem and call write immediately;
       // this preserves the transient user activation required by some browsers.

--- a/frontend/src/components/views/ImageOverlay.vue
+++ b/frontend/src/components/views/ImageOverlay.vue
@@ -810,11 +810,7 @@ import {
   safeDownloadName,
   setInternalDragPayload,
 } from "../../utils/media.js";
-import {
-  API_BASE_URL,
-  appendShareToken,
-  isReadOnly,
-} from "../../utils/apiClient";
+import { API_BASE_URL, appendShareToken, isReadOnly } from "../../utils/apiClient";
 import {
   getPictureMetadata,
   listPictureFaces,
@@ -1656,9 +1652,9 @@ function buildOverlayExpandedStackImages(stackId, fallbackItem, stackCount) {
     ordered.push(img);
   };
 
-  const orderedIds = sortStackMembers(Array.from(imageById.values())).map(
-    (img) => String(img.id),
-  );
+  const orderedIds = sortStackMembers(
+    Array.from(imageById.values()),
+  ).map((img) => String(img.id));
   for (const id of orderedIds) {
     addImage(imageById.get(String(id)));
   }
@@ -2048,8 +2044,7 @@ function showNextImage() {
  */
 function hasNativeCopyContext(target) {
   if (isTypingTarget(target)) return true;
-  const selection =
-    typeof window === "undefined" ? null : window.getSelection?.();
+  const selection = typeof window === "undefined" ? null : window.getSelection?.();
   return Boolean(selection && !selection.isCollapsed && selection.toString());
 }
 
@@ -4046,7 +4041,8 @@ function mediaActionInfo(target = null) {
 }
 
 function mediaActionError(err, fallback = "Please try again.") {
-  return errorDetail(err) || err?.message || String(err || fallback);
+  return (
+    errorDetail(err) || err?.message || String(err || fallback) );
 }
 
 function triggerMediaDownload(blob, filename) {
@@ -4118,18 +4114,14 @@ async function saveMediaAs(target = null) {
     if (desktop?.beginMediaSaveAs && desktop?.completeMediaSaveAs) {
       const choice = await desktop.beginMediaSaveAs(info.filename);
       if (choice?.canceled) return false;
-      if (!choice?.saveId)
-        throw new Error(
-          "The desktop save dialog did not return a save request.",
-        );
+      if (!choice?.saveId) throw new Error("The desktop save dialog did not return a save request.");
       try {
         const blob = await fetchOriginalMedia(info);
         const result = await desktop.completeMediaSaveAs(
           choice.saveId,
           await blob.arrayBuffer(),
         );
-        if (!result?.saved)
-          throw new Error("The desktop app did not write the file.");
+        if (!result?.saved) throw new Error("The desktop app did not write the file.");
       } catch (err) {
         await desktop.cancelMediaSaveAs?.(choice.saveId);
         throw err;
@@ -4190,7 +4182,8 @@ function copyAvailability() {
   if (!desktopCapable && !browserCapable) {
     return {
       available: false,
-      reason: "This browser cannot copy image pixels. Save the media instead.",
+      reason:
+        "This browser cannot copy image pixels. Save the media instead.",
     };
   }
   const video = isSupportedVideoFile(getOverlayFormat(image.value));
@@ -4245,8 +4238,7 @@ async function renderMediaPng(target = null) {
     );
   }
   const blob = await canvasToBlob(canvas, "image/png");
-  if (!blob)
-    throw new Error("This browser could not encode the pixels as PNG.");
+  if (!blob) throw new Error("This browser could not encode the pixels as PNG.");
   return blob;
 }
 
@@ -4265,8 +4257,7 @@ async function copyMedia(target = null) {
       const result = await window.pixlstashDesktop.copyPngToClipboard(
         await png.arrayBuffer(),
       );
-      if (!result?.copied)
-        throw new Error("The desktop clipboard rejected the image.");
+      if (!result?.copied) throw new Error("The desktop clipboard rejected the image.");
     } else {
       // Pass the pending PNG promise to ClipboardItem and call write immediately;
       // this preserves the transient user activation required by some browsers.

--- a/frontend/src/components/widgets/AddToEntityControl.test.js
+++ b/frontend/src/components/widgets/AddToEntityControl.test.js
@@ -86,7 +86,7 @@ function mountControl(props = {}) {
     props: {
       type: "set",
       backendUrl: "http://backend.test",
-      pictureIds: ["101"],
+      subjectIds: ["101"],
       ...props,
     },
     global: {
@@ -183,7 +183,7 @@ describe("AddToEntityControl", () => {
 
     const slowMembership = deferred();
     getPictureSetMembership.mockReturnValueOnce(slowMembership.promise);
-    await wrapper.setProps({ pictureIds: ["202"] });
+    await wrapper.setProps({ subjectIds: ["202"] });
     await flushPromises();
 
     // The previous selection's ticks are gone the moment the selection changes.
@@ -208,12 +208,12 @@ describe("AddToEntityControl", () => {
       .mockReturnValueOnce(slowFirst.promise)
       .mockReturnValueOnce(fastSecond.promise);
 
-    const wrapper = mountControl({ type: "character", pictureIds: ["101"] });
+    const wrapper = mountControl({ type: "character", subjectIds: ["101"] });
     await wrapper.find("button.ate-btn").trigger("click");
     await flushPromises();
 
     // The selection moves on while the first membership read is still open.
-    await wrapper.setProps({ pictureIds: ["202"] });
+    await wrapper.setProps({ subjectIds: ["202"] });
     fastSecond.resolve({
       character_assignments: { 12: ["202"] },
       pictures_with_faces: ["202"],
@@ -268,7 +268,7 @@ async function mountOpen(props = {}) {
     props: {
       type: "character",
       backendUrl: "http://x",
-      pictureIds: ["10", "11"],
+      subjectIds: ["10", "11"],
       allowCreate: true,
       ...props,
     },
@@ -350,7 +350,7 @@ describe("pinned New person row", () => {
   });
 
   it("is disabled when there is no picture selection", async () => {
-    const wrapper = await mountOpen({ pictureIds: [] });
+    const wrapper = await mountOpen({ subjectIds: [] });
     expect(pinnedCreateButton(wrapper).attributes("disabled")).toBeDefined();
   });
 });
@@ -393,7 +393,7 @@ describe("no-match empty state", () => {
   });
 
   it("Enter does nothing when disabled by an empty selection", async () => {
-    const wrapper = await mountOpen({ pictureIds: [] });
+    const wrapper = await mountOpen({ subjectIds: [] });
     const input = wrapper.find(".ate-search input");
     await input.setValue("Zed");
     await input.trigger("keydown.enter");
@@ -688,7 +688,7 @@ describe("keyboard operation and ARIA structure", () => {
       props: {
         type: "set",
         backendUrl: "http://x",
-        pictureIds: ["10", "11"],
+        subjectIds: ["10", "11"],
         ...props,
       },
       attachTo: document.body,
@@ -803,7 +803,7 @@ describe("keyboard operation and ARIA structure", () => {
       props: {
         type: "character",
         backendUrl: "http://x",
-        pictureIds: ["10", "11"],
+        subjectIds: ["10", "11"],
         allowCreate: true,
       },
       attachTo: document.body,

--- a/frontend/src/components/widgets/AddToEntityControl.test.js
+++ b/frontend/src/components/widgets/AddToEntityControl.test.js
@@ -907,3 +907,106 @@ describe("keyboard operation and ARIA structure", () => {
     outside.remove();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Host-driven mode (model shelf F3).
+//
+// The shelf attaches ADAPTERS through this same picker, so the control has to
+// work for subjects it cannot read membership for and must not write. These
+// cases pin the two regressions the generalisation could cause: a picture-only
+// rule leaking into a non-picture host, and the writing paths still firing.
+// ---------------------------------------------------------------------------
+
+describe("host-driven mode", () => {
+  const SETS = [
+    { id: 1, name: "Alpha" },
+    { id: 2, name: "Beta" },
+  ];
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    listPictureSets.mockResolvedValue(SETS);
+    listCharacters.mockResolvedValue(PEOPLE);
+    getPictureSetMembership.mockResolvedValue({});
+    getCharacterMembership.mockResolvedValue({});
+  });
+
+  async function mountHosted(props = {}) {
+    const wrapper = mount(AddToEntityControl, {
+      props: {
+        type: "set",
+        backendUrl: "http://backend.test",
+        subjectIds: ["a", "b", "c"],
+        membership: { 1: new Set(["a", "b"]) },
+        ...props,
+      },
+      global: { plugins: [pinia], stubs: { "v-icon": true, Teleport: true } },
+    });
+    await wrapper.find(".ate-btn").trigger("click");
+    await flushPromises();
+    return wrapper;
+  }
+
+  const rowFor = (wrapper, name) =>
+    wrapper.findAll(".ate-item").find((r) => r.text().includes(name));
+
+  it("reads its tri-state from the host's map, without fetching", async () => {
+    const wrapper = await mountHosted();
+    // Two of the three subjects are in Alpha, so it is partial and says so.
+    expect(rowFor(wrapper, "Alpha").text()).toContain("partially applied");
+    expect(rowFor(wrapper, "Beta").text()).not.toContain("partially applied");
+    // The readers would not understand these ids, so they must not be called.
+    expect(getPictureSetMembership).not.toHaveBeenCalled();
+  });
+
+  it("resolves a partial entity UP, writing only the missing subjects", async () => {
+    // The same rule the writing paths apply. Detaching from a mixed state would
+    // drop an attachment the user never named, and the shelf has no undo.
+    const wrapper = await mountHosted();
+    await rowFor(wrapper, "Alpha").trigger("click");
+
+    expect(wrapper.emitted("detach")).toBeUndefined();
+    expect(wrapper.emitted("attach")[0][0]).toEqual({
+      entityType: "set",
+      entityId: 1,
+      entityName: "Alpha",
+      subjectIds: ["c"],
+    });
+  });
+
+  it("detaches only from a fully applied entity", async () => {
+    const wrapper = await mountHosted({
+      membership: { 1: new Set(["a", "b", "c"]) },
+    });
+    await rowFor(wrapper, "Alpha").trigger("click");
+
+    expect(wrapper.emitted("attach")).toBeUndefined();
+    expect(wrapper.emitted("detach")[0][0]).toEqual({
+      entityType: "set",
+      entityId: 1,
+      subjectIds: ["a", "b", "c"],
+    });
+  });
+
+  it("writes nothing itself", async () => {
+    const wrapper = await mountHosted();
+    await rowFor(wrapper, "Beta").trigger("click");
+    expect(addPictureToSet).not.toHaveBeenCalled();
+    expect(wrapper.emitted("attach")).toHaveLength(1);
+  });
+
+  it("does not narrow character membership by which subjects have faces", async () => {
+    // The regression this generalisation could cause. "A picture with no face
+    // cannot be a character member" is a picture rule; applied to adapters it
+    // filters every id away and the whole list reads unchecked however many are
+    // attached.
+    const wrapper = await mountHosted({
+      type: "character",
+      membership: { 1: new Set(["a", "b", "c"]) },
+    });
+    const alice = rowFor(wrapper, "Alice");
+    expect(alice.classes()).toContain("ate-item--checked");
+    expect(alice.attributes("aria-selected")).toBe("true");
+  });
+});

--- a/frontend/src/components/widgets/AddToEntityControl.vue
+++ b/frontend/src/components/widgets/AddToEntityControl.vue
@@ -210,7 +210,17 @@ const props = defineProps({
   // create rule has to serve both call sites.
   type: { type: String, required: true },
   backendUrl: { type: String, default: () => API_BASE_URL },
-  pictureIds: { type: Array, default: () => [] },
+  // The subjects the tri-state is computed across. Named for what it is rather
+  // than for pictures, because the model shelf attaches ADAPTERS through this
+  // same picker (shelf plan F3) and an adapter is not a picture.
+  //
+  // `required` on purpose, and it is the only protection that works here: every
+  // call site stubs this component in its tests, so a binding that goes missing
+  // would land in `$attrs` with no warning, leave this list empty, and make the
+  // menu open with every row unchecked and every click a no-op. Vue warns for a
+  // missing REQUIRED prop; it says nothing about an unknown attribute. Face
+  // mode has no subject list and passes `[]`.
+  subjectIds: { type: Array, required: true },
   disabled: { type: Boolean, default: false },
   readonly: { type: Boolean, default: false },
   label: { type: String, default: null },
@@ -437,9 +447,9 @@ const baseUrl = computed(() =>
 // means "address the API relatively", which is what a missing prop implies.
 const apiOpts = computed(() => ({ baseUrl: baseUrl.value || "" }));
 
-// --- Normalised picture IDs ---
+// --- Normalised subject IDs ---
 const normalisedPictureIds = computed(() =>
-  (Array.isArray(props.pictureIds) ? props.pictureIds : [])
+  (Array.isArray(props.subjectIds) ? props.subjectIds : [])
     .map((id) => String(id))
     .filter(Boolean),
 );

--- a/frontend/src/components/widgets/AddToEntityControl.vue
+++ b/frontend/src/components/widgets/AddToEntityControl.vue
@@ -229,6 +229,16 @@ const props = defineProps({
   // attachments on the rows it drew, so it hands them straight in and no read
   // happens at all. Null keeps the picture path exactly as it was.
   membership: { type: Object, default: null },
+  // Emit the intent and write nothing. Not a new behaviour: `face` has always
+  // worked this way and so has `project`, which emits `selected` and updates
+  // optimistically. This names it so a fourth host can ask for it, and so the
+  // two existing cases stop reading as special.
+  //
+  // Supplying `membership` implies it. A host that owns the data owns the
+  // writes; "your membership, my API calls" is a combination with no meaning
+  // and no caller, and leaving it representable is how it eventually gets
+  // written by accident.
+  hostOwnsWrites: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
   readonly: { type: Boolean, default: false },
   label: { type: String, default: null },
@@ -275,6 +285,8 @@ const emit = defineEmits([
   "create",
   "assign",
   "unassign",
+  "attach",
+  "detach",
 ]);
 
 // --- Type-derived helpers ---
@@ -363,6 +375,21 @@ const membersById = ref({}); // key: item.key → Set<string> of subject IDs
  * this.
  */
 const effectiveMembers = computed(() => props.membership ?? membersById.value);
+
+/**
+ * Whether this control writes, or only announces.
+ *
+ * `face` and `project` were already announce-only before the flag existed, so
+ * they are listed here rather than converted: the behaviour is unchanged and
+ * the flag simply has three users on its first day instead of one.
+ */
+const writesAreHosted = computed(
+  () =>
+    props.hostOwnsWrites ||
+    Boolean(props.membership) ||
+    isFace.value ||
+    isProject.value,
+);
 // The trigger's aria-controls target. Several of these controls sit in one menu,
 // so the id has to be per-instance.
 const listboxId = useId();
@@ -911,9 +938,56 @@ async function toggleItem(item) {
     selectFacePerson(item);
     return;
   }
+  if (isProject.value) {
+    toggleProject(item);
+    return;
+  }
+  // Announce-only: the host holds the API. The payload carries the resolved
+  // intent rather than the raw click, because only this component knows whether
+  // a partially-applied entity resolves up (it does) and therefore which
+  // subjects still need writing.
+  if (writesAreHosted.value) {
+    announceToggle(item);
+    return;
+  }
   if (isSet.value) await toggleSet(item);
-  else if (isProject.value) toggleProject(item);
   else await toggleCharacter(item);
+}
+
+/**
+ * Emit what a click means, for a host that owns the writes.
+ *
+ * `attach` / `detach` rather than `added` / `removed`: those two are already
+ * spoken for by the picture modes, carry `pictureIds`, and are forwarded
+ * verbatim into grid stores. A new name keeps this addition from reaching any
+ * existing listener.
+ */
+function announceToggle(item) {
+  const ids = normalisedPictureIds.value;
+  if (!ids.length) return;
+  const members = effectiveMembers.value?.[item.key];
+  const state = getItemState(item);
+  if (state === "checked") {
+    emit("detach", {
+      entityType: props.type,
+      entityId: item.id,
+      subjectIds: ids,
+    });
+  } else {
+    // Partial resolves UP, the same rule the writing paths apply: only the
+    // subjects that are not already in get written, and nothing is detached.
+    const missing = members
+      ? ids.filter((id) => !members.has(String(id)))
+      : ids;
+    if (!missing.length) return;
+    emit("attach", {
+      entityType: props.type,
+      entityId: item.id,
+      entityName: item.name,
+      subjectIds: missing,
+    });
+  }
+  closeMenu();
 }
 
 // Face mode performs no writes: the host owns the face-level API calls and its

--- a/frontend/src/components/widgets/AddToEntityControl.vue
+++ b/frontend/src/components/widgets/AddToEntityControl.vue
@@ -221,6 +221,14 @@ const props = defineProps({
   // missing REQUIRED prop; it says nothing about an unknown attribute. Face
   // mode has no subject list and passes `[]`.
   subjectIds: { type: Array, required: true },
+  // Membership supplied by the host: `item.key -> Set<string>` of subject ids.
+  //
+  // Supplying it is the single switch into host-driven mode. The internal
+  // readers below answer "which of these PICTURES are in each entity", which
+  // only the picture hosts can ask; the model shelf already has every adapter's
+  // attachments on the rows it drew, so it hands them straight in and no read
+  // happens at all. Null keeps the picture path exactly as it was.
+  membership: { type: Object, default: null },
   disabled: { type: Boolean, default: false },
   readonly: { type: Boolean, default: false },
   label: { type: String, default: null },
@@ -345,7 +353,16 @@ const searchInputRef = ref(null);
 const menuOpen = ref(false);
 const searchQuery = ref("");
 const statusMessage = ref("");
-const membersById = ref({}); // key: item.key → Set<string> of picture IDs
+const membersById = ref({}); // key: item.key → Set<string> of subject IDs
+
+/**
+ * The membership in play: the host's when it supplied one, else what was read.
+ *
+ * Resolved once so no reader has to remember which mode it is in, and so the
+ * host's map cannot be half-applied — every consumer of membership goes through
+ * this.
+ */
+const effectiveMembers = computed(() => props.membership ?? membersById.value);
 // The trigger's aria-controls target. Several of these controls sit in one menu,
 // so the id has to be per-instance.
 const listboxId = useId();
@@ -558,12 +575,17 @@ function getAriaSelected(item) {
 function getItemState(item) {
   const ids = normalisedPictureIds.value;
   if (!ids.length) return "unchecked";
-  const members = membersById.value?.[item.key];
+  const members = effectiveMembers.value?.[item.key];
   if (!members || members.size === 0) return "unchecked";
 
-  const relevantIds = isCharacter.value
-    ? ids.filter((id) => picturesWithFaces.value.has(String(id)))
-    : ids;
+  // The face narrowing is a PICTURE rule — a picture with no face cannot be a
+  // character member — so it must not survive into host-driven mode. Left in,
+  // it would filter the shelf's adapter ids against a set that never contains
+  // them, and every row would read `unchecked` however many were attached.
+  const relevantIds =
+    isCharacter.value && !props.membership
+      ? ids.filter((id) => picturesWithFaces.value.has(String(id)))
+      : ids;
   if (!relevantIds.length) return "unchecked";
 
   const matched = relevantIds.filter((id) => members.has(String(id))).length;
@@ -782,6 +804,12 @@ function handleOutsideClick(event) {
 async function fetchMembers() {
   const ids = normalisedPictureIds.value;
   const requestKey = normalisedIdsKey.value;
+  // Host-driven: the membership arrived as a prop, so there is nothing to read
+  // and the picture readers would not understand these ids anyway.
+  if (props.membership) {
+    membershipLoaded.value = true;
+    return;
+  }
   if (!props.backendUrl || !ids.length) {
     membersById.value = {};
     picturesWithFaces.value = new Set();

--- a/frontend/src/components/widgets/ImageGridContextMenu.vue
+++ b/frontend/src/components/widgets/ImageGridContextMenu.vue
@@ -4,7 +4,10 @@
       v-if="visible"
       ref="menuRef"
       class="image-ctx-menu"
-      :class="{ 'ctx-flip-sub': submenusFlip, 'image-ctx-menu--on-dark': onDark }"
+      :class="{
+        'ctx-flip-sub': submenusFlip,
+        'image-ctx-menu--on-dark': onDark,
+      }"
       :style="menuStyle"
       role="menu"
       aria-orientation="vertical"
@@ -36,7 +39,9 @@
         >
           <v-icon class="ctx-icon" size="15">mdi-download</v-icon>
           <span>Save {{ overlayMediaNoun }}</span>
-          <span class="ctx-shortcut" aria-hidden="true">{{ saveShortcutHint }}</span>
+          <span class="ctx-shortcut" aria-hidden="true">{{
+            saveShortcutHint
+          }}</span>
         </button>
         <button
           v-if="contextImage?.id"
@@ -45,7 +50,9 @@
           :title="`Choose where to save this ${overlayMediaNoun}`"
           @click="onAction('save-picture-as')"
         >
-          <v-icon class="ctx-icon" size="15">mdi-content-save-edit-outline</v-icon>
+          <v-icon class="ctx-icon" size="15"
+            >mdi-content-save-edit-outline</v-icon
+          >
           Save {{ overlayMediaNoun }} as…
         </button>
         <button
@@ -56,13 +63,17 @@
           :title="copyPictureTitle"
           :aria-keyshortcuts="copyAriaShortcut"
           :aria-describedby="
-            contextImage?.copyAvailable === true ? undefined : overlayCopyReasonId
+            contextImage?.copyAvailable === true
+              ? undefined
+              : overlayCopyReasonId
           "
           @click="onAction('copy-picture')"
         >
           <v-icon class="ctx-icon" size="15">mdi-content-copy</v-icon>
           <span>{{ copyPictureLabel }}</span>
-          <span class="ctx-shortcut" aria-hidden="true">{{ copyShortcutHint }}</span>
+          <span class="ctx-shortcut" aria-hidden="true">{{
+            copyShortcutHint
+          }}</span>
         </button>
         <span
           v-if="contextImage?.id && contextImage?.copyAvailable !== true"
@@ -194,7 +205,11 @@
                   cp.created_at ? formatSnapshotDate(cp.created_at) : ""
                 }}</span>
               </button>
-              <button class="ctx-item" role="menuitem" @click="handleRestoreMore">
+              <button
+                class="ctx-item"
+                role="menuitem"
+                @click="handleRestoreMore"
+              >
                 <v-icon class="ctx-icon" size="14">mdi-dots-horizontal</v-icon>
                 More…
               </button>
@@ -243,371 +258,380 @@
            GRID MODE — the full context menu for grid cells (unchanged).
            ════════════════════════════════════════════════════════════ -->
       <template v-else>
-      <!-- ── Set / Character / Project ─────────────────────────────── -->
-      <template v-if="!isScrapheapView">
-        <AddToEntityControl
-          v-if="entityLists.canSeeProjects"
-          type="project"
-          placement="right"
-          :picture-ids="selectedImageIds"
-          :disabled="!selectedImageIds.length || !!groupingLockReason"
-          :title="groupingLockReason || undefined"
-          :readonly="isReadOnly"
-          @selected="onAction('set-project', $event)"
-        />
-        <AddToEntityControl
-          type="character"
-          placement="right"
-          allow-create
-          :picture-ids="selectedImageIds"
-          :disabled="!selectedImageIds.length || !!groupingLockReason"
-          :title="groupingLockReason || undefined"
-          :readonly="isReadOnly"
-          @added="onAction('add-to-character', $event)"
-          @removed="onAction('remove-from-character', $event)"
-          @create="delegateWith('create-character', $event)"
-        />
-        <AddToEntityControl
-          type="set"
-          placement="right"
-          :picture-ids="selectedImageIds"
-          :disabled="!selectedImageIds.length || !!groupingLockReason"
-          :title="groupingLockReason || undefined"
-          :readonly="isReadOnly"
-          :locked-set-ids="lockedSetIds"
-          @added="onAction('added-to-set', $event)"
-        />
-        <div class="ctx-sep" />
-      </template>
+        <!-- ── Set / Character / Project ─────────────────────────────── -->
+        <template v-if="!isScrapheapView">
+          <AddToEntityControl
+            v-if="entityLists.canSeeProjects"
+            type="project"
+            placement="right"
+            :subject-ids="selectedImageIds"
+            :disabled="!selectedImageIds.length || !!groupingLockReason"
+            :title="groupingLockReason || undefined"
+            :readonly="isReadOnly"
+            @selected="onAction('set-project', $event)"
+          />
+          <AddToEntityControl
+            type="character"
+            placement="right"
+            allow-create
+            :subject-ids="selectedImageIds"
+            :disabled="!selectedImageIds.length || !!groupingLockReason"
+            :title="groupingLockReason || undefined"
+            :readonly="isReadOnly"
+            @added="onAction('add-to-character', $event)"
+            @removed="onAction('remove-from-character', $event)"
+            @create="delegateWith('create-character', $event)"
+          />
+          <AddToEntityControl
+            type="set"
+            placement="right"
+            :subject-ids="selectedImageIds"
+            :disabled="!selectedImageIds.length || !!groupingLockReason"
+            :title="groupingLockReason || undefined"
+            :readonly="isReadOnly"
+            :locked-set-ids="lockedSetIds"
+            @added="onAction('added-to-set', $event)"
+          />
+          <div class="ctx-sep" />
+        </template>
 
-      <!-- ── Stack / Unstack ───────────────────────────────────────── -->
-      <template v-if="!isScrapheapView">
-        <button
-          v-if="showRemoveStackButton"
-          class="ctx-item"
-          :disabled="isReadOnly"
-          title="Remove selected images from their stack"
-          @click="onAction('remove-from-stack')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-layers-off</v-icon>
-          Unstack
-        </button>
-        <button
-          v-else-if="selectedImageIds.length > 1"
-          class="ctx-item"
-          :disabled="isReadOnly"
-          title="Create a stack from the selected images"
-          @click="onAction('create-stack')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-layers</v-icon>
-          Stack
-        </button>
-        <button
-          v-if="showUnstackMultipleButton"
-          class="ctx-item"
-          :disabled="isReadOnly"
-          title="Dissolve all selected stacks"
-          @click="onAction('dissolve-stacks')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-layers-off</v-icon>
-          Unstack all
-        </button>
-        <button
-          v-if="showGroupStackButton"
-          class="ctx-item"
-          :disabled="isReadOnly"
-          title="Create stacks from selected likeness groups"
-          @click="onAction('create-stacks-from-groups')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-layers-plus</v-icon>
-          Stack groups
-        </button>
-        <div v-if="showAnyStackAction" class="ctx-sep" />
-      </template>
+        <!-- ── Stack / Unstack ───────────────────────────────────────── -->
+        <template v-if="!isScrapheapView">
+          <button
+            v-if="showRemoveStackButton"
+            class="ctx-item"
+            :disabled="isReadOnly"
+            title="Remove selected images from their stack"
+            @click="onAction('remove-from-stack')"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-layers-off</v-icon>
+            Unstack
+          </button>
+          <button
+            v-else-if="selectedImageIds.length > 1"
+            class="ctx-item"
+            :disabled="isReadOnly"
+            title="Create a stack from the selected images"
+            @click="onAction('create-stack')"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-layers</v-icon>
+            Stack
+          </button>
+          <button
+            v-if="showUnstackMultipleButton"
+            class="ctx-item"
+            :disabled="isReadOnly"
+            title="Dissolve all selected stacks"
+            @click="onAction('dissolve-stacks')"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-layers-off</v-icon>
+            Unstack all
+          </button>
+          <button
+            v-if="showGroupStackButton"
+            class="ctx-item"
+            :disabled="isReadOnly"
+            title="Create stacks from selected likeness groups"
+            @click="onAction('create-stacks-from-groups')"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-layers-plus</v-icon>
+            Stack groups
+          </button>
+          <div v-if="showAnyStackAction" class="ctx-sep" />
+        </template>
 
-      <!-- ── Tag / Filters / ComfyUI (delegate to SelectionBar panels) ── -->
-      <template v-if="!isScrapheapView">
-        <button
-          class="ctx-item"
-          :title="lockReason || 'Tag selected (T)'"
-          :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
-          @click="delegate('open-tag-panel')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-tag-plus</v-icon>
-          Tag
-        </button>
-        <div
-          v-if="taggerPlugins.length"
-          class="ctx-submenu-wrap"
-          @mouseenter="autoTagSubmenuOpen = true"
-          @mouseleave="autoTagSubmenuOpen = false"
-        >
+        <!-- ── Tag / Filters / ComfyUI (delegate to SelectionBar panels) ── -->
+        <template v-if="!isScrapheapView">
           <button
             class="ctx-item"
-            :title="lockReason || undefined"
+            :title="lockReason || 'Tag selected (T)'"
             :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
+            @click="delegate('open-tag-panel')"
           >
-            <v-icon class="ctx-icon" size="15">mdi-tag-outline</v-icon>
-            Tag automatically
-            <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
+            <v-icon class="ctx-icon" size="15">mdi-tag-plus</v-icon>
+            Tag
           </button>
-          <div v-if="autoTagSubmenuOpen" class="ctx-submenu">
+          <div
+            v-if="taggerPlugins.length"
+            class="ctx-submenu-wrap"
+            @mouseenter="autoTagSubmenuOpen = true"
+            @mouseleave="autoTagSubmenuOpen = false"
+          >
             <button
-              v-for="plugin in taggerPlugins"
-              :key="plugin.name"
               class="ctx-item"
               :title="lockReason || undefined"
               :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
-              @click="onAction('auto-tag', { model: plugin.name })"
             >
               <v-icon class="ctx-icon" size="15">mdi-tag-outline</v-icon>
-              {{ plugin.display_name || plugin.name }}
-              <span v-if="plugin.default_enabled" class="ctx-default-pill"
-                >default</span
-              >
+              Tag automatically
+              <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
             </button>
+            <div v-if="autoTagSubmenuOpen" class="ctx-submenu">
+              <button
+                v-for="plugin in taggerPlugins"
+                :key="plugin.name"
+                class="ctx-item"
+                :title="lockReason || undefined"
+                :disabled="
+                  !selectedImageIds.length || isReadOnly || !!lockReason
+                "
+                @click="onAction('auto-tag', { model: plugin.name })"
+              >
+                <v-icon class="ctx-icon" size="15">mdi-tag-outline</v-icon>
+                {{ plugin.display_name || plugin.name }}
+                <span v-if="plugin.default_enabled" class="ctx-default-pill"
+                  >default</span
+                >
+              </button>
+            </div>
           </div>
-        </div>
-        <div
-          v-if="captionerPlugins.length"
-          class="ctx-submenu-wrap"
-          @mouseenter="descriptionSubmenuOpen = true"
-          @mouseleave="descriptionSubmenuOpen = false"
-        >
-          <button
-            class="ctx-item"
-            :title="lockReason || undefined"
-            :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
+          <div
+            v-if="captionerPlugins.length"
+            class="ctx-submenu-wrap"
+            @mouseenter="descriptionSubmenuOpen = true"
+            @mouseleave="descriptionSubmenuOpen = false"
           >
-            <v-icon class="ctx-icon" size="15">mdi-text-box-outline</v-icon>
-            Generate description
-            <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
-          </button>
-          <div v-if="descriptionSubmenuOpen" class="ctx-submenu">
             <button
-              v-for="plugin in captionerPlugins"
-              :key="plugin.name"
               class="ctx-item"
               :title="lockReason || undefined"
               :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
-              @click="onAction('generate-description', { model: plugin.name })"
             >
               <v-icon class="ctx-icon" size="15">mdi-text-box-outline</v-icon>
-              {{ plugin.display_name || plugin.name }}
-              <span v-if="plugin.default_enabled" class="ctx-default-pill"
-                >default</span
-              >
+              Generate description
+              <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
             </button>
+            <div v-if="descriptionSubmenuOpen" class="ctx-submenu">
+              <button
+                v-for="plugin in captionerPlugins"
+                :key="plugin.name"
+                class="ctx-item"
+                :title="lockReason || undefined"
+                :disabled="
+                  !selectedImageIds.length || isReadOnly || !!lockReason
+                "
+                @click="
+                  onAction('generate-description', { model: plugin.name })
+                "
+              >
+                <v-icon class="ctx-icon" size="15">mdi-text-box-outline</v-icon>
+                {{ plugin.display_name || plugin.name }}
+                <span v-if="plugin.default_enabled" class="ctx-default-pill"
+                  >default</span
+                >
+              </button>
+            </div>
           </div>
-        </div>
-        <button
-          v-if="pluginOptions.length"
-          class="ctx-item"
-          :disabled="!selectedImageIds.length || isReadOnly"
-          @click="delegate('open-plugin-panel')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-tune-variant</v-icon>
-          Filters
-        </button>
-        <button
-          v-if="comfyuiConfigured"
-          class="ctx-item"
-          title="Generate variants from this image"
-          :disabled="!contextImage || isReadOnly"
-          @click="delegateWith('open-remix-dialog', contextImage?.id)"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-auto-fix</v-icon>
-          Generate variants…
-        </button>
-        <button
-          v-if="comfyuiConfigured"
-          class="ctx-item"
-          :disabled="!selectedImageIds.length || isReadOnly"
-          @click="delegate('open-comfyui-panel')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-robot</v-icon>
-          Edit with ComfyUI
-        </button>
-        <button
-          class="ctx-item"
-          title="Detect objects and store bounding boxes"
-          :disabled="!selectedImageIds.length || isReadOnly"
-          @click="onAction('segment')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-shape-outline</v-icon>
-          Segment
-        </button>
-        <div class="ctx-sep" />
-      </template>
-
-      <!-- ── Restore from snapshot ─────────────────────────── -->
-      <template
-        v-if="!isReadOnly && selectedImageIds.length >= 1 && !isScrapheapView"
-      >
-        <div
-          class="ctx-submenu-wrap"
-          @mouseenter="restoreSubmenuOpen = true"
-          @mouseleave="restoreSubmenuOpen = false"
-        >
           <button
+            v-if="pluginOptions.length"
             class="ctx-item"
             :disabled="!selectedImageIds.length || isReadOnly"
+            @click="delegate('open-plugin-panel')"
           >
-            <v-icon class="ctx-icon" size="15">mdi-restore</v-icon>
-            Restore from snapshot
-            <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
+            <v-icon class="ctx-icon" size="15">mdi-tune-variant</v-icon>
+            Filters
           </button>
-          <div v-if="restoreSubmenuOpen" class="ctx-submenu">
-            <button
-              v-for="cp in recentSnapshots"
-              :key="cp.id"
-              class="ctx-item"
-              :disabled="identicalSnapshotIds.has(cp.id)"
-              :title="
-                identicalSnapshotIds.has(cp.id)
-                  ? 'Selection is identical to this snapshot'
-                  : undefined
-              "
-              @click="handleRestoreFromSnapshot(cp.id)"
-            >
-              <v-icon class="ctx-icon" size="14">mdi-camera-outline</v-icon>
-              {{ cp.label || cp.kind }}
-              <span class="ctx-default-pill">{{
-                cp.created_at ? formatSnapshotDate(cp.created_at) : ""
-              }}</span>
-            </button>
-            <button class="ctx-item" @click="handleRestoreMore">
-              <v-icon class="ctx-icon" size="14">mdi-dots-horizontal</v-icon>
-              More…
-            </button>
-          </div>
-        </div>
-      </template>
+          <button
+            v-if="comfyuiConfigured"
+            class="ctx-item"
+            title="Generate variants from this image"
+            :disabled="!contextImage || isReadOnly"
+            @click="delegateWith('open-remix-dialog', contextImage?.id)"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-auto-fix</v-icon>
+            Generate variants…
+          </button>
+          <button
+            v-if="comfyuiConfigured"
+            class="ctx-item"
+            :disabled="!selectedImageIds.length || isReadOnly"
+            @click="delegate('open-comfyui-panel')"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-robot</v-icon>
+            Edit with ComfyUI
+          </button>
+          <button
+            class="ctx-item"
+            title="Detect objects and store bounding boxes"
+            :disabled="!selectedImageIds.length || isReadOnly"
+            @click="onAction('segment')"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-shape-outline</v-icon>
+            Segment
+          </button>
+          <div class="ctx-sep" />
+        </template>
 
-      <!-- ── Find similar faces ─────────────────────────────── -->
-      <template
-        v-if="
-          contextImage?.id &&
-          !isScrapheapView &&
-          selectedImageIds.length === 1 &&
-          contextImageFaces.length
-        "
-      >
-        <!-- Direct action when a specific face was right-clicked, or only one face exists -->
-        <button
-          v-if="contextClickedFace || contextImageFaces.length === 1"
-          class="ctx-item"
-          title="Find pictures with similar faces"
-          @click="
-            onAction(
-              'find-similar-faces',
-              (contextClickedFace ?? contextImageFaces[0]).id,
-            )
+        <!-- ── Restore from snapshot ─────────────────────────── -->
+        <template
+          v-if="!isReadOnly && selectedImageIds.length >= 1 && !isScrapheapView"
+        >
+          <div
+            class="ctx-submenu-wrap"
+            @mouseenter="restoreSubmenuOpen = true"
+            @mouseleave="restoreSubmenuOpen = false"
+          >
+            <button
+              class="ctx-item"
+              :disabled="!selectedImageIds.length || isReadOnly"
+            >
+              <v-icon class="ctx-icon" size="15">mdi-restore</v-icon>
+              Restore from snapshot
+              <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
+            </button>
+            <div v-if="restoreSubmenuOpen" class="ctx-submenu">
+              <button
+                v-for="cp in recentSnapshots"
+                :key="cp.id"
+                class="ctx-item"
+                :disabled="identicalSnapshotIds.has(cp.id)"
+                :title="
+                  identicalSnapshotIds.has(cp.id)
+                    ? 'Selection is identical to this snapshot'
+                    : undefined
+                "
+                @click="handleRestoreFromSnapshot(cp.id)"
+              >
+                <v-icon class="ctx-icon" size="14">mdi-camera-outline</v-icon>
+                {{ cp.label || cp.kind }}
+                <span class="ctx-default-pill">{{
+                  cp.created_at ? formatSnapshotDate(cp.created_at) : ""
+                }}</span>
+              </button>
+              <button class="ctx-item" @click="handleRestoreMore">
+                <v-icon class="ctx-icon" size="14">mdi-dots-horizontal</v-icon>
+                More…
+              </button>
+            </div>
+          </div>
+        </template>
+
+        <!-- ── Find similar faces ─────────────────────────────── -->
+        <template
+          v-if="
+            contextImage?.id &&
+            !isScrapheapView &&
+            selectedImageIds.length === 1 &&
+            contextImageFaces.length
           "
         >
-          <v-icon class="ctx-icon" size="15">mdi-face-recognition</v-icon>
-          Find similar faces
-        </button>
-        <!-- Submenu to pick a face when not right-clicking on one -->
-        <div
-          v-else
-          class="ctx-submenu-wrap"
-          @mouseenter="openFaceSubmenu"
-          @mouseleave="findFacesSubmenuOpen = false"
-        >
-          <button class="ctx-item">
+          <!-- Direct action when a specific face was right-clicked, or only one face exists -->
+          <button
+            v-if="contextClickedFace || contextImageFaces.length === 1"
+            class="ctx-item"
+            title="Find pictures with similar faces"
+            @click="
+              onAction(
+                'find-similar-faces',
+                (contextClickedFace ?? contextImageFaces[0]).id,
+              )
+            "
+          >
             <v-icon class="ctx-icon" size="15">mdi-face-recognition</v-icon>
             Find similar faces
-            <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
           </button>
-          <div v-if="findFacesSubmenuOpen" class="ctx-submenu ctx-face-submenu">
-            <button
-              v-for="(face, idx) in contextImageFaces"
-              :key="face.id ?? idx"
-              class="ctx-item ctx-face-item"
-              @click="onAction('find-similar-faces', face.id)"
-            >
-              <div
-                class="ctx-face-thumb"
-                :style="getFaceThumbStyle(face, idx)"
-              />
-              <span>{{ faceLabel(face, idx) }}</span>
+          <!-- Submenu to pick a face when not right-clicking on one -->
+          <div
+            v-else
+            class="ctx-submenu-wrap"
+            @mouseenter="openFaceSubmenu"
+            @mouseleave="findFacesSubmenuOpen = false"
+          >
+            <button class="ctx-item">
+              <v-icon class="ctx-icon" size="15">mdi-face-recognition</v-icon>
+              Find similar faces
+              <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
             </button>
+            <div
+              v-if="findFacesSubmenuOpen"
+              class="ctx-submenu ctx-face-submenu"
+            >
+              <button
+                v-for="(face, idx) in contextImageFaces"
+                :key="face.id ?? idx"
+                class="ctx-item ctx-face-item"
+                @click="onAction('find-similar-faces', face.id)"
+              >
+                <div
+                  class="ctx-face-thumb"
+                  :style="getFaceThumbStyle(face, idx)"
+                />
+                <span>{{ faceLabel(face, idx) }}</span>
+              </button>
+            </div>
           </div>
-        </div>
-      </template>
+        </template>
 
-      <!-- ── Reverse image search ────────────────────────────── -->
-      <template v-if="contextImage?.id && !isScrapheapView">
-        <button
-          class="ctx-item"
-          :disabled="!selectedImageIds.length"
-          title="Find visually similar images"
-          @click="onAction('reverse-image-search')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-image-search-outline</v-icon>
-          Reverse image search
-        </button>
-        <div class="ctx-sep" />
-      </template>
+        <!-- ── Reverse image search ────────────────────────────── -->
+        <template v-if="contextImage?.id && !isScrapheapView">
+          <button
+            class="ctx-item"
+            :disabled="!selectedImageIds.length"
+            title="Find visually similar images"
+            @click="onAction('reverse-image-search')"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-image-search-outline</v-icon>
+            Reverse image search
+          </button>
+          <div class="ctx-sep" />
+        </template>
 
-      <!-- ── Share image ──────────────────────────────────────────── -->
-      <template v-if="contextImage?.id && selectedImageIds.length === 1">
-        <button
-          class="ctx-item"
-          :disabled="isReadOnly"
-          @click="onAction('share-picture')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-link-variant</v-icon>
-          Share image
-        </button>
-        <button
-          v-if="isShared"
-          class="ctx-item ctx-item--danger"
-          :disabled="isReadOnly"
-          @click="onAction('remove-picture-shares')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-link-variant-off</v-icon>
-          Remove all shares
-        </button>
-        <div class="ctx-sep" />
-      </template>
+        <!-- ── Share image ──────────────────────────────────────────── -->
+        <template v-if="contextImage?.id && selectedImageIds.length === 1">
+          <button
+            class="ctx-item"
+            :disabled="isReadOnly"
+            @click="onAction('share-picture')"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-link-variant</v-icon>
+            Share image
+          </button>
+          <button
+            v-if="isShared"
+            class="ctx-item ctx-item--danger"
+            :disabled="isReadOnly"
+            @click="onAction('remove-picture-shares')"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-link-variant-off</v-icon>
+            Remove all shares
+          </button>
+          <div class="ctx-sep" />
+        </template>
 
-      <!-- ── Remove / Delete ───────────────────────────────────────────
+        <!-- ── Remove / Delete ───────────────────────────────────────────
            The trailing danger group, ordered by escalating severity:
            Keep cover only → Move to the Scrapheap → Delete forever. Keep cover
            only is recoverable and touches only stacks; Delete moves the whole
            selection; the scrapheap view's Delete destroys files. -->
-      <button
-        v-if="showKeepCoverOnly"
-        class="ctx-item ctx-item--danger"
-        :disabled="isReadOnly || !!keepCoverOnlyLockReason"
-        :title="
-          keepCoverOnlyLockReason ||
-          'Keep each selected stack\'s cover and move its other pictures to the Scrapheap'
-        "
-        @click="onAction('keep-cover-only')"
-      >
-        <v-icon class="ctx-icon" size="15">{{ KEEP_COVER_ONLY_ICON }}</v-icon>
-        {{ keepCoverOnlyLabel }}
-      </button>
-      <button
-        v-if="showRemoveButton"
-        class="ctx-item ctx-item--danger"
-        :disabled="!selectedImageIds.length || isReadOnly"
-        @click="onAction('remove-from-group')"
-      >
-        {{ removeButtonLabel }}
-      </button>
-      <button
-        class="ctx-item ctx-item--danger"
-        :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
-        :title="lockReason || 'Delete selected items (DEL)'"
-        @click="onAction('delete-selected')"
-      >
-        <v-icon class="ctx-icon" size="15">mdi-delete</v-icon>
-        {{ deleteButtonLabel }}
-      </button>
+        <button
+          v-if="showKeepCoverOnly"
+          class="ctx-item ctx-item--danger"
+          :disabled="isReadOnly || !!keepCoverOnlyLockReason"
+          :title="
+            keepCoverOnlyLockReason ||
+            'Keep each selected stack\'s cover and move its other pictures to the Scrapheap'
+          "
+          @click="onAction('keep-cover-only')"
+        >
+          <v-icon class="ctx-icon" size="15">{{ KEEP_COVER_ONLY_ICON }}</v-icon>
+          {{ keepCoverOnlyLabel }}
+        </button>
+        <button
+          v-if="showRemoveButton"
+          class="ctx-item ctx-item--danger"
+          :disabled="!selectedImageIds.length || isReadOnly"
+          @click="onAction('remove-from-group')"
+        >
+          {{ removeButtonLabel }}
+        </button>
+        <button
+          class="ctx-item ctx-item--danger"
+          :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
+          :title="lockReason || 'Delete selected items (DEL)'"
+          @click="onAction('delete-selected')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-delete</v-icon>
+          {{ deleteButtonLabel }}
+        </button>
       </template>
     </div>
   </Teleport>
@@ -683,19 +707,17 @@ const props = defineProps({
 // The dark-surface skin is tied to overlay invocation — the menu renders over
 // the dark lightbox there and nowhere else.
 const onDark = computed(() => props.overlayMode);
-const isOverlayVideo = computed(() => props.contextImage?.mediaKind === "video");
+const isOverlayVideo = computed(
+  () => props.contextImage?.mediaKind === "video",
+);
 const overlayMediaNoun = computed(() =>
   isOverlayVideo.value ? "video" : "picture",
 );
 const copyPictureLabel = computed(() =>
   isOverlayVideo.value ? "Copy current frame" : "Copy picture",
 );
-const saveShortcutHint = computed(() =>
-  isApplePlatform() ? "⌘S" : "Ctrl+S",
-);
-const copyShortcutHint = computed(() =>
-  isApplePlatform() ? "⌘C" : "Ctrl+C",
-);
+const saveShortcutHint = computed(() => (isApplePlatform() ? "⌘S" : "Ctrl+S"));
+const copyShortcutHint = computed(() => (isApplePlatform() ? "⌘C" : "Ctrl+C"));
 const saveAriaShortcut = computed(() =>
   isApplePlatform() ? "Meta+S" : "Control+S",
 );

--- a/frontend/src/components/widgets/ImageGridContextMenu.vue
+++ b/frontend/src/components/widgets/ImageGridContextMenu.vue
@@ -4,10 +4,7 @@
       v-if="visible"
       ref="menuRef"
       class="image-ctx-menu"
-      :class="{
-        'ctx-flip-sub': submenusFlip,
-        'image-ctx-menu--on-dark': onDark,
-      }"
+      :class="{ 'ctx-flip-sub': submenusFlip, 'image-ctx-menu--on-dark': onDark }"
       :style="menuStyle"
       role="menu"
       aria-orientation="vertical"
@@ -39,9 +36,7 @@
         >
           <v-icon class="ctx-icon" size="15">mdi-download</v-icon>
           <span>Save {{ overlayMediaNoun }}</span>
-          <span class="ctx-shortcut" aria-hidden="true">{{
-            saveShortcutHint
-          }}</span>
+          <span class="ctx-shortcut" aria-hidden="true">{{ saveShortcutHint }}</span>
         </button>
         <button
           v-if="contextImage?.id"
@@ -50,9 +45,7 @@
           :title="`Choose where to save this ${overlayMediaNoun}`"
           @click="onAction('save-picture-as')"
         >
-          <v-icon class="ctx-icon" size="15"
-            >mdi-content-save-edit-outline</v-icon
-          >
+          <v-icon class="ctx-icon" size="15">mdi-content-save-edit-outline</v-icon>
           Save {{ overlayMediaNoun }} as…
         </button>
         <button
@@ -63,17 +56,13 @@
           :title="copyPictureTitle"
           :aria-keyshortcuts="copyAriaShortcut"
           :aria-describedby="
-            contextImage?.copyAvailable === true
-              ? undefined
-              : overlayCopyReasonId
+            contextImage?.copyAvailable === true ? undefined : overlayCopyReasonId
           "
           @click="onAction('copy-picture')"
         >
           <v-icon class="ctx-icon" size="15">mdi-content-copy</v-icon>
           <span>{{ copyPictureLabel }}</span>
-          <span class="ctx-shortcut" aria-hidden="true">{{
-            copyShortcutHint
-          }}</span>
+          <span class="ctx-shortcut" aria-hidden="true">{{ copyShortcutHint }}</span>
         </button>
         <span
           v-if="contextImage?.id && contextImage?.copyAvailable !== true"
@@ -205,11 +194,7 @@
                   cp.created_at ? formatSnapshotDate(cp.created_at) : ""
                 }}</span>
               </button>
-              <button
-                class="ctx-item"
-                role="menuitem"
-                @click="handleRestoreMore"
-              >
+              <button class="ctx-item" role="menuitem" @click="handleRestoreMore">
                 <v-icon class="ctx-icon" size="14">mdi-dots-horizontal</v-icon>
                 More…
               </button>
@@ -258,380 +243,371 @@
            GRID MODE — the full context menu for grid cells (unchanged).
            ════════════════════════════════════════════════════════════ -->
       <template v-else>
-        <!-- ── Set / Character / Project ─────────────────────────────── -->
-        <template v-if="!isScrapheapView">
-          <AddToEntityControl
-            v-if="entityLists.canSeeProjects"
-            type="project"
-            placement="right"
-            :subject-ids="selectedImageIds"
-            :disabled="!selectedImageIds.length || !!groupingLockReason"
-            :title="groupingLockReason || undefined"
-            :readonly="isReadOnly"
-            @selected="onAction('set-project', $event)"
-          />
-          <AddToEntityControl
-            type="character"
-            placement="right"
-            allow-create
-            :subject-ids="selectedImageIds"
-            :disabled="!selectedImageIds.length || !!groupingLockReason"
-            :title="groupingLockReason || undefined"
-            :readonly="isReadOnly"
-            @added="onAction('add-to-character', $event)"
-            @removed="onAction('remove-from-character', $event)"
-            @create="delegateWith('create-character', $event)"
-          />
-          <AddToEntityControl
-            type="set"
-            placement="right"
-            :subject-ids="selectedImageIds"
-            :disabled="!selectedImageIds.length || !!groupingLockReason"
-            :title="groupingLockReason || undefined"
-            :readonly="isReadOnly"
-            :locked-set-ids="lockedSetIds"
-            @added="onAction('added-to-set', $event)"
-          />
-          <div class="ctx-sep" />
-        </template>
+      <!-- ── Set / Character / Project ─────────────────────────────── -->
+      <template v-if="!isScrapheapView">
+        <AddToEntityControl
+          v-if="entityLists.canSeeProjects"
+          type="project"
+          placement="right"
+          :subject-ids="selectedImageIds"
+          :disabled="!selectedImageIds.length || !!groupingLockReason"
+          :title="groupingLockReason || undefined"
+          :readonly="isReadOnly"
+          @selected="onAction('set-project', $event)"
+        />
+        <AddToEntityControl
+          type="character"
+          placement="right"
+          allow-create
+          :subject-ids="selectedImageIds"
+          :disabled="!selectedImageIds.length || !!groupingLockReason"
+          :title="groupingLockReason || undefined"
+          :readonly="isReadOnly"
+          @added="onAction('add-to-character', $event)"
+          @removed="onAction('remove-from-character', $event)"
+          @create="delegateWith('create-character', $event)"
+        />
+        <AddToEntityControl
+          type="set"
+          placement="right"
+          :subject-ids="selectedImageIds"
+          :disabled="!selectedImageIds.length || !!groupingLockReason"
+          :title="groupingLockReason || undefined"
+          :readonly="isReadOnly"
+          :locked-set-ids="lockedSetIds"
+          @added="onAction('added-to-set', $event)"
+        />
+        <div class="ctx-sep" />
+      </template>
 
-        <!-- ── Stack / Unstack ───────────────────────────────────────── -->
-        <template v-if="!isScrapheapView">
-          <button
-            v-if="showRemoveStackButton"
-            class="ctx-item"
-            :disabled="isReadOnly"
-            title="Remove selected images from their stack"
-            @click="onAction('remove-from-stack')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-layers-off</v-icon>
-            Unstack
-          </button>
-          <button
-            v-else-if="selectedImageIds.length > 1"
-            class="ctx-item"
-            :disabled="isReadOnly"
-            title="Create a stack from the selected images"
-            @click="onAction('create-stack')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-layers</v-icon>
-            Stack
-          </button>
-          <button
-            v-if="showUnstackMultipleButton"
-            class="ctx-item"
-            :disabled="isReadOnly"
-            title="Dissolve all selected stacks"
-            @click="onAction('dissolve-stacks')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-layers-off</v-icon>
-            Unstack all
-          </button>
-          <button
-            v-if="showGroupStackButton"
-            class="ctx-item"
-            :disabled="isReadOnly"
-            title="Create stacks from selected likeness groups"
-            @click="onAction('create-stacks-from-groups')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-layers-plus</v-icon>
-            Stack groups
-          </button>
-          <div v-if="showAnyStackAction" class="ctx-sep" />
-        </template>
+      <!-- ── Stack / Unstack ───────────────────────────────────────── -->
+      <template v-if="!isScrapheapView">
+        <button
+          v-if="showRemoveStackButton"
+          class="ctx-item"
+          :disabled="isReadOnly"
+          title="Remove selected images from their stack"
+          @click="onAction('remove-from-stack')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-layers-off</v-icon>
+          Unstack
+        </button>
+        <button
+          v-else-if="selectedImageIds.length > 1"
+          class="ctx-item"
+          :disabled="isReadOnly"
+          title="Create a stack from the selected images"
+          @click="onAction('create-stack')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-layers</v-icon>
+          Stack
+        </button>
+        <button
+          v-if="showUnstackMultipleButton"
+          class="ctx-item"
+          :disabled="isReadOnly"
+          title="Dissolve all selected stacks"
+          @click="onAction('dissolve-stacks')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-layers-off</v-icon>
+          Unstack all
+        </button>
+        <button
+          v-if="showGroupStackButton"
+          class="ctx-item"
+          :disabled="isReadOnly"
+          title="Create stacks from selected likeness groups"
+          @click="onAction('create-stacks-from-groups')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-layers-plus</v-icon>
+          Stack groups
+        </button>
+        <div v-if="showAnyStackAction" class="ctx-sep" />
+      </template>
 
-        <!-- ── Tag / Filters / ComfyUI (delegate to SelectionBar panels) ── -->
-        <template v-if="!isScrapheapView">
+      <!-- ── Tag / Filters / ComfyUI (delegate to SelectionBar panels) ── -->
+      <template v-if="!isScrapheapView">
+        <button
+          class="ctx-item"
+          :title="lockReason || 'Tag selected (T)'"
+          :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
+          @click="delegate('open-tag-panel')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-tag-plus</v-icon>
+          Tag
+        </button>
+        <div
+          v-if="taggerPlugins.length"
+          class="ctx-submenu-wrap"
+          @mouseenter="autoTagSubmenuOpen = true"
+          @mouseleave="autoTagSubmenuOpen = false"
+        >
           <button
             class="ctx-item"
-            :title="lockReason || 'Tag selected (T)'"
+            :title="lockReason || undefined"
             :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
-            @click="delegate('open-tag-panel')"
           >
-            <v-icon class="ctx-icon" size="15">mdi-tag-plus</v-icon>
-            Tag
+            <v-icon class="ctx-icon" size="15">mdi-tag-outline</v-icon>
+            Tag automatically
+            <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
           </button>
-          <div
-            v-if="taggerPlugins.length"
-            class="ctx-submenu-wrap"
-            @mouseenter="autoTagSubmenuOpen = true"
-            @mouseleave="autoTagSubmenuOpen = false"
-          >
+          <div v-if="autoTagSubmenuOpen" class="ctx-submenu">
             <button
+              v-for="plugin in taggerPlugins"
+              :key="plugin.name"
               class="ctx-item"
               :title="lockReason || undefined"
               :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
+              @click="onAction('auto-tag', { model: plugin.name })"
             >
               <v-icon class="ctx-icon" size="15">mdi-tag-outline</v-icon>
-              Tag automatically
-              <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
-            </button>
-            <div v-if="autoTagSubmenuOpen" class="ctx-submenu">
-              <button
-                v-for="plugin in taggerPlugins"
-                :key="plugin.name"
-                class="ctx-item"
-                :title="lockReason || undefined"
-                :disabled="
-                  !selectedImageIds.length || isReadOnly || !!lockReason
-                "
-                @click="onAction('auto-tag', { model: plugin.name })"
+              {{ plugin.display_name || plugin.name }}
+              <span v-if="plugin.default_enabled" class="ctx-default-pill"
+                >default</span
               >
-                <v-icon class="ctx-icon" size="15">mdi-tag-outline</v-icon>
-                {{ plugin.display_name || plugin.name }}
-                <span v-if="plugin.default_enabled" class="ctx-default-pill"
-                  >default</span
-                >
-              </button>
-            </div>
+            </button>
           </div>
-          <div
-            v-if="captionerPlugins.length"
-            class="ctx-submenu-wrap"
-            @mouseenter="descriptionSubmenuOpen = true"
-            @mouseleave="descriptionSubmenuOpen = false"
+        </div>
+        <div
+          v-if="captionerPlugins.length"
+          class="ctx-submenu-wrap"
+          @mouseenter="descriptionSubmenuOpen = true"
+          @mouseleave="descriptionSubmenuOpen = false"
+        >
+          <button
+            class="ctx-item"
+            :title="lockReason || undefined"
+            :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
           >
+            <v-icon class="ctx-icon" size="15">mdi-text-box-outline</v-icon>
+            Generate description
+            <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
+          </button>
+          <div v-if="descriptionSubmenuOpen" class="ctx-submenu">
             <button
+              v-for="plugin in captionerPlugins"
+              :key="plugin.name"
               class="ctx-item"
               :title="lockReason || undefined"
               :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
+              @click="onAction('generate-description', { model: plugin.name })"
             >
               <v-icon class="ctx-icon" size="15">mdi-text-box-outline</v-icon>
-              Generate description
-              <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
-            </button>
-            <div v-if="descriptionSubmenuOpen" class="ctx-submenu">
-              <button
-                v-for="plugin in captionerPlugins"
-                :key="plugin.name"
-                class="ctx-item"
-                :title="lockReason || undefined"
-                :disabled="
-                  !selectedImageIds.length || isReadOnly || !!lockReason
-                "
-                @click="
-                  onAction('generate-description', { model: plugin.name })
-                "
+              {{ plugin.display_name || plugin.name }}
+              <span v-if="plugin.default_enabled" class="ctx-default-pill"
+                >default</span
               >
-                <v-icon class="ctx-icon" size="15">mdi-text-box-outline</v-icon>
-                {{ plugin.display_name || plugin.name }}
-                <span v-if="plugin.default_enabled" class="ctx-default-pill"
-                  >default</span
-                >
-              </button>
-            </div>
+            </button>
           </div>
-          <button
-            v-if="pluginOptions.length"
-            class="ctx-item"
-            :disabled="!selectedImageIds.length || isReadOnly"
-            @click="delegate('open-plugin-panel')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-tune-variant</v-icon>
-            Filters
-          </button>
-          <button
-            v-if="comfyuiConfigured"
-            class="ctx-item"
-            title="Generate variants from this image"
-            :disabled="!contextImage || isReadOnly"
-            @click="delegateWith('open-remix-dialog', contextImage?.id)"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-auto-fix</v-icon>
-            Generate variants…
-          </button>
-          <button
-            v-if="comfyuiConfigured"
-            class="ctx-item"
-            :disabled="!selectedImageIds.length || isReadOnly"
-            @click="delegate('open-comfyui-panel')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-robot</v-icon>
-            Edit with ComfyUI
-          </button>
-          <button
-            class="ctx-item"
-            title="Detect objects and store bounding boxes"
-            :disabled="!selectedImageIds.length || isReadOnly"
-            @click="onAction('segment')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-shape-outline</v-icon>
-            Segment
-          </button>
-          <div class="ctx-sep" />
-        </template>
-
-        <!-- ── Restore from snapshot ─────────────────────────── -->
-        <template
-          v-if="!isReadOnly && selectedImageIds.length >= 1 && !isScrapheapView"
+        </div>
+        <button
+          v-if="pluginOptions.length"
+          class="ctx-item"
+          :disabled="!selectedImageIds.length || isReadOnly"
+          @click="delegate('open-plugin-panel')"
         >
-          <div
-            class="ctx-submenu-wrap"
-            @mouseenter="restoreSubmenuOpen = true"
-            @mouseleave="restoreSubmenuOpen = false"
-          >
-            <button
-              class="ctx-item"
-              :disabled="!selectedImageIds.length || isReadOnly"
-            >
-              <v-icon class="ctx-icon" size="15">mdi-restore</v-icon>
-              Restore from snapshot
-              <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
-            </button>
-            <div v-if="restoreSubmenuOpen" class="ctx-submenu">
-              <button
-                v-for="cp in recentSnapshots"
-                :key="cp.id"
-                class="ctx-item"
-                :disabled="identicalSnapshotIds.has(cp.id)"
-                :title="
-                  identicalSnapshotIds.has(cp.id)
-                    ? 'Selection is identical to this snapshot'
-                    : undefined
-                "
-                @click="handleRestoreFromSnapshot(cp.id)"
-              >
-                <v-icon class="ctx-icon" size="14">mdi-camera-outline</v-icon>
-                {{ cp.label || cp.kind }}
-                <span class="ctx-default-pill">{{
-                  cp.created_at ? formatSnapshotDate(cp.created_at) : ""
-                }}</span>
-              </button>
-              <button class="ctx-item" @click="handleRestoreMore">
-                <v-icon class="ctx-icon" size="14">mdi-dots-horizontal</v-icon>
-                More…
-              </button>
-            </div>
-          </div>
-        </template>
+          <v-icon class="ctx-icon" size="15">mdi-tune-variant</v-icon>
+          Filters
+        </button>
+        <button
+          v-if="comfyuiConfigured"
+          class="ctx-item"
+          title="Generate variants from this image"
+          :disabled="!contextImage || isReadOnly"
+          @click="delegateWith('open-remix-dialog', contextImage?.id)"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-auto-fix</v-icon>
+          Generate variants…
+        </button>
+        <button
+          v-if="comfyuiConfigured"
+          class="ctx-item"
+          :disabled="!selectedImageIds.length || isReadOnly"
+          @click="delegate('open-comfyui-panel')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-robot</v-icon>
+          Edit with ComfyUI
+        </button>
+        <button
+          class="ctx-item"
+          title="Detect objects and store bounding boxes"
+          :disabled="!selectedImageIds.length || isReadOnly"
+          @click="onAction('segment')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-shape-outline</v-icon>
+          Segment
+        </button>
+        <div class="ctx-sep" />
+      </template>
 
-        <!-- ── Find similar faces ─────────────────────────────── -->
-        <template
-          v-if="
-            contextImage?.id &&
-            !isScrapheapView &&
-            selectedImageIds.length === 1 &&
-            contextImageFaces.length
+      <!-- ── Restore from snapshot ─────────────────────────── -->
+      <template
+        v-if="!isReadOnly && selectedImageIds.length >= 1 && !isScrapheapView"
+      >
+        <div
+          class="ctx-submenu-wrap"
+          @mouseenter="restoreSubmenuOpen = true"
+          @mouseleave="restoreSubmenuOpen = false"
+        >
+          <button
+            class="ctx-item"
+            :disabled="!selectedImageIds.length || isReadOnly"
+          >
+            <v-icon class="ctx-icon" size="15">mdi-restore</v-icon>
+            Restore from snapshot
+            <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
+          </button>
+          <div v-if="restoreSubmenuOpen" class="ctx-submenu">
+            <button
+              v-for="cp in recentSnapshots"
+              :key="cp.id"
+              class="ctx-item"
+              :disabled="identicalSnapshotIds.has(cp.id)"
+              :title="
+                identicalSnapshotIds.has(cp.id)
+                  ? 'Selection is identical to this snapshot'
+                  : undefined
+              "
+              @click="handleRestoreFromSnapshot(cp.id)"
+            >
+              <v-icon class="ctx-icon" size="14">mdi-camera-outline</v-icon>
+              {{ cp.label || cp.kind }}
+              <span class="ctx-default-pill">{{
+                cp.created_at ? formatSnapshotDate(cp.created_at) : ""
+              }}</span>
+            </button>
+            <button class="ctx-item" @click="handleRestoreMore">
+              <v-icon class="ctx-icon" size="14">mdi-dots-horizontal</v-icon>
+              More…
+            </button>
+          </div>
+        </div>
+      </template>
+
+      <!-- ── Find similar faces ─────────────────────────────── -->
+      <template
+        v-if="
+          contextImage?.id &&
+          !isScrapheapView &&
+          selectedImageIds.length === 1 &&
+          contextImageFaces.length
+        "
+      >
+        <!-- Direct action when a specific face was right-clicked, or only one face exists -->
+        <button
+          v-if="contextClickedFace || contextImageFaces.length === 1"
+          class="ctx-item"
+          title="Find pictures with similar faces"
+          @click="
+            onAction(
+              'find-similar-faces',
+              (contextClickedFace ?? contextImageFaces[0]).id,
+            )
           "
         >
-          <!-- Direct action when a specific face was right-clicked, or only one face exists -->
-          <button
-            v-if="contextClickedFace || contextImageFaces.length === 1"
-            class="ctx-item"
-            title="Find pictures with similar faces"
-            @click="
-              onAction(
-                'find-similar-faces',
-                (contextClickedFace ?? contextImageFaces[0]).id,
-              )
-            "
-          >
+          <v-icon class="ctx-icon" size="15">mdi-face-recognition</v-icon>
+          Find similar faces
+        </button>
+        <!-- Submenu to pick a face when not right-clicking on one -->
+        <div
+          v-else
+          class="ctx-submenu-wrap"
+          @mouseenter="openFaceSubmenu"
+          @mouseleave="findFacesSubmenuOpen = false"
+        >
+          <button class="ctx-item">
             <v-icon class="ctx-icon" size="15">mdi-face-recognition</v-icon>
             Find similar faces
+            <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
           </button>
-          <!-- Submenu to pick a face when not right-clicking on one -->
-          <div
-            v-else
-            class="ctx-submenu-wrap"
-            @mouseenter="openFaceSubmenu"
-            @mouseleave="findFacesSubmenuOpen = false"
-          >
-            <button class="ctx-item">
-              <v-icon class="ctx-icon" size="15">mdi-face-recognition</v-icon>
-              Find similar faces
-              <v-icon class="ctx-arrow" size="14">mdi-chevron-right</v-icon>
-            </button>
-            <div
-              v-if="findFacesSubmenuOpen"
-              class="ctx-submenu ctx-face-submenu"
+          <div v-if="findFacesSubmenuOpen" class="ctx-submenu ctx-face-submenu">
+            <button
+              v-for="(face, idx) in contextImageFaces"
+              :key="face.id ?? idx"
+              class="ctx-item ctx-face-item"
+              @click="onAction('find-similar-faces', face.id)"
             >
-              <button
-                v-for="(face, idx) in contextImageFaces"
-                :key="face.id ?? idx"
-                class="ctx-item ctx-face-item"
-                @click="onAction('find-similar-faces', face.id)"
-              >
-                <div
-                  class="ctx-face-thumb"
-                  :style="getFaceThumbStyle(face, idx)"
-                />
-                <span>{{ faceLabel(face, idx) }}</span>
-              </button>
-            </div>
+              <div
+                class="ctx-face-thumb"
+                :style="getFaceThumbStyle(face, idx)"
+              />
+              <span>{{ faceLabel(face, idx) }}</span>
+            </button>
           </div>
-        </template>
+        </div>
+      </template>
 
-        <!-- ── Reverse image search ────────────────────────────── -->
-        <template v-if="contextImage?.id && !isScrapheapView">
-          <button
-            class="ctx-item"
-            :disabled="!selectedImageIds.length"
-            title="Find visually similar images"
-            @click="onAction('reverse-image-search')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-image-search-outline</v-icon>
-            Reverse image search
-          </button>
-          <div class="ctx-sep" />
-        </template>
+      <!-- ── Reverse image search ────────────────────────────── -->
+      <template v-if="contextImage?.id && !isScrapheapView">
+        <button
+          class="ctx-item"
+          :disabled="!selectedImageIds.length"
+          title="Find visually similar images"
+          @click="onAction('reverse-image-search')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-image-search-outline</v-icon>
+          Reverse image search
+        </button>
+        <div class="ctx-sep" />
+      </template>
 
-        <!-- ── Share image ──────────────────────────────────────────── -->
-        <template v-if="contextImage?.id && selectedImageIds.length === 1">
-          <button
-            class="ctx-item"
-            :disabled="isReadOnly"
-            @click="onAction('share-picture')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-link-variant</v-icon>
-            Share image
-          </button>
-          <button
-            v-if="isShared"
-            class="ctx-item ctx-item--danger"
-            :disabled="isReadOnly"
-            @click="onAction('remove-picture-shares')"
-          >
-            <v-icon class="ctx-icon" size="15">mdi-link-variant-off</v-icon>
-            Remove all shares
-          </button>
-          <div class="ctx-sep" />
-        </template>
+      <!-- ── Share image ──────────────────────────────────────────── -->
+      <template v-if="contextImage?.id && selectedImageIds.length === 1">
+        <button
+          class="ctx-item"
+          :disabled="isReadOnly"
+          @click="onAction('share-picture')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-link-variant</v-icon>
+          Share image
+        </button>
+        <button
+          v-if="isShared"
+          class="ctx-item ctx-item--danger"
+          :disabled="isReadOnly"
+          @click="onAction('remove-picture-shares')"
+        >
+          <v-icon class="ctx-icon" size="15">mdi-link-variant-off</v-icon>
+          Remove all shares
+        </button>
+        <div class="ctx-sep" />
+      </template>
 
-        <!-- ── Remove / Delete ───────────────────────────────────────────
+      <!-- ── Remove / Delete ───────────────────────────────────────────
            The trailing danger group, ordered by escalating severity:
            Keep cover only → Move to the Scrapheap → Delete forever. Keep cover
            only is recoverable and touches only stacks; Delete moves the whole
            selection; the scrapheap view's Delete destroys files. -->
-        <button
-          v-if="showKeepCoverOnly"
-          class="ctx-item ctx-item--danger"
-          :disabled="isReadOnly || !!keepCoverOnlyLockReason"
-          :title="
-            keepCoverOnlyLockReason ||
-            'Keep each selected stack\'s cover and move its other pictures to the Scrapheap'
-          "
-          @click="onAction('keep-cover-only')"
-        >
-          <v-icon class="ctx-icon" size="15">{{ KEEP_COVER_ONLY_ICON }}</v-icon>
-          {{ keepCoverOnlyLabel }}
-        </button>
-        <button
-          v-if="showRemoveButton"
-          class="ctx-item ctx-item--danger"
-          :disabled="!selectedImageIds.length || isReadOnly"
-          @click="onAction('remove-from-group')"
-        >
-          {{ removeButtonLabel }}
-        </button>
-        <button
-          class="ctx-item ctx-item--danger"
-          :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
-          :title="lockReason || 'Delete selected items (DEL)'"
-          @click="onAction('delete-selected')"
-        >
-          <v-icon class="ctx-icon" size="15">mdi-delete</v-icon>
-          {{ deleteButtonLabel }}
-        </button>
+      <button
+        v-if="showKeepCoverOnly"
+        class="ctx-item ctx-item--danger"
+        :disabled="isReadOnly || !!keepCoverOnlyLockReason"
+        :title="
+          keepCoverOnlyLockReason ||
+          'Keep each selected stack\'s cover and move its other pictures to the Scrapheap'
+        "
+        @click="onAction('keep-cover-only')"
+      >
+        <v-icon class="ctx-icon" size="15">{{ KEEP_COVER_ONLY_ICON }}</v-icon>
+        {{ keepCoverOnlyLabel }}
+      </button>
+      <button
+        v-if="showRemoveButton"
+        class="ctx-item ctx-item--danger"
+        :disabled="!selectedImageIds.length || isReadOnly"
+        @click="onAction('remove-from-group')"
+      >
+        {{ removeButtonLabel }}
+      </button>
+      <button
+        class="ctx-item ctx-item--danger"
+        :disabled="!selectedImageIds.length || isReadOnly || !!lockReason"
+        :title="lockReason || 'Delete selected items (DEL)'"
+        @click="onAction('delete-selected')"
+      >
+        <v-icon class="ctx-icon" size="15">mdi-delete</v-icon>
+        {{ deleteButtonLabel }}
+      </button>
       </template>
     </div>
   </Teleport>
@@ -707,17 +683,19 @@ const props = defineProps({
 // The dark-surface skin is tied to overlay invocation — the menu renders over
 // the dark lightbox there and nowhere else.
 const onDark = computed(() => props.overlayMode);
-const isOverlayVideo = computed(
-  () => props.contextImage?.mediaKind === "video",
-);
+const isOverlayVideo = computed(() => props.contextImage?.mediaKind === "video");
 const overlayMediaNoun = computed(() =>
   isOverlayVideo.value ? "video" : "picture",
 );
 const copyPictureLabel = computed(() =>
   isOverlayVideo.value ? "Copy current frame" : "Copy picture",
 );
-const saveShortcutHint = computed(() => (isApplePlatform() ? "⌘S" : "Ctrl+S"));
-const copyShortcutHint = computed(() => (isApplePlatform() ? "⌘C" : "Ctrl+C"));
+const saveShortcutHint = computed(() =>
+  isApplePlatform() ? "⌘S" : "Ctrl+S",
+);
+const copyShortcutHint = computed(() =>
+  isApplePlatform() ? "⌘C" : "Ctrl+C",
+);
 const saveAriaShortcut = computed(() =>
   isApplePlatform() ? "Meta+S" : "Control+S",
 );


### PR DESCRIPTION
Groundwork for the shelf's fifth verb (Assign). Ruled by `ui-ux-expert` and
`senior-frontend-developer`: **generalise the shared control, do not build a
shelf-local one.** The grid's behaviour is unchanged — that is the claim this PR
has to earn, and there are tests for it.

No shelf code here. This lands and merges on its own; the shelf host follows
once #871/#873 are in.

## Why generalise

The semantics the shelf needs already exist and are already ruled. `getItemState`
resolves a selection to unchecked/partial/checked, and **partial resolves up** —
confirmed in *both* write paths, `toggleSet:907` and `toggleCharacter:1030`. A
shelf-local control would mean re-deriving that cycle, and the copy that
eventually resolved *down* would teach two meanings for one glyph.

The control was also already half-generic: `face` performs no writes, and so
does `project` (it emits `selected` plus an optimistic update). Host-owns-writes
was 2 of 4 modes before this PR; it just had no name.

## Three commits

1. **`pictureIds` → `subjectIds`, `required: true`.** The rename is cosmetic; the
   `required` is not. Every call site stubs this component in its tests, so a
   binding that went missing would land in `$attrs` with **no** Vue warning,
   leave the id list empty, and make the menu open with every row unchecked and
   every click a silent no-op. Vue warns for a missing *required* prop and says
   nothing about an unknown attribute. That is why there is no deprecated
   `pictureIds` alias: an alias postpones the failure instead of making it loud,
   and "deprecated" in a 1541-line four-mode component means permanent.
2. **`membership` prop.** Supplying it bypasses the internal readers entirely.
   The shelf already has every adapter's attachments on the rows it drew, so it
   hands them in and no read happens.
3. **`hostOwnsWrites`.** Names what `face` and `project` already did, so the flag
   has three users on its first day. Supplying `membership` implies it: "your
   data, my API calls" is a combination with no caller, and leaving it
   representable is how it gets written by accident.

## The regression this could have caused

`getItemState` narrowed character membership by `picturesWithFaces` — a picture
rule ("a picture with no face cannot be a character member"). Left in place it
would filter the shelf's adapter ids against a set that never contains them, and
every row would read unchecked however many were attached. It is now scoped to
the picture path, and a test pins it.

## Verification

2,806 frontend tests; 5 new for host-driven mode. Both regression guards are
mutation-checked: letting the face filter leak into host mode turns one red,
and making partial resolve down turns the other red.

The UX ruling's tripwire — "if that PR touches `.ate-*` styles, it has gone
wrong" — holds: zero style changes. The last commit reverts 672 lines of
prettier churn in `ImageGridContextMenu.vue`, which is not formatted on
`develop` and whose real change here is three bindings.