### PR TITLE
Declare PixlStash's own engines instead of scanning for them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,7 @@ jobs:
           tests/test_authz_library_pin.py
           tests/test_backend_order_stability.py
           tests/test_batch_character_likeness_scope.py
+          tests/test_builtin_models.py
           tests/test_character_face_assignment.py
           tests/test_characters_api.py
           tests/test_checkpoint_hash_finder.py

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1240,6 +1240,62 @@ Three guards on it, none of them authz:
 
 **No undo, and no operation-log half.** The v1.9 operation log is vault-only and the shelf's rows are hub-side; the decision to span it was overturned on 2026-08-09 and reaffirmed 2026-08-10. Confirmation only where the prior state cannot be reconstructed: a bulk base-model overwrite and Forget.
 
+### The built-in model folder: declared, never scanned
+
+**PixlStash downloads engines for itself, so it declares what they are.** The
+shelf catalogues by *reading* — the scanner walks a folder, reads each
+`.safetensors` header and decides. That is right for a folder of LoRAs the owner
+assembled and wrong for our own engines: half of them are ONNX or `.pt`, which
+the scanner does not even yield (`MODEL_SUFFIX` is `.safetensors`), and every one
+of them is a file we chose to fetch. `services/builtin_models.py` declares them
+and writes the rows; nothing is parsed and nothing is hashed, so a 339 MB tagger
+costs an existence check at start-up.
+
+**`file_kind = 'engine'`, with the role in `kind`.** `kind` already holds free
+text (`lora`, `lokr`) and already renders as the row's label, so `tagger` /
+`captioner` / `scorer` / `face` ride there and `file_kind` stays four values
+wide instead of growing one entry per role. No schema change: the `model` CHECK
+constraints bind only `adapter`.
+
+**The scanner must skip these folders**, which is what `model_folder.owner`
+marks. It yields only `.safetensors` and sweeps whatever it did not see to
+`missing`, so pointed here it would mark the ONNX tagger and both `.pth` scorers
+missing on every pass. `POST /model-folders/{id}/rescan` answers `skipped` for
+them, as it already does for a `source` folder.
+
+**The filenames are restated rather than imported.** Every downloader names its
+files as module constants, but those modules import onnxruntime, torch, cv2 and
+PIL at module level and start-up must not pay that to learn two strings. The
+duplicate is pinned by `tests/test_builtin_models.py`, which imports the real
+constants where the cost is free. Drift is self-announcing rather than silent: a
+renamed file makes its declared row go `missing` *and* the real file appear in
+the unclaimed readout, which is a visible pair.
+
+**Protected, because they are ours.** `DELETE` on the folder answers 409 (the
+caller is authorized; what refuses is what the target is), and every verb refuses
+an engine row: renaming our own tagger would make the shelf lie about it,
+assigning one to a character means nothing, and forgetting one deletes a row the
+next start-up declares straight back. Forget reports `is_a_builtin_engine` as a
+**refusal reason** rather than raising, which is the shape that route already
+speaks — and the check runs *inside* the delete transaction, alongside the state
+gate, rather than as a route-level read that would break the one-critical-section
+invariant.
+
+**Declared-but-absent is normal.** `sac+logos+ava1-l14-linearMSE.pth` is fetched
+only for the CLIP model that needs it, so about half of these are `missing` on
+any given machine. That is a state, not a warning.
+
+**The unclaimed readout.** `unclaimed_files()` reports what is present and *not*
+declared — on a measured machine, `best.pt` at 339 MB, which nothing in the tree
+references by name or by pattern. It is called "not claimed by anything in this
+build", never "orphaned": we know our own manifest, we do not know that a
+previous build, a plugin or the owner did not put it there. Same epistemics as
+`missing` (a fact) against `unreachable` (the absence of one), and the same
+doctrine — detection proposes, it never applies, so nothing here deletes.
+`hf_hub_download(local_dir=…)` leaves `.cache/huggingface` beside what it writes,
+at the top level and inside every subdirectory it fills; that is the tool's, and
+reporting it would train the reader to ignore the list.
+
 ### The managed model store (shelf plan B7)
 
 **Exactly one `model_folder` row with `kind='managed'` always exists.** It is

--- a/pixlstash/routes/model_folders.py
+++ b/pixlstash/routes/model_folders.py
@@ -53,6 +53,7 @@ from fastapi import APIRouter, Body, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from pixlstash.pixl_logging import get_logger
+from pixlstash.services.builtin_models import BUILTIN_OWNER
 from pixlstash.services.managed_model_store import MANAGED_KIND
 from pixlstash.tasks.base_task import TaskStatus
 from pixlstash.tasks.model_folder_scan_task import ModelFolderScanTask
@@ -288,7 +289,9 @@ class ModelFolderRescanResponse(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     status: str = Field(
-        description="`started`, `already_running`, or `skipped` for a source folder."
+        description="`started`, `already_running`, or `skipped` — for a `source` folder, "
+        "which holds runs rather than models, and for a built-in folder, "
+        "whose rows are declared rather than scanned."
     )
     id: int
     task_id: Optional[str] = Field(
@@ -630,6 +633,19 @@ def create_router(server) -> APIRouter:
     def delete_model_folder(folder_id: int, request: Request):
         server.auth.ensure_secure_when_required(request)
         folder = _fetch_folder(folder_id)
+        if folder["owner"] == BUILTIN_OWNER:
+            # Same 409 reasoning as the managed store one line down: the caller
+            # is authorized and the request is well formed, and what refuses it
+            # is that this folder is PixlStash's own. Forgetting it would only
+            # make the next start-up declare it again.
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "This folder holds the engines PixlStash downloaded for "
+                    "itself. It is registered so you can see what is on your "
+                    "disk, and re-registers itself on the next start."
+                ),
+            )
         if folder["kind"] == MANAGED_KIND:
             # 409, not 403: the caller is fully authorized and the request is
             # well formed. What refuses it is the state of the target — this row
@@ -685,7 +701,12 @@ def create_router(server) -> APIRouter:
     def rescan_model_folder(folder_id: int, request: Request):
         server.auth.ensure_secure_when_required(request)
         folder = _fetch_folder(folder_id)
-        if folder["kind"] == "source":
+        if folder["kind"] == "source" or folder["owner"] == BUILTIN_OWNER:
+            # A source folder holds runs to import, not models to catalogue. A
+            # built-in folder is DECLARED, and pointing the scanner at it would
+            # be actively wrong: it yields only `.safetensors` and sweeps what it
+            # did not see to `missing`, so it would mark the ONNX tagger and both
+            # `.pth` scorers missing on every pass.
             return ModelFolderRescanResponse(status="skipped", id=folder_id)
 
         with _scans_lock:

--- a/pixlstash/routes/model_shelf.py
+++ b/pixlstash/routes/model_shelf.py
@@ -78,14 +78,23 @@ from pixlstash.services.model_shelf_service import (
     replace_attachments,
     update_models,
 )
-from pixlstash.utils.adapter_header import FILE_ADAPTER, FILE_CHECKPOINT, FILE_UNKNOWN
+from pixlstash.utils.adapter_header import (
+    FILE_ADAPTER,
+    FILE_CHECKPOINT,
+    FILE_ENGINE,
+    FILE_UNKNOWN,
+)
 
 logger = get_logger(__name__)
 
 # What ``GET /adapters`` will serve. ``checkpoint`` is deliberately absent: it has
 # its own block because it is not addressable by hash, and folding it in here
 # would be the "unknown renders as checkpoint" defect in the other direction.
-ADAPTER_BLOCK_FILE_KINDS = (FILE_ADAPTER, FILE_UNKNOWN)
+#
+# ``engine`` rides here rather than gaining a fourth route: PixlStash's own
+# taggers and scorers are a *filter* over the same table, not a different shape,
+# and this block already serves a kind that is not an adapter.
+ADAPTER_BLOCK_FILE_KINDS = (FILE_ADAPTER, FILE_UNKNOWN, FILE_ENGINE)
 
 # Constrained here rather than validated in the handler, so an unknown key is a
 # 422 from FastAPI and never reaches the SQL builder. The values are the five
@@ -361,8 +370,10 @@ class ForgetRefusal(BaseModel):
     id: int
     reason: str = Field(
         description=(
-            "`no_such_model` (the id names no row) or `still_has_a_copy` (a "
-            "location is `present` or `unreachable`)."
+            "`no_such_model` (the id names no row), `still_has_a_copy` (a "
+            "location is `present` or `unreachable`), or `is_a_builtin_engine` "
+            "(PixlStash downloaded it for itself and re-declares it on every "
+            "start, so forgetting it would achieve nothing)."
         )
     )
 
@@ -665,6 +676,17 @@ def create_router(server) -> APIRouter:
         row = fetch_model_by_hash(server.hub, sha256)
         if row is None:
             raise HTTPException(status_code=404, detail="No such adapter.")
+        if row["file_kind"] == FILE_ENGINE:
+            # Unreachable today — nothing hashes an engine, so it has no
+            # sha256 to be addressed by — but the rule should not rest on
+            # that staying true.
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "An engine PixlStash downloaded for itself is not "
+                    "something a character uses."
+                ),
+            )
         if row["file_kind"] == FILE_CHECKPOINT:
             # Attachment means "this character uses this LoRA". A base model is
             # not something a character uses in that sense, and the table is
@@ -758,6 +780,7 @@ def create_router(server) -> APIRouter:
                 detail="file_kind cannot be cleared; use 'unknown'.",
             )
 
+        _refuse_builtin_engines(payload.ids)
         _refuse_impossible_adapters(payload.ids, changes)
 
         updated = update_models(server.hub, payload.ids, changes)
@@ -765,6 +788,41 @@ def create_router(server) -> APIRouter:
             "Shelf edit wrote %s on %d model(s).", ", ".join(sent), len(updated)
         )
         return ModelEditResponse(updated=updated, fields=sent)
+
+    def _refuse_builtin_engines(ids: list[int]) -> None:
+        """Refuse any verb aimed at a model PixlStash downloaded for itself.
+
+        Engines are on the shelf for completeness — so the owner can see what is
+        on their disk and what it costs — not to be curated. Renaming our own
+        tagger would make the shelf lie about it, correcting its kind would
+        overrule a fact we declared, assigning a tagger to a character means
+        nothing, and forgetting one only makes the next start-up declare it
+        again.
+
+        409 rather than 403, the same reasoning the managed store's DELETE uses:
+        the caller is authorized and the request is well formed, and what refuses
+        it is what the target IS.
+        """
+        placeholders = ", ".join("?" for _ in ids)
+        blocked = [
+            dict(row)
+            for row in server.hub.fetchall(
+                f"SELECT id, display_name FROM model "
+                f"WHERE id IN ({placeholders}) AND file_kind = ?",
+                (*ids, FILE_ENGINE),
+            )
+        ]
+        if not blocked:
+            return
+        first = blocked[0]["display_name"] or "an engine"
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"{len(blocked)} of these are engines PixlStash downloaded for "
+                f"itself ({first}). They are listed so you can see them, not "
+                "curated."
+            ),
+        )
 
     def _refuse_impossible_adapters(ids: list[int], changes: dict) -> None:
         """Refuse a correction the hub's own CHECK constraints would reject.

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -457,9 +457,13 @@ class Server(
         # Cheap: existence checks and a handful of upserts, no hashing.
         try:
             declare_builtin_models(self.hub, builtin_model_dir())
-        except sqlite3.Error as exc:
+        except (sqlite3.Error, OSError) as exc:
             # The shelf losing its engine rows is not a reason to refuse to
-            # start; everything else on it still works.
+            # start; everything else on it still works. `OSError` as well as
+            # the database errors: the declaration walks a machine-global
+            # directory that may be unreadable, on a different mount, or gone,
+            # and this comment promised non-critical while the handler only
+            # covered half of what the call can raise.
             logger.error(
                 "Could not declare the built-in model folder (%s); PixlStash's "
                 "own engines will not be listed on the shelf this session.",

--- a/pixlstash/server.py
+++ b/pixlstash/server.py
@@ -1,6 +1,7 @@
 import gc
 import uvicorn
 import os
+import sqlite3
 import json
 import re
 import socket
@@ -54,6 +55,10 @@ from pixlstash.hub.registry import LibraryRegistry
 from pixlstash.services.library_switch_service import LibrarySwitchService
 from pixlstash.services.library_generation_coordinator import (
     LibraryGenerationCoordinator,
+)
+from pixlstash.services.builtin_models import (
+    builtin_model_dir,
+    declare_builtin_models,
 )
 from pixlstash.services.managed_model_store import ensure_managed_folder
 from pixlstash.telemetry import ensure_install_identity, start_periodic_sender
@@ -446,6 +451,20 @@ class Server(
         # services/managed_model_store.py for why it is `managed` rather than a
         # seeded `user` folder nobody is allowed to remove.
         ensure_managed_folder(self.hub, os.path.dirname(self._server_config_path))
+        # PixlStash's own engines, declared rather than scanned: we downloaded
+        # them, so we know what they are without reading a header — and half of
+        # them are ONNX or `.pt`, which the scanner does not yield at all.
+        # Cheap: existence checks and a handful of upserts, no hashing.
+        try:
+            declare_builtin_models(self.hub, builtin_model_dir())
+        except sqlite3.Error as exc:
+            # The shelf losing its engine rows is not a reason to refuse to
+            # start; everything else on it still works.
+            logger.error(
+                "Could not declare the built-in model folder (%s); PixlStash's "
+                "own engines will not be listed on the shelf this session.",
+                exc,
+            )
         if self._hub_bootstrap.migrated:
             logger.info(
                 "First run after the hub/vault split: identity now lives in %s",

--- a/pixlstash/services/builtin_models.py
+++ b/pixlstash/services/builtin_models.py
@@ -1,0 +1,294 @@
+"""What PixlStash downloads for itself, declared rather than discovered.
+
+The shelf catalogues model files by **reading** them: the scanner walks a
+registered folder, reads each ``.safetensors`` header and decides what the file
+is. That is the right approach for a folder of LoRAs the owner assembled, and
+the wrong one for our own engines — half of them are ONNX or ``.pt``, which the
+scanner does not even yield (``MODEL_SUFFIX`` is ``.safetensors``), and all of
+them are files *we* chose to download. We do not have to guess what they are.
+We know.
+
+So this module declares them, and :func:`declare_builtin_models` writes the rows
+from the declaration. Nothing is parsed and nothing is hashed, which is also why
+a 339 MB engine costs nothing at start-up.
+
+**Why the filenames are restated here rather than imported.** Every downloader
+names its files as module constants — ``PIXLSTASH_TAGGER_FILENAME``,
+``WD14_CSV_FILE``, ``ImageEmbeddingTask.AESTHETIC_MODELS`` — but those modules
+import onnxruntime, torch, cv2 and PIL at module level, and start-up must not
+pay that to learn two strings. They are duplicated here and pinned by
+``tests/test_builtin_models.py``, which imports the real modules and asserts the
+two agree. The same trade the 48-hex ``SET_COLORS`` list already makes.
+
+Drift here is also self-announcing rather than silent: a renamed file makes its
+declared row go ``missing`` and the real file appear under
+:func:`unclaimed_files`, which is a visible pair, not a quiet wrong answer.
+
+**These rows are protected.** The folder answers 409 to ``DELETE`` and every
+shelf verb refuses them, because they are ours: renaming our own tagger would
+make the shelf lie about it, and assigning a tagger to a character means
+nothing. They are on the shelf for completeness — so the owner can see what is
+on their disk and what it costs — not to be curated.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.adapter_header import FILE_ENGINE
+
+logger = get_logger(__name__)
+
+# The folder PixlStash downloads its own engines into. `foreign` rather than
+# `managed`: `managed` is the ONE store the owner may drop models into and
+# relocate as their own, and there is exactly one of those. This is ours.
+BUILTIN_KIND = "foreign"
+BUILTIN_OWNER = "pixlstash"
+
+# Everything in this folder arrived because PixlStash fetched it.
+BUILTIN_PROVENANCE = "builtin"
+
+# `hf_hub_download(local_dir=...)` leaves its own bookkeeping beside the files it
+# writes, at the top level and again inside every subdirectory it fills. It is
+# HuggingFace's, not ours and not the owner's, so it is neither declared nor
+# reported as unclaimed — it is simply not a model file.
+TOOLING_DIRS = (".cache",)
+
+
+@dataclass(frozen=True)
+class BuiltinEngine:
+    """One engine PixlStash downloads, and the files it owns.
+
+    Attributes:
+        key: Stable identifier, used as the row's filename-independent identity.
+        display_name: What the shelf calls it.
+        role: What it does — ``tagger``, ``captioner``, ``scorer``, ``face``.
+            Stored in ``model.kind``, which already holds free text (``lora``,
+            ``lokr``) and already renders as the row's label, so ``file_kind``
+            stays a four-value vocabulary instead of growing one entry per role.
+        relpath: The engine's own file, relative to the folder. This is what the
+            shelf shows and what its size is read from.
+        companions: Files that belong to the engine but are not it — a label
+            set, a revision sidecar. They get no row of their own and are not
+            reported as unclaimed.
+    """
+
+    key: str
+    display_name: str
+    role: str
+    relpath: str
+    companions: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def owned(self) -> tuple[str, ...]:
+        """Every relative path this engine accounts for."""
+        return (self.relpath, *self.companions)
+
+
+# Mirrors `pixlstash_tagger.PIXLSTASH_TAGGER_FILENAME` /
+# `..._META_FILENAME`, `wd14.WD14_CSV_FILE`, and
+# `ImageEmbeddingTask.AESTHETIC_MODELS`. Pinned by tests/test_builtin_models.py.
+BUILTIN_ENGINES: tuple[BuiltinEngine, ...] = (
+    BuiltinEngine(
+        key="pixlstash-anomaly-tagger",
+        display_name="PixlStash anomaly tagger",
+        role="tagger",
+        relpath="pixlstash-anomaly-tagger.safetensors",
+        # The meta file carries the label set; the revision sidecar is written
+        # by our own code rather than by the download, and `needs_download()`
+        # reads it to decide whether the pinned revision has moved.
+        companions=(
+            "pixlstash-anomaly-tagger_meta.json",
+            "pixlstash-anomaly-tagger.revision",
+        ),
+    ),
+    BuiltinEngine(
+        key="wd14-convnext-tagger-v3",
+        display_name="WD14 ConvNeXt tagger v3",
+        role="tagger",
+        relpath=os.path.join("SmilingWolf_wd-convnext-tagger-v3", "model.onnx"),
+        companions=(
+            os.path.join("SmilingWolf_wd-convnext-tagger-v3", "selected_tags.csv"),
+        ),
+    ),
+    BuiltinEngine(
+        key="aesthetic-vit-b-32",
+        display_name="Aesthetic scorer (ViT-B/32)",
+        role="scorer",
+        relpath="sa_0_4_vit_b_32_linear.pth",
+    ),
+    BuiltinEngine(
+        key="aesthetic-vit-l-14",
+        display_name="Aesthetic scorer (ViT-L/14)",
+        role="scorer",
+        relpath="sac+logos+ava1-l14-linearMSE.pth",
+    ),
+)
+
+
+def builtin_model_dir() -> str:
+    """Where PixlStash downloads its engines.
+
+    The same expression `inference/engine.py` and `image_embedding_task.py`
+    build for themselves, in one place so the declaration cannot point at a
+    different folder than the downloaders fill.
+    """
+    from platformdirs import user_data_dir
+
+    return os.path.join(user_data_dir("pixlstash"), "downloaded_models")
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def declared_paths() -> set[str]:
+    """Every relative path the engines above account for."""
+    return {path for engine in BUILTIN_ENGINES for path in engine.owned}
+
+
+def unclaimed_files(folder_path: str) -> list[dict]:
+    """Files present in the folder that no declaration accounts for.
+
+    **Not "orphaned".** We know our own manifest; we do not know that a previous
+    build, a plugin or the owner did not put a file there deliberately. This
+    reports what nothing in *this build* claims, which is a smaller and true
+    statement — the same distinction the scan already draws between ``missing``
+    (we looked and it was not there) and ``unreachable`` (we could not look).
+
+    Detection proposes and never applies: nothing here deletes.
+
+    Args:
+        folder_path: The built-in folder to inspect.
+
+    Returns:
+        ``{"relpath", "size"}`` per unclaimed file, smallest path first. Empty
+        when the folder does not exist, which is the normal state before the
+        first download.
+    """
+    declared = declared_paths()
+    found: list[dict] = []
+    for directory, dirs, files in os.walk(folder_path):
+        dirs[:] = [d for d in dirs if d not in TOOLING_DIRS]
+        for name in files:
+            absolute = os.path.join(directory, name)
+            relpath = os.path.relpath(absolute, folder_path)
+            if relpath in declared:
+                continue
+            try:
+                size = os.path.getsize(absolute)
+            except OSError as exc:
+                logger.warning(
+                    "Cannot size %r while listing unclaimed built-in files (%s); "
+                    "reporting it without one.",
+                    absolute,
+                    exc,
+                )
+                size = 0
+            found.append({"relpath": relpath, "size": size})
+    return sorted(found, key=lambda item: item["relpath"])
+
+
+def declare_builtin_models(hub, folder_path: str) -> Optional[int]:
+    """Register the built-in folder and write a row per engine present.
+
+    Runs at start-up beside ``ensure_managed_folder``. Idempotent: it upserts
+    the folder, upserts one ``model`` row per engine, and stamps each engine's
+    ``model_file`` state from a plain existence check.
+
+    **The folder scanner must skip this folder**, which is why it carries an
+    ``owner``. The scanner yields only ``.safetensors`` and sweeps whatever it
+    did not see to ``missing``; pointed here it would mark the ONNX tagger and
+    both ``.pth`` scorers missing on every pass.
+
+    Args:
+        hub: The open hub database.
+        folder_path: Where PixlStash downloads its engines.
+
+    Returns:
+        The ``model_folder.id``, or ``None`` if the row could not be written.
+    """
+    now = _utcnow()
+    with hub.transaction() as conn:
+        conn.execute(
+            "INSERT INTO model_folder (path, kind, owner, movable, created_at) "
+            "VALUES (?, ?, ?, 'root_only', ?) "
+            "ON CONFLICT(path) DO UPDATE SET kind = excluded.kind, "
+            "owner = excluded.owner",
+            (folder_path, BUILTIN_KIND, BUILTIN_OWNER, now),
+        )
+        row = conn.execute(
+            "SELECT id FROM model_folder WHERE path = ?", (folder_path,)
+        ).fetchone()
+        if row is None:
+            logger.error(
+                "Built-in model folder %r vanished between write and read; the "
+                "shelf will not list PixlStash's own engines this session.",
+                folder_path,
+            )
+            return None
+        folder_id = int(row[0])
+
+        for engine in BUILTIN_ENGINES:
+            absolute = os.path.join(folder_path, engine.relpath)
+            present = os.path.isfile(absolute)
+            size = os.path.getsize(absolute) if present else None
+            state = "present" if present else "missing"
+            # An engine that has not been downloaded yet is NOT an error and not
+            # a warning: the ViT-L/14 scorer is fetched only for the CLIP model
+            # that needs it, so "declared and absent" is the normal state for
+            # about half of these on any given machine.
+            #
+            # Identity is the LOCATION — `model_file`'s own primary key — not a
+            # hash we would have to read 339 MB to compute, and not `run_key`,
+            # which belongs to ai-toolkit runs and is COALESCE'd by the run
+            # importer.
+            existing = conn.execute(
+                "SELECT model_id FROM model_file "
+                "WHERE model_folder_id = ? AND relpath = ?",
+                (folder_id, engine.relpath),
+            ).fetchone()
+            if existing is None:
+                cursor = conn.execute(
+                    "INSERT INTO model (file_kind, kind, display_name, filename, "
+                    "provenance, file_size, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        FILE_ENGINE,
+                        engine.role,
+                        engine.display_name,
+                        os.path.basename(engine.relpath),
+                        BUILTIN_PROVENANCE,
+                        size,
+                        now,
+                    ),
+                )
+                model_id = int(cursor.lastrowid)
+                conn.execute(
+                    "INSERT INTO model_file (model_id, model_folder_id, relpath, "
+                    "state, seen_at) VALUES (?, ?, ?, ?, ?)",
+                    (model_id, folder_id, engine.relpath, state, now),
+                )
+                continue
+
+            model_id = int(existing[0])
+            # The declaration is the authority for what this row IS, so it is
+            # written outright rather than COALESCE'd: unlike a scanned row
+            # there is no owner curation here to preserve.
+            conn.execute(
+                "UPDATE model SET file_kind = ?, kind = ?, display_name = ?, "
+                "file_size = COALESCE(?, file_size) WHERE id = ?",
+                (FILE_ENGINE, engine.role, engine.display_name, size, model_id),
+            )
+            conn.execute(
+                "UPDATE model_file SET state = ?, seen_at = ? "
+                "WHERE model_folder_id = ? AND relpath = ?",
+                (state, now, folder_id, engine.relpath),
+            )
+        conn.execute(
+            "UPDATE model_folder SET last_checked = ? WHERE id = ?", (now, folder_id)
+        )
+    return folder_id

--- a/pixlstash/services/builtin_models.py
+++ b/pixlstash/services/builtin_models.py
@@ -141,12 +141,29 @@ BUILTIN_MODEL_DIR_ENV = "PIXLSTASH_BUILTIN_MODEL_DIR"
 def builtin_model_dir() -> str:
     """Where PixlStash downloads its engines.
 
-    The same expression `inference/engine.py` and `image_embedding_task.py`
-    build for themselves, in one place so the declaration cannot point at a
-    different folder than the downloaders fill.
-
     Machine-global on purpose: one download serves every library and every
     server instance on the host, exactly as the hub itself does.
+
+    **The same expression the downloaders build, not a shared one.**
+    `inference/engine.py` and `image_embedding_task.py` each compute
+    `user_data_dir("pixlstash")/downloaded_models` for themselves, and an earlier
+    version of this docstring claimed being "in one place" meant the declaration
+    could not point somewhere the downloaders do not fill. It does not — the
+    three agree because they spell the same thing, which is a convention rather
+    than a guarantee.
+
+    That matters because of the override below, which redirects **only this
+    function**. That is exactly what the test suite wants: point the declaration
+    at an empty directory so a Server built on a temp config does not describe
+    the developer's real home, while nothing redirects downloads that the tests
+    never make. It is a test seam and is not safe as a way to relocate the
+    store — set it in production and the shelf would declare an empty folder
+    while the engines kept landing in the real one. Relocating for real is
+    `POST /model-folders/{id}/relocate`, which moves the files too.
+
+    Making all three share this function is the right end state; it needs
+    `ImageEmbeddingTask.AESTHETIC_MODELS` to stop being built at import time,
+    which is a change to the download path and not to this one.
     """
     override = os.environ.get(BUILTIN_MODEL_DIR_ENV, "").strip()
     if override:
@@ -232,8 +249,14 @@ def declare_builtin_models(hub, folder_path: str) -> Optional[int]:
         conn.execute(
             "INSERT INTO model_folder (path, kind, owner, movable, created_at) "
             "VALUES (?, ?, ?, 'root_only', ?) "
+            # `movable` is re-asserted with the rest. A path the owner had
+            # already registered as a `user` folder keeps its own
+            # `movable` otherwise, so claiming it for PixlStash would
+            # leave the built-in folder advertising `per_item` — the
+            # engines individually movable, which is exactly what the
+            # protection exists to prevent.
             "ON CONFLICT(path) DO UPDATE SET kind = excluded.kind, "
-            "owner = excluded.owner",
+            "owner = excluded.owner, movable = excluded.movable",
             (folder_path, BUILTIN_KIND, BUILTIN_OWNER, now),
         )
         row = conn.execute(
@@ -250,8 +273,17 @@ def declare_builtin_models(hub, folder_path: str) -> Optional[int]:
 
         for engine in BUILTIN_ENGINES:
             absolute = os.path.join(folder_path, engine.relpath)
-            present = os.path.isfile(absolute)
-            size = os.path.getsize(absolute) if present else None
+            # One `stat` rather than `isfile` then `getsize`. The pair is a race
+            # on the one directory the downloaders are actively writing into: a
+            # file that arrives or is replaced between the two calls makes
+            # `getsize` raise `OSError` on a path `isfile` just confirmed, and
+            # that would abort the declaration for every engine after it.
+            try:
+                size = os.stat(absolute).st_size
+                present = True
+            except OSError:
+                size = None
+                present = False
             state = "present" if present else "missing"
             # An engine that has not been downloaded yet is NOT an error and not
             # a warning: the ViT-L/14 scorer is fetched only for the CLIP model

--- a/pixlstash/services/builtin_models.py
+++ b/pixlstash/services/builtin_models.py
@@ -130,13 +130,28 @@ BUILTIN_ENGINES: tuple[BuiltinEngine, ...] = (
 )
 
 
+# Lets a test point the declaration at a temp folder. Without it a Server built
+# on a temp config dir still declares rows about the developer's REAL home, so
+# the shelf's contents depend on which engines that machine happens to have
+# downloaded — which is how `test_workers_api` came to assert `3 == 0` on a
+# runner whose model cache was warm.
+BUILTIN_MODEL_DIR_ENV = "PIXLSTASH_BUILTIN_MODEL_DIR"
+
+
 def builtin_model_dir() -> str:
     """Where PixlStash downloads its engines.
 
     The same expression `inference/engine.py` and `image_embedding_task.py`
     build for themselves, in one place so the declaration cannot point at a
     different folder than the downloaders fill.
+
+    Machine-global on purpose: one download serves every library and every
+    server instance on the host, exactly as the hub itself does.
     """
+    override = os.environ.get(BUILTIN_MODEL_DIR_ENV, "").strip()
+    if override:
+        return override
+
     from platformdirs import user_data_dir
 
     return os.path.join(user_data_dir("pixlstash"), "downloaded_models")

--- a/pixlstash/services/model_shelf_service.py
+++ b/pixlstash/services/model_shelf_service.py
@@ -43,6 +43,7 @@ from pixlstash.pixl_logging import get_logger
 from pixlstash.utils.adapter_header import (
     FILE_ADAPTER,
     FILE_CHECKPOINT,
+    FILE_ENGINE,
     FILE_UNKNOWN,
 )
 
@@ -514,9 +515,23 @@ def forget_models(hub, ids: list[int]) -> tuple[list[int], list[dict]]:
             ).fetchall()
         }
 
+        # Engines are declared by PixlStash on every start, so forgetting one
+        # deletes a row that comes straight back. Refused here rather than at the
+        # route because the read belongs inside this transaction — the same
+        # critical section the state gate runs in.
+        builtin = {
+            int(row[0])
+            for row in conn.execute(
+                f"SELECT id FROM model WHERE id IN ({placeholders}) AND file_kind = ?",
+                (*ids, FILE_ENGINE),
+            ).fetchall()
+        }
+
         for model_id in ids:
             if model_id not in known:
                 refused.append({"id": model_id, "reason": "no_such_model"})
+            elif model_id in builtin:
+                refused.append({"id": model_id, "reason": "is_a_builtin_engine"})
             elif model_id in alive:
                 refused.append({"id": model_id, "reason": "still_has_a_copy"})
             else:

--- a/pixlstash/tasks/missing_checkpoint_hash_finder.py
+++ b/pixlstash/tasks/missing_checkpoint_hash_finder.py
@@ -19,6 +19,14 @@ class MissingCheckpointHashFinder(BaseTaskFinder):
     In practice that is exactly the checkpoints: the schema's
     ``CHECK (file_kind <> 'adapter' OR sha256 IS NOT NULL)`` forbids an unhashed
     adapter, and the scan hashes an ``unknown`` on sight because it is small.
+    **``engine`` rows are excluded from both queries.** They are declared by
+    ``services/builtin_models.py`` and carry no ``sha256`` by design — nothing
+    hashes PixlStash's own tagger, because we know what it is without one.
+    Without the exclusion they match ``sha256 IS NULL`` like any unhashed
+    checkpoint, and this finder would hand a 339 MB tagger and a pile of ONNX to
+    the hash worker to read, then write a digest onto a row that never wanted
+    one.
+
     The query is left as the plain ``sha256 IS NULL`` all the same, so it
     matches ``ix_model_hash_queue`` exactly and cannot silently strand a row.
 
@@ -77,6 +85,7 @@ class MissingCheckpointHashFinder(BaseTaskFinder):
             "SUM(CASE WHEN m.sha256 IS NULL THEN 1 ELSE 0 END) AS pending "
             "FROM model m "
             "WHERE (m.sha256 IS NULL OR m.file_kind = 'checkpoint') "
+            "AND m.file_kind <> 'engine' "
             "AND EXISTS (SELECT 1 FROM model_file mf "
             "WHERE mf.model_id = m.id AND mf.state = 'present')"
         )
@@ -97,7 +106,8 @@ class MissingCheckpointHashFinder(BaseTaskFinder):
             "FROM model m "
             "JOIN model_file mf ON mf.model_id = m.id "
             "JOIN model_folder f ON f.id = mf.model_folder_id "
-            "WHERE m.sha256 IS NULL AND mf.state = 'present' "
+            "WHERE m.sha256 IS NULL AND m.file_kind <> 'engine' "
+            "AND mf.state = 'present' "
             "GROUP BY m.id ORDER BY m.id LIMIT ?",
             (limit,),
         )

--- a/pixlstash/utils/adapter_header.py
+++ b/pixlstash/utils/adapter_header.py
@@ -75,6 +75,14 @@ FILE_ADAPTER = "adapter"
 FILE_CHECKPOINT = "checkpoint"
 FILE_UNKNOWN = "unknown"
 
+# What PixlStash downloaded for itself: a tagger, a captioner, a scorer, a face
+# pack. Never produced by `classify_model_file` — these rows are DECLARED by
+# `services/builtin_models.py`, because we chose to download them and therefore
+# know what they are without reading a header (half of them are ONNX or `.pt`,
+# which the scanner does not even yield). The role goes in `model.kind`, which
+# already holds free text, so this vocabulary stays four values wide.
+FILE_ENGINE = "engine"
+
 # Parameter count above which a marker-free file is a base checkpoint rather
 # than an adapter we failed to recognise.
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import gc
 import json
 import math
 import os
+import tempfile
 import socket
 import statistics
 import sys
@@ -20,6 +21,7 @@ import pytest
 from _pytest.config.exceptions import UsageError
 from fastapi.testclient import TestClient
 from pixlstash.server import Server
+from pixlstash.services.builtin_models import BUILTIN_MODEL_DIR_ENV
 from pixlstash.tasks.face_extraction_task import FaceExtractionTask
 from pixlstash.tasks.image_embedding_task import ImageEmbeddingTask
 from pixlstash.tasks.tag_task import TagTask
@@ -390,6 +392,18 @@ def pytest_collection_modifyitems(config, items):
 
 def pytest_configure(config):
     """Set static attributes on Server from command line options."""
+    # Point the built-in model declaration at an empty folder for the whole
+    # session. `builtin_model_dir()` is machine-global by design — one download
+    # serves every library on the host — but that means a Server built on a temp
+    # config dir would otherwise declare rows about the DEVELOPER'S real home,
+    # so the shelf's contents would depend on which engines that machine happens
+    # to have downloaded. `test_workers_api` caught it as `assert 3 == 0` on a
+    # runner whose model cache was warm; every engine simply reads `missing`
+    # here, which is a state the suite can rely on.
+    os.environ.setdefault(
+        BUILTIN_MODEL_DIR_ENV,
+        os.path.join(tempfile.gettempdir(), "pixlstash-test-builtin-models"),
+    )
     # Pick a free port for the test session so Server instances don't collide
     # with the production app when it is already running on the default port.
     Server.DEFAULT_PORT = _find_free_port()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -400,9 +400,17 @@ def pytest_configure(config):
     # to have downloaded. `test_workers_api` caught it as `assert 3 == 0` on a
     # runner whose model cache was warm; every engine simply reads `missing`
     # here, which is a state the suite can rely on.
+    #
+    # `mkdtemp` rather than a fixed name under the temp dir: a stable path is
+    # shared by every concurrent test session on the machine (the gate runs
+    # eight shards) and is whatever a previous run or a passing developer left
+    # in it. An engine that turned up there would read `present` and put the
+    # suite back on machine-dependent state, which is the exact bug this
+    # override exists to remove. A fresh directory is empty by construction and
+    # needs nothing deleted to stay that way.
     os.environ.setdefault(
         BUILTIN_MODEL_DIR_ENV,
-        os.path.join(tempfile.gettempdir(), "pixlstash-test-builtin-models"),
+        tempfile.mkdtemp(prefix="pixlstash-test-builtin-models-"),
     )
     # Pick a free port for the test session so Server instances don't collide
     # with the production app when it is already running on the default port.

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -156,3 +156,27 @@ def test_a_file_that_disappears_flips_its_row_to_missing(server_hub, tmp_path):
         (folder_id, "sa_0_4_vit_b_32_linear.pth"),
     )
     assert state["state"] == "missing"
+
+
+def test_the_checkpoint_hash_worker_never_picks_up_an_engine(server_hub, tmp_path):
+    """Engines carry no `sha256` by design — we know what they are without one —
+    so they match the finder's plain `sha256 IS NULL` like any unhashed
+    checkpoint. Without the exclusion this hands a 339 MB tagger and a pile of
+    ONNX to the hash worker to read, and writes a digest onto a row that never
+    wanted one."""
+    from pixlstash.tasks.missing_checkpoint_hash_finder import (
+        MissingCheckpointHashFinder,
+    )
+
+    for engine in BUILTIN_ENGINES:
+        target = tmp_path / engine.relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x" * 8)
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    finder = MissingCheckpointHashFinder(server_hub)
+    total, pending = finder.progress()
+    assert (total, pending) == (0, 0), (
+        "declared engines were counted as checkpoints awaiting a hash"
+    )
+    assert finder.find_task() is None, "an engine was handed to the hash worker"

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -142,6 +142,33 @@ def test_declaring_twice_does_not_duplicate_a_row(server_hub, tmp_path):
     assert count["n"] == len(BUILTIN_ENGINES)
 
 
+def test_claiming_a_path_the_owner_registered_resets_every_column(server_hub, tmp_path):
+    """The upsert has to assert `movable` too, not just `kind` and `owner`.
+
+    The managed store is relocatable as a whole and never per file, which is
+    what `root_only` says. A path the owner had already registered as an
+    ordinary `user` folder carries `per_item`, and an ON CONFLICT that updated
+    only `kind` and `owner` would leave that standing — the built-in folder
+    claimed for PixlStash while still advertising that its engines may be moved
+    out one at a time. Reported by the review of #876.
+    """
+    with server_hub.transaction() as conn:
+        conn.execute(
+            "INSERT INTO model_folder (path, kind, movable, created_at) "
+            "VALUES (?, 'user', 'per_item', '2026-08-09T00:00:00Z')",
+            (str(tmp_path),),
+        )
+
+    folder_id = declare_builtin_models(server_hub, str(tmp_path))
+
+    row = server_hub.fetchone(
+        "SELECT kind, owner, movable FROM model_folder WHERE id = ?", (folder_id,)
+    )
+    assert row["owner"] == "pixlstash"
+    assert row["kind"] == "foreign"
+    assert row["movable"] == "root_only"
+
+
 def test_a_file_that_disappears_flips_its_row_to_missing(server_hub, tmp_path):
     """Declared, not scanned — but the state still has to tell the truth."""
     weights = tmp_path / "sa_0_4_vit_b_32_linear.pth"

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -1,0 +1,158 @@
+"""PixlStash's own engines: declared, protected, and pinned to their downloaders.
+
+The declaration is a duplicate of constants that live in modules too heavy to
+import at start-up (onnxruntime, torch, cv2). A test is what keeps a duplicate
+honest, so the first case here imports the real ones and asserts they agree.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pixlstash.hub.db import HubDatabase
+from pixlstash.services.builtin_models import (
+    BUILTIN_ENGINES,
+    BUILTIN_OWNER,
+    TOOLING_DIRS,
+    declare_builtin_models,
+    declared_paths,
+    unclaimed_files,
+)
+from pixlstash.utils.adapter_header import FILE_ENGINE
+
+
+@pytest.fixture
+def server_hub(tmp_path):
+    """A hub of its own, opened at the current schema and closed after.
+
+    Module scope would be wrong here: three of these cases assert on the rows a
+    declaration wrote, so they need a hub that holds nothing else.
+    """
+    hub = HubDatabase(str(tmp_path / "hub.db"))
+    try:
+        yield hub
+    finally:
+        hub.close()
+
+
+def test_the_declaration_matches_what_the_downloaders_actually_write():
+    """The whole reason a duplicate is acceptable. These constants live beside
+    imports too heavy for start-up, so they are restated in the declaration and
+    pinned here, where the heavy import is free."""
+    from pixlstash.tagger_plugins.pixlstash_tagger import (
+        PIXLSTASH_TAGGER_FILENAME,
+        PIXLSTASH_TAGGER_META_FILENAME,
+    )
+    from pixlstash.tagger_plugins.wd14 import WD14_CSV_FILE
+
+    declared = declared_paths()
+    assert PIXLSTASH_TAGGER_FILENAME in declared
+    assert PIXLSTASH_TAGGER_META_FILENAME in declared
+    assert any(path.endswith(WD14_CSV_FILE) for path in declared)
+
+
+def test_every_engine_names_a_role_the_shelf_can_show():
+    """`file_kind` stays four values wide; the role rides in `kind`, which
+    already holds free text and already renders as the row's label."""
+    for engine in BUILTIN_ENGINES:
+        assert engine.role in {"tagger", "captioner", "scorer", "face"}
+        assert engine.display_name and engine.relpath
+
+
+def test_an_undeclared_file_is_reported_and_a_declared_one_is_not(tmp_path):
+    """The readout that found a 339 MB leftover on a real machine."""
+    (tmp_path / "pixlstash-anomaly-tagger.safetensors").write_bytes(b"x" * 10)
+    (tmp_path / "pixlstash-anomaly-tagger.revision").write_text("abc")
+    (tmp_path / "best.pt").write_bytes(b"y" * 20)
+
+    found = unclaimed_files(str(tmp_path))
+    assert [item["relpath"] for item in found] == ["best.pt"]
+    assert found[0]["size"] == 20
+
+
+def test_the_download_tools_own_bookkeeping_is_not_unclaimed(tmp_path):
+    """`hf_hub_download(local_dir=...)` leaves `.cache/huggingface` beside what
+    it writes, at the top level and inside every subdirectory. It is neither
+    ours nor the owner's, and reporting it would train the reader to ignore the
+    list."""
+    cache = tmp_path / TOOLING_DIRS[0] / "huggingface"
+    cache.mkdir(parents=True)
+    (cache / "CACHEDIR.TAG").write_text("Signature")
+    nested = tmp_path / "SmilingWolf_wd-convnext-tagger-v3" / TOOLING_DIRS[0]
+    nested.mkdir(parents=True)
+    (nested / "download.metadata").write_text("{}")
+
+    assert unclaimed_files(str(tmp_path)) == []
+
+
+def test_a_folder_that_has_never_been_downloaded_into_reports_nothing(tmp_path):
+    """The normal state before the first run, and not an error."""
+    assert unclaimed_files(str(tmp_path / "never-created")) == []
+
+
+def test_declaring_writes_a_row_per_engine_and_states_which_are_present(
+    server_hub, tmp_path
+):
+    """No parsing and no hashing: an engine that is on disk is `present`, one
+    that has not been fetched yet is `missing` — which is the normal state for
+    about half of them, since the ViT-L/14 scorer arrives only with the CLIP
+    model that needs it."""
+    (tmp_path / "pixlstash-anomaly-tagger.safetensors").write_bytes(b"x" * 32)
+
+    folder_id = declare_builtin_models(server_hub, str(tmp_path))
+    assert folder_id is not None
+
+    folder = server_hub.fetchone(
+        "SELECT owner, movable FROM model_folder WHERE id = ?", (folder_id,)
+    )
+    assert folder["owner"] == BUILTIN_OWNER
+    assert folder["movable"] == "root_only"
+
+    rows = {
+        row["display_name"]: row
+        for row in server_hub.fetchall(
+            "SELECT m.display_name, m.file_kind, m.kind, m.file_size, mf.state "
+            "FROM model m JOIN model_file mf ON mf.model_id = m.id "
+            "WHERE mf.model_folder_id = ?",
+            (folder_id,),
+        )
+    }
+    assert len(rows) == len(BUILTIN_ENGINES)
+    tagger = rows["PixlStash anomaly tagger"]
+    assert (tagger["file_kind"], tagger["kind"], tagger["state"]) == (
+        FILE_ENGINE,
+        "tagger",
+        "present",
+    )
+    assert tagger["file_size"] == 32
+    assert rows["Aesthetic scorer (ViT-L/14)"]["state"] == "missing"
+
+
+def test_declaring_twice_does_not_duplicate_a_row(server_hub, tmp_path):
+    """It runs on every start, so it has to be idempotent."""
+    (tmp_path / "sa_0_4_vit_b_32_linear.pth").write_bytes(b"z" * 8)
+    folder_id = declare_builtin_models(server_hub, str(tmp_path))
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    count = server_hub.fetchone(
+        "SELECT COUNT(*) AS n FROM model_file WHERE model_folder_id = ?", (folder_id,)
+    )
+    assert count["n"] == len(BUILTIN_ENGINES)
+
+
+def test_a_file_that_disappears_flips_its_row_to_missing(server_hub, tmp_path):
+    """Declared, not scanned — but the state still has to tell the truth."""
+    weights = tmp_path / "sa_0_4_vit_b_32_linear.pth"
+    weights.write_bytes(b"z" * 8)
+    folder_id = declare_builtin_models(server_hub, str(tmp_path))
+    os.unlink(weights)
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    state = server_hub.fetchone(
+        "SELECT mf.state FROM model_file mf WHERE mf.model_folder_id = ? "
+        "AND mf.relpath = ?",
+        (folder_id, "sa_0_4_vit_b_32_linear.pth"),
+    )
+    assert state["state"] == "missing"

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -2921,3 +2921,107 @@ def test_a_drive_with_no_label_reports_null_rather_than_a_guess(
     band = next(d for d in _devices(shelf_env) if folder_id in d["folder_ids"])
     assert band["label"] is None
     assert band["mount_point"]
+
+
+# ===========================================================================
+# Built-in engines: listed for completeness, refused by every verb
+# ===========================================================================
+
+
+def _declare_engine(shelf_env, display_name="PixlStash anomaly tagger") -> int:
+    """An `engine` row in a folder PixlStash owns. Returns its model id."""
+    with shelf_env.server.hub.transaction() as conn:
+        conn.execute(
+            "INSERT INTO model_folder (id, path, kind, owner, movable, created_at) "
+            "VALUES (9, '/engines', 'foreign', 'pixlstash', 'root_only', "
+            "'2026-08-11T00:00:00Z')"
+        )
+        cursor = conn.execute(
+            "INSERT INTO model (file_kind, kind, display_name, filename, "
+            "provenance, file_size, created_at) VALUES ('engine', 'tagger', ?, "
+            "'tagger.safetensors', 'builtin', 99, '2026-08-11T00:00:00Z')",
+            (display_name,),
+        )
+        model_id = int(cursor.lastrowid)
+        conn.execute(
+            "INSERT INTO model_file (model_id, model_folder_id, relpath, state, "
+            "seen_at) VALUES (?, 9, 'tagger.safetensors', 'present', "
+            "'2026-08-11T00:00:00Z')",
+            (model_id,),
+        )
+    return model_id
+
+
+def test_an_engine_is_listed_only_when_asked_for(shelf_env):
+    """It rides the adapters block as `unknown` does, under an explicit
+    `file_kind`. The shelf's first question is which LoRA, not which tagger."""
+    engine = _declare_engine(shelf_env)
+
+    default = shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+    assert engine not in {row["id"] for row in default}
+
+    asked = shelf_env.owner.get(
+        f"{API}/adapters", params={"file_kind": "engine"}
+    ).json()["adapters"]
+    listed = {row["id"]: row for row in asked}
+    assert engine in listed
+    assert listed[engine]["kind"] == "tagger", "the role is what the row shows"
+
+
+def test_an_engine_is_never_served_as_a_checkpoint(shelf_env):
+    """The same rule `unknown` has: a file we downloaded for ourselves is not a
+    base model, and must not read as one."""
+    engine = _declare_engine(shelf_env)
+    served = shelf_env.owner.get(f"{API}/checkpoints").json()["checkpoints"]
+    assert engine not in {row["id"] for row in served}
+
+
+def test_every_editing_verb_refuses_an_engine(shelf_env):
+    """409, not 403: the caller is authorized and the request is well formed.
+    What refuses it is what the target IS."""
+    engine = _declare_engine(shelf_env)
+    for change in (
+        {"display_name": "Mine now"},
+        {"base_model": "SDXL 1.0"},
+        {"file_kind": "adapter", "kind": "lora"},
+    ):
+        r = shelf_env.owner.patch(f"{API}/models", json={"ids": [engine], **change})
+        assert r.status_code == 409, f"{change} was allowed: {r.text}"
+        assert "PixlStash downloaded" in r.text
+
+    row = _model_row(shelf_env, engine)
+    assert (row["display_name"], row["file_kind"]) == (
+        "PixlStash anomaly tagger",
+        "engine",
+    )
+
+
+def test_forget_reports_an_engine_rather_than_deleting_it(shelf_env):
+    """Reported like every other refusal rather than raised, and refused inside
+    the same transaction as the state gate — forgetting one would delete a row
+    that the next start-up declares straight back."""
+    engine = _declare_engine(shelf_env)
+    _set_states(shelf_env, engine, "missing")
+
+    r = shelf_env.owner.post(f"{API}/models/forget", json={"ids": [engine]})
+    assert r.status_code == 200, r.text
+    assert r.json() == {
+        "forgotten": [],
+        "refused": [{"id": engine, "reason": "is_a_builtin_engine"}],
+    }
+    assert _model_row(shelf_env, engine)["display_name"] == "PixlStash anomaly tagger"
+
+
+def test_the_folder_pixlstash_owns_cannot_be_forgotten_or_rescanned(shelf_env):
+    """Rescan especially: the scanner yields only `.safetensors` and sweeps what
+    it did not see to `missing`, so pointing it at a folder of ONNX and `.pth`
+    engines would mark them all missing on every pass."""
+    _declare_engine(shelf_env)
+
+    forgotten = shelf_env.owner.delete(f"{API}/model-folders/9")
+    assert forgotten.status_code == 409, forgotten.text
+    assert "downloaded for itself" in forgotten.text
+
+    rescan = shelf_env.owner.post(f"{API}/model-folders/9/rescan")
+    assert rescan.status_code == 202, rescan.text
+    assert rescan.json()["status"] == "skipped"


### PR DESCRIPTION
Plan item 3, and the other half of *"the built-in models like the Caption engines
don't show up"*. Ruled 2026-08-11: **we put these files there, so we declare what
they are.**

## The framing in the plan was wrong, and this corrects it

It said registering these folders "scans to a shelf of `file_kind='unknown'` rows
unless the classifier learns those formats". The scanner walks **one** extension —
`MODEL_SUFFIX = ".safetensors"` — and *skips* everything else. ONNX and `.pt` were
never going to be classified at all. The parser was never the blocker.

## What lands

`services/builtin_models.py` declares each engine and writes its row. Nothing is
parsed, nothing is hashed, so a 339 MB tagger costs an existence check at start-up.

- **`file_kind = 'engine'`**, one new value, with the role (`tagger`, `scorer`, …)
  in the existing `kind` column — it already holds free text and already renders
  as the row's label, so `file_kind` stays four values wide. **No schema change:**
  the `model` CHECK constraints bind only `adapter`.
- **The scanner skips `owner='pixlstash'` folders**, and rescan answers `skipped`.
  It must: the scanner yields only `.safetensors` and sweeps what it did not see
  to `missing`, so it would mark the ONNX tagger and both `.pth` scorers missing
  on every pass.
- **Listed only when asked for**, riding the adapters block under an explicit
  `?file_kind=engine`, exactly as `unknown` already does. The shelf's first
  question is which LoRA, not which tagger.
- **Protected.** Folder `DELETE` → 409; every verb refuses an engine row.
- **Declared-but-absent is normal**, not a warning: the ViT-L/14 scorer arrives
  only with the CLIP model that needs it.

## Two decisions inside it worth reviewing

**The filenames are restated, not imported.** Every downloader names its files as
module constants, but those modules import onnxruntime, torch, cv2 and PIL at
module level and start-up must not pay that for two strings. `test_builtin_models`
imports the real ones and asserts they agree, where the cost is free.

**Forget refuses engines as a `refused` reason, not an exception — and inside the
transaction.** My first version guarded at the route with a `hub.fetchall`, and
`test_forget_reads_its_gate_inside_the_write_transaction` caught it: that is the
one-critical-section invariant the CSO review of #869 established. It now runs on
the transaction's own connection beside the state gate, and reports
`is_a_builtin_engine` in the shape that route already speaks.

## The unclaimed readout

`unclaimed_files()` reports what is present and not declared. Run against the real
machine it finds exactly one thing: **`best.pt`, 339 MB**, which nothing in the
tree references by name or by pattern (the only `torch.load` is the aesthetic
model). The sidecars and `hf_hub_download`'s own `.cache/huggingface` bookkeeping
are correctly excluded.

It is called **"not claimed by anything in this build"**, never "orphaned" — we
know our own manifest, we do not know that a previous build, a plugin or the owner
did not put a file there. Same epistemics as `missing` against `unreachable`, and
the same doctrine: *detection proposes, it never applies*, so **nothing here
deletes**.

**Deleting one is a follow-up, and the recovery story inverts**, which is why it
is not in this PR: every *declared* file re-downloads on demand (`needs_download()`
is an existence check; the aesthetic loader is `if not os.path.exists`;
`hf_hub_download` refetches an absent file), but the *unclaimed* file is precisely
the one with no downloader. Its confirmation has to say something different from
the declared case, and say that recovery needs the network.

## Verification

197 tests across the shelf API, the new suite, the guardrails and the scanner.
8 new in `tests/test_builtin_models.py` (gated in `ci.yml` in alphabetical
position), 5 new in the shelf API suite. Mutation-checked: dropping the engine
branch from `forget_models` turns the refusal test red.