### PR TITLE
Open hub write transactions with BEGIN IMMEDIATE

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -167,10 +167,28 @@ Decompose by domain first, then fan out. **Independent** sub-tasks should run co
 
 - **Install dependencies:** `pip install -e .`
 - **Run server:** `python -m pixlstash.app`
-- **Run tests:** `python -m pytest -s -vvv --fast-captions --force-cpu`
+- **Run tests:** `python -m pytest -s -vvv --fast-captions`
 - **Check formatting:** `ruff check pixlstash`
 - **Build frontend:** `npm run build` (in `frontend/`)
 - **Dev frontend:** `npm run dev` (in `frontend/`)
+
+### Do not pass `--force-cpu` locally
+
+**`--force-cpu` is a CI flag, not a local one.** The gate passes it in
+`PYTEST_FLAGS` (`.github/workflows/ci.yml`) because GitHub's runners have no
+GPU. A development box here does, and forcing CPU inference throws it away:
+every model in the suite runs on the CPU instead, for no coverage that the GPU
+path does not already give.
+
+Copying the CI invocation verbatim is the easy mistake, and this file used to
+invite it by listing the flag under **Run tests**.
+
+**Also do not run the whole suite in one local process.** The gate shards it
+eight ways for a reason (`--ci-shard N/8`), and a single serial `pytest tests/`
+does all eight shards' work. Run the files your change actually touches and let
+the sharded gate cover the rest. When a change is to something shared enough
+that "the files it touches" is most of the suite, shard it locally the same way
+CI does rather than waiting on one process.
 
 ## Never open a PR onto another PR
 
@@ -259,6 +277,38 @@ The corollary for anyone orchestrating parallel agents: per-agent instructions
 bound each agent's diff, and nothing bounds the *aggregate*. Counting the PRs
 across all in-flight lanes is the orchestrator's job, and it is the one that was
 not being done when the number reached 13.
+
+## Answering a review: reply and resolve, don't just push a fix
+
+**Addressing a review comment is three acts, not one: push the fix, reply on the
+thread, resolve the thread.** A fix pushed in silence is invisible as an answer.
+The reviewer is left with an open thread and a changed file, and has to
+reconstruct whether the two are related, which is the work they asked you to do.
+
+- **Reply on each thread**, naming the commit and what actually changed:
+  `gh api repos/OWNER/REPO/pulls/N/comments/<comment_id>/replies -f body=...`
+- **Then resolve it.** Only GraphQL can:
+  `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<id>"}) { thread { isResolved } } }'`
+  Thread ids come from `pullRequest(number: N) { reviewThreads(first: 20) { nodes { id isResolved path comments(first: 1) { nodes { databaseId body } } } } }`.
+- **Resolving without replying is worse than leaving it open**, because it reads
+  as answered. Never resolve a thread you did not act on.
+- **Disagreeing is a reply, not a silence.** If the comment is wrong, or the fix
+  is deliberately different from what it asked for, say so on the thread and
+  leave it for a human to resolve.
+- **Collapsed "suppressed comments" have no thread**, so there is nothing to
+  resolve and nothing tracking them. Pick them up in a top-level PR comment or
+  they are simply lost. A Copilot review hides them in a `<details>` block below
+  the per-file summary, which is easy to skim past.
+
+**Verify the fix is on the PR head before calling the review answered**, by
+grepping the *remote* branch for a symbol the fix introduces:
+`git grep -q '<symbol>' origin/<branch>`. Do not use `headRefOid` for this. As
+the corollary in "Never open a PR onto another PR" says of merges: for a merged
+PR that value *is* the merged commit, so comparing against it is a tautology
+that cannot fail. On 2026-08-11 two review fixes went missing behind exactly
+that, one to a merge that beat the push by 40 seconds, and one to a push made 14
+minutes after the merge and then "verified" with `headRefOid` and reported as
+landed.
 
 ## New test files must be gated in CI
 

--- a/pixlstash/hub/db.py
+++ b/pixlstash/hub/db.py
@@ -315,10 +315,38 @@ class HubDatabase:
         Deliberately minimal: the hub's multi-process contract depends on write
         transactions staying short, so this is for one logical write, never for
         a block that also touches the filesystem or waits on a user.
+
+        **The ``BEGIN IMMEDIATE`` is load-bearing, not a tidiness flourish.**
+        ``with self._conn`` commits on exit but never begins, and the connection
+        is opened ``isolation_level=""`` (see :meth:`_connect`), which defers
+        ``BEGIN`` to the first *DML* statement. A block that reads before it
+        writes therefore ran its reads in **autocommit**, and in WAL an
+        autocommit read takes no lock at all, so another process could commit
+        between the read and the write, and the write would still land on the
+        strength of what the read saw. Every caller that gates a write on a
+        preceding ``SELECT`` was exposed, and several document a critical
+        section they did not have. ``BEGIN IMMEDIATE`` takes the write lock up
+        front, so the whole block is one transaction and ``HUB_BUSY_TIMEOUT_S``
+        applies to acquiring it.
+
+        The other process is not hypothetical: this module exists because the
+        server and the ``pixlstash.libraries`` CLI open this file at the same
+        moment (see the module docstring). ``self._lock`` is a ``threading``
+        lock and does nothing about that.
         """
         with self._lock:
             try:
                 with self._conn:
+                    # Guarded because SQLite has no nested transactions: a second
+                    # `BEGIN` raises. One can already be open here without any
+                    # nesting in this module's own callers, because
+                    # `HubDatabase.connection` hands the raw connection out and
+                    # a caller that ran DML on it left a transaction behind.
+                    # Deliberately only the BEGIN is skipped: `with self._conn`
+                    # still owns commit and rollback, exactly as before, so this
+                    # adds no second way for a hub write to be published.
+                    if not self._conn.in_transaction:
+                        self._conn.execute("BEGIN IMMEDIATE")
                     yield self._conn
             except sqlite3.Error as exc:
                 logger.error("Hub transaction on %s rolled back: %s", self._path, exc)

--- a/pixlstash/hub/registry.py
+++ b/pixlstash/hub/registry.py
@@ -400,16 +400,19 @@ class LibraryRegistry:
         """Atomically register a legacy vault and its explicit migration intent.
 
         This is the sole registry path that may create ``pending`` identity
-        migration state. ``BEGIN IMMEDIATE`` makes the owner recheck, optional
-        registry insertion, and operation insertion one serialization point
-        across CLI and server processes.
+        migration state. The owner recheck, optional registry insertion, and
+        operation insertion are one serialization point across CLI and server
+        processes, because :meth:`~pixlstash.hub.db.HubDatabase.transaction`
+        opens with ``BEGIN IMMEDIATE``. This method used to issue that itself,
+        which was correct and is now redundant: the guarantee moved into
+        ``transaction()`` so that every caller gets it rather than the three
+        that remembered to ask.
         """
         cleaned = name.strip() or os.path.basename(resolved_path)
         fingerprint = read_vault_uuid(resolved_path)
         now = datetime.now(timezone.utc).isoformat()
         try:
             with self._hub.transaction() as conn:
-                conn.execute("BEGIN IMMEDIATE")
                 row = conn.execute(
                     f"SELECT {_LIBRARY_COLUMNS} FROM library WHERE path = ?",
                     (resolved_path,),

--- a/pixlstash/services/model_shelf_service.py
+++ b/pixlstash/services/model_shelf_service.py
@@ -506,8 +506,10 @@ def forget_models(hub, ids: list[int]) -> tuple[list[int], list[dict]]:
     # `BEGIN IMMEDIATE`: pysqlite defers `BEGIN` to the first DML, so these
     # SELECTs ran in autocommit and took no lock at all in WAL. The claim above
     # is only true because of that, which is why it is asserted over in
-    # `test_transaction_holds_the_write_lock_before_its_first_write` rather than
-    # here.
+    # `test_transaction_is_already_open_before_its_first_write` (the SELECTs are
+    # inside a transaction) and
+    # `test_another_process_cannot_write_between_a_gate_read_and_its_write` (that
+    # transaction holds the write lock), rather than here.
     with hub.transaction() as conn:
         known = {
             int(row[0])

--- a/pixlstash/services/model_shelf_service.py
+++ b/pixlstash/services/model_shelf_service.py
@@ -499,6 +499,15 @@ def forget_models(hub, ids: list[int]) -> tuple[list[int], list[dict]]:
     # from `missing` back to `present` between the check and the DELETE — and
     # the model would be forgotten anyway. Small window, unrecoverable
     # consequence, on the one shelf operation with no undo behind it.
+    #
+    # Reading on `conn` closes that against threads in THIS process, because
+    # `HubDatabase._lock` is held for the whole block. It closed nothing against
+    # the `pixlstash.libraries` CLI until `transaction()` began issuing
+    # `BEGIN IMMEDIATE`: pysqlite defers `BEGIN` to the first DML, so these
+    # SELECTs ran in autocommit and took no lock at all in WAL. The claim above
+    # is only true because of that, which is why it is asserted over in
+    # `test_transaction_holds_the_write_lock_before_its_first_write` rather than
+    # here.
     with hub.transaction() as conn:
         known = {
             int(row[0])

--- a/pixlstash/services/stack_detector.py
+++ b/pixlstash/services/stack_detector.py
@@ -210,6 +210,14 @@ def apply_stack(hub: HubDatabase, model_ids: list[int], name: str | None) -> int
     its own UPDATE changes nothing and aborts the whole stack rather than being
     torn out of the stack it already has.
 
+    :meth:`~pixlstash.hub.db.HubDatabase.transaction` now issues
+    ``BEGIN IMMEDIATE``, so the leading SELECT is inside the write transaction
+    after all and the race described above can no longer be scheduled. The
+    re-check stays regardless. It keeps the invariant *local*: reading this
+    function tells you the guard holds, without also knowing what a different
+    module does at ``BEGIN``, and it is the half that survives if anyone ever
+    relaxes that.
+
     The same reasoning applies to the ``present`` gate. ``propose_stacks``
     refuses a model with no copy on disk, and refusing it here too is what stops
     the route being a way to do what the dry run never offers.

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -1004,7 +1004,7 @@ def test_hub_file_is_the_only_database_touched(hub_path, tmp_path):
     assert not os.path.exists(os.path.join(str(tmp_path), "vault.db"))
 
 
-def test_transaction_holds_the_write_lock_before_its_first_write(hub_path):
+def test_transaction_is_already_open_before_its_first_write(hub_path):
     """A gate read inside ``transaction()`` must already be in the transaction.
 
     ``with self._conn`` commits on exit but never begins, and the connection is
@@ -1014,8 +1014,14 @@ def test_transaction_holds_the_write_lock_before_its_first_write(hub_path):
     preceding ``SELECT`` -- ``forget_models``, ``apply_stack`` -- documented a
     critical section they did not have.
 
-    Asserting ``in_transaction`` right after a read is the whole check: it is
-    False on the unfixed code and True once ``BEGIN IMMEDIATE`` leads the block.
+    **This proves the transaction is OPEN, and deliberately not that it is
+    ``IMMEDIATE``.** ``in_transaction`` is equally true of a plain deferred
+    ``BEGIN``, which acquires no write lock at all, so the name must not claim
+    one. Measured, not assumed: mutating ``BEGIN IMMEDIATE`` to ``BEGIN`` leaves
+    this test green and turns only
+    :func:`test_another_process_cannot_write_between_a_gate_read_and_its_write`
+    red. That test owns the lock half; this one owns the "not in autocommit"
+    half, and both are needed because either mutant alone survives the other.
     """
     hub = HubDatabase(hub_path)
     try:

--- a/tests/test_hub_engine.py
+++ b/tests/test_hub_engine.py
@@ -1002,3 +1002,92 @@ def test_hub_file_is_the_only_database_touched(hub_path, tmp_path):
     """Opening the hub must not create a vault next to it."""
     HubEngine(hub_path).close()
     assert not os.path.exists(os.path.join(str(tmp_path), "vault.db"))
+
+
+def test_transaction_holds_the_write_lock_before_its_first_write(hub_path):
+    """A gate read inside ``transaction()`` must already be in the transaction.
+
+    ``with self._conn`` commits on exit but never begins, and the connection is
+    opened ``isolation_level=""``, which defers ``BEGIN`` to the first *DML*
+    statement. So a block that read before it wrote ran its read in autocommit
+    and only became a transaction at the write. Callers that gate a write on a
+    preceding ``SELECT`` -- ``forget_models``, ``apply_stack`` -- documented a
+    critical section they did not have.
+
+    Asserting ``in_transaction`` right after a read is the whole check: it is
+    False on the unfixed code and True once ``BEGIN IMMEDIATE`` leads the block.
+    """
+    hub = HubDatabase(hub_path)
+    try:
+        with hub.transaction() as conn:
+            conn.execute("SELECT COUNT(*) FROM model").fetchone()
+            assert conn.in_transaction, (
+                "the gate read ran in autocommit -- another process can commit "
+                "between it and the write it is gating"
+            )
+    finally:
+        hub.close()
+
+
+def test_another_process_cannot_write_between_a_gate_read_and_its_write(hub_path):
+    """The window this closes is cross-process, so prove it with a real one.
+
+    ``self._lock`` is a ``threading`` lock, and the module docstring is explicit
+    that the server and the ``pixlstash.libraries`` CLI open this file at the
+    same moment. In WAL an autocommit read takes no lock whatsoever, so the
+    second connection here could previously acquire the write lock *while the
+    first was between its gate read and its DELETE* -- which is the race in
+    exactly the shape a separate process runs it.
+
+    The second connection asks for the write lock directly rather than writing a
+    row, so the assertion does not depend on any table's columns.
+    """
+    hub = HubDatabase(hub_path)
+    other = sqlite3.connect(hub_path, isolation_level="")
+    other.execute("PRAGMA busy_timeout=100")  # do not wait out the hub's 5 s
+    try:
+        with hub.transaction() as conn:
+            conn.execute("SELECT COUNT(*) FROM model").fetchone()
+            with pytest.raises(sqlite3.OperationalError, match="locked"):
+                other.execute("BEGIN IMMEDIATE")
+    finally:
+        other.close()
+        hub.close()
+
+
+def test_transaction_survives_an_already_open_transaction(hub_path):
+    """``BEGIN IMMEDIATE`` must not fire when one is already open.
+
+    SQLite has no nested transactions, so an unguarded second ``BEGIN`` raises
+    "cannot start a transaction within a transaction". This is reachable without
+    any nesting in ``pixlstash``'s own callers: :attr:`HubDatabase.connection`
+    hands the raw connection out, and a caller that runs DML on it leaves a
+    transaction open behind ``transaction()``'s back. Several tests in
+    ``test_hub_registry.py`` do exactly that.
+
+    The guard skips only the ``BEGIN``. ``with self._conn`` still owns the
+    commit, so the write below lands just as it did before the fix.
+    """
+    hub = HubDatabase(hub_path)
+    try:
+        # Leave a transaction open the way `hub.connection` lets a caller do.
+        hub.connection.execute(
+            "INSERT INTO model_folder (path, kind, movable) VALUES (?, ?, ?)",
+            ("/left/open", "lora", "no"),
+        )
+        assert hub.connection.in_transaction, "precondition: DML opened one"
+
+        with hub.transaction() as conn:  # must not raise
+            conn.execute(
+                "INSERT INTO model_folder (path, kind, movable) VALUES (?, ?, ?)",
+                ("/written/inside", "lora", "no"),
+            )
+    finally:
+        hub.close()
+
+    survivor = sqlite3.connect(hub_path)
+    try:
+        paths = {row[0] for row in survivor.execute("SELECT path FROM model_folder")}
+    finally:
+        survivor.close()
+    assert "/written/inside" in paths, "the block's own write must still commit"

--- a/tests/test_stack_detection.py
+++ b/tests/test_stack_detection.py
@@ -294,26 +294,34 @@ def test_applying_refuses_a_model_with_no_copy_on_disk(hub, tmp_path):
     assert exc.value.reason == "already_stacked"
 
 
-def test_a_writer_that_lands_between_the_gate_and_the_update_cannot_be_overwritten(
+def test_a_row_that_stops_being_loose_between_the_gate_and_the_update_aborts(
     hub, tmp_path
 ):
-    """The window pysqlite leaves open, closed on the UPDATE itself.
+    """The gate is re-checked on the UPDATE itself, not merely read first.
 
-    The hub connects with `isolation_level=""`, so a transaction opens on DML
-    only: the gate SELECT runs in autocommit and the INSERT is what begins the
-    write. A second connection committing in that gap used to be silently
-    overwritten.
+    **This test used to drive a SECOND CONNECTION into the gap**, because the
+    gap was reachable: the hub connects ``isolation_level=""``, so pysqlite
+    opened a transaction on DML only and the gate SELECT ran in autocommit,
+    taking no lock. `HubDatabase.transaction` now opens with ``BEGIN
+    IMMEDIATE``, so that connection is refused the write lock instead of
+    slipping in, and the old version of this test failed with "database is
+    locked" rather than proving anything. The cross-process half is asserted
+    directly now, in
+    `test_hub_engine.py::test_another_process_cannot_write_between_a_gate_read_and_its_write`.
 
-    **The writer is forced INTO that gap rather than run before it.** A first
-    attempt at this test committed from the other connection before calling
-    `apply_stack`, which the gate SELECT simply excluded — it exercised the
-    SELECT and left the UPDATE guard untested, and stayed green with that guard
-    deleted. `_step_of` is called by the cover sort, which runs after the SELECT
-    and before the first UPDATE, so patching it is what puts the commit exactly
-    where the race is.
+    So the interleaved write goes through `hub.connection` instead, which is the
+    SAME connection `apply_stack` is holding, and therefore lands inside its open
+    transaction. That still exercises exactly what the guard is for: a row that
+    is loose when the gate reads it and is not loose by the time its own UPDATE
+    runs, whatever moved it.
+
+    **The write is forced INTO the gap rather than run before it.** A first
+    attempt committed before calling `apply_stack`, which the gate SELECT simply
+    excluded: it exercised the SELECT, left the UPDATE guard untested, and
+    stayed green with that guard deleted. `_step_of` is called by the cover sort,
+    which runs after the SELECT and before the first UPDATE, so patching it is
+    what puts the write exactly where the guard has to catch it.
     """
-    import sqlite3
-
     from pixlstash.services import stack_detector
 
     folder = _folder(hub, str(tmp_path / "loras"))
@@ -323,38 +331,40 @@ def test_a_writer_that_lands_between_the_gate_and_the_update_cannot_be_overwritt
     real_step_of = stack_detector._step_of
     landed = []
 
-    def commit_from_another_connection(filename):
+    def write_inside_the_open_transaction(filename):
         if not landed:
             landed.append(True)
-            other = sqlite3.connect(hub.path, isolation_level="")
-            try:
-                other.execute(
-                    "INSERT INTO adapter_stack (id, name, created_at, updated_at) "
-                    "VALUES (99, 'Other', '2026-08-11T00:00:00Z', "
-                    "'2026-08-11T00:00:00Z')"
-                )
-                other.execute("UPDATE model SET stack_id = 99 WHERE id = ?", (second,))
-                other.commit()
-            finally:
-                other.close()
+            conn = hub.connection
+            conn.execute(
+                "INSERT INTO adapter_stack (id, name, created_at, updated_at) "
+                "VALUES (99, 'Other', '2026-08-11T00:00:00Z', "
+                "'2026-08-11T00:00:00Z')"
+            )
+            conn.execute("UPDATE model SET stack_id = 99 WHERE id = ?", (second,))
         return real_step_of(filename)
 
-    stack_detector._step_of = commit_from_another_connection
+    stack_detector._step_of = write_inside_the_open_transaction
     try:
         with pytest.raises(StackRefused):
             apply_stack(hub, [first, second], "Race")
     finally:
         stack_detector._step_of = real_step_of
 
-    assert landed, "the interleaved writer never ran; the window was not exercised"
+    assert landed, "the interleaved write never ran; the window was not exercised"
 
-    # The other writer's stack is intact and nothing half-landed.
+    # StackRefused is not a sqlite3.Error, so it leaves `transaction()` through
+    # `with self._conn`, which rolls back. Nothing half-landed: not the stack the
+    # call was trying to build, and not the interleaved write either.
     row = hub.fetchone("SELECT stack_id FROM model WHERE id = ?", (second,))
-    assert row["stack_id"] == 99
+    assert row["stack_id"] is None
     row = hub.fetchone("SELECT stack_id FROM model WHERE id = ?", (first,))
     assert row["stack_id"] is None
+    assert hub.fetchone("SELECT id FROM adapter_stack WHERE id = 99") is None
     stacks = hub.fetchone("SELECT COUNT(*) AS n FROM adapter_stack")
-    assert stacks["n"] == 1, "the rolled-back INSERT left an orphan stack row"
+    # Zero, where the second-connection version of this test expected one: the
+    # interleaved write is now inside the SAME transaction, so the rollback
+    # takes it too. There is no committed outside writer left to survive.
+    assert stacks["n"] == 0, "a rolled-back INSERT left an orphan stack row"
 
 
 def test_applying_refuses_models_that_are_not_all_in_one_folder(hub, tmp_path):


### PR DESCRIPTION
Started as "fix the `forget_models` defect" and turned out not to be a `forget_models` bug at all.

## The defect

`HubDatabase.transaction()` wrapped `with self._conn`, which **commits on exit but never begins**, on a connection opened `isolation_level=""`. pysqlite defers `BEGIN` to the first *DML* statement, so **any block that read before it wrote ran its reads in autocommit** and only became a transaction at the write. In WAL an autocommit read takes no lock at all.

That is not a theoretical window. This module exists because "the long-running server and the short-lived `pixlstash.libraries` CLI" open the file at the same moment (its own docstring). `self._lock` is a `threading` lock and does nothing about another process.

So `forget_models` and `apply_stack` each documented a critical section they did not have. Fixing it at either call site would have left the other 32.

## What the fix found

**`registry.register_legacy_vault` was already issuing `BEGIN IMMEDIATE` by hand**, with a docstring explaining precisely this hazard. So did two paths in `hub/schema.py`. The knowledge was in the codebase; it just had to be remembered per call site, and twice it wasn't.

- The `registry.py` one is now redundant and is removed. Leaving it in is a nested `BEGIN`, which raises.
- **The two in `hub/schema.py` stay.** They run on the raw connection during `__init__` (`apply_migrations(self._conn)` at `db.py:276`), never through `transaction()`, so there is nothing to nest inside.

I found these the bad way: 28 tests went red. My survey had checked callers for filesystem work inside the block and never grepped them for an existing `BEGIN`.

## Scope

`isolation_level=""` appears **only** in `hub/db.py`. `snapshot_service.py` uses `isolation_level=None` deliberately for `VACUUM INTO`, and the vault goes through SQLAlchemy `Session`, which begins explicitly. There is no sibling to chase.

## The guard the fix does not remove

`apply_stack` keeps re-checking `stack_id IS NULL` **on the UPDATE**. It is defence in depth now rather than the only defence, and it stays because it keeps the invariant local: reading that function tells you the guard holds without also knowing what a different module does at `BEGIN`.

Its race test drove a **second connection** into the gap. The fix refuses that connection the write lock, so the old test failed with "database is locked" rather than proving anything. It now drives the same interleaving through `hub.connection`, which is the *same* connection `apply_stack` holds, so the write lands inside the open transaction. Same thing under test: a row loose at the gate and not loose at its own UPDATE, whatever moved it.

## Verification

- 546 tests pass across the 14 files covering every `transaction()` caller.
- Three new tests in `test_hub_engine.py`, each failing on the unfixed code. There are **two** rather than one for the cross-process property because a *deferred* `BEGIN` sets `in_transaction` but takes no write lock, so only the second-connection test catches that mutant.
- Mutants killed: no `BEGIN` (2 red), deferred `BEGIN` instead of `IMMEDIATE` (1 red), nested-`BEGIN` guard dropped (1 red), `apply_stack`'s UPDATE guard dropped (1 red), its rowcount check dropped (1 red). All restored green.

One mutant first came back as a syntax error rather than a behaviour change: deleting the `BEGIN` line empties the `if` body. It is applied as `pass` instead, and the harness now asserts the mutated file actually differs before trusting a red.

## Second commit: two CLAUDE.md rules

Unrelated to the fix, folded in because the gate has no `paths:` filter, so a docs-only PR costs the same full ~200 runner-minutes.

- **Answering a review is push, reply, resolve.** A fix pushed in silence is invisible as an answer; resolving without replying is worse than leaving it open. Includes the `gh` invocations (resolving is GraphQL-only) and that collapsed "suppressed comments" have no thread and vanish unless picked up separately. Also: verify the fix reached the PR head by grepping the remote for a symbol, **never** `headRefOid`, which is a tautology on a merged PR and is how two review fixes went missing today.
- **`--force-cpu` is a CI flag.** The runners have no GPU; this box does. The file listed it under **Run tests** and invited the copy. Plus: don't run the whole suite in one local process, which does all eight shards' work serially.

https://claude.ai/code/session_01PYbmp1GkvEqEM8zA2qN3bh