### PR TITLE
Rotate the default picture set icon and color (#457)

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -935,6 +935,7 @@ File type helpers.
 | `SET_ICON_CATEGORIES` | Array of `{label, icons[]}` groups for the icon picker grid (Photography, Favourites, Family, Clothing, Home, Travel, Sports, Work, Events, Arts, Seasons, Food). Must be kept in sync with `pixlstash/routes/picture_sets.py`. |
 | `SET_ICONS` | Flat list of all icon values (derived from categories). |
 | `SET_COLORS` | Array of colour hex values for the set colour picker. |
+| `nextSetAppearance(allSets, siblingSets)` | `{set_icon, set_color}` a new set defaults to (#457): the palette entry after the newest set's (so consecutive sets differ, and a set created in an empty project does not restart at the head of the palette), skipping anything a sibling already uses. `SideBar.createSet` seeds the editor with it; the backend applies the same rule in `_auto_assign_icon_color` for sets created without an appearance. |
 
 ---
 

--- a/frontend/src/components/panels/SideBar.vue
+++ b/frontend/src/components/panels/SideBar.vue
@@ -63,10 +63,10 @@ import {
   withEntityProjectIds,
 } from "../../utils/projectMembership.js";
 import {
-  SET_ICONS,
   SET_COLORS,
   SET_ICON_CATEGORIES,
   ICON_CARDS,
+  nextSetAppearance,
 } from "../../utils/setAppearance.js";
 import { useEntityNamesStore } from "../../stores/useEntityNamesStore";
 import { useEntityListsStore } from "../../stores/useEntityListsStore";
@@ -1129,30 +1129,17 @@ function createSet() {
   const defaultProjectId =
     projectViewMode.value === "project" ? selectedProjectId.value : null;
 
-  // Pick an icon and color not already in use by sibling sets.
+  // Rotate on from the newest set, skipping what the siblings already use.
   const siblingScope =
     defaultProjectId !== null
       ? nonReferenceSets.value.filter((s) =>
           entityBelongsToProject(s, defaultProjectId),
         )
       : nonReferenceSets.value;
-  const usedIcons = new Set(
-    siblingScope.map((s) => s.set_icon).filter(Boolean),
-  );
-  const usedColors = new Set(
-    siblingScope.map((s) => s.set_color).filter(Boolean),
-  );
-  const autoIcon =
-    SET_ICONS.find((i) => !usedIcons.has(i.value))?.value ??
-    SET_ICONS[siblingScope.length % SET_ICONS.length].value;
-  const autoColor =
-    SET_COLORS.find((c) => !usedColors.has(c.value))?.value ??
-    SET_COLORS[siblingScope.length % SET_COLORS.length].value;
 
   setEditorSet.value = {
     ...(defaultProjectId !== null ? { project_id: defaultProjectId } : {}),
-    set_icon: autoIcon,
-    set_color: autoColor,
+    ...nextSetAppearance(nonReferenceSets.value, siblingScope),
   };
   setEditorOpen.value = true;
 }

--- a/frontend/src/utils/setAppearance.js
+++ b/frontend/src/utils/setAppearance.js
@@ -199,3 +199,48 @@ export const SET_COLORS = [
   { value: "#a1887f", label: "Warm Brown" },
   { value: "#76ff03", label: "Electric Green" },
 ];
+
+/**
+ * The palette entry after `lastValue`, skipping anything in `used`.
+ * `lastValue` absent from the palette starts the scan at the head.
+ */
+function nextFromPalette(palette, lastValue, used) {
+  const start = palette.indexOf(lastValue) + 1;
+  for (let offset = 0; offset < palette.length; offset++) {
+    const candidate = palette[(start + offset) % palette.length];
+    if (!used.has(candidate)) return candidate;
+  }
+  return palette[start % palette.length];
+}
+
+/**
+ * Default icon and colour for a new set (#457).
+ *
+ * Rotates on from the most recently created set rather than always offering
+ * the head of the palette: picking the first *unused* entry handed out
+ * `mdi-camera` / red again every time a set was made in a fresh project, or
+ * whenever the user replaced an earlier default with a hand-picked icon.
+ *
+ * @param {Array<Object>} allSets - every set; only the newest one is read, so
+ *   the rotation continues across projects.
+ * @param {Array<Object>} [siblingSets=allSets] - the sets the new one will sit
+ *   beside; their icons and colours are skipped so siblings stay distinct.
+ * @returns {{set_icon: string, set_color: string}}
+ */
+export function nextSetAppearance(allSets, siblingSets = allSets) {
+  const icons = SET_ICONS.map((ic) => ic.value);
+  const colors = SET_COLORS.map((c) => c.value);
+  const newestFirst = [...allSets].sort((a, b) => (b.id ?? 0) - (a.id ?? 0));
+  return {
+    set_icon: nextFromPalette(
+      icons,
+      newestFirst.map((s) => s.set_icon).find((v) => icons.includes(v)),
+      new Set(siblingSets.map((s) => s.set_icon)),
+    ),
+    set_color: nextFromPalette(
+      colors,
+      newestFirst.map((s) => s.set_color).find((v) => colors.includes(v)),
+      new Set(siblingSets.map((s) => s.set_color)),
+    ),
+  };
+}

--- a/frontend/src/utils/setAppearance.js
+++ b/frontend/src/utils/setAppearance.js
@@ -200,6 +200,9 @@ export const SET_COLORS = [
   { value: "#76ff03", label: "Electric Green" },
 ];
 
+const ICON_VALUES = SET_ICONS.map((ic) => ic.value);
+const COLOR_VALUES = SET_COLORS.map((c) => c.value);
+
 /**
  * The palette entry after `lastValue`, skipping anything in `used`.
  * `lastValue` absent from the palette starts the scan at the head.
@@ -221,25 +224,39 @@ function nextFromPalette(palette, lastValue, used) {
  * `mdi-camera` / red again every time a set was made in a fresh project, or
  * whenever the user replaced an earlier default with a hand-picked icon.
  *
- * @param {Array<Object>} allSets - every set; only the newest one is read, so
- *   the rotation continues across projects.
+ * @param {Array<Object>} allSets - every set; scanned once for the highest-id
+ *   set carrying a palette icon, and the same for a colour, so the rotation
+ *   continues across projects. Sets holding neither (reference sets, the card
+ *   stack) are passed over.
  * @param {Array<Object>} [siblingSets=allSets] - the sets the new one will sit
  *   beside; their icons and colours are skipped so siblings stay distinct.
  * @returns {{set_icon: string, set_color: string}}
  */
 export function nextSetAppearance(allSets, siblingSets = allSets) {
-  const icons = SET_ICONS.map((ic) => ic.value);
-  const colors = SET_COLORS.map((c) => c.value);
-  const newestFirst = [...allSets].sort((a, b) => (b.id ?? 0) - (a.id ?? 0));
+  let lastIcon;
+  let lastIconId = -Infinity;
+  let lastColor;
+  let lastColorId = -Infinity;
+  for (const set of allSets) {
+    const id = set.id ?? 0;
+    if (id >= lastIconId && ICON_VALUES.includes(set.set_icon)) {
+      lastIcon = set.set_icon;
+      lastIconId = id;
+    }
+    if (id >= lastColorId && COLOR_VALUES.includes(set.set_color)) {
+      lastColor = set.set_color;
+      lastColorId = id;
+    }
+  }
   return {
     set_icon: nextFromPalette(
-      icons,
-      newestFirst.map((s) => s.set_icon).find((v) => icons.includes(v)),
+      ICON_VALUES,
+      lastIcon,
       new Set(siblingSets.map((s) => s.set_icon)),
     ),
     set_color: nextFromPalette(
-      colors,
-      newestFirst.map((s) => s.set_color).find((v) => colors.includes(v)),
+      COLOR_VALUES,
+      lastColor,
       new Set(siblingSets.map((s) => s.set_color)),
     ),
   };

--- a/frontend/src/utils/setAppearance.test.js
+++ b/frontend/src/utils/setAppearance.test.js
@@ -1,0 +1,73 @@
+// Default appearance for a new picture set (#457): the sidebar used to offer
+// the first *unused* palette entry, which meant mdi-camera + red every time a
+// set was created in a fresh project. It now rotates on from the newest set.
+
+import { describe, it, expect } from "vitest";
+import { SET_ICONS, SET_COLORS, nextSetAppearance } from "./setAppearance";
+
+const ICONS = SET_ICONS.map((ic) => ic.value);
+const COLORS = SET_COLORS.map((c) => c.value);
+
+describe("nextSetAppearance", () => {
+  it("starts at the head of the palette for the first set", () => {
+    expect(nextSetAppearance([])).toEqual({
+      set_icon: ICONS[0],
+      set_color: COLORS[0],
+    });
+  });
+
+  it("continues after the newest set even in an empty project", () => {
+    const sets = [{ id: 4, set_icon: ICONS[2], set_color: COLORS[2] }];
+    // Sibling scope is empty (a new project), so the old "first unused" rule
+    // handed back ICONS[0]/COLORS[0] here.
+    expect(nextSetAppearance(sets, [])).toEqual({
+      set_icon: ICONS[3],
+      set_color: COLORS[3],
+    });
+  });
+
+  it("reads the newest set by id, not list order", () => {
+    const sets = [
+      { id: 9, set_icon: ICONS[5], set_color: COLORS[5] },
+      { id: 2, set_icon: ICONS[1], set_color: COLORS[1] },
+    ];
+    expect(nextSetAppearance(sets.slice().reverse())).toEqual({
+      set_icon: ICONS[6],
+      set_color: COLORS[6],
+    });
+  });
+
+  it("skips what a sibling already uses", () => {
+    const newest = [{ id: 1, set_icon: ICONS[0], set_color: COLORS[0] }];
+    const siblings = [
+      ...newest,
+      { id: 2, set_icon: ICONS[1], set_color: COLORS[1] },
+    ];
+    expect(nextSetAppearance(newest, siblings)).toEqual({
+      set_icon: ICONS[2],
+      set_color: COLORS[2],
+    });
+  });
+
+  it("ignores sets with no palette value (card stack, reference sets)", () => {
+    const sets = [
+      { id: 7, set_icon: "cards", set_color: null },
+      { id: 3, set_icon: ICONS[4], set_color: COLORS[4] },
+    ];
+    expect(nextSetAppearance(sets)).toEqual({
+      set_icon: ICONS[5],
+      set_color: COLORS[5],
+    });
+  });
+
+  it("wraps rather than running out when every entry is taken", () => {
+    const all = ICONS.map((icon, i) => ({
+      id: i + 1,
+      set_icon: icon,
+      set_color: COLORS[i % COLORS.length],
+    }));
+    const next = nextSetAppearance(all);
+    expect(ICONS).toContain(next.set_icon);
+    expect(COLORS).toContain(next.set_color);
+  });
+});

--- a/pixlstash/routes/picture_sets.py
+++ b/pixlstash/routes/picture_sets.py
@@ -765,40 +765,121 @@ def create_router(server) -> APIRouter:
         "#a1887f",
         "#76ff03",
     ]
+    # Same order as SET_ICONS in frontend/src/utils/setAppearance.js, so a set
+    # created through the API rotates through the palette the UI shows.
     _SET_ICONS = [
+        "mdi-camera",
+        "mdi-image-multiple",
+        "mdi-image-album",
+        "mdi-bookmark",
+        "mdi-folder-image",
+        "mdi-camera-iris",
+        "mdi-film",
+        "mdi-image-frame",
         "mdi-star",
         "mdi-heart",
-        "mdi-camera",
+        "mdi-crown",
+        "mdi-trophy",
+        "mdi-flag",
+        "mdi-alert",
+        "mdi-fire",
+        "mdi-diamond-stone",
+        "mdi-account-group",
+        "mdi-human-male-female-child",
+        "mdi-baby-face-outline",
+        "mdi-human-child",
+        "mdi-dog",
+        "mdi-cat",
+        "mdi-baby-carriage",
+        "mdi-home-heart",
+        "mdi-hanger",
+        "mdi-tshirt-crew",
+        "mdi-shoe-heel",
+        "mdi-sunglasses",
+        "mdi-hat-fedora",
+        "mdi-bag-personal",
+        "mdi-watch",
+        "mdi-tie",
+        "mdi-home",
+        "mdi-bed",
+        "mdi-sofa",
         "mdi-music",
-        "mdi-run",
-        "mdi-bike",
+        "mdi-television",
+        "mdi-shower",
+        "mdi-desk-lamp",
+        "mdi-fireplace",
+        "mdi-silverware-fork-knife",
+        "mdi-cup",
+        "mdi-glass-cocktail",
+        "mdi-food-apple",
+        "mdi-cake-variant",
+        "mdi-coffee",
+        "mdi-pizza",
+        "mdi-beer",
+        "mdi-airplane",
+        "mdi-beach",
         "mdi-hiking",
+        "mdi-city-variant",
         "mdi-pine-tree",
         "mdi-flower",
-        "mdi-beach",
-        "mdi-airplane",
-        "mdi-city-variant",
-        "mdi-food-apple",
-        "mdi-trophy",
-        "mdi-home",
-        "mdi-bookmark",
-        "mdi-crown",
-        "mdi-silverware-fork-knife",
+        "mdi-map-marker",
+        "mdi-tent",
+        "mdi-car",
+        "mdi-bike",
+        "mdi-run",
+        "mdi-bus",
+        "mdi-train",
+        "mdi-motorbike",
+        "mdi-walk",
+        "mdi-tram",
+        "mdi-basketball",
+        "mdi-football",
+        "mdi-weight-lifter",
+        "mdi-swim",
+        "mdi-table-tennis",
+        "mdi-ski",
+        "mdi-bowling",
+        "mdi-golf",
         "mdi-briefcase",
         "mdi-gamepad-variant",
+        "mdi-monitor",
+        "mdi-school",
+        "mdi-code-braces",
+        "mdi-chart-bar",
+        "mdi-stethoscope",
+        "mdi-flask",
     ]
 
+    def _next_from_palette(palette, last_value, used):
+        """The palette entry after ``last_value``, skipping anything in ``used``.
+
+        A ``last_value`` that is not in the palette (None, the ``cards``
+        sentinel, a value from an older palette) starts the scan at the head.
+        """
+        start = palette.index(last_value) + 1 if last_value in palette else 0
+        for offset in range(len(palette)):
+            candidate = palette[(start + offset) % len(palette)]
+            if candidate not in used:
+                return candidate
+        return palette[start % len(palette)]
+
     def _auto_assign_icon_color(session, project_ids):
-        """Return (icon, color) not already used by sibling sets.
+        """Return the (icon, color) a new set defaults to (#457).
+
+        Rotates on from the newest set that carries a palette icon/colour, so
+        consecutive sets differ. Taking the first *unused* entry instead handed
+        out ``mdi-camera``/red again for every set created in a fresh project,
+        and again whenever an earlier default had been replaced by hand.
 
         Args:
             session: A pre-opened session.
-            project_ids: The projects the new set is joining. Siblings are the
-                sets sharing any of them; with no projects, every set is a
-                sibling (the pre-#125 unscoped behaviour).
+            project_ids: The projects the new set is joining. Siblings — whose
+                icons and colours are skipped so they stay distinguishable in
+                one list — are the sets sharing any of them; with no projects,
+                every set is a sibling (the pre-#125 unscoped behaviour).
         """
         wanted = sorted({int(pid) for pid in (project_ids or []) if pid is not None})
-        existing = session.exec(
+        siblings = session.exec(
             select(PictureSet.set_icon, PictureSet.set_color)
             .join(
                 PictureSetProjectMember,
@@ -809,15 +890,23 @@ def create_router(server) -> APIRouter:
             if wanted
             else select(PictureSet.set_icon, PictureSet.set_color)
         ).all()
-        used_icons = {row[0] for row in existing if row[0] and row[0] != "cards"}
-        used_colors = {row[1] for row in existing if row[1]}
-        icon = next(
-            (i for i in _SET_ICONS if i not in used_icons),
-            _SET_ICONS[len(existing) % len(_SET_ICONS)],
+        # Newest set holding a palette value — reference sets and sets left on
+        # the card-stack default carry none, so they are skipped by the filter.
+        last_icon = session.exec(
+            select(PictureSet.set_icon)
+            .where(PictureSet.set_icon.in_(_SET_ICONS))
+            .order_by(PictureSet.id.desc())
+        ).first()
+        last_color = session.exec(
+            select(PictureSet.set_color)
+            .where(PictureSet.set_color.in_(_SET_COLORS))
+            .order_by(PictureSet.id.desc())
+        ).first()
+        icon = _next_from_palette(
+            _SET_ICONS, last_icon, {row[0] for row in siblings if row[0]}
         )
-        color = next(
-            (c for c in _SET_COLORS if c not in used_colors),
-            _SET_COLORS[len(existing) % len(_SET_COLORS)],
+        color = _next_from_palette(
+            _SET_COLORS, last_color, {row[1] for row in siblings if row[1]}
         )
         return icon, color
 

--- a/tests/test_picture_sets.py
+++ b/tests/test_picture_sets.py
@@ -187,6 +187,47 @@ def test_update_and_delete_picture_set():
         gc.collect()
 
 
+def test_new_sets_rotate_default_icon_and_color():
+    """A set created without an appearance differs from the previous one (#457).
+
+    Includes a set in a fresh project: the rotation continues from the newest
+    set library-wide, so an empty project no longer restarts at the head of the
+    palette (the bug this test pins).
+    """
+    temp_dir, client, server = setup_server_with_temp_db()
+    try:
+        seen = []
+        for name in ("Rot A", "Rot B", "Rot C"):
+            resp = client.post("/picture_sets", json={"name": name})
+            assert resp.status_code == 200
+            created = resp.json()["picture_set"]
+            seen.append((created["set_icon"], created["set_color"]))
+
+        project_id = client.post("/projects", json={"name": "Rot Project"}).json()["id"]
+        resp = client.post(
+            "/picture_sets", json={"name": "Rot D", "project_id": project_id}
+        )
+        assert resp.status_code == 200
+        created = resp.json()["picture_set"]
+        seen.append((created["set_icon"], created["set_color"]))
+
+        assert all(icon and color for icon, color in seen)
+        assert len({icon for icon, _ in seen}) == len(seen), seen
+        assert len({color for _, color in seen}) == len(seen), seen
+
+        # An explicit appearance still wins over the rotation.
+        resp = client.post(
+            "/picture_sets",
+            json={"name": "Rot E", "set_icon": "cards", "set_color": "#123456"},
+        )
+        assert resp.json()["picture_set"]["set_icon"] == "cards"
+        assert resp.json()["picture_set"]["set_color"] == "#123456"
+    finally:
+        server.vault.close()
+        temp_dir.cleanup()
+        gc.collect()
+
+
 def test_reassigning_set_project_reconciles_member_picture_memberships():
     temp_dir, client, server = setup_server_with_temp_db()
     try:


### PR DESCRIPTION
Closes #457.

## What was wrong

Both the sidebar and the `POST /picture_sets` fallback already picked an appearance for a new set, but both picked **the first entry the siblings weren't using** — and the sibling scope is the current project. So the head of the palette kept coming back: every set created in a fresh project got `mdi-camera` + red again, and so did any set created after the earlier default had been replaced by hand.

It shows in a real vault — `mdi-camera` on three sets, `#00acc1` on two:

| set | project | icon | colour |
|---|---|---|---|
| Additional Website Pictures | – | mdi-camera | #ff5252 |
| Set A | 5 | mdi-camera | #e53935 |
| Set B | 5 | mdi-image-multiple | #00acc1 |
| Boozy diner | 2 | mdi-camera | #00acc1 |

## What changed

The rule is now what the issue asks for: **the entry after the newest set's**, library-wide, then skipping anything a sibling in the same project already uses so one list still stays readable. Wraps when the palette runs out.

- `frontend/src/utils/setAppearance.js` — new `nextSetAppearance(allSets, siblingSets)`; `SideBar.createSet` is now three lines that call it. This is the path the UI actually takes (it sends the icon/colour it showed you in the dialog).
- `pixlstash/routes/picture_sets.py` — `_auto_assign_icon_color` follows the same rule for sets created through the API without an appearance. Its icon palette had also drifted: 20 icons in a different order from the 79 the UI offers, despite the "kept in sync" comment. Now synced (the colour list already matched). An explicit `set_icon`/`set_color` in the request still wins, unchanged.
- Tests: `setAppearance.test.js` (6 cases, incl. the empty-project regression) and `test_new_sets_rotate_default_icon_and_color` in the existing `tests/test_picture_sets.py`.
- `docs/frontend_architecture.md` — `setAppearance.js` export table.

## Verification

Frontend: `vitest` — 484 tests pass, `eslint` clean, `npm run build` clean.

The backend test is **not run locally** — this worktree has no Python environment with the backend's dependencies (no pytest, fastapi or torch), and installing the stack was out of proportion to the change. It needs CI to go green.
