### PR TITLE
Fix two shelf test flakes at their causes

### DIFF
--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -25,6 +25,20 @@ vi.mock("../../api/modelShelf", () => ({
 // assertion read the default view back.
 const listModelFolderDevices = vi.fn();
 const listModelFolders = vi.fn();
+// `onMounted` calls `moves.adopt()`, which reads the move job so a move
+// started before a reload is picked up. Left unmocked it reaches the network,
+// fails, and `console.warn`s from a promise nothing in the test awaits — which
+// lands AFTER the file tears down and kills the whole vitest run with
+// `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`.
+// Every file passed and the runner still exited 1 (#880's first CI run). It is
+// timing-dependent, so a local run can be green with the same bug present.
+const getModelMoveStatus = vi.fn();
+vi.mock("../../api/modelMoves", () => ({
+  getModelMoveStatus: (...args) => getModelMoveStatus(...args),
+  startModelMove: vi.fn(),
+  cancelModelMove: vi.fn(),
+}));
+
 vi.mock("../../api/modelFolders", async (importOriginal) => ({
   ...(await importOriginal()),
   listModelFolderDevices: (...args) => listModelFolderDevices(...args),
@@ -99,6 +113,11 @@ beforeEach(() => {
   listModelFolderDevices.mockResolvedValue([]);
   listModelFolders.mockReset();
   listModelFolders.mockResolvedValue([]);
+  // `idle` is what a machine with no move in flight reports, and `adopt()`
+  // adopts nothing from it — so the mount path stays silent instead of warning
+  // from an unawaited promise.
+  getModelMoveStatus.mockReset();
+  getModelMoveStatus.mockResolvedValue({ status: "idle", results: [] });
 });
 
 describe("a row with nothing in its header", () => {

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -2751,16 +2751,48 @@ def test_forget_reads_its_gate_inside_the_write_transaction(shelf_env):
     `missing` back to `present` before the DELETE lands — and the model is
     forgotten anyway. Counting the reads that go OUTSIDE the transaction is the
     assertion, because the race itself cannot be scheduled reliably. Reported by
-    the CSO review of #869."""
+    the CSO review of #869.
+
+    **Counted per THREAD, and that is what makes the count mean anything.**
+    `hub.fetchall` is patched on the shared, module-scoped server, so every
+    caller in the process goes through it — including the background finders,
+    and `MissingCheckpointHashFinder` queries `model` on the hub in both
+    `progress()` and `find_task()`. A sweep landing inside the request window
+    put its SQL in this list and failed the test with a diagnostic pointing at
+    the forget, which had done nothing wrong. Measured: red once in four runs of
+    a loaded four-file combination.
+
+    The allowlist is the same one the N+1 guard above uses, and for the same
+    reason: Starlette serves a sync handler on its own threadpool, whose threads
+    are named "AnyIO worker thread", and nothing else in this process is. A
+    denylist of background worker names was tried twice there and lost twice.
+
+    Pinning to the TEST's thread id instead does not work and is worth recording
+    — it was tried here first. The handler is `def`, so FastAPI runs it in that
+    threadpool rather than on the caller, which means an ident match excludes
+    every read the request makes and turns this into a green assertion about
+    nothing. It was caught by moving the builtin gate out of the transaction and
+    watching the test stay green.
+
+    **This assertion is satisfied by an empty list, and that is intended**: a
+    correct `forget_models` makes NO `hub.fetchall` call at all, because every
+    read it needs happens on the transaction's own connection. So there is no
+    in-test way to prove the allowlist still matches — an added "we saw at least
+    one" check fails on correct code. Liveness is proved by the N+1 guard above,
+    which uses the same prefix and asserts an exact count, so a renamed
+    threadpool goes red there rather than silently emptying this."""
     alice = shelf_env.model_ids["alice.safetensors"]
     _set_states(shelf_env, alice, "missing")
 
     hub = shelf_env.server.hub
     original = hub.fetchall
     outside: list[str] = []
+    request_thread_prefix = "AnyIO worker thread"
 
     def counting(sql, params=()):
-        if "model" in sql:
+        if "model" in sql and threading.current_thread().name.startswith(
+            request_thread_prefix
+        ):
             outside.append(sql)
         return original(sql, params)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,28 +38,59 @@ def poll_until_zero(
     )
 
 
-def wait_for_import_task(client, task_id, timeout_s=10, poll_interval=0.1):
+def wait_for_import_task(client, task_id, timeout_s=30, poll_interval=0.1):
+    """Poll ``GET /pictures/import/status`` until the task settles.
+
+    **30s, not 10s, and the number follows from what is actually being waited
+    on.** The import runs on a detached executor thread, but the write inside it
+    goes through ``vault.db.run_task``, which queues onto the *single* DB worker.
+    So this bounds "the DB queue drained far enough to run my write", not "the
+    import worked — and in a test that imports twenty-one pictures in a loop,
+    each iteration queues behind the tagging and embedding writes of the ones
+    before it. At 10s that was a wall-clock race the loaded Windows shards lost
+    (`test_server.py::test_semantic_search`, run 31481874866): a timeout there
+    said nothing about the import and everything about how busy the queue was.
+    30s matches ``wait_for_faces``, which waits on the same kind of queued work.
+
+    A genuinely hung import now takes 30s to report instead of 10s, which is why
+    the message below carries the last status and the elapsed time: a hang and a
+    slow queue must not read the same.
+    """
     start = time.time()
+    status = None
+    payload = None
     while time.time() - start < timeout_s:
         status_resp = client.get(
             f"{API_PREFIX}/pictures/import/status", params={"task_id": task_id}
         )
         assert status_resp.status_code == 200, f"Error: {status_resp.text}"
-        status_payload = status_resp.json()
-        status = status_payload.get("status")
+        payload = status_resp.json()
+        status = payload.get("status")
         if status in {"completed", "failed"}:
-            return status_payload
+            return payload
         time.sleep(poll_interval)
-    raise AssertionError(f"Import task did not complete in {timeout_s}s")
+    raise AssertionError(
+        f"Import task did not complete in {timeout_s}s "
+        f"(waited {time.time() - start:.1f}s, last status {status!r}, "
+        f"processed {(payload or {}).get('processed')!r} of "
+        f"{(payload or {}).get('total')!r})"
+    )
 
 
 def upload_pictures_and_wait(
     client,
     files,
-    timeout_s=10,
+    timeout_s=30,
     poll_interval=0.1,
     form_data=None,
 ):
+    """Upload and wait for the import to settle.
+
+    The default tracks :func:`wait_for_import_task`'s deliberately — this is the
+    wrapper almost every caller actually uses (including the loop in
+    `test_semantic_search` that flaked), so leaving it at 10 would have kept the
+    old bound in place everywhere while looking fixed.
+    """
     kwargs = {"files": files}
     if form_data:
         kwargs["data"] = form_data


### PR DESCRIPTION
Two flakes found while landing #876/#878/#879, neither belonging in a feature PR. Both fixed at the cause rather than retried.

## 1. `test_semantic_search` — the import wait bounded the wrong thing

**Symptom:** `AssertionError: Import task did not complete in 10s` on `backend-windows shard 2`. It cost a re-run on #876. No HuggingFace 429s in the log, so not the rate-limit flake.

**Cause:** `run_import_task` runs on a detached executor thread, but the write inside it goes through `vault.db.run_task`, which queues onto the **single DB worker**. So the 10s bounded "the DB queue drained far enough to run my write", not "the import worked". `test_semantic_search` imports 21 pictures **one at a time in a loop**, so by the tenth iteration each import is queued behind the tagging and embedding writes of every picture before it. That is not a slow machine; it is the wrong measurement.

**Fix:** 30s, matching `wait_for_faces`, which waits on the same kind of queued work. Both `wait_for_import_task` and `upload_pictures_and_wait` — the latter deliberately, because it is the wrapper nearly every caller actually uses (including the loop that flaked), so leaving it at 10 would have kept the old bound everywhere while looking fixed.

A genuinely hung import now takes 30s to report instead of 10s, so the message carries the last status and the elapsed time: a hang and a slow queue must not read the same.

## 2. `test_forget_reads_its_gate_inside_the_write_transaction` — the counter caught everyone

**Symptom:** intermittent failure with a diagnostic pointing at the forget, which had done nothing wrong. Measured red once in four runs of a loaded four-file combination.

**Cause:** it patches `hub.fetchall` on the **shared, module-scoped server**, so every caller in the process goes through it — including background finders. `MissingCheckpointHashFinder` queries `model` on the hub in both `progress()` and `find_task()`, so a sweep landing inside the request window put its SQL in the list.

**Fix:** filter to the request's own threadpool, using the `"AnyIO worker thread"` allowlist that the N+1 guard directly above it already uses — where a denylist of worker names was tried twice and lost twice.

**One wrong turn, recorded in the docstring because it is the interesting part.** I first pinned to the *test's* thread id. That is wrong: the handler is `def`, so FastAPI runs it in the threadpool rather than on the caller, and the filter matched nothing — turning the test into a green assertion about nothing. It was caught by mutating `forget_models` to read its gate outside the transaction and watching the test stay **green**.

Also recorded: this assertion is satisfied by an *empty* list on purpose, because a correct `forget_models` makes no `hub.fetchall` call at all — every read it needs is on the transaction's own connection. So there is no in-test liveness check to add; one was tried and fails on correct code. A renamed threadpool goes red in the N+1 guard beside it, which asserts an exact count.

## Verification

- Mutation-checked: moving the builtin gate outside the transaction turns the forget test **red**, and restoring it green.
- The background-sweep exclusion proved directly against the real worker names (`CHECKPOINT_HASH-cpu-0`, `CHECKPOINT_HASH-gpu`, `model-folder-rescan`): none counted, while an `AnyIO worker thread` read still is.
- **165 tests pass** across `test_model_shelf_api.py`, `test_import_scrapheap_match.py` and `test_picture_sets.py` — the last two chosen because they exercise the changed shared helper.
- `tests/utils.py` has 152 call sites; a longer bound can only fail later, never sooner, so no caller changes behaviour on success.

https://claude.ai/code/session_01PYbmp1GkvEqEM8zA2qN3bh