### PR TITLE
Model shelf bar: total size, and Stack these

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1615,6 +1615,39 @@ collapse a folder of the same name.
 
 #### The verbs (the selection bar, F3)
 
+**Everything that changes a file lives on the row or in the selection bar,
+never in the toolbar** (#896). The toolbar is where the view is switched, so a
+mutating control beside `Sort` and `Show` would be one stray click from a
+different question. The four toolbar buttons are audited against that rule and
+all four hold: `Show` and `Sort` write only view state; `Model folders` and
+`Import from ai-toolkit` open a dialog and write nothing on the press, and the
+import is confirmed against a listing of the runs it found. `Group training
+runs` is the same shape — it opens the dry run, and the applying half is behind
+the dialog's own confirmation. Import and detection stay in the toolbar because
+neither has a selection to act on: their subject is a source folder full of
+files the shelf does not list yet, so there is no row and no selection to hang
+them off.
+
+**The bar states the count AND what the selection weighs**, `40 models selected
+· 12.4 GB`, in the `·` separator the grid's own `SelectionBar` uses. The size is
+what makes a bulk verb reviewable before it runs: "Forget these 40" says nothing
+about what is being reclaimed. It is summed off each row's `members` rather than
+the payload's `total_size`, for the reason `collapseStacks` counts what is
+*shown* — a filter can hide part of a run, and a figure covering rows the reader
+cannot reach would not describe the selection they made. When nothing in the
+selection has a recorded size (an unhashed shelf) the figure is **dropped**
+rather than shown as `0 B`, which would claim the selection is empty.
+
+**`Stack these` is the manual half of grouping**, beside the toolbar's sweep
+rather than instead of it. Detection proposes only files differing by a training
+step, so a run it cannot read as one had no way to be said at all. The bar
+checks every gate `services/stack_detector.apply_stack` enforces — two or more
+models, adapters only, none already stacked, each with a `present` copy, and one
+folder holding all of them — so the button is never offered where it could only
+come back refused, and the failing gate is the tooltip. It is a confirmation and
+not a second dry run: the reader assembled the group themselves and is looking
+at it. The prompt exists because nothing unstacks a model run afterwards.
+
 **Selection is by MODEL, not by rendered row.** Under folder grouping one model
 is drawn once per folder holding a copy of it, and the verbs write the model, so
 a per-row selection would let the same file be half selected and ask the reader

--- a/frontend/src/components/panels/ShelfSelectionBar.test.js
+++ b/frontend/src/components/panels/ShelfSelectionBar.test.js
@@ -201,6 +201,85 @@ describe("the selection bar", () => {
     });
   });
 
+  it("says what the selection weighs, stack members included", async () => {
+    // The figure is what makes a bulk verb reviewable: "Forget these 2" says
+    // nothing about what is reclaimed. A stack counts every member, because the
+    // verbs act on the whole run and one row stands for all of it.
+    selectRows([
+      row(1, "present", { file_size: 1024 * 1024 * 200 }),
+      row(2, "present", {
+        file_size: 1024 * 1024 * 100,
+        stack_id: 7,
+        stack_position: 0,
+      }),
+      row(3, "present", {
+        file_size: 1024 * 1024 * 100,
+        stack_id: 7,
+        stack_position: 1,
+      }),
+    ]);
+    const wrapper = mount(ShelfSelectionBar, globalOpts);
+    // Two rows drawn (the stack folded into one), three files counted.
+    expect(wrapper.find(".shelf-selbar-count").text()).toBe(
+      "2 models selected · 400.0 MB",
+    );
+  });
+
+  it("states the count alone when no size is recorded", async () => {
+    // A file the hash worker has not reached has no size. `0 B` would claim the
+    // selection is empty, which is a different and wrong statement.
+    selectRows([row(1, "present")]);
+    const wrapper = mount(ShelfSelectionBar, globalOpts);
+    expect(wrapper.find(".shelf-selbar-count").text()).toBe("1 model selected");
+  });
+
+  it("offers Stack for two present adapters in one folder", async () => {
+    selectRows([row(1, "present"), row(2, "present")]);
+    const wrapper = mount(ShelfSelectionBar, globalOpts);
+    await verb(wrapper, "Stack these").trigger("click");
+    expect(wrapper.emitted("stack")).toHaveLength(1);
+  });
+
+  it("refuses Stack across folders, which would invent a run", async () => {
+    // The gate the route enforces in `apply_stack`: a run is files that sit
+    // together, so stacking across two drives would create one that never was.
+    selectRows([
+      row(1, "present"),
+      row(2, "present", {
+        locations: [{ state: "present", folder_id: 2, relpath: "y" }],
+      }),
+    ]);
+    const wrapper = mount(ShelfSelectionBar, globalOpts);
+    const stack = verb(wrapper, "Stack these");
+    expect(stack.attributes("disabled")).toBeDefined();
+    expect(stack.attributes("title")).toContain("one folder");
+  });
+
+  it("refuses Stack on one model, a checkpoint, or a row already in a run", async () => {
+    const store = selectRows([row(1, "present")]);
+    const wrapper = mount(ShelfSelectionBar, globalOpts);
+    expect(verb(wrapper, "Stack these").attributes("disabled")).toBeDefined();
+
+    store.rows = [
+      ...store.rows,
+      row(2, "present", { file_kind: "checkpoint" }),
+    ];
+    store.toggleSelected(2);
+    await wrapper.vm.$nextTick();
+    expect(verb(wrapper, "Stack these").attributes("title")).toContain(
+      "Only adapters",
+    );
+
+    store.rows = [row(1, "present"), row(3, "present", { stack_id: 7 })];
+    store.clearSelection();
+    store.toggleSelected(1);
+    store.toggleSelected(3);
+    await wrapper.vm.$nextTick();
+    expect(verb(wrapper, "Stack these").attributes("title")).toContain(
+      "already part of a run",
+    );
+  });
+
   it("clears the selection without touching the rows", async () => {
     const store = selectRows([row(1, "present")]);
     const wrapper = mount(ShelfSelectionBar, globalOpts);

--- a/frontend/src/components/panels/ShelfSelectionBar.test.js
+++ b/frontend/src/components/panels/ShelfSelectionBar.test.js
@@ -255,6 +255,18 @@ describe("the selection bar", () => {
     expect(stack.attributes("title")).toContain("one folder");
   });
 
+  it("names the missing file, not the folders, when a copy is not there", async () => {
+    // The two refusals are different repairs. An unplugged drive is fixed by
+    // plugging it in; being told the files are in different folders would send
+    // the reader to move something instead, and they are in one folder.
+    selectRows([row(1, "present"), row(2, "unreachable")]);
+    const wrapper = mount(ShelfSelectionBar, globalOpts);
+    const stack = verb(wrapper, "Stack these");
+    expect(stack.attributes("disabled")).toBeDefined();
+    expect(stack.attributes("title")).toContain("on this machine");
+    expect(stack.attributes("title")).not.toContain("folder");
+  });
+
   it("refuses Stack on one model, a checkpoint, or a row already in a run", async () => {
     const store = selectRows([row(1, "present")]);
     const wrapper = mount(ShelfSelectionBar, globalOpts);

--- a/frontend/src/components/panels/ShelfSelectionBar.vue
+++ b/frontend/src/components/panels/ShelfSelectionBar.vue
@@ -338,11 +338,12 @@ const moveTitle = computed(() => {
 });
 
 /**
- * Whether the selection could become one training run.
+ * Why this selection cannot become one training run, or `""` when it can.
  *
- * The manual counterpart to the toolbar's detection sweep, which proposes only
- * files differing by a training step: a run the detector cannot name is
- * otherwise ungroupable, and there is no other way to say "these are one run".
+ * Stack is the manual counterpart to the toolbar's detection sweep, which
+ * proposes only files differing by a training step: a run the detector cannot
+ * name is otherwise ungroupable, and there is no other way to say "these are
+ * one run".
  *
  * Every gate the route enforces (`services/stack_detector.apply_stack`) is
  * checked here, so the button is never offered where it could only come back
@@ -350,41 +351,54 @@ const moveTitle = computed(() => {
  * with a copy actually present, and ONE folder holding all of them — a run is
  * files that sit together, and stacking across folders would invent one and put
  * its members on two drives.
+ *
+ * The gate and its sentence are ONE computed rather than a boolean beside a
+ * message that has to be kept in step with it. Written as two, the tooltip
+ * named the shared-folder rule for every refusal the boolean made after the
+ * cheap checks — so a selection blocked by an unplugged drive was told its files
+ * were in different folders, which is a different fact and sends the reader to
+ * fix the wrong thing.
  */
-const stackable = computed(() => {
+const stackRefusal = computed(() => {
   const rows = store.selectedRows;
-  if (rows.length < 2) return false;
-  let shared = null;
-  for (const row of rows) {
-    if (row.file_kind !== "adapter" || row.stack_id != null) return false;
-    const here = (row.locations || [])
-      .filter((loc) => loc.state === "present")
-      .map((loc) => Number(loc.folder_id));
-    if (!here.length) return false;
-    shared =
-      shared === null
-        ? new Set(here)
-        : new Set(here.filter((id) => shared.has(id)));
-    if (!shared.size) return false;
-  }
-  return true;
-});
-
-const stackTitle = computed(() => {
-  const rows = store.selectedRows;
-  if (rows.length < 2)
+  if (rows.length < 2) {
     return "Select the files of one training run to group them";
+  }
   if (rows.some((row) => row.stack_id != null)) {
     return "Something here is already part of a run";
   }
   if (rows.some((row) => row.file_kind !== "adapter")) {
     return "Only adapters are training runs";
   }
-  if (!stackable.value) {
-    return "A run is files that sit together: they must all be present in one folder";
+  let shared = null;
+  for (const row of rows) {
+    const here = (row.locations || [])
+      .filter((loc) => loc.state === "present")
+      .map((loc) => Number(loc.folder_id));
+    // Its own refusal, and not the folder one: `missing` and `unreachable` mean
+    // there is no file here to group, which the reader fixes by plugging a
+    // drive in rather than by moving anything.
+    if (!here.length) {
+      return "Only files that are actually on this machine can be grouped";
+    }
+    shared =
+      shared === null
+        ? new Set(here)
+        : new Set(here.filter((id) => shared.has(id)));
+    if (!shared.size) {
+      return "A run is files that sit together, so they must all be in one folder";
+    }
   }
-  return `Group these ${rows.length.toLocaleString()} files into one run`;
+  return "";
 });
+
+const stackable = computed(() => !stackRefusal.value);
+
+const stackTitle = computed(
+  () =>
+    stackRefusal.value ||
+    `Group these ${store.selectedRows.length.toLocaleString()} files into one run`,
+);
 
 /** The selected models that actually have an icon to clear. */
 const withIcons = computed(() =>

--- a/frontend/src/components/panels/ShelfSelectionBar.vue
+++ b/frontend/src/components/panels/ShelfSelectionBar.vue
@@ -49,6 +49,21 @@
       Set kind
     </AppButton>
 
+    <!-- Stack, the manual half of grouping. The toolbar's sweep proposes only
+         what a training step spells out; a run whose files the detector cannot
+         read as one has no other way to be said. Gated on every rule the route
+         enforces, with the failing one in the tooltip. -->
+    <AppButton
+      size="sm"
+      variant="secondary"
+      icon-left="layers-outline"
+      :disabled="!stackable"
+      :title="stackTitle"
+      @click="emit('stack')"
+    >
+      Stack these
+    </AppButton>
+
     <!-- Assign, the fifth verb, as two pickers rather than a button: it names
          an entity, and the shelf uses the same picker the grid does so the
          search, the tri-state and the keyboard model are learned once. Both are
@@ -154,12 +169,13 @@ import AppButton from "../widgets/AppButton.vue";
 import { useModelFoldersStore } from "../../stores/useModelFoldersStore";
 import { useModelMovesStore } from "../../stores/useModelMovesStore";
 import { useModelShelfStore } from "../../stores/useModelShelfStore";
-import { movableCopies } from "../../utils/modelShelf";
+import { formatModelSize, movableCopies } from "../../utils/modelShelf";
 
 const emit = defineEmits([
   "rename",
   "set-base-model",
   "set-kind",
+  "stack",
   "set-icon",
   "clear-icons",
   "move",
@@ -170,9 +186,39 @@ const store = useModelShelfStore();
 const folders = useModelFoldersStore();
 const moves = useModelMovesStore();
 
+/**
+ * What the selection weighs, stack members included.
+ *
+ * Summed off `members` rather than the payload's `total_size` for the reason
+ * {@link collapseStacks} counts what is shown: a filter can hide part of a run,
+ * and a figure covering rows the reader cannot reach would not describe the
+ * selection they made. A row that stands alone carries no `members`.
+ */
+const selectedBytes = computed(() =>
+  store.selectedRows.reduce(
+    (total, row) =>
+      total +
+      (row.members
+        ? row.members.reduce((sum, m) => sum + (Number(m.file_size) || 0), 0)
+        : Number(row.file_size) || 0),
+    0,
+  ),
+);
+
+/**
+ * The count and what it weighs, in the separator the app already uses.
+ *
+ * The size is what makes a bulk verb reviewable before it runs: "Forget these
+ * 40" says nothing about what is being reclaimed and "12.4 GB" does. Dropped
+ * rather than shown as `0 B` when nothing in the selection has a recorded size,
+ * because a shelf that has not been hashed yet would otherwise claim the
+ * selection is empty.
+ */
 const countLabel = computed(() => {
   const n = store.selectedRows.length;
-  return `${n.toLocaleString()} ${n === 1 ? "model" : "models"} selected`;
+  const head = `${n.toLocaleString()} ${n === 1 ? "model" : "models"} selected`;
+  const size = formatModelSize(selectedBytes.value);
+  return selectedBytes.value && size ? `${head} · ${size}` : head;
 });
 
 /**
@@ -291,6 +337,55 @@ const moveTitle = computed(() => {
   return `Move ${n.toLocaleString()} ${n === 1 ? "file" : "files"} into another folder`;
 });
 
+/**
+ * Whether the selection could become one training run.
+ *
+ * The manual counterpart to the toolbar's detection sweep, which proposes only
+ * files differing by a training step: a run the detector cannot name is
+ * otherwise ungroupable, and there is no other way to say "these are one run".
+ *
+ * Every gate the route enforces (`services/stack_detector.apply_stack`) is
+ * checked here, so the button is never offered where it could only come back
+ * refused: two or more models, adapters only, none already in a stack, each
+ * with a copy actually present, and ONE folder holding all of them — a run is
+ * files that sit together, and stacking across folders would invent one and put
+ * its members on two drives.
+ */
+const stackable = computed(() => {
+  const rows = store.selectedRows;
+  if (rows.length < 2) return false;
+  let shared = null;
+  for (const row of rows) {
+    if (row.file_kind !== "adapter" || row.stack_id != null) return false;
+    const here = (row.locations || [])
+      .filter((loc) => loc.state === "present")
+      .map((loc) => Number(loc.folder_id));
+    if (!here.length) return false;
+    shared =
+      shared === null
+        ? new Set(here)
+        : new Set(here.filter((id) => shared.has(id)));
+    if (!shared.size) return false;
+  }
+  return true;
+});
+
+const stackTitle = computed(() => {
+  const rows = store.selectedRows;
+  if (rows.length < 2)
+    return "Select the files of one training run to group them";
+  if (rows.some((row) => row.stack_id != null)) {
+    return "Something here is already part of a run";
+  }
+  if (rows.some((row) => row.file_kind !== "adapter")) {
+    return "Only adapters are training runs";
+  }
+  if (!stackable.value) {
+    return "A run is files that sit together: they must all be present in one folder";
+  }
+  return `Group these ${rows.length.toLocaleString()} files into one run`;
+});
+
 /** The selected models that actually have an icon to clear. */
 const withIcons = computed(() =>
   store.selectedRows.filter((row) => row.icon_sha256),
@@ -316,7 +411,15 @@ function clear() {
   store.clearSelection();
 }
 
-defineExpose({ forgettable, assignable, membership, movable, withIcons });
+defineExpose({
+  forgettable,
+  assignable,
+  membership,
+  movable,
+  selectedBytes,
+  stackable,
+  withIcons,
+});
 </script>
 
 <style scoped>

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -46,6 +46,15 @@ vi.mock("../../api/modelMoves", () => ({
   cancelModelMove: vi.fn(),
 }));
 
+// The manual stack verb's only write. Mocked here rather than left real
+// because the bar's button is what this suite drives, and the assertion worth
+// having is which ids reach the route.
+const createStack = vi.fn();
+vi.mock("../../api/modelStacks", () => ({
+  createStack: (...args) => createStack(...args),
+  listStackProposals: vi.fn(),
+}));
+
 vi.mock("../../api/modelFolders", async (importOriginal) => ({
   ...(await importOriginal()),
   listModelFolderDevices: (...args) => listModelFolderDevices(...args),
@@ -1236,6 +1245,47 @@ describe("the icon verb", () => {
     const wrapper = await mountShelf([adapter({ id: 1 })]);
     const input = wrapper.find('input[type="file"]');
     expect(input.attributes("accept")).toBe("image/png,image/jpeg,image/webp");
+  });
+});
+
+describe("the manual stack verb", () => {
+  it("sends the selected models, and only after the prompt is answered", async () => {
+    // Two present adapters in one folder are the case the route accepts; the
+    // gate itself is asserted in the bar's own suite. What matters here is that
+    // nothing is written until the confirmation comes back, because there is no
+    // way to unstack a run afterwards.
+    const inFolder = (id, sha) =>
+      adapter({
+        id,
+        sha256: sha.repeat(64),
+        locations: [
+          {
+            state: "present",
+            folder_id: 1,
+            folder_path: "/m",
+            relpath: `${id}`,
+          },
+        ],
+      });
+    const wrapper = await mountShelf([inFolder(1, "a"), inFolder(2, "b")]);
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    store.toggleSelected(2);
+    await wrapper.vm.$nextTick();
+    const stack = () =>
+      wrapper.findAll("button").find((b) => b.text().includes("Stack these"));
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    await stack().trigger("click");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(createStack).not.toHaveBeenCalled();
+
+    confirmSpy.mockReturnValue(true);
+    createStack.mockResolvedValue({ stack_id: 3, member_count: 2 });
+    await stack().trigger("click");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(createStack).toHaveBeenCalledWith([1, 2]);
+    confirmSpy.mockRestore();
   });
 });
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -177,6 +177,7 @@
       @rename="editVerb = 'rename'"
       @set-base-model="editVerb = 'base-model'"
       @set-kind="editVerb = 'kind'"
+      @stack="confirmStack"
       @move="openMove(store.selectedRows)"
       @set-icon="pickIcon"
       @clear-icons="confirmClearIcons"
@@ -538,9 +539,12 @@ import ModelMark from "../widgets/ModelMark.vue";
 import ProgressOverlay from "../widgets/ProgressOverlay.vue";
 import StackEdgeTicks from "../widgets/StackEdgeTicks.vue";
 import { useConfirm } from "../../composables/useConfirm";
+import { createStack } from "../../api/modelStacks";
 import { useModelShelfStore } from "../../stores/useModelShelfStore";
 import { useModelFoldersStore } from "../../stores/useModelFoldersStore";
 import { useModelMovesStore } from "../../stores/useModelMovesStore";
+import { useNoticeStore } from "../../stores/useNoticeStore";
+import { errorDetail } from "../../utils/apiError";
 import { isModelFileDrag, setInternalDragPayload } from "../../utils/media";
 import {
   bandGroups,
@@ -550,6 +554,7 @@ import {
   GROUP_BY_LABELS,
   movableCopies,
   SORT_LABELS,
+  stackReceipt,
   trainingStep,
   sortDirectionLabel,
 } from "../../utils/modelShelf";
@@ -823,6 +828,44 @@ async function confirmClearIcons() {
 const openStacks = ref(new Set());
 const stacksOpen = ref(false);
 const stacksBtnRef = ref(null);
+
+/**
+ * Group the selection into one run, the bar's manual counterpart to the sweep.
+ *
+ * A confirmation and not a dry run, unlike the toolbar's proposals dialog: the
+ * reader assembled this group themselves and is looking at it, so there is
+ * nothing to show them they have not already chosen. It is still a prompt,
+ * because there is no way back — nothing unstacks a model shelf run — and every
+ * verb afterwards acts on the whole run rather than the file that was clicked.
+ *
+ * The bar refuses anything the route would, so a failure here is the shelf
+ * having changed underneath (409) rather than a gesture that should not have
+ * been offered; it is reported and nothing local is guessed at.
+ */
+async function confirmStack() {
+  const ids = store.selectedModelIds;
+  if (ids.length < 2) return;
+  const ok = await confirm({
+    title: `Group ${ids.length} files into one run?`,
+    message:
+      "They become one row on the shelf — the bare final file, or the highest " +
+      "step, stands for the run — and every verb then acts on all of them.",
+    warning: "Nothing unstacks a run afterwards.",
+    confirmLabel: "Group them",
+  });
+  if (!ok) return;
+  const notices = useNoticeStore();
+  try {
+    await createStack(ids);
+    await store.fetchRows();
+    notices.push({ level: "success", text: stackReceipt(1, 0) });
+  } catch (err) {
+    notices.push({
+      level: "error",
+      text: errorDetail(err) || "Those files could not be grouped.",
+    });
+  }
+}
 
 async function closeStacks() {
   stacksOpen.value = false;


### PR DESCRIPTION
Closes #896.

The bar already gained `Set base model` after the issue was written, so what was
left is the size, the one verb from the settled set that had no home, and the
toolbar audit.

## The selection's total size

`40 models selected · 12.4 GB`, in the `·` separator the grid's own
`SelectionBar` already uses. The count alone gives no sense of what a bulk verb
is about to reclaim.

Summed off each row's `members`, not the payload's `total_size`, for the reason
`collapseStacks` counts what is *shown*: a filter can hide part of a run, and a
figure covering rows the reader cannot reach would not describe the selection
they made. When nothing selected has a recorded size (an unhashed shelf) the
figure is dropped rather than shown as `0 B`, which would claim the selection is
empty.

## `Stack these`

The last verb from the settled set (`set base model, stack these, assign to…,
remove from shelf`) that was not reachable from the bar. Grouping existed only
as the toolbar's detection sweep, which proposes files differing by a training
step and nothing else — so a run the detector cannot read as one had no way to
be said at all.

It reuses `POST /model-stacks` as it stands; no backend change. The bar checks
every gate `services/stack_detector.apply_stack` enforces — two or more models,
adapters only, none already stacked, each with a `present` copy, and one folder
holding all of them — so the button is never offered where it could only come
back refused, and the failing gate is the tooltip. Confirmation rather than a
second dry run (the reader assembled the group and is looking at it), and it is
a prompt at all because nothing unstacks a model run afterwards.

## The toolbar audit

The rule is that everything which changes files lives on a row or in the bar,
never beside `Sort` and `Show`. All four toolbar buttons hold, so nothing moved:

- `Show` / `Sort` — view state only.
- `Model folders` — opens a dialog; registering a folder writes no file.
- `Import from ai-toolkit` — opens a dialog and writes nothing on the press; the
  import is confirmed against a listing of the runs found.
- `Group training runs` — opens the dry run; the applying half is behind that
  dialog's own confirmation.

Import and detection stay in the toolbar because neither has a selection to act
on: their subject is a source folder of files the shelf does not list yet, so
there is no row to hang them off. Moving them would delete the only entry point
for each. Recorded in `docs/frontend_architecture.md` §9.1 so the next change is
audited against it rather than re-deciding it.

## Verbs deliberately left alone

The issue's four-verb list is a summary, not a demolition order — it says as
much itself ("regardless of how the verb list is settled"). Rename, Set kind,
Set icon, Clear icon and Move are shipped, documented and tested, and removing
them would take real capability away, so they stay.

## Tests

`ShelfSelectionBar.test.js`: the size (stack members counted, count-only when no
size is recorded) and the Stack gate (offered for two present adapters in one
folder; refused across folders, on a checkpoint, on a row already in a run, and
on one model). `ModelShelf.test.js`: nothing is written until the prompt is
answered, and the selected model ids are what reach the route.

Full frontend suite green (2943 tests). No backend change.

Note: the branch was cut from a commit that predates the shelf, so it was
fast-forwarded onto `develop` before the work — the diff here is the five files
above and nothing else.

## Testing

Test at: this branch's worktree (based on `develop`)

    cd <worktree>/frontend && npm run dev

Select two adapters that sit in one folder and were not proposed by
`Group training runs`; the bar states their combined size and offers
`Stack these`.
