### PR TITLE
Recover two merged-but-missing shelf changes, and adopt the folded base model

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -172,6 +172,42 @@ Decompose by domain first, then fan out. **Independent** sub-tasks should run co
 - **Build frontend:** `npm run build` (in `frontend/`)
 - **Dev frontend:** `npm run dev` (in `frontend/`)
 
+## Never open a PR onto another PR
+
+**A PR's base must be a long-lived branch — `develop`, `main`, a release branch.
+Never another PR's branch.** Stacking reads as tidy and loses work.
+
+It lost work here on 2026-08-11. Three shelf PRs merged inside forty seconds:
+
+* **#873** had **#871**'s branch as its base. #871 merged to `develop`; #873 then
+  merged **into #871's branch**, not into `develop`. GitHub only auto-retargets a
+  PR when its base branch is *deleted*, and this one was not. The badge said
+  merged, the content was not in the product, and it was found by chance two
+  hours later — `grep -c withEmptyFolders frontend/src/utils/modelShelf.js`
+  returned **0** on `develop`.
+* **#872** merged at the head GitHub had recorded, which was one commit behind
+  what had just been pushed to it. The newer commit was simply left on the
+  branch. Same silent shape, different cause.
+
+Neither was recoverable by looking at the PR list, because both said MERGED.
+
+**If you need to add to an open PR, there are exactly two ways:**
+
+1. **Push the commits onto that PR's own branch.** This is almost always right.
+   The PR updates, its checks re-run, and there is one thing to merge.
+2. **Open a replacement PR carrying the old PR's full history, targeting the same
+   base the old one did** (usually `develop`), then close the old one. Use this
+   when the addition deserves its own review rather than riding along.
+
+Both keep a single merge into a long-lived branch. Neither creates a base that
+can be merged, deleted or retargeted out from under you.
+
+**Corollary — verify the merge, not the badge.** After a PR you care about is
+merged, confirm its content actually reached the target:
+`git merge-base --is-ancestor <head-at-merge> origin/develop`, or grep for a
+symbol the PR introduced. `MERGED` is a statement about a pull request, not about
+the branch you are going to build on next.
+
 ## Fixing a CI failure: update the existing PR, do not open another
 
 **One full gate run costs ~200 runner-minutes** (8 Linux shards, 4 Windows, e2e,

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1405,6 +1405,13 @@ models is thirty-six headers. Under `Folder` the second level is spent on the
     folder", discriminated on `last_checked IS NULL` rather than on a zero count,
     because a folder nothing has walked has no count to be zero. Only one of the
     two states is the owner's to act on.
+  - **Absence from `groups` does not mean empty**, which is why the registry's
+    `file_count` decides and not the group list. `groups` is built from the
+    VISIBLE rows, so a folder full of adapters has no group at all while `Show`
+    is narrowed to checkpoints; synthesising an empty group there would print
+    "No models in this folder" over a folder holding ninety. A folder with
+    `file_count > 0` is skipped and stays absent from a filtered view, exactly
+    as every other filtered-out row does.
   - The note is a plain `<li>`, never a `role="option"`: there is no model there
     for a verb to write.
   - It applies under `Group by: Folder` only. A folder appearing while grouped by

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1394,6 +1394,24 @@ models is thirty-six headers. Under `Folder` the second level is spent on the
   arithmetic — the inner offset is the outer's measured height, which no token
   knows — and the band is a label with a meter rather than something worth
   pinning while the reader scans one folder. So there is still one sticky offset.
+- **A registered folder holding no models still gets a group.** Groups are built
+  from `model_file` rows, so a folder with nothing in it produces none — and the
+  managed store is exactly that on every fresh install, despite being the ruled
+  default destination for a drop or an import. A destination you cannot see is
+  not a destination. `withEmptyFolders` merges the registry into the folder
+  groups, which is why `ModelShelf.vue` now fetches the folder list on mount
+  rather than leaving `ModelFoldersDialog` as its only reader.
+  - It says **which** empty it is: "Not scanned yet" against "No models in this
+    folder", discriminated on `last_checked IS NULL` rather than on a zero count,
+    because a folder nothing has walked has no count to be zero. Only one of the
+    two states is the owner's to act on.
+  - The note is a plain `<li>`, never a `role="option"`: there is no model there
+    for a verb to write.
+  - It applies under `Group by: Folder` only. A folder appearing while grouped by
+    base model would be a category error.
+  - A shelf holding **no** models at all still shows its own empty state instead
+    of a list of empty folders, because "add the folder where you keep them" is
+    the better answer on a fresh install than an inventory of nothing.
 - **The band is named by the volume, not by the mount point.** A Linux mount
   point runs to `/media/glindkvist/102AB4B6757AF9A3` and crowds the header out,
   so the band shows `label` behind a disk glyph and keeps `mount_point` as its

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1453,6 +1453,18 @@ models is thirty-six headers. Under `Folder` the second level is spent on the
 F5's stacks nest inside a *row*, not inside a header, so they do not want a
 third level.
 
+**Grouped, filtered, faceted and sorted on `base_model_folded`; displayed as
+`base_model`.** `baseModelKey()` prefers the server's canonical label and falls
+back to the raw string, so `sdxl_base_v1-0`, `SDXL`, `sdxl base` and `stable
+diffusion xl` make one header, one facet and one filter match instead of four —
+while a base model the table has never heard of stays selectable in its own
+right rather than being swept into "not set". The row keeps showing the raw
+spelling, because that is what the file actually says.
+
+All four uses had to move together. A facet list built from folded values with a
+filter matching raw ones would offer a box that hides most of the rows it
+promises, which is the failure a test now pins.
+
 - **`Base model not set` sorts last, always, and is expanded by default.** It is
   the absence of a value rather than a value, so it never joins the alphabetical
   run and never swaps ends with the direction. That matters because it is not a

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -24,9 +24,11 @@ vi.mock("../../api/modelShelf", () => ({
 // reset — which empties the shelf store MID-TEST and made an unrelated sort
 // assertion read the default view back.
 const listModelFolderDevices = vi.fn();
+const listModelFolders = vi.fn();
 vi.mock("../../api/modelFolders", async (importOriginal) => ({
   ...(await importOriginal()),
   listModelFolderDevices: (...args) => listModelFolderDevices(...args),
+  listModelFolders: (...args) => listModelFolders(...args),
 }));
 
 import ModelShelf from "./ModelShelf.vue";
@@ -89,6 +91,8 @@ beforeEach(() => {
   listCheckpoints.mockReset();
   listModelFolderDevices.mockReset();
   listModelFolderDevices.mockResolvedValue([]);
+  listModelFolders.mockReset();
+  listModelFolders.mockResolvedValue([]);
 });
 
 describe("a row with nothing in its header", () => {
@@ -816,5 +820,107 @@ describe("a click that ends a text drag", () => {
 
     window.getSelection.mockRestore();
     outside.remove();
+  });
+});
+
+describe("a registered folder holding no models", () => {
+  it("gets a group of its own, so the managed store is visible", async () => {
+    // It is ruled to always exist and to be the default destination for a drop
+    // or an import. A destination you cannot see is not a destination.
+    listModelFolders.mockResolvedValue([
+      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      { id: 2, path: "/models/store", last_checked: "2026-08-10T00:00:00Z" },
+    ]);
+    const wrapper = await mountShelf([
+      adapter({
+        locations: [
+          {
+            state: "present",
+            folder_id: 1,
+            folder_path: "/models/loras",
+            relpath: "a",
+          },
+        ],
+      }),
+    ]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "alpha" });
+    await wrapper.vm.$nextTick();
+
+    const labels = wrapper.findAll(".shelf-group-label").map((l) => l.text());
+    expect(labels).toContain("/models/store");
+    expect(textOf(wrapper.find(".shelf-empty-folder"))).toBe(
+      "No models in this folder.",
+    );
+  });
+
+  it("says it has not been looked in yet when it has not", async () => {
+    // "We have not looked" is the owner's to act on; "we looked and it is
+    // empty" is not, and a bare "0 models" says neither.
+    //
+    // A shelf with NO models at all renders its own empty state instead of the
+    // group list, which is the better answer there ("add a folder"), so the
+    // case asserted is the one the owner actually hits: models elsewhere, and
+    // one folder nothing has looked in.
+    listModelFolders.mockResolvedValue([
+      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      { id: 2, path: "/models/store", last_checked: null },
+    ]);
+    const wrapper = await mountShelf([
+      adapter({
+        locations: [
+          {
+            state: "present",
+            folder_id: 1,
+            folder_path: "/models/loras",
+            relpath: "a",
+          },
+        ],
+      }),
+    ]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "alpha" });
+    await wrapper.vm.$nextTick();
+
+    expect(textOf(wrapper.find(".shelf-empty-folder"))).toBe(
+      "Not scanned yet.",
+    );
+  });
+
+  it("stays out of the way on every other axis", async () => {
+    // The folder registry is a fact about folders. Grouping by base model and
+    // seeing a folder appear would be a category error.
+    listModelFolders.mockResolvedValue([
+      { id: 2, path: "/models/store", last_checked: null },
+    ]);
+    const wrapper = await mountShelf([adapter({ base_model: "sdxl" })]);
+    useModelShelfStore().setView({ groupBy: "base_model" });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".shelf-empty-folder").exists()).toBe(false);
+  });
+
+  it("is not selectable, having no model to act on", async () => {
+    // A verb armed against a folder would be a verb with nothing to write.
+    listModelFolders.mockResolvedValue([
+      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      { id: 2, path: "/models/store", last_checked: null },
+    ]);
+    const wrapper = await mountShelf([
+      adapter({
+        locations: [
+          {
+            state: "present",
+            folder_id: 1,
+            folder_path: "/models/loras",
+            relpath: "a",
+          },
+        ],
+      }),
+    ]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "alpha" });
+    await wrapper.vm.$nextTick();
+
+    const note = wrapper.find(".shelf-empty-folder");
+    expect(note.attributes("role")).toBeUndefined();
+    expect(note.attributes("tabindex")).toBeUndefined();
   });
 });

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -828,7 +828,12 @@ describe("a registered folder holding no models", () => {
     // It is ruled to always exist and to be the default destination for a drop
     // or an import. A destination you cannot see is not a destination.
     listModelFolders.mockResolvedValue([
-      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      {
+        id: 1,
+        path: "/models/loras",
+        last_checked: "2026-08-10T00:00:00Z",
+        file_count: 1,
+      },
       { id: 2, path: "/models/store", last_checked: "2026-08-10T00:00:00Z" },
     ]);
     const wrapper = await mountShelf([
@@ -862,7 +867,12 @@ describe("a registered folder holding no models", () => {
     // case asserted is the one the owner actually hits: models elsewhere, and
     // one folder nothing has looked in.
     listModelFolders.mockResolvedValue([
-      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      {
+        id: 1,
+        path: "/models/loras",
+        last_checked: "2026-08-10T00:00:00Z",
+        file_count: 1,
+      },
       { id: 2, path: "/models/store", last_checked: null },
     ]);
     const wrapper = await mountShelf([
@@ -901,7 +911,12 @@ describe("a registered folder holding no models", () => {
   it("is not selectable, having no model to act on", async () => {
     // A verb armed against a folder would be a verb with nothing to write.
     listModelFolders.mockResolvedValue([
-      { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+      {
+        id: 1,
+        path: "/models/loras",
+        last_checked: "2026-08-10T00:00:00Z",
+        file_count: 1,
+      },
       { id: 2, path: "/models/store", last_checked: null },
     ]);
     const wrapper = await mountShelf([

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -728,8 +728,13 @@ onMounted(() => {
   // slow or offline mount must not hold up the models. The folder list comes
   // with them now, because a folder holding nothing is only visible if the
   // shelf knows it is registered — the dialog used to be its only reader.
+  //
+  // NOT `quiet`: that suppresses the folder store's `loading`, and the folders
+  // dialog reads it. Opening the dialog while this first fetch is in flight
+  // would show an empty list with no "Reading the registered folders…" state.
+  // Unawaited already means it does not hold up the shelf.
   foldersStore.refreshDevices();
-  foldersStore.refresh({ quiet: true });
+  foldersStore.refresh();
 });
 
 // A credential change (logout, login, share token, restore) empties the store,

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -285,6 +285,13 @@
             aria-multiselectable="true"
             :aria-label="grouped ? group.label : 'Models'"
           >
+            <!-- Not a `role="option"`: there is nothing here to select. A
+                 registered folder with no models says which of the two states
+                 it is in, because "we have not looked yet" is the owner's to
+                 act on and "we looked and it is empty" is not. -->
+            <li v-if="!group.rows.length" class="shelf-empty-folder">
+              {{ EMPTY_FOLDER_NOTE[group.emptyReason] }}
+            </li>
             <li
               v-for="row in group.rows"
               :key="row.rowKey"
@@ -360,6 +367,7 @@ import { useModelFoldersStore } from "../../stores/useModelFoldersStore";
 import {
   bandGroups,
   bandUsage,
+  withEmptyFolders,
   formatModelSize,
   GROUP_BY_LABELS,
   SORT_LABELS,
@@ -588,6 +596,17 @@ function onRowKeydown(row, event) {
   }
 }
 
+/**
+ * What an empty folder group says, per reason.
+ *
+ * Never a bare "0 models": the count is already in the header, and the reader's
+ * question is whether the shelf has looked.
+ */
+const EMPTY_FOLDER_NOTE = {
+  unscanned: "Not scanned yet.",
+  empty: "No models in this folder.",
+};
+
 /** "1 model" / "12 models", so no line ever reads "1 models". */
 function modelCount(n) {
   return `${n.toLocaleString()} ${n === 1 ? "model" : "models"}`;
@@ -603,10 +622,14 @@ function modelCount(n) {
  * arrangement is still testable without a component.
  */
 const shownGroups = computed(() => {
-  if (store.view.groupBy !== "folder" || store.view.folderLayout !== "drive") {
-    return store.groups;
-  }
-  return bandGroups(store.groups, foldersStore.deviceByFolderId);
+  if (store.view.groupBy !== "folder") return store.groups;
+  // A registered folder holding nothing has no rows and therefore no group.
+  // The managed store is exactly that on a fresh install, and it is the ruled
+  // default destination for a drop or an import — which it cannot be while the
+  // owner has no way to see it.
+  const groups = withEmptyFolders(store.groups, foldersStore.folders);
+  if (store.view.folderLayout !== "drive") return groups;
+  return bandGroups(groups, foldersStore.deviceByFolderId);
 });
 
 function usage(band) {
@@ -702,8 +725,11 @@ onMounted(() => {
   rootEl.value?.focus();
   store.fetchRows();
   // Unawaited and never blocking the list: the drives decorate the bands, and a
-  // slow or offline mount must not hold up the models.
+  // slow or offline mount must not hold up the models. The folder list comes
+  // with them now, because a folder holding nothing is only visible if the
+  // shelf knows it is registered — the dialog used to be its only reader.
   foldersStore.refreshDevices();
+  foldersStore.refresh({ quiet: true });
 });
 
 // A credential change (logout, login, share token, restore) empties the store,

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -11,6 +11,7 @@ import { onSessionReset } from "../utils/apiClient";
 import { useNoticeStore } from "./useNoticeStore";
 import { errorDetail } from "../utils/apiError";
 import {
+  baseModelKey,
   compareGroups,
   locationState,
   modelName,
@@ -78,7 +79,8 @@ const SORT_VALUE = {
   // The cover alone understates a six-step run by about six times, in the
   // column the shelf exists to answer.
   size: (row) => row.total_size ?? row.file_size ?? null,
-  base_model: (row) => row.base_model || null,
+  // Sorted by the folded value so the run is by base rather than by spelling.
+  base_model: (row) => baseModelKey(row) || null,
 };
 
 /**
@@ -316,7 +318,10 @@ function storedCollapsed() {
  */
 function groupsOf(row, axis) {
   if (axis === "base_model") {
-    const base = row.base_model || "";
+    // Grouped by the FOLDED value, so four spellings of one base make one
+    // header. The label is that canonical string: a header reading
+    // `sdxl_base_v1-0` over rows that say `SDXL` would be the fold leaking.
+    const base = baseModelKey(row);
     return base
       ? [{ key: base, label: base, labelKind: "name" }]
       : [
@@ -465,10 +470,13 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
    * a row the filter quietly drops.
    */
   const baseModelOptions = computed(() => {
+    // Faceted on the folded value too, or the filter offers four boxes that
+    // each tick a quarter of one base — and ticking "SDXL" would hide the rows
+    // whose file happens to spell it `sdxl base`.
     const named = [
-      ...new Set(rows.value.map((r) => r.base_model).filter(Boolean)),
+      ...new Set(rows.value.map(baseModelKey).filter(Boolean)),
     ].sort();
-    const hasUnset = rows.value.some((r) => !r.base_model);
+    const hasUnset = rows.value.some((r) => !baseModelKey(r));
     return hasUnset ? [...named, BASE_MODEL_UNASSIGNED] : named;
   });
 
@@ -485,7 +493,8 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
           if (!kinds.includes(String(row.kind))) return false;
         }
         if (bases.length) {
-          const key = row.base_model || BASE_MODEL_UNASSIGNED;
+          // Matched against the same key the facet list was built from.
+          const key = baseModelKey(row) || BASE_MODEL_UNASSIGNED;
           if (!bases.includes(key)) return false;
         }
         return true;

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -10,7 +10,12 @@ import {
 import { onSessionReset } from "../utils/apiClient";
 import { useNoticeStore } from "./useNoticeStore";
 import { errorDetail } from "../utils/apiError";
-import { locationState, modelName } from "../utils/modelShelf";
+import {
+  compareGroups,
+  locationState,
+  modelName,
+  UNSET_GROUP_KEY,
+} from "../utils/modelShelf";
 
 /** Where the `Show` selection is remembered between visits. */
 const FILTERS_KEY = "pixlstash:modelShelfFilters";
@@ -299,9 +304,6 @@ function storedCollapsed() {
   return collapsed;
 }
 
-/** The group a row with no value on the current axis falls into. */
-const UNSET_GROUP_KEY = "\u0000unset";
-
 /**
  * Every group a row belongs to on one axis, as `{key, label, labelKind}`.
  *
@@ -341,30 +343,6 @@ function groupsOf(row, axis) {
     labelKind: "path",
     location: loc,
   }));
-}
-
-/**
- * Order two groups.
- *
- * Alphabetical by label, with the "not set" group ALWAYS last, in both sort
- * directions. It is the absence of a value rather than a value, so it never
- * joins the alphabetical run and never swaps ends when the direction flips.
- * That is the same rule `baseModelOptions` already applies to the filter's
- * `UNASSIGNED` option, and it matters here because "not set" is not a tail: 37%
- * of real adapters record no base model, so it is one of the largest groups on
- * the shelf and putting it first would bury everything identifiable under it.
- *
- * The sort keys never reorder groups, only rows inside them. Switching to
- * "Largest first" moving every header out from under the reader would be a
- * different view, not a sorted one.
- */
-function compareGroups(a, b) {
-  if (a.key === UNSET_GROUP_KEY) return b.key === UNSET_GROUP_KEY ? 0 : 1;
-  if (b.key === UNSET_GROUP_KEY) return -1;
-  return a.label.localeCompare(b.label, undefined, {
-    numeric: true,
-    sensitivity: "base",
-  });
 }
 
 /** The three top-level type checkboxes, each one request and one row bucket. */

--- a/frontend/src/stores/useModelShelfStore.test.js
+++ b/frontend/src/stores/useModelShelfStore.test.js
@@ -755,3 +755,52 @@ describe("what a verb may reach", () => {
     expect([...store.selectedIds]).toEqual([1, 2]);
   });
 });
+
+describe("the folded base model", () => {
+  const folded = (id, raw, canonical) =>
+    adapter({ id, base_model: raw, base_model_folded: canonical });
+
+  it("groups four spellings of one base under one header", async () => {
+    const store = useModelShelfStore();
+    store.rows = [
+      folded(1, "sdxl_base_v1-0", "SDXL 1.0"),
+      folded(2, "SDXL", "SDXL 1.0"),
+      folded(3, "flux.1-dev", "FLUX.1 dev"),
+    ];
+    store.setView({ groupBy: "base_model" });
+
+    const labels = store.groups.map((g) => g.label);
+    expect(labels).toEqual(["FLUX.1 dev", "SDXL 1.0"]);
+  });
+
+  it("offers one facet per base, not one per spelling", () => {
+    const store = useModelShelfStore();
+    store.rows = [
+      folded(1, "sdxl_base_v1-0", "SDXL 1.0"),
+      folded(2, "stable diffusion xl", "SDXL 1.0"),
+    ];
+    expect(store.baseModelOptions).toEqual(["SDXL 1.0"]);
+  });
+
+  it("selects every spelling when its one facet is ticked", () => {
+    // The half that would break silently: a facet built from folded values and
+    // a filter matching raw ones would tick a box that hides most of its rows.
+    const store = useModelShelfStore();
+    store.rows = [
+      folded(1, "sdxl_base_v1-0", "SDXL 1.0"),
+      folded(2, "SDXL", "SDXL 1.0"),
+      folded(3, "flux.1-dev", "FLUX.1 dev"),
+    ];
+    store.setFilters({ baseModels: ["SDXL 1.0"] });
+    expect(store.visibleRows.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it("keeps an unrecognised base model selectable in its own right", () => {
+    const store = useModelShelfStore();
+    store.rows = [folded(1, "my private base v3", null), folded(2, null, null)];
+    expect(store.baseModelOptions).toEqual([
+      "my private base v3",
+      "UNASSIGNED",
+    ]);
+  });
+});

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -151,6 +151,73 @@ export function formatModelSize(bytes) {
   return `${value.toFixed(digits)} ${SIZE_UNITS[unit]}`;
 }
 
+/**
+ * The group a row with no value on the current axis falls into.
+ *
+ * Here rather than in the store because {@link compareGroups} needs it and the
+ * store imports this module, so the other direction would be a cycle.
+ */
+export const UNSET_GROUP_KEY = "\u0000unset";
+
+/**
+ * Order two groups.
+ *
+ * Alphabetical by label, with the "not set" group ALWAYS last, in both sort
+ * directions. It is the absence of a value rather than a value, so it never
+ * joins the alphabetical run and never swaps ends when the direction flips.
+ * That is the same rule `baseModelOptions` already applies to the filter's
+ * `UNASSIGNED` option, and it matters here because "not set" is not a tail: 37%
+ * of real adapters record no base model, so it is one of the largest groups on
+ * the shelf and putting it first would bury everything identifiable under it.
+ *
+ * The sort keys never reorder groups, only rows inside them. Switching to
+ * "Largest first" moving every header out from under the reader would be a
+ * different view, not a sorted one.
+ */
+export function compareGroups(a, b) {
+  if (a.key === UNSET_GROUP_KEY) return b.key === UNSET_GROUP_KEY ? 0 : 1;
+  if (b.key === UNSET_GROUP_KEY) return -1;
+  return a.label.localeCompare(b.label, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+/**
+ * Add a group for every registered folder that has none.
+ *
+ * Groups are built from `model_file` rows, so a folder holding nothing produces
+ * no group at all — and the managed store holds nothing on every fresh install,
+ * despite being the ruled default destination for a drop or an import. A
+ * destination you cannot see is not a destination.
+ *
+ * The empty group carries `emptyReason`, because "registered and empty" and
+ * "never scanned" are different facts and only one of them is the owner's to
+ * act on. `last_checked` is the discriminator rather than a zero count: a
+ * folder that has never been walked has no count to be zero.
+ *
+ * @param {Array<Object>} groups - the folder groups the rows produced.
+ * @param {Array<Object>} folders - rows from `GET /model-folders`.
+ * @returns {Array<Object>} groups plus the empties, in one sorted run.
+ */
+export function withEmptyFolders(groups, folders) {
+  const held = new Set(groups.map((group) => group.key));
+  const empties = [];
+  for (const folder of folders || []) {
+    const key = String(folder.path || folder.id || "");
+    if (!key || held.has(key)) continue;
+    empties.push({
+      key,
+      label: key,
+      labelKind: "path",
+      folderId: Number(folder.id),
+      emptyReason: folder.last_checked ? "empty" : "unscanned",
+      rows: [],
+    });
+  }
+  return empties.length ? [...groups, ...empties].sort(compareGroups) : groups;
+}
+
 /** What each folder layout is called, and the glyph that stands for it. */
 export const FOLDER_LAYOUT_LABELS = {
   drive: { label: "Drive, then folder", icon: "mdi-harddisk" },

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -231,6 +231,26 @@ export function withEmptyFolders(groups, folders) {
   return empties.length ? [...groups, ...empties].sort(compareGroups) : groups;
 }
 
+/**
+ * The base model a row should be GROUPED, FILTERED and FACETED by.
+ *
+ * `base_model_folded` when the server recognised the string, the raw one when
+ * it did not. Folding is what makes `sdxl_base_v1-0`, `SDXL`, `sdxl base` and
+ * `stable diffusion xl` one bucket instead of four; falling back to the raw
+ * value is what keeps a base model nobody has heard of selectable rather than
+ * swept into "not set".
+ *
+ * Note what this is NOT for: the row still DISPLAYS `base_model`, because the
+ * raw spelling is what the file actually says. Group by the fold, show the
+ * original.
+ *
+ * @param {Object} row - a row from `/adapters` or `/checkpoints`.
+ * @returns {string} the grouping key, or `""` when the row records nothing.
+ */
+export function baseModelKey(row) {
+  return row?.base_model_folded || row?.base_model || "";
+}
+
 /** What each folder layout is called, and the glyph that stands for it. */
 export const FOLDER_LAYOUT_LABELS = {
   drive: { label: "Drive, then folder", icon: "mdi-harddisk" },

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -193,8 +193,12 @@ export function compareGroups(a, b) {
  *
  * The empty group carries `emptyReason`, because "registered and empty" and
  * "never scanned" are different facts and only one of them is the owner's to
- * act on. `last_checked` is the discriminator rather than a zero count: a
- * folder that has never been walked has no count to be zero.
+ * act on. `last_checked` is the discriminator for that pair rather than a zero
+ * count: a folder that has never been walked has no count to be zero.
+ *
+ * `file_count` decides something else — whether the folder is empty at all.
+ * Absence from `groups` cannot answer that, because `groups` is built from the
+ * visible rows and a filter can empty a folder that is full.
  *
  * @param {Array<Object>} groups - the folder groups the rows produced.
  * @param {Array<Object>} folders - rows from `GET /model-folders`.
@@ -206,12 +210,21 @@ export function withEmptyFolders(groups, folders) {
   for (const folder of folders || []) {
     const key = String(folder.path || folder.id || "");
     if (!key || held.has(key)) continue;
+    // "Has no group" is NOT "is empty". `groups` is built from the VISIBLE
+    // rows, so a folder full of adapters has no group at all while Show is
+    // narrowed to checkpoints — and calling that folder empty would be a plain
+    // lie about the disk. The registry knows better: `file_count` counts the
+    // copies registered under the folder in any state, so a folder that holds
+    // something is skipped and simply stays absent from a filtered view, which
+    // is what every other filtered-out row does.
+    const unscanned = !folder.last_checked;
+    if (!unscanned && Number(folder.file_count) > 0) continue;
     empties.push({
       key,
       label: key,
       labelKind: "path",
       folderId: Number(folder.id),
-      emptyReason: folder.last_checked ? "empty" : "unscanned",
+      emptyReason: unscanned ? "unscanned" : "empty",
       rows: [],
     });
   }

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -260,6 +260,41 @@ describe("withEmptyFolders", () => {
     expect(arranged[1].folderId).toBe(2);
   });
 
+  it("does not call a folder empty just because a filter hid its models", () => {
+    // The failure this guards: `groups` is built from the VISIBLE rows, so a
+    // folder full of adapters has no group while Show is narrowed to
+    // checkpoints. Reading "no group" as "no models" would print "No models in
+    // this folder" over a folder holding ninety.
+    const arranged = withEmptyFolders(
+      [],
+      [
+        {
+          id: 1,
+          path: "/models/loras",
+          last_checked: "2026-08-10T00:00:00Z",
+          file_count: 91,
+        },
+        {
+          id: 2,
+          path: "/models/store",
+          last_checked: "2026-08-10T00:00:00Z",
+          file_count: 0,
+        },
+      ],
+    );
+    expect(arranged.map((g) => g.label)).toEqual(["/models/store"]);
+  });
+
+  it("still shows a folder nothing has looked in, whatever its count says", () => {
+    // `file_count` is 0 for an unscanned folder too, but the two are different
+    // facts and only this one is the owner's to act on.
+    const [only] = withEmptyFolders(
+      [],
+      [{ id: 1, path: "/models/new", last_checked: null, file_count: 0 }],
+    );
+    expect(only.emptyReason).toBe("unscanned");
+  });
+
   it("keeps 'never scanned' apart from 'scanned and empty'", () => {
     // Only one of the two is the owner's to act on, and `last_checked` is the
     // discriminator: a folder that has never been walked has no count to be

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import {
   bandGroups,
   bandUsage,
+  withEmptyFolders,
   cleanAssetName,
   deriveModelName,
   formatModelSize,
@@ -228,5 +229,67 @@ describe("bandUsage", () => {
       shelfBytes: 5000,
     });
     expect(usage.shelfPct).toBe(usage.usedPct);
+  });
+});
+
+describe("withEmptyFolders", () => {
+  const group = (path) => ({
+    key: path,
+    label: path,
+    labelKind: "path",
+    folderId: 1,
+    rows: [{ id: 1 }],
+  });
+
+  it("adds the registered folder that produced no group", () => {
+    // The managed store is exactly this on a fresh install: registered, ruled
+    // to be the default drop destination, and holding nothing — so it has no
+    // rows, no group, and no way to be seen.
+    const arranged = withEmptyFolders(
+      [group("/models/loras")],
+      [
+        { id: 1, path: "/models/loras", last_checked: "2026-08-10T00:00:00Z" },
+        { id: 2, path: "/models/store", last_checked: "2026-08-10T00:00:00Z" },
+      ],
+    );
+    expect(arranged.map((g) => g.label)).toEqual([
+      "/models/loras",
+      "/models/store",
+    ]);
+    expect(arranged[1].rows).toEqual([]);
+    expect(arranged[1].folderId).toBe(2);
+  });
+
+  it("keeps 'never scanned' apart from 'scanned and empty'", () => {
+    // Only one of the two is the owner's to act on, and `last_checked` is the
+    // discriminator: a folder that has never been walked has no count to be
+    // zero.
+    const [never, walked] = withEmptyFolders(
+      [],
+      [
+        { id: 1, path: "/a", last_checked: null },
+        { id: 2, path: "/b", last_checked: "2026-08-10T00:00:00Z" },
+      ],
+    );
+    expect(never.emptyReason).toBe("unscanned");
+    expect(walked.emptyReason).toBe("empty");
+  });
+
+  it("never duplicates a folder that already has rows", () => {
+    const arranged = withEmptyFolders(
+      [group("/models/loras")],
+      [{ id: 1, path: "/models/loras", last_checked: null }],
+    );
+    expect(arranged).toHaveLength(1);
+    expect(arranged[0].rows).toHaveLength(1);
+  });
+
+  it("returns the groups untouched when every folder has some", () => {
+    // Identity, not a copy: the caller bands this result, and a needless new
+    // array would invalidate every downstream computed on each keystroke.
+    const groups = [group("/models/loras")];
+    expect(withEmptyFolders(groups, [{ id: 1, path: "/models/loras" }])).toBe(
+      groups,
+    );
   });
 });

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import {
   bandGroups,
   bandUsage,
+  baseModelKey,
   withEmptyFolders,
   cleanAssetName,
   deriveModelName,
@@ -326,5 +327,35 @@ describe("withEmptyFolders", () => {
     expect(withEmptyFolders(groups, [{ id: 1, path: "/models/loras" }])).toBe(
       groups,
     );
+  });
+});
+
+describe("baseModelKey", () => {
+  it("prefers the folded label, so four spellings make one bucket", () => {
+    const rows = [
+      { base_model: "sdxl_base_v1-0", base_model_folded: "SDXL 1.0" },
+      { base_model: "SDXL", base_model_folded: "SDXL 1.0" },
+      { base_model: "stable diffusion xl", base_model_folded: "SDXL 1.0" },
+    ];
+    expect(new Set(rows.map(baseModelKey)).size).toBe(1);
+  });
+
+  it("falls back to the raw string the server did not recognise", () => {
+    // Not "not set": an unrecognised base model is a real value the owner can
+    // still group and filter by. Sweeping it into the unset bucket would hide
+    // every private or brand-new base.
+    expect(
+      baseModelKey({
+        base_model: "my private base v3",
+        base_model_folded: null,
+      }),
+    ).toBe("my private base v3");
+  });
+
+  it("reports nothing for a row that records nothing", () => {
+    expect(baseModelKey({ base_model: null, base_model_folded: null })).toBe(
+      "",
+    );
+    expect(baseModelKey(undefined)).toBe("");
   });
 });

--- a/pixlstash/routes/model_shelf.py
+++ b/pixlstash/routes/model_shelf.py
@@ -19,6 +19,15 @@ default. It surfaces on the *adapters* block under an explicit
 is therefore hash-addressable exactly as an adapter is. ``/checkpoints`` never
 returns one.
 
+**Folding happens on the way out, not in the database.** Every row carries
+``base_model_folded`` beside its raw ``base_model``. That is where the fold
+belongs: ``base_model`` is free text by rule, and the shelf sorts, filters,
+groups and builds its facets **client-side** (one request per selected block,
+concatenated — see ``useModelShelfStore``), so a canonical column or a SQLite
+collation would fold the one path the shelf does not use and leave the other
+four unfolded. One computed field serves all of them, costs a dict lookup per
+row, and needs no migration.
+
 **A null ``base_model`` is a bulk state, not an edge case.** Measured against 91
 real adapters, 37 % carry no title, no base model and no trigger word at all. So
 ``base_model`` is serialised as ``null`` rather than coerced to a string, is never
@@ -79,6 +88,7 @@ from pixlstash.services.model_shelf_service import (
     update_models,
 )
 from pixlstash.utils.adapter_header import FILE_ADAPTER, FILE_CHECKPOINT, FILE_UNKNOWN
+from pixlstash.utils.known_base_models import fold
 
 logger = get_logger(__name__)
 
@@ -193,6 +203,20 @@ class ModelResponse(BaseModel):
             "What the trainer said this was trained against, verbatim. Null for "
             "the large minority of real adapters that record nothing — shown as "
             "'Not set', never dropped, and selectable with base_model=UNASSIGNED."
+        ),
+    )
+    base_model_folded: Optional[str] = Field(
+        default=None,
+        description=(
+            "The canonical label `base_model` folds to, or null when the string "
+            "is one `known_base_models` does not recognise (which is not an "
+            "error: it is stored and displayed verbatim either way).\n\n"
+            "Computed per response rather than stored, because folding is a "
+            "**display** concern and the column is free text by rule. Group, "
+            "filter and facet on this so `sdxl_base_v1-0`, `SDXL`, `sdxl base` "
+            "and `stable diffusion xl` land in one bucket rather than four; "
+            "**show `base_model`**, because the raw spelling is what the file "
+            "actually says."
         ),
     )
     trigger_words: Optional[str] = None
@@ -412,6 +436,7 @@ def _to_response(
         display_name=row["display_name"],
         filename=row["filename"],
         base_model=row["base_model"],
+        base_model_folded=fold(row["base_model"]),
         trigger_words=row["trigger_words"],
         provenance=row["provenance"],
         training_run_id=row["training_run_id"],

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -2921,3 +2921,77 @@ def test_a_drive_with_no_label_reports_null_rather_than_a_guess(
     band = next(d for d in _devices(shelf_env) if folder_id in d["folder_ids"])
     assert band["label"] is None
     assert band["mount_point"]
+
+
+# ===========================================================================
+# base_model_folded — the fold applied on the way out
+# ===========================================================================
+
+
+def test_a_row_carries_the_canonical_label_beside_the_raw_one(shelf_env):
+    """Both, never one. The raw string is what the file says and is what the
+    shelf displays; the folded one is what a grouping or a facet should key on,
+    so `sdxl_base_v1-0` and `SDXL` land in one bucket rather than two."""
+    alice = shelf_env.model_ids["alice.safetensors"]
+    with shelf_env.server.hub.transaction() as conn:
+        conn.execute(
+            "UPDATE model SET base_model = 'sdxl_base_v1-0' WHERE id = ?", (alice,)
+        )
+
+    row = next(
+        r
+        for r in shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+        if r["id"] == alice
+    )
+    assert row["base_model"] == "sdxl_base_v1-0", "the raw spelling was rewritten"
+    assert row["base_model_folded"] == "SDXL 1.0"
+
+
+def test_two_spellings_of_one_base_fold_together(shelf_env):
+    """The whole point: the shelf can group on this and get one row per base
+    rather than one per spelling."""
+    alice = shelf_env.model_ids["alice.safetensors"]
+    bob = shelf_env.model_ids["bob.safetensors"]
+    with shelf_env.server.hub.transaction() as conn:
+        conn.execute("UPDATE model SET base_model = 'SDXL' WHERE id = ?", (alice,))
+        conn.execute(
+            "UPDATE model SET base_model = 'stable diffusion xl' WHERE id = ?", (bob,)
+        )
+
+    folded = {
+        r["id"]: r["base_model_folded"]
+        for r in shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+    }
+    assert folded[alice] == "SDXL 1.0"
+    assert folded[bob] == folded[alice], "two spellings of one base did not meet"
+
+
+def test_an_unrecognised_base_model_folds_to_null_and_is_still_served(shelf_env):
+    """Not an error, and not a reason to drop or rewrite the row: an unknown
+    string is stored verbatim, displayed verbatim, and simply has no canonical
+    label yet."""
+    alice = shelf_env.model_ids["alice.safetensors"]
+    with shelf_env.server.hub.transaction() as conn:
+        conn.execute(
+            "UPDATE model SET base_model = 'my private base v3' WHERE id = ?",
+            (alice,),
+        )
+
+    row = next(
+        r
+        for r in shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+        if r["id"] == alice
+    )
+    assert row["base_model"] == "my private base v3"
+    assert row["base_model_folded"] is None
+
+
+def test_a_row_with_no_base_model_folds_to_null(shelf_env):
+    """37% of real adapters record nothing. Null in, null out, no exception."""
+    row = next(
+        r
+        for r in shelf_env.owner.get(f"{API}/adapters").json()["adapters"]
+        if r["id"] == shelf_env.model_ids["sd_xl_noname.safetensors"]
+    )
+    assert row["base_model"] is None
+    assert row["base_model_folded"] is None


### PR DESCRIPTION
**Read this part first: two changes that show as merged are not on `develop`.** I
found it while starting the folding adoption and checking my baseline.

| PR | What happened |
|---|---|
| **#872** | Merged at head `1b43d113`. My later commit `0f2c033d` — the `base_model_folded` field — was pushed after that and **was never merged**. |
| **#873** | Merged into **`feature/shelf-file-manager-selection`**, not `develop`. Its base was never retargeted when #871 landed, so the merge commit `e54b8dd6` sits on that branch and none of it reached `develop`. |

Neither was lost — #872's commit was still on its branch and #873's on its base
branch — and both are recovered here. Verifiable on `develop` before this PR:
`grep -c withEmptyFolders frontend/src/utils/modelShelf.js` → **0**, and
`grep -c base_model_folded pixlstash/routes/model_shelf.py` → **0**.

Worth a look at the merge settings: a PR whose base branch is another PR's branch
will merge *there*, and GitHub only auto-retargets when the base is deleted.

## What this PR contains

1. **#872's missing commit**, cherry-picked: `base_model_folded` computed in
   `_to_response`, with its four tests.
2. **#873's missing work**, recovered by merging its base branch: registered
   folders that hold no models get a group, `withEmptyFolders`, and the move of
   `compareGroups` / `UNSET_GROUP_KEY` into `utils/modelShelf.js`.
3. **The adoption itself** — the actual new work.

## The adoption

`baseModelKey()` prefers the folded label and falls back to the raw string. Four
call sites moved together, and they had to:

- **group** — one header per base instead of one per spelling;
- **facet** — one checkbox per base;
- **filter** — matched on the same key the facet was built from;
- **sort** — a run ordered by base rather than by how the trainer typed it.

Splitting them would have been the silent failure: a facet list built from folded
values with a filter matching raw ones offers a box that hides most of the rows it
promises. A test pins exactly that.

An unrecognised base model keeps its raw string as its key, so a private or
brand-new base stays selectable rather than being swept into "not set". The row
still **displays** `base_model`, because the raw spelling is what the file says.

## Verification

2,835 frontend tests, 7 new. Mutation-checked: dropping the folded preference from
`baseModelKey` turns four of them red across both suites — which is also the proof
that the four call sites are genuinely wired to one helper.