### PR TITLE
Make the three sidebar destinations keyboard-operable buttons

### DIFF
--- a/frontend/e2e/specs/read-only-features.spec.js
+++ b/frontend/e2e/specs/read-only-features.spec.js
@@ -71,7 +71,13 @@ test.describe('read-only session: owner-only features stay visible', () => {
       // cannot read, so it must never appear.
       await expect(duplicates.locator('.sidebar-dedup-dot')).toHaveCount(0)
 
-      await duplicates.click()
+      // `force`, because the row is a <button aria-disabled="true"> now (it was
+      // a div until #837 made the sidebar destinations keyboard-operable).
+      // Playwright's actionability check reads aria-disabled on button-role
+      // elements as disabled and would wait out the timeout rather than click —
+      // which is the right reading, and exactly what this test needs to bypass:
+      // the point is that a user CAN still press it and nothing happens.
+      await duplicates.click({ force: true })
       await page.waitForTimeout(500)
       expect(new URL(page.url()).pathname).not.toContain('duplicates')
 

--- a/frontend/src/components/panels/SideBar.css
+++ b/frontend/src/components/panels/SideBar.css
@@ -1200,6 +1200,12 @@
   justify-content: center;
   border-radius: var(--sidebar-item-radius);
   cursor: pointer;
+  /* Same reason as .sidebar-list-item: the dock's destinations are <button>s. */
+  appearance: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-family: inherit;
   color: rgb(var(--v-theme-sidebar-text));
   position: relative;
   transition:
@@ -1426,7 +1432,22 @@
     background 0.12s,
     color 0.12s,
     border-color 0.12s;
+  /* The destination rows are <button>s (keyboard reach); the rest of this class
+     is still on <div>s. Neutralise the UA button chrome so both render alike. */
+  appearance: none;
+  font-family: inherit;
+  text-align: left;
+  border: 0;
   border-left: 3px solid transparent;
+}
+
+/* Inset, not the token's outer ring: these rows run edge to edge in the
+   sidebar, so an outer 3px stroke is clipped on both sides. Same colour, same
+   width — `inset var(--focus-ring)` expands to `inset 0 0 0 3px accent`. */
+.sidebar-list-item:focus-visible,
+.sidebar-collapsed-item:focus-visible {
+  outline: none;
+  box-shadow: inset var(--focus-ring);
 }
 
 .sidebar-footer-spacer {

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -2477,6 +2477,16 @@ const isAllPicturesRowActive = computed(() => {
   return true;
 });
 
+// One source for the Scrapheap highlight. The expanded row and the docked rail
+// each need it twice (the `active` class and `aria-current`), and four copies of
+// the same expression is four chances for the styling and the screen-reader
+// state to drift apart.
+const isScrapheapRowActive = computed(
+  () =>
+    selectionStore.selectedCharacter === SCRAPHEAP_PICTURES_ID &&
+    selectionOwnsHighlight.value,
+);
+
 const allPicturesRowLabel = computed(() => {
   if (projectViewMode.value === "global") return "All Pictures";
   return "Project Pictures";
@@ -4933,18 +4943,9 @@ defineExpose({
               :class="[
                 'sidebar-collapsed-item',
                 'sidebar-collapsed-item--scrapheap',
-                {
-                  active:
-                    selectionStore.selectedCharacter ===
-                      SCRAPHEAP_PICTURES_ID && selectionOwnsHighlight,
-                },
+                { active: isScrapheapRowActive },
               ]"
-              :aria-current="
-                selectionStore.selectedCharacter === SCRAPHEAP_PICTURES_ID &&
-                selectionOwnsHighlight
-                  ? 'page'
-                  : undefined
-              "
+              :aria-current="isScrapheapRowActive ? 'page' : undefined"
               aria-label="Scrapheap"
               title="Scrapheap"
               @click="selectCharacter(SCRAPHEAP_PICTURES_ID, 'Scrapheap')"
@@ -5384,20 +5385,8 @@ defineExpose({
             <div v-if="!isReadOnly" class="sidebar-all-pictures-row">
               <button
                 type="button"
-                :class="[
-                  'sidebar-list-item',
-                  {
-                    active:
-                      selectionStore.selectedCharacter ===
-                        SCRAPHEAP_PICTURES_ID && selectionOwnsHighlight,
-                  },
-                ]"
-                :aria-current="
-                  selectionStore.selectedCharacter === SCRAPHEAP_PICTURES_ID &&
-                  selectionOwnsHighlight
-                    ? 'page'
-                    : undefined
-                "
+                :class="['sidebar-list-item', { active: isScrapheapRowActive }]"
+                :aria-current="isScrapheapRowActive ? 'page' : undefined"
                 @click="selectCharacter(SCRAPHEAP_PICTURES_ID, 'Scrapheap')"
                 @contextmenu.prevent="
                   openSidebarCtxMenu('scrapheap', null, $event)

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -4374,11 +4374,14 @@ defineExpose({
               { active: isAllPicturesRowActive },
             ]"
           >
-            <div
+            <button
+              type="button"
               :class="[
                 'sidebar-collapsed-item',
                 { active: isAllPicturesRowActive },
               ]"
+              :aria-current="isAllPicturesRowActive ? 'page' : undefined"
+              aria-label="All Pictures"
               title="All Pictures"
               @click="selectCharacter(ALL_PICTURES_ID, 'All Pictures')"
               @contextmenu.prevent.stop="
@@ -4386,7 +4389,7 @@ defineExpose({
               "
             >
               <v-icon>mdi-image-multiple</v-icon>
-            </div>
+            </button>
           </div>
           <div
             v-if="sidebarPrimaryTab !== 'folders'"
@@ -4886,7 +4889,8 @@ defineExpose({
           <div
             :class="['sidebar-collapsed-row', { active: isDuplicatesView }]"
           >
-            <div
+            <button
+              type="button"
               :class="[
                 'sidebar-collapsed-item',
                 {
@@ -4894,7 +4898,9 @@ defineExpose({
                   'sidebar-collapsed-item--unavailable': isReadOnly,
                 },
               ]"
+              :aria-current="isDuplicatesView ? 'page' : undefined"
               :aria-disabled="isReadOnly || undefined"
+              aria-label="Duplicates"
               :title="isReadOnly ? READ_ONLY_DEDUP_HINT : 'Duplicates'"
               @click="isReadOnly || emit('select-duplicates', {})"
             >
@@ -4904,7 +4910,7 @@ defineExpose({
                 class="sidebar-collapsed-dedup-badge"
                 title="There are duplicates to review"
               ></span>
-            </div>
+            </button>
           </div>
 
           <!-- Scrap Heap at bottom of dock. The flex spacer above it fills most
@@ -4922,7 +4928,8 @@ defineExpose({
               },
             ]"
           >
-            <div
+            <button
+              type="button"
               :class="[
                 'sidebar-collapsed-item',
                 'sidebar-collapsed-item--scrapheap',
@@ -4932,6 +4939,13 @@ defineExpose({
                       SCRAPHEAP_PICTURES_ID && selectionOwnsHighlight,
                 },
               ]"
+              :aria-current="
+                selectionStore.selectedCharacter === SCRAPHEAP_PICTURES_ID &&
+                selectionOwnsHighlight
+                  ? 'page'
+                  : undefined
+              "
+              aria-label="Scrapheap"
               title="Scrapheap"
               @click="selectCharacter(SCRAPHEAP_PICTURES_ID, 'Scrapheap')"
               @contextmenu.prevent.stop="
@@ -4939,7 +4953,7 @@ defineExpose({
               "
             >
               <v-icon>mdi-trash-can-outline</v-icon>
-            </div>
+            </button>
           </div>
         </div>
       </template>
@@ -5294,11 +5308,16 @@ defineExpose({
           <!-- ══ GLOBAL tab content ══ -->
           <template v-if="projectViewMode === 'global'">
             <div v-if="!scopedResourceType" class="sidebar-all-pictures-row">
-              <div
+              <!-- A destination is a real <button>: keyboard reach and
+                   Enter/Space activation come for free, and `aria-current`
+                   is what tells a screen reader which one you are in. -->
+              <button
+                type="button"
                 :class="[
                   'sidebar-list-item',
                   { active: isAllPicturesRowActive },
                 ]"
+                :aria-current="isAllPicturesRowActive ? 'page' : undefined"
                 @click="selectCharacter(ALL_PICTURES_ID, allPicturesRowLabel)"
                 @contextmenu.prevent="
                   openSidebarCtxMenu('all-pictures', null, $event)
@@ -5313,7 +5332,7 @@ defineExpose({
                 <span class="sidebar-list-count">{{
                   categoryCounts[ALL_PICTURES_ID] ?? ""
                 }}</span>
-              </div>
+              </button>
             </div>
 
             <!-- Duplicates earns a sidebar row because it is the one thing
@@ -5321,7 +5340,11 @@ defineExpose({
                  works, which is what a destination is for. Stacked and
                  unstacked stay a filter. -->
             <div class="sidebar-all-pictures-row">
-              <div
+              <!-- `aria-disabled`, not `disabled`: a read-only session must
+                   still be able to focus the row and read the title that
+                   explains why it is inert. The click guard stays. -->
+              <button
+                type="button"
                 :class="[
                   'sidebar-list-item',
                   {
@@ -5329,6 +5352,7 @@ defineExpose({
                     'sidebar-list-item--unavailable': isReadOnly,
                   },
                 ]"
+                :aria-current="isDuplicatesView ? 'page' : undefined"
                 :aria-disabled="isReadOnly || undefined"
                 :title="isReadOnly ? READ_ONLY_DEDUP_HINT : undefined"
                 @click="isReadOnly || emit('select-duplicates', {})"
@@ -5354,11 +5378,12 @@ defineExpose({
                   class="sidebar-dedup-dot"
                   title="There are duplicates to review"
                 ></span>
-              </div>
+              </button>
             </div>
 
             <div v-if="!isReadOnly" class="sidebar-all-pictures-row">
-              <div
+              <button
+                type="button"
                 :class="[
                   'sidebar-list-item',
                   {
@@ -5367,6 +5392,12 @@ defineExpose({
                         SCRAPHEAP_PICTURES_ID && selectionOwnsHighlight,
                   },
                 ]"
+                :aria-current="
+                  selectionStore.selectedCharacter === SCRAPHEAP_PICTURES_ID &&
+                  selectionOwnsHighlight
+                    ? 'page'
+                    : undefined
+                "
                 @click="selectCharacter(SCRAPHEAP_PICTURES_ID, 'Scrapheap')"
                 @contextmenu.prevent="
                   openSidebarCtxMenu('scrapheap', null, $event)
@@ -5384,7 +5415,7 @@ defineExpose({
                 <span class="sidebar-list-count">{{
                   categoryCounts[SCRAPHEAP_PICTURES_ID] ?? ""
                 }}</span>
-              </div>
+              </button>
             </div>
 
             <div class="sidebar-section-divider" />

--- a/frontend/src/components/panels/SideBarDestinationA11y.test.js
+++ b/frontend/src/components/panels/SideBarDestinationA11y.test.js
@@ -1,0 +1,285 @@
+// The sidebar's top-level destinations, as keyboard-operable controls.
+//
+// All Pictures, Duplicates and Scrapheap were clickable `<div>`s: no tabindex,
+// no role, no `aria-current`. A keyboard-only user could not reach or activate
+// any of them, and a screen reader was never told which destination the session
+// was in. Both layouts rendered them the same way, so the docked rail was
+// unreachable too.
+//
+// They are `<button>`s now, which is what buys Tab reach and Enter/Space
+// activation — neither of which jsdom simulates, so what is asserted here is
+// the element type that provides them, plus the `aria-current` that no element
+// type provides for free. Both directions: the active destination announces as
+// current, the inactive ones say nothing, and clicking still does what it did.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount, flushPromises } from "@vue/test-utils";
+import { reactive, ref } from "vue";
+
+const apiGet = vi.fn();
+
+vi.mock("../../utils/apiClient", async () => {
+  const { ref: makeRef } = await import("vue");
+  return {
+    apiClient: {
+      get: (...args) => apiGet(...args),
+      post: vi.fn().mockResolvedValue({ data: {} }),
+      patch: vi.fn().mockResolvedValue({ data: {} }),
+      put: vi.fn().mockResolvedValue({ data: {} }),
+      delete: vi.fn().mockResolvedValue({ data: {} }),
+    },
+    onSessionReset: () => () => {},
+    activateShareToken: vi.fn(),
+    appendShareToken: (url) => url,
+    checkLoginStatus: vi.fn(),
+    checkSession: vi.fn(),
+    isAuthenticated: makeRef(true),
+    isReadOnly: makeRef(false),
+    sessionContext: makeRef(null),
+    login: vi.fn(),
+    logout: vi.fn(),
+    newOperationBatchId: () => "cli-test",
+    operationBatchHeaders: () => undefined,
+    setRequestClientId: vi.fn(),
+    notifySessionReset: vi.fn(),
+    toBackendWebSocketUrl: () => "",
+    API_BASE_URL: "/api/v1",
+  };
+});
+
+vi.mock("vuetify/components", () => {
+  const stubs = new Map();
+  return new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === "__esModule") return true;
+        if (typeof prop !== "string") return undefined;
+        if (!stubs.has(prop)) {
+          stubs.set(prop, { name: prop, template: "<div><slot /></div>" });
+        }
+        return stubs.get(prop);
+      },
+      has: () => true,
+    },
+  );
+});
+
+// Reactive, because `isDuplicatesView` is a computed over `route.name`: a plain
+// object would let the test set the name and see nothing re-render.
+const route = reactive({
+  query: {},
+  params: {},
+  path: "/",
+  name: "all-pictures",
+});
+
+vi.mock("vue-router", () => ({
+  useRoute: () => route,
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    currentRoute: ref({ query: {} }),
+  }),
+}));
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+globalThis.IntersectionObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+import { isReadOnly, sessionContext } from "../../utils/apiClient";
+import { useSelectionStore } from "../../stores/useSelectionStore";
+import { useSidebarStore } from "../../stores/useSidebarStore";
+import SideBar from "./SideBar.vue";
+
+const ALL_ID = "ALL";
+const SCRAPHEAP_ID = "SCRAPHEAP";
+const DESTINATIONS = ["All Pictures", "Duplicates", "Scrapheap"];
+
+function respond(url) {
+  const u = String(url ?? "");
+  if (u.includes("/characters")) return { data: [] };
+  if (u.includes("/projects")) return { data: [] };
+  if (u.includes("/picture_sets")) return { data: [] };
+  if (u.includes("/summary")) return { data: { image_count: 0 } };
+  return { data: [] };
+}
+
+async function mountSidebar() {
+  const wrapper = mount(SideBar, {
+    shallow: true,
+    props: { backendUrl: "/api/v1" },
+    global: {
+      config: {
+        compilerOptions: { isCustomElement: (tag) => tag.startsWith("v-") },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+/** The expanded sidebar's destination row, located by its visible label. */
+function destination(wrapper, label) {
+  return wrapper
+    .findAll(".sidebar-list-item")
+    .find(
+      (el) =>
+        el.find(".sidebar-list-label").exists() &&
+        el.find(".sidebar-list-label").text() === label,
+    );
+}
+
+/** The docked rail's destination, located by its title (the rail has no labels). */
+function dockedDestination(wrapper, label) {
+  return wrapper
+    .findAll(".sidebar-collapsed-item")
+    .find((el) => el.attributes("title") === label);
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  // The docked/expanded choice is persisted, so without this the rail test
+  // leaks into every test after it and the expanded rows stop rendering.
+  window.localStorage.clear();
+  isReadOnly.value = false;
+  sessionContext.value = null;
+  route.name = "all-pictures";
+  apiGet.mockReset().mockImplementation((url) => Promise.resolve(respond(url)));
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the sidebar's destinations are keyboard-operable", () => {
+  it("renders every destination as a button", async () => {
+    // The whole defect in one assertion: a <div> here is unreachable by Tab and
+    // deaf to Enter and Space, however it is styled.
+    const wrapper = await mountSidebar();
+
+    for (const label of DESTINATIONS) {
+      const row = destination(wrapper, label);
+      expect(row, `${label} row is missing`).toBeTruthy();
+      expect(row.element.tagName, label).toBe("BUTTON");
+      // A button taken out of the tab order would be the same bug wearing the
+      // right tag.
+      expect(row.attributes("tabindex")).toBeUndefined();
+    }
+
+    wrapper.unmount();
+  });
+
+  it("renders the docked rail's destinations as buttons too", async () => {
+    // The rail is the same three destinations in the narrow layout. Fixing only
+    // the wide one leaves a keyboard user stranded whenever the sidebar docks.
+    const wrapper = await mountSidebar();
+    useSidebarStore().setSidebarDocked(true);
+    await wrapper.vm.$nextTick();
+
+    for (const label of DESTINATIONS) {
+      const item = dockedDestination(wrapper, label);
+      expect(item, `${label} rail item is missing`).toBeTruthy();
+      expect(item.element.tagName, label).toBe("BUTTON");
+      // The rail shows an icon and no text, so the name has to be spelled out.
+      expect(item.attributes("aria-label")).toBe(label);
+    }
+
+    wrapper.unmount();
+  });
+});
+
+describe("aria-current names the destination you are in", () => {
+  it("marks All Pictures and nothing else", async () => {
+    const selection = useSelectionStore();
+    const wrapper = await mountSidebar();
+    selection.selectedCharacter = ALL_ID;
+    selection.selectedCharacterIds = [];
+    await wrapper.vm.$nextTick();
+
+    expect(
+      destination(wrapper, "All Pictures").attributes("aria-current"),
+    ).toBe("page");
+    expect(
+      destination(wrapper, "Scrapheap").attributes("aria-current"),
+    ).toBeUndefined();
+    expect(
+      destination(wrapper, "Duplicates").attributes("aria-current"),
+    ).toBeUndefined();
+
+    wrapper.unmount();
+  });
+
+  it("moves to Scrapheap when the selection does", async () => {
+    const selection = useSelectionStore();
+    const wrapper = await mountSidebar();
+    selection.selectedCharacter = SCRAPHEAP_ID;
+    selection.selectedCharacterIds = [];
+    await wrapper.vm.$nextTick();
+
+    expect(destination(wrapper, "Scrapheap").attributes("aria-current")).toBe(
+      "page",
+    );
+    expect(
+      destination(wrapper, "All Pictures").attributes("aria-current"),
+    ).toBeUndefined();
+
+    wrapper.unmount();
+  });
+
+  it("marks Duplicates on the duplicates route", async () => {
+    // Duplicates is addressed by route name, not by a selection sentinel.
+    const wrapper = await mountSidebar();
+    route.name = "duplicates";
+    await wrapper.vm.$nextTick();
+
+    expect(destination(wrapper, "Duplicates").attributes("aria-current")).toBe(
+      "page",
+    );
+    expect(
+      destination(wrapper, "All Pictures").attributes("aria-current"),
+    ).toBeUndefined();
+
+    wrapper.unmount();
+  });
+});
+
+describe("what the conversion must not change", () => {
+  it("still activates on click", async () => {
+    const wrapper = await mountSidebar();
+
+    await destination(wrapper, "Duplicates").trigger("click");
+
+    expect(wrapper.emitted("select-duplicates")).toHaveLength(1);
+
+    wrapper.unmount();
+  });
+
+  it("keeps a read-only Duplicates focusable and explained", async () => {
+    // `disabled` would take the row out of the tab order AND kill the title
+    // that is the only statement of why it is inert. `aria-disabled` says the
+    // same thing to assistive tech without either loss.
+    isReadOnly.value = true;
+    const wrapper = await mountSidebar();
+
+    const row = destination(wrapper, "Duplicates");
+    expect(row.attributes("disabled")).toBeUndefined();
+    expect(row.attributes("aria-disabled")).toBe("true");
+    expect(row.attributes("title")).toBeTruthy();
+
+    await row.trigger("click");
+    expect(wrapper.emitted("select-duplicates")).toBeUndefined();
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
Closes #837.

## What was wrong

All Pictures, Duplicates and Scrapheap were clickable `<div>`s in the sidebar: no
`tabindex`, no role, no `aria-current`. Tab could not reach them, Enter/Space did
nothing, and a screen reader was never told which destination the session was in.

## What changed

`frontend/src/components/panels/SideBar.vue` — the three destinations are now
`<button type="button">` with `:aria-current="… ? 'page' : undefined"` driven by
the same expression that already drove the `active` class.

**Six elements, three destinations.** The sidebar renders the same three
destinations twice: the labelled rows in the expanded panel and the icon-only
rail when `sidebarStore.effectiveDocked` is on. Both were divs, so fixing only
the expanded rows would leave a keyboard user stranded whenever the sidebar
docks. The rail items also get an `aria-label`, since they show an icon and no
text.

Read-only Duplicates keeps `aria-disabled` and its click guard rather than
becoming `disabled`: `disabled` would drop it out of the tab order *and* kill the
`title` that is the only statement of why the row is inert (the CSS already
carries a comment saying pointer events must stay on for exactly that reason).

`frontend/src/components/panels/SideBar.css` — two things:

- UA button chrome neutralised on `.sidebar-list-item` / `.sidebar-collapsed-item`
  (`appearance`, `border`, `padding`, `background`, `font-family`, `text-align`)
  so buttons and the remaining divs sharing those classes render identically. No
  new colours, spacings or radii.
- A focus ring from the existing token: `box-shadow: inset var(--focus-ring)`.
  Inset rather than the token's outer form because these rows run edge to edge in
  the sidebar, where an outer 3px stroke is clipped on both sides — same colour,
  same 3px, same single focus language.

## Roving focus

The issue flagged the `.ate-btn` roving-focus interaction from #759. Checked: that
selector logic lives in `SelectionMenu.vue`, and the sidebar has no
querySelector-driven roving focus of its own, so nothing needed teaching about the
new focusables and nothing needed excluding.

## Tests

New `SideBarDestinationA11y.test.js` (7 tests): every destination is a `BUTTON` and
not `tabindex`-removed, in both layouts; `aria-current` marks exactly the active
destination and moves with the selection and with the duplicates route; and the
things the conversion must not change — click still emits, read-only Duplicates is
still focusable, still explained, still inert.

Full frontend suite passes (2554 tests), `eslint` clean, `vite build` clean.

## Not verified

No browser pass: this checkout has no Python env with `pixlstash` installed, so the
Playwright harness (which serves the SPA from the backend) cannot boot here. The
focus ring and the button-chrome reset are argued from the CSS, not seen. Worth a
look on the reviewer's machine, in both themes.
