### PR TITLE
Warm the Windows model cache on a branch, and stop pull requests writing it

### DIFF
--- a/.github/actions/model-cache/action.yml
+++ b/.github/actions/model-cache/action.yml
@@ -7,7 +7,10 @@ description: >-
   Covers Linux and Windows. Windows had its own inline copy of this cache in
   ci.yml, with different paths and a key that hashed three of these six files;
   the two definitions could not share an entry and the Windows one was never
-  warmed on a branch. See the `warm_models` matrix in ci.yml.
+  warmed on a branch. The writers are now `warm_models` and
+  `warm_models_windows` in ci.yml — two jobs rather than one matrix, because
+  `needs:` on a matrix job waits for every leg and that would put a Windows
+  runner on the Linux gate's critical path.
 
   RESTORE-ONLY for readers, deliberately. `actions/cache` writes only on a key
   MISS, so a model missing from an entry that keeps hitting its primary key can

--- a/.github/actions/model-cache/action.yml
+++ b/.github/actions/model-cache/action.yml
@@ -4,6 +4,11 @@ description: >-
   The single source of truth for the cache's paths and key: every job restores,
   and exactly one job — `warm_models` in ci.yml — saves.
 
+  Covers Linux and Windows. Windows had its own inline copy of this cache in
+  ci.yml, with different paths and a key that hashed three of these six files;
+  the two definitions could not share an entry and the Windows one was never
+  warmed on a branch. See the `warm_models` matrix in ci.yml.
+
   RESTORE-ONLY for readers, deliberately. `actions/cache` writes only on a key
   MISS, so a model missing from an entry that keeps hitting its primary key can
   never be added to it. CLIP was missing from the 1.77 GB entry for exactly that
@@ -38,6 +43,12 @@ runs:
     #    user_data_dir, where the WD14 and PixlStash taggers land because they
     #    call hf_hub_download(local_dir=...), which bypasses the hub cache
     #    entirely.
+    #  * ~/AppData/Local/pixlstash/pixlstash/downloaded_models — the same
+    #    user_data_dir on Windows (the doubled "pixlstash" is platformdirs'
+    #    appauthor=appname default). Listed unconditionally rather than behind
+    #    a `runner.os` branch so there stays exactly ONE path list and ONE key
+    #    expression; `actions/cache` skips a path that does not exist, so each
+    #    OS simply ignores the other's.
     # A warm cache makes needs_download() (a pure file-existence check) return
     # False, so download() is never issued; and for the models that have no such
     # check, a cache hit lets huggingface_hub fall back to the cached file when
@@ -55,6 +66,7 @@ runs:
         path: |
           ~/.cache/huggingface
           ~/.local/share/pixlstash/downloaded_models
+          ~/AppData/Local/pixlstash/pixlstash/downloaded_models
         key: hf-models-${{ runner.os }}-${{ hashFiles('pixlstash/tagger_plugins/clip_service.py', 'pixlstash/tagger_plugins/sbert.py', 'pixlstash/tagger_plugins/wd14.py', 'pixlstash/tagger_plugins/pixlstash_tagger.py', 'pixlstash/tagger_plugins/florence2.py', 'scripts/prefetch_ci_models.py') }}
         restore-keys: hf-models-${{ runner.os }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,23 @@ jobs:
         if: steps.models.outputs.hit != 'true'
         run: python scripts/prefetch_ci_models.py
 
+      # Saved only from a BRANCH run, never from a pull request.
+      #
+      # A cache written by a `pull_request` run lands in refs/pull/N/merge and
+      # is deleted with the PR, so it can never warm anything but itself — while
+      # still counting against the repo's 10 GB budget for as long as the PR is
+      # open. Four open PRs were holding three 1.7 GB Windows entries and a
+      # duplicate 1.7 GB Linux one, with the repo at ~9 GB of 10, which is how a
+      # branch-scoped entry gets LRU-evicted and the whole scheme quietly stops
+      # working.
+      #
+      # A PR that changes the model set is therefore not fully cold: the
+      # `restore-keys` prefix restores the previous set and only the delta is
+      # fetched, which is what that fallback is for.
       - name: Save the model cache
-        if: success() && steps.models.outputs.hit != 'true'
+        if: >-
+          success() && steps.models.outputs.hit != 'true'
+          && github.event_name == 'push'
         uses: ./.github/actions/model-cache
         with:
           mode: save
@@ -321,6 +336,62 @@ jobs:
   # flake to debug. Sharding across jobs buys the same wall clock with one
   # single-threaded pytest per runner and no new native-teardown concurrency.
   # Revisit `-n 2` only with a green measured run behind it.
+  # ---------------------------------------------------------------------------
+  # The Windows half of the same scheme, as a SEPARATE job rather than a matrix
+  # leg of `warm_models`: `backend` does `needs: warm_models`, and `needs:` on a
+  # matrix job waits for every leg, so a matrix would put a Windows runner on
+  # the Linux gate's critical path for nothing.
+  #
+  # Nothing was writing a Windows entry to a branch scope before this. The four
+  # `backend_windows` shards each carried an inline read/write `actions/cache`,
+  # which on a `pull_request` run writes into refs/pull/N/merge — a scope that
+  # dies with the PR. Every PR therefore paid four cold ~1.7 GB downloads that
+  # hit HuggingFace in parallel and 429'd, which is exactly the stampede
+  # `warm_models` above exists to prevent, one platform later. Measured on run
+  # 31418525447: `likeness pipeline did not settle in time` behind five retries
+  # of `HTTP Error 429` per file.
+  # ---------------------------------------------------------------------------
+  warm_models_windows:
+    name: warm model cache (Windows)
+    runs-on: windows-latest
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: models
+        uses: ./.github/actions/model-cache
+
+      # `setup-backend` caches pip at ~/.cache/pip, which is not where pip
+      # caches on Windows, so it is Linux-only and this is its counterpart.
+      # Deliberately no pip cache: this job installs only to run the prefetch,
+      # and a second 0.4 GB Windows entry is not worth it against the 10 GB
+      # repo budget this change is trying to get back under.
+      - name: Set up Python
+        if: steps.models.outputs.hit != 'true'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        if: steps.models.outputs.hit != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test,dev]
+
+      - name: Download every model the Windows shards load
+        if: steps.models.outputs.hit != 'true'
+        run: python scripts/prefetch_ci_models.py
+
+      - name: Save the model cache
+        if: >-
+          success() && steps.models.outputs.hit != 'true'
+          && github.event_name == 'push'
+        uses: ./.github/actions/model-cache
+        with:
+          mode: save
+          key: ${{ steps.models.outputs.key }}
+
   # ---------------------------------------------------------------------------
   backend:
     name: backend shard ${{ matrix.shard }}
@@ -781,6 +852,11 @@ jobs:
   # ---------------------------------------------------------------------------
   backend_windows:
     name: backend-windows shard ${{ matrix.shard }}
+    # Same reason `backend` waits for `warm_models`: without the gate all four
+    # shards start cold together and re-run the very stampede the warm job
+    # exists to absorb. On the warm path this costs the shards a checkout and a
+    # cache restore they were doing anyway.
+    needs: warm_models_windows
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -829,24 +905,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test,dev]
 
-      - name: Cache HuggingFace models
-        uses: actions/cache@v5
-        with:
-          # Read/write, unlike Linux: these four shards run a small OS-sensitive
-          # subset that loads no CLIP or SBert, so there is no eight-way
-          # stampede to serialise and this cache self-heals on its own key bust.
-          # See the Linux setup-backend action for the rationale. The taggers
-          # download via hf_hub_download(local_dir=...) into platformdirs'
-          # Windows user_data_dir —
-          # %LOCALAPPDATA%\pixlstash\pixlstash\downloaded_models (the doubled
-          # "pixlstash" is platformdirs' appauthor=appname default) — NOT
-          # ~\.cache\huggingface. Caching both is what makes a warm runner skip
-          # the HEAD revalidation that returns the 429.
-          path: |
-            ~\.cache\huggingface
-            ~\AppData\Local\pixlstash\pixlstash\downloaded_models
-          key: hf-models-${{ runner.os }}-${{ hashFiles('pixlstash/tagger_plugins/wd14.py', 'pixlstash/tagger_plugins/pixlstash_tagger.py', 'pixlstash/tagger_plugins/florence2.py') }}
-          restore-keys: hf-models-${{ runner.os }}-
+      # Restore-only, through the same action every Linux job uses. This was an
+      # inline read/write `actions/cache` with its own paths and a key hashing
+      # three of the six files the shared one hashes — two definitions that
+      # could never share an entry, and the writing half is what filled the
+      # repo's cache budget with per-PR copies. `warm_models (windows-latest)`
+      # is now the single writer, exactly as on Linux.
+      - name: Restore the HuggingFace model cache
+        uses: ./.github/actions/model-cache
 
       - name: OS-sensitive backend tests (shard ${{ matrix.shard }} of 4)
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,14 @@ jobs:
     # requirement. Absent on fork PRs by design; the prefetch then runs
     # anonymously, which one sequential job is far more likely to survive than
     # eight parallel ones were.
+    # Only a `push` can save this cache (see the save step), so only a `push`
+    # runs the prefetch — and a run that never fetches has no use for the
+    # token. Scoping it this way keeps the secret out of the environment on
+    # pull-request runs, which are the ones that execute the PR's own tree via
+    # `pip install .`. The shards below still carry it unconditionally: they
+    # reach HuggingFace during the tests themselves.
     env:
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_TOKEN: ${{ github.event_name == 'push' && secrets.HF_TOKEN || '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -178,11 +184,11 @@ jobs:
 
       # Only needed to run the prefetch, so it is skipped whenever the cache is
       # already complete — which is every run that does not change the model set.
-      - if: steps.models.outputs.hit != 'true'
+      - if: steps.models.outputs.hit != 'true' && github.event_name == 'push'
         uses: ./.github/actions/setup-backend
 
       - name: Download every model the gate loads
-        if: steps.models.outputs.hit != 'true'
+        if: steps.models.outputs.hit != 'true' && github.event_name == 'push'
         run: python scripts/prefetch_ci_models.py
 
       # Saved only from a BRANCH run, never from a pull request.
@@ -354,8 +360,14 @@ jobs:
   warm_models_windows:
     name: warm model cache (Windows)
     runs-on: windows-latest
+    # Only a `push` can save this cache (see the save step), so only a `push`
+    # runs the prefetch — and a run that never fetches has no use for the
+    # token. Scoping it this way keeps the secret out of the environment on
+    # pull-request runs, which are the ones that execute the PR's own tree via
+    # `pip install .`. The shards below still carry it unconditionally: they
+    # reach HuggingFace during the tests themselves.
     env:
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_TOKEN: ${{ github.event_name == 'push' && secrets.HF_TOKEN || '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -368,19 +380,19 @@ jobs:
       # and a second 0.4 GB Windows entry is not worth it against the 10 GB
       # repo budget this change is trying to get back under.
       - name: Set up Python
-        if: steps.models.outputs.hit != 'true'
+        if: steps.models.outputs.hit != 'true' && github.event_name == 'push'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
       - name: Install dependencies
-        if: steps.models.outputs.hit != 'true'
+        if: steps.models.outputs.hit != 'true' && github.event_name == 'push'
         run: |
           python -m pip install --upgrade pip
           pip install .[test,dev]
 
       - name: Download every model the Windows shards load
-        if: steps.models.outputs.hit != 'true'
+        if: steps.models.outputs.hit != 'true' && github.event_name == 'push'
         run: python scripts/prefetch_ci_models.py
 
       - name: Save the model cache


### PR DESCRIPTION
**CSO-reviewed and cleared with changes; both changes are in.**

## The defect

The HuggingFace model cache is warmed on Linux only. `gh cache list` for the
whole repo, before this change:

| key | ref |
|---|---|
| `hf-models-Linux-f101fdb…` | **`refs/heads/develop`** |
| `hf-models-Linux-f101fdb…` | `refs/pull/873/merge` |
| `hf-models-Windows-984b4b…` | `refs/pull/873/merge` |
| `hf-models-Windows-984b4b…` | `refs/pull/874/merge` |

There has never been a Windows entry on a branch. `warm_models` is
`ubuntu-latest`, and the four `backend_windows` shards each carried their own
inline read/write `actions/cache` instead — which on a `pull_request` writes into
`refs/pull/N/merge`, a scope that dies with the PR. So every PR paid four cold
~1.7 GB downloads in parallel, HuggingFace 429'd them, and a test timed out
(run 31418525447, "likeness pipeline did not settle in time"). That is precisely
the stampede `warm_models` was built to prevent, one platform later.

Two definitions were in play and could never share an entry: different paths, and
a key hashing three files against the shared action's six.

**The repo is also at ~9 GB of GitHub's 10 GB cache limit**, holding three 1.686 GB
Windows entries — one per open PR. So a warmer alone would not have worked: the
branch-scoped entry would be LRU-evicted by the per-PR copies.

## The fix

- `model-cache` gains the Windows `user_data_dir`, so one action covers both
  platforms with one key expression.
- **`warm_models_windows`**, a separate job — *not* a matrix leg. `backend` does
  `needs: warm_models`, and `needs:` on a matrix job waits for **every** leg, so a
  matrix would have put a Windows runner on the Linux gate's critical path.
  `backend_windows` now gates on it for the same reason `backend` gates on the
  Linux warmer.
- The Windows shards become **restore-only**, through the shared action.
- **A cache is written only from a branch run.** A PR's cache can only warm
  itself while still consuming the shared 10 GB.

Expected model-cache usage after: ~3.4 GB instead of ~6.7 GB and climbing.

A PR that changes the model set is not left cold: `restore-keys` restores the
previous set and only the delta is fetched.

## From the security review

`HF_TOKEN` is already job-wide on four jobs including `backend_windows` itself
(ci.yml:791) — roughly 13 runners per PR hold it today, so a 14th was not a
material change. The CSO's two findings were:

1. **The prefetch ran on pull requests for a cache it is now forbidden to save.**
   Install and prefetch are now gated to `push` alongside the save, and the token
   is scoped `github.event_name == 'push' && secrets.HF_TOKEN || ''` so it is not
   in the environment on PR runs of these two jobs. Honest scoping: this trims 2
   of ~14 PR-run executions of PR-authored code with the token — a CI-cost fix
   that happens to reduce surface, not a security fix. The shards still need it.
2. **A comment described a matrix the final design does not use.** Corrected.

Verified: fork PRs are unaffected (trigger is `pull_request`, not
`pull_request_target`; GitHub withholds secrets from fork runs). Workflow
`permissions:` stays `contents: read`. The floating `actions/cache@v5` disappears
in favour of the SHA-pinned composite.

## Verification

YAML parses, the job graph resolves, `tests/test_ci_shards.py` 142 passed. No
`hf-models` key remains in `ci.yml` — it lives in the one action now. The first
develop push after this merges pays one cold Windows warm job, once.