### PR TITLE
The icon verb's frontend: marks, and setting them

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1712,6 +1712,50 @@ that is about to be wrong; a veil that only *looks* disabled leaves every row
 clickable and in the tab order, which is worse than none. The toolbar stays
 live, because Show and Sort still answer correctly while files are in flight.
 
+#### The icon verb, on the shelf
+
+**Unset is never blank.** The identity column used to be a bare kind glyph, so
+every checkpoint row and the 37% of adapters carrying no title rendered
+identically — the blank column the icon verb exists to fill. `ModelMark` draws
+the row's icon if it has one, else a generated mark.
+
+**The mark is a pure function of the row**, and deliberately not
+`character_color`'s rule. Characters take the *first unused* colour, which needs
+a bounded set and a moment of assignment; models are unbounded and have neither,
+and a mark that shifted when a neighbour was deleted would be worse than no
+mark. So the colour is `SET_COLORS[hash(foldedBaseModel) % 48]` and the initials
+come from the same name chain the row's label uses. **The two rules must not be
+unified**, however similar the palettes look.
+
+Keyed on the **folded** base model, so every spelling of FLUX.2 lands on one
+colour instead of scattering across the palette — which is what the folding
+table is for. A row recording no base model hashes on the empty string and
+shares one colour with every other unset row: correct, because they are one
+group, and the shelf already treats "not set" as a value rather than an absence.
+
+The mark is `aria-hidden`: the row's accessible name already says which model it
+is, and a mark announcing "FL" would be the same fact twice, less usefully.
+
+**Set is single-row, clear is bulk.** An icon answers "which one is this?", so
+giving forty rows one mark would remove the only thing telling them apart — Set
+icon is gated to a selection of one, shown-and-disabled like Rename. Clear
+appears only when something in the selection has one. Setting or clearing a
+single row prompts for nothing (both are reconstructable by doing them again); a
+**bulk** clear is not and confirms, the same test the bulk base-model overwrite
+falls on.
+
+**One upload path.** The picker is a real `<input type="file">` — the platform's
+own chooser, keyboard-accessible for free — and the client posts the bytes. That
+is what makes "pick a library picture" a *copy* rather than a reference into the
+vault, which is the constraint the hub/vault split imposes.
+
+**The sample/icon view toggle is NOT built, and cannot be yet.** The ruling
+defines two fallback chains (sample → icon → mark, and icon → mark), but the
+shelf's payload carries **no sample field at all** — not on `ModelResponse`, not
+on the `model` table. Both settings would therefore render identically, so the
+toggle would be a control that does nothing. It needs a sample source on the
+shelf row first.
+
 #### Stacks (F5)
 
 **A run is one row, and the fold happens client-side.** The list query returns

--- a/frontend/src/api/modelIcons.js
+++ b/frontend/src/api/modelIcons.js
@@ -1,0 +1,57 @@
+// The model shelf's icon store — /models/{id}/icon, /model-icons/{sha256}.
+//
+// An icon is what a model IS: authored, singular, chosen once. It is not a
+// sample, which is what a model produces. The store is content-addressed, so
+// forty models given one logo share one file and one cached response.
+
+import { apiClient } from "../utils/apiClient";
+import { unwrap } from "../utils/unwrap";
+
+/**
+ * The URL of one stored icon, for an `<img src>`.
+ *
+ * Addressed by CONTENT hash rather than by model id, which is the point: every
+ * row sharing a mark resolves to one URL, so the browser fetches and caches it
+ * once however many rows are on screen.
+ *
+ * @param {string} sha256
+ * @returns {string}
+ */
+export function modelIconUrl(sha256) {
+  const base = apiClient.defaults.baseURL || "";
+  return `${base}/model-icons/${encodeURIComponent(sha256)}`;
+}
+
+/**
+ * Set a model's icon from image bytes.
+ *
+ * The single write path for all three ways of choosing one — uploading a file,
+ * picking a library picture, promoting a sample — because all three produce the
+ * same thing: bytes in the store and a hash in the column. Picking a picture
+ * therefore sends the *pixels*, which is what makes the icon a copy rather than
+ * a reference into the vault.
+ *
+ * @param {number} modelId
+ * @param {File|Blob} file - PNG, JPEG or WebP. Checked server-side by magic
+ *   bytes, not by name or declared type.
+ * @returns {Promise<{model_id: number, icon_sha256: string}>}
+ */
+export async function setModelIcon(modelId, file) {
+  const form = new FormData();
+  form.append("file", file);
+  return unwrap(apiClient.post(`/models/${modelId}/icon`, form));
+}
+
+/**
+ * Clear the icon on one or more models.
+ *
+ * The stored file is deliberately left on disk: the store is shared, so another
+ * model may name the same hash. The response reports what actually changed, not
+ * what was sent.
+ *
+ * @param {Array<number>} ids
+ * @returns {Promise<{cleared: Array<number>}>}
+ */
+export async function clearModelIcons(ids) {
+  return unwrap(apiClient.post("/models/icons/clear", { ids }));
+}

--- a/frontend/src/components/panels/ShelfSelectionBar.vue
+++ b/frontend/src/components/panels/ShelfSelectionBar.vue
@@ -77,6 +77,31 @@
       @detach="onAttach($event, false)"
     />
 
+    <!-- An icon answers "which one is this?", so it is single-row by nature:
+         giving forty rows one mark would remove the only thing telling them
+         apart. Shown and disabled rather than hidden, like Rename. -->
+    <AppButton
+      size="sm"
+      variant="secondary"
+      icon-left="image-outline"
+      :disabled="store.selectedRows.length !== 1"
+      :title="iconTitle"
+      @click="emit('set-icon')"
+    >
+      Set icon
+    </AppButton>
+
+    <AppButton
+      v-if="withIcons.length"
+      size="sm"
+      variant="secondary"
+      icon-left="image-off-outline"
+      :title="clearIconTitle"
+      @click="emit('clear-icons')"
+    >
+      Clear icon
+    </AppButton>
+
     <!-- Move is the keyboard path to what a drag does. The shelf's definition
          of done requires every verb to be reachable without a pointer, and a
          drag is not; it is also where the move is stated in files, bytes and
@@ -135,6 +160,8 @@ const emit = defineEmits([
   "rename",
   "set-base-model",
   "set-kind",
+  "set-icon",
+  "clear-icons",
   "move",
   "forget",
 ]);
@@ -264,6 +291,23 @@ const moveTitle = computed(() => {
   return `Move ${n.toLocaleString()} ${n === 1 ? "file" : "files"} into another folder`;
 });
 
+/** The selected models that actually have an icon to clear. */
+const withIcons = computed(() =>
+  store.selectedRows.filter((row) => row.icon_sha256),
+);
+
+const iconTitle = computed(() =>
+  store.selectedRows.length === 1
+    ? "Give this model a mark of its own"
+    : "Select one model to give it an icon",
+);
+
+const clearIconTitle = computed(() =>
+  withIcons.value.length === 1
+    ? "Clear this model's icon"
+    : `Clear the icon on ${withIcons.value.length} models`,
+);
+
 function onAttach(payload, attach) {
   return store.setAttachment({ ...payload, attach });
 }
@@ -272,7 +316,7 @@ function clear() {
   store.clearSelection();
 }
 
-defineExpose({ forgettable, assignable, membership, movable });
+defineExpose({ forgettable, assignable, membership, movable, withIcons });
 </script>
 
 <style scoped>

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -1158,6 +1158,49 @@ describe("a run's disclosure", () => {
   });
 });
 
+describe("the icon verb", () => {
+  it("offers Set icon for one model and refuses it for two", async () => {
+    const wrapper = await mountShelf([
+      adapter({ id: 1 }),
+      adapter({ id: 2, sha256: "b".repeat(64) }),
+    ]);
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+    const setIcon = () =>
+      wrapper.findAll("button").find((b) => b.text().includes("Set icon"));
+    expect(setIcon().attributes("disabled")).toBeUndefined();
+
+    store.toggleSelected(2);
+    await wrapper.vm.$nextTick();
+    expect(setIcon().attributes("disabled")).toBeDefined();
+  });
+
+  it("offers Clear icon only when something has one", async () => {
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+    const clear = () =>
+      wrapper.findAll("button").find((b) => b.text().includes("Clear icon"));
+    expect(clear()).toBeUndefined();
+
+    store.rows = [adapter({ id: 1, icon_sha256: "a".repeat(64) })];
+    await wrapper.vm.$nextTick();
+    expect(clear()).toBeDefined();
+  });
+
+  it("accepts only the image types the store will take", async () => {
+    // The server checks magic bytes, but the picker should not offer a file it
+    // is going to refuse.
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const input = wrapper.find('input[type="file"]');
+    expect(input.attributes("accept")).toBe(
+      "image/png,image/jpeg,image/webp",
+    );
+  });
+});
+
 describe("Escape", () => {
   it("clears the selection from anywhere in the shelf, not only from a row", async () => {
     // It used to be handled on the row, so it only worked while a row held the

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -389,7 +389,13 @@
                     v-if="row.memberCount > 1"
                     :count="row.memberCount"
                   />
-                  <v-icon size="16">{{ KIND_ICON[row.file_kind] }}</v-icon>
+                  <!-- The identity slot: the model's icon if it has one, else a
+                       generated mark. Never the bare kind glyph on its own —
+                       every checkpoint row and 37% of adapter rows would then
+                       be visually identical, which is the blank column the
+                       icon verb exists to fill. The kind is still said on the
+                       metadata line below, so nothing is lost by the swap. -->
+                  <ModelMark :row="row" />
                 </span>
                 <span class="shelf-row-label">
                   <span
@@ -513,6 +519,7 @@ import ShelfMoveDialog from "../panels/ShelfMoveDialog.vue";
 import ModelFoldersDialog from "../panels/ModelFoldersDialog.vue";
 import ModelImportDialog from "../panels/ModelImportDialog.vue";
 import ShelfStackProposalsDialog from "../panels/ShelfStackProposalsDialog.vue";
+import ModelMark from "../widgets/ModelMark.vue";
 import ProgressOverlay from "../widgets/ProgressOverlay.vue";
 import StackEdgeTicks from "../widgets/StackEdgeTicks.vue";
 import { useConfirm } from "../../composables/useConfirm";

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -178,7 +178,22 @@
       @set-base-model="editVerb = 'base-model'"
       @set-kind="editVerb = 'kind'"
       @move="openMove(store.selectedRows)"
+      @set-icon="pickIcon"
+      @clear-icons="confirmClearIcons"
       @forget="confirmForget"
+    />
+
+    <!-- The file picker the Set icon button drives. A real <input type=file>
+         rather than a drop zone or a dialog: it is the platform's own chooser,
+         it is keyboard-accessible for free, and picking a file is the whole
+         interaction. Hidden rather than styled, because the button beside it
+         is already the affordance. -->
+    <input
+      ref="iconInputRef"
+      class="visually-hidden"
+      type="file"
+      accept="image/png,image/jpeg,image/webp"
+      @change="onIconChosen"
     />
 
     <!-- `inert` while a move runs, not merely dimmed. A move repoints
@@ -744,6 +759,50 @@ function onShelfEscape(event) {
   if (!store.selectedRows.length) return;
   event.preventDefault();
   store.clearSelection();
+}
+
+// ── The icon verb ───────────────────────────────────────────────────────────
+
+const iconInputRef = ref(null);
+
+function pickIcon() {
+  // Cleared first, so choosing the SAME file twice still fires `change` — the
+  // obvious way to retry after a refusal, and silent if the value persisted.
+  if (iconInputRef.value) iconInputRef.value.value = "";
+  iconInputRef.value?.click();
+}
+
+async function onIconChosen(event) {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  await store.setIconOnSelected(file);
+}
+
+/**
+ * Clearing one row needs no prompt; clearing a selection does.
+ *
+ * The shelf's rule is to confirm only where the prior state cannot be
+ * reconstructed. One icon is one file-picker away from back; a bulk clear is
+ * not, and falls on the same side of that test as the bulk base-model
+ * overwrite. Counted on the rows that HAVE one, because that is what the verb
+ * will actually destroy.
+ */
+async function confirmClearIcons() {
+  const withIcons = store.selectedRows.filter((row) => row.icon_sha256);
+  if (!withIcons.length) return;
+  if (withIcons.length > 1) {
+    const ok = await confirm({
+      title: `Clear ${withIcons.length} icons?`,
+      message:
+        "Those models go back to a generated mark. The images stay in the " +
+        "icon store, but which model wore which is not recorded anywhere else.",
+      warning: "There is no undo for this.",
+      confirmLabel: "Clear them",
+      danger: true,
+    });
+    if (!ok) return;
+  }
+  await store.clearIconsOnSelected();
 }
 
 // ── Stacks (shelf plan F5) ──────────────────────────────────────────────────

--- a/frontend/src/components/widgets/ModelMark.test.js
+++ b/frontend/src/components/widgets/ModelMark.test.js
@@ -1,0 +1,77 @@
+// The shelf's identity slot.
+//
+// The assertion worth having is that it is NEVER blank: a checkpoint has no
+// sample by construction, and 37% of real adapters carry no title, so the
+// generated mark is the common path rather than the fallback.
+
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+vi.mock("../../api/modelIcons", () => ({
+  modelIconUrl: (sha) => `/api/v1/model-icons/${sha}`,
+}));
+
+import ModelMark from "./ModelMark.vue";
+
+function row(overrides = {}) {
+  return {
+    display_name: "Cyanwood Style",
+    filename: "Cyanwood_Style_000000250.safetensors",
+    base_model: "flux.1-dev",
+    icon_sha256: null,
+    ...overrides,
+  };
+}
+
+const mountMark = (props) => mount(ModelMark, { props: { row: row(props) } });
+
+describe("ModelMark", () => {
+  it("draws the icon when there is one", () => {
+    const wrapper = mountMark({ icon_sha256: "a".repeat(64) });
+    expect(wrapper.find("img").attributes("src")).toContain("a".repeat(64));
+    expect(wrapper.find(".mmark-initials").exists()).toBe(false);
+  });
+
+  it("is never blank without one", () => {
+    const wrapper = mountMark();
+    expect(wrapper.find("img").exists()).toBe(false);
+    expect(wrapper.find(".mmark-initials").text()).toBe("CS");
+  });
+
+  it("still marks a row with no name at all", () => {
+    // `000002750.safetensors` strips to nothing, so the name chain falls back
+    // to the raw filename — the mark has to survive that too.
+    const wrapper = mountMark({
+      display_name: null,
+      filename: "000002750.safetensors",
+    });
+    expect(wrapper.find(".mmark-initials").text()).not.toBe("");
+  });
+
+  it("gives every spelling of one base model the same colour", () => {
+    // The whole reason the mark keys on the FOLDED value: four spellings of
+    // FLUX.2 scattering across the palette would defeat the point of a mark.
+    const a = mountMark({ base_model: "FLUX.2", base_model_folded: "flux.2" });
+    const b = mountMark({ base_model: "flux 2", base_model_folded: "flux.2" });
+    expect(a.find(".mmark-initials").attributes("style")).toBe(
+      b.find(".mmark-initials").attributes("style"),
+    );
+  });
+
+  it("is stable for one row and does not depend on its neighbours", () => {
+    // `character_color` takes the first UNUSED colour, which needs a bounded
+    // set and a moment of assignment. A model's mark is a pure function of the
+    // row, so deleting a neighbour cannot change it.
+    const first = mountMark().find(".mmark-initials").attributes("style");
+    const again = mountMark().find(".mmark-initials").attributes("style");
+    expect(first).toBe(again);
+  });
+
+  it("does not announce itself, because the row already says the name", () => {
+    // Found by class rather than through the wrapper root: `attributes()` on
+    // the wrapper read undefined here, so a bare `.toContain("aria-hidden")`
+    // would have been a substring match on the whole subtree rather than a
+    // statement about this element.
+    expect(mountMark().find(".mmark").attributes("aria-hidden")).toBe("true");
+  });
+});

--- a/frontend/src/components/widgets/ModelMark.vue
+++ b/frontend/src/components/widgets/ModelMark.vue
@@ -1,0 +1,94 @@
+<template>
+  <!-- One slot, two possible fills, and never a blank. `aria-hidden` because
+       the row's own accessible name already says which model this is: a mark
+       that also announced "FL" would be the same fact twice, less usefully. -->
+  <span
+    class="mmark"
+    :class="{ 'mmark--generated': !iconUrl }"
+    aria-hidden="true"
+  >
+    <img
+      v-if="iconUrl"
+      class="mmark-img"
+      :src="iconUrl"
+      alt=""
+      loading="lazy"
+    />
+    <span
+      v-else
+      class="mmark-initials"
+      :style="{ backgroundColor: mark.color }"
+    >
+      {{ mark.initials }}
+    </span>
+  </span>
+</template>
+
+<script setup>
+// The shelf's identity slot (shelf plan, the sixth verb).
+//
+// **Unset is never blank.** PixlStash generates no sample for a checkpoint — it
+// registers one in place, possibly at 24 GB — and 37% of real adapters carry no
+// title, base model or trigger either, so an empty slot is the common case
+// rather than the edge one. A row with no icon draws a generated mark computed
+// at render from the row itself.
+//
+// The colour is keyed on a HASH of the folded base model, deliberately not on
+// the first-unused rule `character_color` uses: models are unbounded and have no
+// moment of assignment, and a mark that shifted when a neighbour was deleted
+// would be worse than no mark. See `generatedMark`.
+
+import { computed } from "vue";
+
+import { modelIconUrl } from "../../api/modelIcons";
+import { generatedMark } from "../../utils/modelShelf";
+
+const props = defineProps({
+  /**
+   * A shelf row. Only `icon_sha256`, the base-model fields, `display_name` and
+   * `filename` are read.
+   */
+  row: { type: Object, required: true },
+});
+
+const iconUrl = computed(() =>
+  props.row?.icon_sha256 ? modelIconUrl(props.row.icon_sha256) : "",
+);
+
+const mark = computed(() => generatedMark(props.row));
+</script>
+
+<style scoped>
+.mmark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--entity-thumb);
+  height: var(--entity-thumb);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  flex: 0 0 auto;
+}
+
+.mmark-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* The initials carry their own colour from the frozen 48, so the contrast pair
+   is fixed rather than themed: a mark that inverted with the theme would be a
+   different mark for the same model. */
+.mmark-initials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: #fff;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.02em;
+}
+</style>

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -1,5 +1,6 @@
 import { computed, onScopeDispose, reactive, ref } from "vue";
 import { defineStore } from "pinia";
+import { clearModelIcons, setModelIcon } from "../api/modelIcons";
 import {
   BASE_MODEL_UNASSIGNED,
   editModels,
@@ -998,6 +999,75 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
     return done > 0;
   }
 
+  /**
+   * Give one model an icon.
+   *
+   * Single-row by nature, and gated that way in the bar: an icon answers
+   * "which one is this?", so giving forty rows the same mark would remove the
+   * only thing telling them apart. (Two models legitimately SHARING a logo is
+   * different — that is the owner setting each one, and the content-addressed
+   * store then keeps one file.)
+   *
+   * No confirmation: setting an icon is reconstructable by setting it again.
+   *
+   * @param {File|Blob} file
+   * @returns {Promise<boolean>} true when the icon landed.
+   */
+  async function setIconOnSelected(file) {
+    const notices = useNoticeStore();
+    const row = selectedRows.value[0];
+    if (!row || !file) return false;
+    try {
+      await setModelIcon(row.id, file);
+      await fetchRows();
+      notices.push({
+        level: "success",
+        text: `Set the icon on ${row.name.text}.`,
+      });
+      return true;
+    } catch (err) {
+      notices.push({
+        level: "error",
+        text: errorDetail(err) || "Could not set that icon.",
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Clear the icon on the selection.
+   *
+   * The caller confirms a BULK clear: one row is reconstructable by setting it
+   * again, and a selection is not — the same test the bulk base-model overwrite
+   * falls on. The server reports which rows actually had one, so the receipt
+   * says what changed rather than how many ids were sent.
+   *
+   * @returns {Promise<boolean>} true when the call was made.
+   */
+  async function clearIconsOnSelected() {
+    const notices = useNoticeStore();
+    const ids = selectedModelIds.value;
+    if (!ids.length) return false;
+    try {
+      const body = await clearModelIcons(ids);
+      await fetchRows();
+      const cleared = body?.cleared?.length ?? 0;
+      notices.push({
+        level: cleared ? "success" : "info",
+        text: cleared
+          ? `Cleared the icon on ${modelCount(cleared)}.`
+          : "None of those had an icon.",
+      });
+      return true;
+    } catch (err) {
+      notices.push({
+        level: "error",
+        text: errorDetail(err) || "Could not clear those icons.",
+      });
+      return false;
+    }
+  }
+
   function resetForSession() {
     epoch += 1;
     rows.value = [];
@@ -1045,6 +1115,8 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
     clearSelection,
     editSelected,
     forgetSelected,
+    setIconOnSelected,
+    clearIconsOnSelected,
     selectedModelIds,
     setAttachment,
     rows,

--- a/frontend/src/stores/useModelShelfStore.test.js
+++ b/frontend/src/stores/useModelShelfStore.test.js
@@ -14,6 +14,8 @@ const listCheckpoints = vi.fn();
 const editModels = vi.fn();
 const forgetModels = vi.fn();
 const setAdapterAttachments = vi.fn();
+const setModelIcon = vi.fn();
+const clearModelIcons = vi.fn();
 
 vi.mock("../api/modelShelf", () => ({
   BASE_MODEL_UNASSIGNED: "UNASSIGNED",
@@ -22,6 +24,12 @@ vi.mock("../api/modelShelf", () => ({
   editModels: (...args) => editModels(...args),
   forgetModels: (...args) => forgetModels(...args),
   setAdapterAttachments: (...args) => setAdapterAttachments(...args),
+}));
+
+vi.mock("../api/modelIcons", () => ({
+  setModelIcon: (...args) => setModelIcon(...args),
+  clearModelIcons: (...args) => clearModelIcons(...args),
+  modelIconUrl: (sha) => `/api/v1/model-icons/${sha}`,
 }));
 
 import {
@@ -885,6 +893,59 @@ describe("Assign", () => {
     expect(notice.text).toBe(
       "Assigned 1 model to Alice. 1 model could not be written.",
     );
+  });
+});
+
+describe("the icon verb", () => {
+  beforeEach(() => {
+    setModelIcon.mockReset().mockResolvedValue({ icon_sha256: "a".repeat(64) });
+    clearModelIcons.mockReset().mockResolvedValue({ cleared: [] });
+    listAdapters.mockResolvedValue([]);
+    listCheckpoints.mockResolvedValue([]);
+  });
+
+  it("sets the icon on the one selected model", async () => {
+    const store = useModelShelfStore();
+    store.rows = [adapter({ id: 1 })];
+    store.toggleSelected(1);
+    const file = new Blob(["x"], { type: "image/png" });
+
+    expect(await store.setIconOnSelected(file)).toBe(true);
+    expect(setModelIcon).toHaveBeenCalledWith(1, file);
+  });
+
+  it("does nothing without a file, rather than posting an empty body", async () => {
+    const store = useModelShelfStore();
+    store.rows = [adapter({ id: 1 })];
+    store.toggleSelected(1);
+    expect(await store.setIconOnSelected(null)).toBe(false);
+    expect(setModelIcon).not.toHaveBeenCalled();
+  });
+
+  it("reports what the clear changed, not what was sent", async () => {
+    // A selection of two where one had an icon is "1 model", not "2".
+    const store = useModelShelfStore();
+    store.rows = [
+      adapter({ id: 1, icon_sha256: "a".repeat(64) }),
+      adapter({ id: 2, sha256: "b".repeat(64) }),
+    ];
+    store.toggleSelected(1);
+    store.toggleSelected(2);
+    clearModelIcons.mockResolvedValue({ cleared: [1] });
+
+    await store.clearIconsOnSelected();
+    expect(clearModelIcons).toHaveBeenCalledWith([1, 2]);
+    expect(useNoticeStore().notices.at(-1).text).toBe(
+      "Cleared the icon on 1 model.",
+    );
+  });
+
+  it("says so plainly when none of them had one", async () => {
+    const store = useModelShelfStore();
+    store.rows = [adapter({ id: 1 })];
+    store.toggleSelected(1);
+    await store.clearIconsOnSelected();
+    expect(useNoticeStore().notices.at(-1).text).toContain("None of those");
   });
 });
 

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -10,6 +10,8 @@
 //   * A missing value is still rendered. "Base model not set" occupies the same
 //     slot in the same type as a real value; a blank cell is the failure mode.
 
+import { SET_COLORS } from "./setAppearance";
+
 /** Trailing tokens that record where in a training run a file was saved.
  *
  * Mirrors `_TRAINING_SUFFIX_RE` in `pixlstash/utils/model_utils.py`. The
@@ -557,4 +559,59 @@ export function trainingStep(filename) {
   if (!last || !TRAINING_SUFFIX_RE.test(last)) return null;
   const digits = last.replace(/\D/g, "");
   return digits ? Number(digits) : null;
+}
+
+/**
+ * A stable 32-bit hash of a string. FNV-1a, which is small and has no
+ * dependencies; nothing here is security-sensitive, only stable.
+ */
+function hash32(text) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+/** Up to two initials for a mark, from whatever the row is actually called. */
+function initialsOf(text) {
+  const words = String(text || "")
+    .split(/[\s_\-.]+/)
+    .filter(Boolean);
+  if (!words.length) return "?";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}
+
+/**
+ * The mark a model wears when it has no icon.
+ *
+ * **Unset is never blank.** A checkpoint never has a sample — PixlStash
+ * registers it in place and generates nothing for it — and 37% of real adapters
+ * carry no title, base model or trigger either, so an empty identity slot is
+ * the common case rather than the edge one.
+ *
+ * **Computed at render from a hash, and deliberately NOT the rule characters
+ * use.** `character_color` takes the *first unused* colour from this same list,
+ * which needs a bounded set and a moment of assignment. Models are unbounded
+ * and have no such moment, and a mark that shifted when a neighbour was deleted
+ * would be worse than no mark — so this is a pure function of the row. The two
+ * must not be unified, however similar the palettes look.
+ *
+ * **Keyed on the FOLDED base model**, so every spelling of FLUX.2 lands on one
+ * colour instead of scattering across the palette — which is the whole reason
+ * the folding table exists. A row recording no base model hashes on the empty
+ * string and so shares one colour with every other unset row: correct, because
+ * they genuinely are one group, and the shelf already treats "not set" as a
+ * value rather than an absence.
+ *
+ * @param {Object} row - a shelf row.
+ * @returns {{color: string, initials: string}}
+ */
+export function generatedMark(row) {
+  const key = baseModelKey(row);
+  const color = SET_COLORS[hash32(key) % SET_COLORS.length].value;
+  const name = modelName(row);
+  return { color, initials: initialsOf(name.text) };
 }


### PR DESCRIPTION
The frontend half of the icon verb, on top of #882's backend.

## Unset is never blank

The identity column was a bare kind glyph, so **every checkpoint row and the 37% of adapters carrying no title rendered identically** — the blank column the icon verb exists to fill. `ModelMark` draws the row's icon if it has one, else a generated mark.

## The mark is a pure function of the row

Colour is `SET_COLORS[hash(foldedBaseModel) % 48]` over the same frozen list sets already use; initials come from the same name chain as the row's label.

**Deliberately not `character_color`'s rule.** Characters take the *first unused* colour, which needs a bounded set and a moment of assignment. Models are unbounded and have neither — and a mark that shifted when a neighbour was deleted would be worse than no mark. The ruling is explicit that the two must not be unified, however similar the palettes look, and the tests pin both halves: same folded base model → same colour, and the same row → the same colour regardless of what else is on the shelf.

Keyed on the **folded** value, so every spelling of FLUX.2 lands on one colour rather than scattering — which is what the folding table is for. Rows recording no base model share one colour, which is correct: they are one group, and the shelf already treats "not set" as a value.

The mark is `aria-hidden` — the row's accessible name already says which model it is.

## Set is single-row, clear is bulk

An icon answers "which one is this?", so giving forty rows one mark removes the only thing telling them apart: **Set icon is gated to a selection of one**, shown-and-disabled like Rename. **Clear icon appears only when something selected has one.**

Per the no-undo rule, setting or clearing a single row prompts for nothing — both are reconstructable by doing them again. A **bulk** clear is not, and confirms, on the same test as the bulk base-model overwrite. The confirmation counts the rows that actually have an icon, since that is what the verb destroys.

The picker is a real `<input type="file">`: the platform's own chooser, keyboard-accessible for free. The client posts the **bytes**, which is what makes "pick a library picture" a copy rather than a reference into the vault.

## What is NOT here, and why

**The sample/icon view toggle cannot be built yet.** The ruling defines two fallback chains — sample → icon → mark, and icon → mark — but I checked, and the shelf's payload carries **no sample field at all**: not on `ModelResponse`, not on the `model` table, not in `MODEL_COLUMNS`. Both toggle settings would render identically, so it would be a control that does nothing. It needs a sample source on the shelf row first, which is its own piece of work.

So this PR ships the half of the chain that has data: **icon → generated mark**, in both the row and (once a toggle exists) what would be icon view.

Also absent, and unchanged from the backend PR: no third-party logo assets are bundled, per the ruling.

## Verification

- **2927 tests pass** across 166 files.
- Three mutations checked, each with the edit proved present first: keying the mark on the raw base model instead of the folded one (1 red), allowing Set icon on a multi-row selection (1 red), and reporting the ids sent instead of what the clear changed (2 red).
- One test of mine was weaker than it looked and got fixed: `wrapper.attributes("aria-hidden")` read `undefined`, and my first repair was `.toContain("aria-hidden")` — a substring match over the whole subtree. It now finds the element by class and asserts the attribute on it.

https://claude.ai/code/session_01PYbmp1GkvEqEM8zA2qN3bh