### PR TITLE
Settle #902 (movable gains 'fixed') and the test-handoff convention

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,50 @@ Test at: ~/Projects/pixlstash/worktrees/<name>   (branch <branch>, based on <bas
 If the work is already merged, say `develop/` instead and say to pull. "It's on
 the branch" is not a test path.
 
+### Say what to test, not only where — the `## Test this` section
+
+**A path is not a handoff.** The session that wrote the change is the only party
+that knows which screen it lands on, what number should appear, and which of its
+own steps it is least sure about. Ending at "test at `<path>`" leaves the person
+testing to reverse-engineer all three from a diff, and the honest answer they
+give back is *"I don't know what to test."* That happened, and it is the failure
+this section exists to stop.
+
+**Every PR that changes behaviour carries a `## Test this` section in its body.**
+The PR body rather than a chat message or a `docs/` file: it is where a tester
+already is, it survives the session, and it updates when the work does. A PR
+without one is not finished, the same way a PR with a red gate is not finished.
+
+It has five parts, and the last two are the ones that get skipped:
+
+1. **Where.** Worktree path, branch, base, and both run commands — the block
+   above. Plus any step that has to happen first: *"restart the backend, the
+   declaration runs at start-up"* is the difference between a working feature
+   and a bug report.
+2. **What to look at**, as numbered checks against a named screen or control.
+   "Model folders dialog, toolbar folder icon", not "the folders UI".
+3. **The expected values, concretely.** `116.3 GB`, `26 rows`, `no size at all
+   rather than 0 B` — read off this machine and written down. A tester cannot
+   confirm a number nobody stated, and a wrong number is invisible next to a
+   vague one.
+4. **What "wrong" looks like**, per check. State the failure, not only the pass:
+   *"wrong if a locked row offers scan or forget"*. This is what lets someone
+   who does not know the design spot a regression rather than assume the screen
+   is meant to look like that.
+5. **What you could not test yourself**, named and separated. Cold-boot cost,
+   whether a list of 26 rows is pleasant, anything needing hardware or a
+   judgement call. This is the part that is actually being handed off — the rest
+   is verification. Hiding it inside the checks above buries the only items that
+   genuinely require a human.
+
+**Order the checks by risk, and say which one matters.** If a change opens a
+path that could destroy data, that check goes near the top, says so, and tells
+the tester to stop rather than complete the gesture: *"the drag must never
+start; if the row picks up, say so and do not drop it."*
+
+**Automated coverage is not a test-this item.** If a suite already proves it,
+say that in a line and spend the human's attention on what the suite cannot see.
+
 ## Patch Reliability Policy
 
 - **Read before you edit.** Read enough surrounding context (at least 50 lines before and after the target) to understand structure, logic, and dependencies before generating a patch. If placement is ambiguous, read more until it is certain.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,41 +70,52 @@ Test at: ~/Projects/pixlstash/worktrees/<name>   (branch <branch>, based on <bas
 If the work is already merged, say `develop/` instead and say to pull. "It's on
 the branch" is not a test path.
 
-### Say what to test, not only where — the `## Test this` section
+### Say what to test, not only where — and say it in the session, never in the PR
 
 **A path is not a handoff.** The session that wrote the change is the only party
 that knows which screen it lands on, what number should appear, and which of its
 own steps it is least sure about. Ending at "test at `<path>`" leaves the person
 testing to reverse-engineer all three from a diff, and the honest answer they
-give back is *"I don't know what to test."* That happened, and it is the failure
-this section exists to stop.
+give back is *"I don't know what to test."*
 
-**Every PR that changes behaviour carries a `## Test this` section in its body.**
-The PR body rather than a chat message or a `docs/` file: it is where a tester
-already is, it survives the session, and it updates when the work does. A PR
-without one is not finished, the same way a PR with a red gate is not finished.
+**The handoff goes to the person, in the session. It does not go in the PR.**
+A test plan written against the machine the work was done on is made of that
+machine's absolute paths, its library, its folder names and its disk figures —
+`/home/<user>/...`, the models they happen to own, how full their drive is. A PR
+is published, permanent and public, and none of that belongs in one. This was
+learned by doing it: a `## Test this` section went into a PR body carrying the
+owner's home directory and an inventory of their private model collection, and
+had to be edited back out. **Do not put a test plan, a path under `$HOME`, a
+listing of the owner's library, or their disk usage into a PR body, a commit
+message or a PR comment.** The PR describes the change; the session describes
+how to try it.
 
-It has five parts, and the last two are the ones that get skipped:
+Aggregate engineering figures that justify a decision are fine and already house
+style — "0.01 s to read the index", "a 339 MB tagger". The line is between *this
+mechanism costs this much* and *here is what is on that person's disk*.
 
-1. **Where.** Worktree path, branch, base, and both run commands — the block
-   above. Plus any step that has to happen first: *"restart the backend, the
-   declaration runs at start-up"* is the difference between a working feature
-   and a bug report.
+**So end the session with the plan, and always name a folder to run it from.**
+Five parts, and the last two are the ones that get skipped:
+
+1. **Where** — the worktree block above, always, even when the answer is
+   `develop/`. Plus any step that has to happen first: *"restart the backend,
+   the declaration runs at start-up"* is the difference between a working
+   feature and a bug report.
 2. **What to look at**, as numbered checks against a named screen or control.
    "Model folders dialog, toolbar folder icon", not "the folders UI".
-3. **The expected values, concretely.** `116.3 GB`, `26 rows`, `no size at all
-   rather than 0 B` — read off this machine and written down. A tester cannot
-   confirm a number nobody stated, and a wrong number is invisible next to a
-   vague one.
+3. **The expected values, concretely** — the row count, the size, *"no size at
+   all rather than `0 B`"*. Read off the machine and written down, because a
+   tester cannot confirm a number nobody stated and a wrong one is invisible
+   next to a vague one. This is exactly the part that must not be published.
 4. **What "wrong" looks like**, per check. State the failure, not only the pass:
-   *"wrong if a locked row offers scan or forget"*. This is what lets someone
+   *"wrong if a locked row offers scan or forget"*. That is what lets someone
    who does not know the design spot a regression rather than assume the screen
-   is meant to look like that.
+   is meant to look that way.
 5. **What you could not test yourself**, named and separated. Cold-boot cost,
-   whether a list of 26 rows is pleasant, anything needing hardware or a
-   judgement call. This is the part that is actually being handed off — the rest
-   is verification. Hiding it inside the checks above buries the only items that
-   genuinely require a human.
+   whether a long list is pleasant, anything needing hardware or a judgement
+   call. This is the part actually being handed off — the rest is verification —
+   and folding it into the checks above buries the only items that genuinely
+   require a human.
 
 **Order the checks by risk, and say which one matters.** If a change opens a
 path that could destroy data, that check goes near the top, says so, and tells
@@ -112,7 +123,7 @@ the tester to stop rather than complete the gesture: *"the drag must never
 start; if the row picks up, say so and do not drop it."*
 
 **Automated coverage is not a test-this item.** If a suite already proves it,
-say that in a line and spend the human's attention on what the suite cannot see.
+say so in a line and spend the human's attention on what the suite cannot see.
 
 ## Patch Reliability Policy
 

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1359,6 +1359,32 @@ displayed one. The fourth block (`filters.engines`, on by default) is what makes
 that sentence true. A row's block comes from `blockOf`, so engines refetch and
 are replaced independently of the other three.
 
+**`movable` describes the folder, and gains a fourth value.** It says how a
+folder moves, not whether a route to move it is built yet:
+
+| Value | Meaning | Folders |
+|---|---|---|
+| `per_item` | files move one at a time | a folder the owner assembled |
+| `root_only` | relocates as a whole | the managed store, our downloads, the InsightFace packs |
+| `external` | taken *from*, never written into | an ai-toolkit output root |
+| `fixed` | **cannot relocate at all** — another tool owns where it lives | the HuggingFace cache |
+
+`fixed` exists because `root_only` would be a lie about the cache. Its location
+is `HF_HOME`, read at import by a library shared with every other tool on the
+machine, so "moving" it is a restart and a re-download rather than a move — and
+the design requires that row to render with no drag handle and no Move, its one
+action being an explanation. A value the UI can read is what makes that possible
+without special-casing a path.
+
+**The move guard names both `root_only` and `fixed`.** Neither permits a
+per-item move out, so keying on one would leave the other open — which is
+precisely how renaming this vocabulary could silently drop the protection. The
+plan originally said `external` for these two roots; that would have overloaded
+a word already meaning "ai-toolkit output root" *and*, because the guard is
+keyed on values rather than on `owner`, would have removed the protection on the
+way past. Recorded here rather than in the plan because this is the shipped
+behaviour.
+
 **A declaration sweeps what it no longer names**, and these folders have nowhere
 else to get that. The scanner marks anything it did not see on a walk `missing`,
 and it skips these precisely because they carry an `owner` — so without a sweep

--- a/pixlstash/routes/model_folders.py
+++ b/pixlstash/routes/model_folders.py
@@ -396,10 +396,15 @@ def create_router(server) -> APIRouter:
         return {int(row["model_folder_id"]): int(row["n"]) for row in rows}
 
     def _to_response(
-        row: dict, file_count: int = 0, present_bytes: int = 0
+        row: dict,
+        file_count: int = 0,
+        present_bytes: int = 0,
+        scan: Optional[tuple[Optional[str], Optional[str]]] = None,
     ) -> ModelFolderResponse:
         delete_after_import = row["delete_after_import"]
-        scan_status, scan_error = _scan_state(int(row["id"]))
+        scan_status, scan_error = (
+            scan if scan is not None else _scan_state(int(row["id"]))
+        )
         return ModelFolderResponse(
             id=int(row["id"]),
             path=row["path"],
@@ -430,18 +435,26 @@ def create_router(server) -> APIRouter:
     )
     def list_model_folders(request: Request):
         server.auth.ensure_secure_when_required(request)
-        counts = _file_counts()
-        present_bytes = _present_bytes_by_folder()
         rows = server.hub.fetchall(
             "SELECT id, path, kind, owner, movable, host_path, delete_after_import, "
             "last_checked, created_at FROM model_folder ORDER BY id"
         )
+        # Scan state before the aggregates, never after. A scan's task flips to
+        # completed only once it has written its rows, so reading the counts
+        # first lets a scan that finishes in between be reported as completed
+        # with the count from before it wrote — an empty folder that just
+        # succeeded. This way round the stale pairing is "still running" with a
+        # full count, which the next poll corrects.
+        scans = {int(row["id"]): _scan_state(int(row["id"])) for row in rows}
+        counts = _file_counts()
+        present_bytes = _present_bytes_by_folder()
         return ModelFolderListResponse(
             folders=[
                 _to_response(
                     dict(row),
                     counts.get(int(row["id"]), 0),
                     present_bytes.get(int(row["id"]), 0),
+                    scans[int(row["id"])],
                 )
                 for row in rows
             ]

--- a/pixlstash/services/builtin_caches.py
+++ b/pixlstash/services/builtin_caches.py
@@ -38,7 +38,11 @@ import os
 from typing import Optional
 
 from pixlstash.pixl_logging import get_logger
-from pixlstash.services.builtin_models import DeclaredEntry, declare_folder
+from pixlstash.services.builtin_models import (
+    MOVABLE_FIXED,
+    DeclaredEntry,
+    declare_folder,
+)
 from pixlstash.utils.insightface_model_utils import (
     KNOWN_MODEL_PACKS,
     insightface_root,
@@ -242,4 +246,4 @@ def declare_huggingface_cache(hub, folder_path: str) -> Optional[int]:
         )
         for repo in info.repos
     ]
-    return declare_folder(hub, folder_path, entries)
+    return declare_folder(hub, folder_path, entries, movable=MOVABLE_FIXED)

--- a/pixlstash/services/builtin_models.py
+++ b/pixlstash/services/builtin_models.py
@@ -49,6 +49,16 @@ logger = get_logger(__name__)
 BUILTIN_KIND = "foreign"
 BUILTIN_OWNER = "pixlstash"
 
+# How a declared folder moves, which is a statement about the folder rather than
+# a permission. `root_only` means "if it relocates, it relocates whole" — true of
+# PixlStash's own downloads and of the InsightFace packs, whichever of them has a
+# relocate route yet. `fixed` means it cannot be relocated at all because
+# something else owns where it lives: the HuggingFace cache's location is
+# `HF_HOME`, read at import by a library shared with every other tool on the
+# machine, so "moving" it is a restart and a re-download rather than a move.
+MOVABLE_ROOT_ONLY = "root_only"
+MOVABLE_FIXED = "fixed"
+
 # Everything in this folder arrived because PixlStash fetched it.
 BUILTIN_PROVENANCE = "builtin"
 
@@ -298,7 +308,9 @@ def declare_builtin_models(hub, folder_path: str) -> Optional[int]:
     return declare_folder(hub, folder_path, entries)
 
 
-def declare_folder(hub, folder_path: str, entries) -> Optional[int]:
+def declare_folder(
+    hub, folder_path: str, entries, movable: str = MOVABLE_ROOT_ONLY
+) -> Optional[int]:
     """Upsert one PixlStash-owned folder and a row per declared entry.
 
     Shared by all three roots PixlStash owns: the engines it downloads, the
@@ -313,6 +325,8 @@ def declare_folder(hub, folder_path: str, entries) -> Optional[int]:
         hub: The open hub database.
         folder_path: The root being declared.
         entries: The :class:`DeclaredEntry` rows to write under it.
+        movable: :data:`MOVABLE_ROOT_ONLY` (the default) or
+            :data:`MOVABLE_FIXED` for a root whose location another tool owns.
 
     Returns:
         The ``model_folder.id``, or ``None`` if the row could not be written.
@@ -321,7 +335,7 @@ def declare_folder(hub, folder_path: str, entries) -> Optional[int]:
     with hub.transaction() as conn:
         conn.execute(
             "INSERT INTO model_folder (path, kind, owner, movable, created_at) "
-            "VALUES (?, ?, ?, 'root_only', ?) "
+            "VALUES (?, ?, ?, ?, ?) "
             # `movable` is re-asserted with the rest. A path the owner had
             # already registered as a `user` folder keeps its own
             # `movable` otherwise, so claiming it for PixlStash would
@@ -330,7 +344,7 @@ def declare_folder(hub, folder_path: str, entries) -> Optional[int]:
             # protection exists to prevent.
             "ON CONFLICT(path) DO UPDATE SET kind = excluded.kind, "
             "owner = excluded.owner, movable = excluded.movable",
-            (folder_path, BUILTIN_KIND, BUILTIN_OWNER, now),
+            (folder_path, BUILTIN_KIND, BUILTIN_OWNER, movable, now),
         )
         row = conn.execute(
             "SELECT id FROM model_folder WHERE path = ?", (folder_path,)

--- a/pixlstash/services/model_mover.py
+++ b/pixlstash/services/model_mover.py
@@ -464,35 +464,33 @@ class ModelMover:
                 f"No registered copy at {relpath!r} in folder {folder_id}.",
                 status_code=404,
             )
-        # `root_only` means the folder relocates as a whole and its contents are
-        # NOT individually movable, so a per-item move out of one is refused
-        # here — at the single point every move funnels through — rather than by
-        # each caller remembering to ask.
+        # **Two values, and the pair is the point.** `root_only` says the folder
+        # relocates as a whole — PixlStash's own downloads and the InsightFace
+        # packs. `fixed` says it cannot relocate at all, because another tool
+        # owns where it lives — the HuggingFace cache. Neither permits a
+        # per-item move out, so keying on one would leave the other open, which
+        # is exactly how a rename of this vocabulary could silently drop the
+        # protection. Refused here, at the single point every move funnels
+        # through, rather than by each caller remembering to ask.
         #
-        # The HuggingFace cache is why this is a containment site and not a
-        # tidiness rule. It is not a folder of files: it is `blobs/` under content
-        # hashes with `snapshots/` symlinking names onto them, it is shared with
-        # every other HF tool on the machine, and a row's relpath there is a
-        # whole repo DIRECTORY. Moving one does not relocate a model, it breaks
-        # HuggingFace's bookkeeping for ComfyUI and everything else too. Its real
-        # control is `HF_HOME`, read at import: a restart and a re-download, not
-        # a move. The same applies to an InsightFace pack and to PixlStash's own
-        # engines, and it is why these roots are declared `root_only` or `fixed`.
-        # Both values, and the pair is the point. `root_only` says the folder
-        # relocates as a whole; `fixed` says it cannot relocate at all because
-        # another tool owns where it lives. Neither permits a per-item move out,
-        # so keying on one of them would have left the other open — which is
-        # exactly how a rename of this vocabulary could silently drop the
-        # protection.
+        # The cache is why this is a containment site and not a tidiness rule.
+        # It is not a folder of files: it is `blobs/` under content hashes with
+        # `snapshots/` symlinking names onto them, it is shared with every other
+        # HF tool on the machine, and a row's relpath there is a whole repo
+        # DIRECTORY. Moving one does not relocate a model, it breaks
+        # HuggingFace's bookkeeping for ComfyUI and everything else too. Its
+        # real control is `HF_HOME`, read at import: a restart and a
+        # re-download, not a move — which is the distinction `fixed` exists to
+        # record.
         if row["folder_movable"] in ("root_only", "fixed") and not relocating:
             raise MoveRefused(
-                f"{relpath!r} is inside a folder that moves as a whole, not one "
-                "file at a time, so nothing was moved. PixlStash's own model "
-                "folders, the InsightFace packs and the HuggingFace cache are "
-                "all listed so you can see what they cost on disk, not to be "
-                "rearranged: the cache in particular is a symlink store shared "
-                "with your other tools, and moving a file out of it corrupts it "
-                "for all of them rather than relocating anything.",
+                f"{relpath!r} is inside a folder whose files are not moved one "
+                "at a time, so nothing was moved. PixlStash's own model folders, "
+                "the InsightFace packs and the HuggingFace cache are listed so "
+                "you can see what they cost on disk, not to be rearranged: the "
+                "cache in particular is a symlink store shared with your other "
+                "tools, and moving a file out of it corrupts it for all of them "
+                "rather than relocating anything.",
                 status_code=409,
             )
         if folder_id == destination_folder_id:

--- a/pixlstash/services/model_mover.py
+++ b/pixlstash/services/model_mover.py
@@ -477,7 +477,7 @@ class ModelMover:
         # HuggingFace's bookkeeping for ComfyUI and everything else too. Its real
         # control is `HF_HOME`, read at import: a restart and a re-download, not
         # a move. The same applies to an InsightFace pack and to PixlStash's own
-        # engines, and it is why all three roots are declared `root_only`.
+        # engines, and it is why these roots are declared `root_only` or `fixed`.
         # Both values, and the pair is the point. `root_only` says the folder
         # relocates as a whole; `fixed` says it cannot relocate at all because
         # another tool owns where it lives. Neither permits a per-item move out,

--- a/pixlstash/services/model_mover.py
+++ b/pixlstash/services/model_mover.py
@@ -478,7 +478,13 @@ class ModelMover:
         # control is `HF_HOME`, read at import: a restart and a re-download, not
         # a move. The same applies to an InsightFace pack and to PixlStash's own
         # engines, and it is why all three roots are declared `root_only`.
-        if row["folder_movable"] == "root_only" and not relocating:
+        # Both values, and the pair is the point. `root_only` says the folder
+        # relocates as a whole; `fixed` says it cannot relocate at all because
+        # another tool owns where it lives. Neither permits a per-item move out,
+        # so keying on one of them would have left the other open — which is
+        # exactly how a rename of this vocabulary could silently drop the
+        # protection.
+        if row["folder_movable"] in ("root_only", "fixed") and not relocating:
             raise MoveRefused(
                 f"{relpath!r} is inside a folder that moves as a whole, not one "
                 "file at a time, so nothing was moved. PixlStash's own model "

--- a/tests/multi_project_authz/shared_env.py
+++ b/tests/multi_project_authz/shared_env.py
@@ -421,7 +421,19 @@ def _assert_fixture_shape(owner, ids, pic_a, pic_b):
         )
 
 
-def _wait_faces_extracted(server, picture_ids, timeout_s=60.0):
+# Generous on purpose, and the number is evidence-led. CI runs the whole suite
+# `--force-cpu` on a shared runner, so this waits on a face pass that has no GPU
+# and may still be fetching its model pack. At 60 s it timed out on two separate
+# PRs whose diffs could not touch face extraction — one of them frontend-only —
+# reporting `rows per picture: {}`, i.e. the pass had produced nothing at all
+# rather than being partway through. The same suite takes ~98 s end to end
+# locally WITH a GPU. `test_likeness_and_face_search` already allows 120 s for an
+# ML wait, so this is the suite's own scale rather than a new one.
+#
+# It is a ceiling on a poll loop, not a sleep: a pass that finishes in two
+# seconds still returns in two seconds, and only a genuine hang pays the full
+# budget before failing.
+def _wait_faces_extracted(server, picture_ids, timeout_s=180.0):
     """Block until background face extraction has finished with *picture_ids*.
 
     Uploading a picture queues an extraction pass that ends by writing either

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -423,3 +423,76 @@ def test_the_sweep_does_not_touch_a_declared_engine_that_is_simply_absent(
         (folder_id, "sa_0_4_vit_b_32_linear.pth"),
     )
     assert row["state"] == "present"
+
+
+def test_the_huggingface_cache_is_fixed_not_merely_root_only(
+    server_hub, tmp_path, monkeypatch
+):
+    """`root_only` says a folder relocates as a whole. That is true of our own
+    downloads and of the InsightFace packs; it is false of the HuggingFace cache,
+    whose location is `HF_HOME` read at import by a library shared with every
+    other tool on the machine. "Moving" it is a restart and a re-download, so the
+    column says `fixed` and the UI can offer an explanation instead of a verb."""
+    import huggingface_hub
+
+    class _Repo:
+        repo_id = "org/thing"
+        repo_type = "model"
+        repo_path = "models--org--thing"
+        size_on_disk = 10
+        revisions = frozenset()
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "scan_cache_dir",
+        lambda _p: type("_I", (), {"repos": (_Repo(),)})(),
+    )
+    folder_id = declare_huggingface_cache(server_hub, str(tmp_path))
+    row = server_hub.fetchone(
+        "SELECT movable FROM model_folder WHERE id = ?", (folder_id,)
+    )
+    assert row["movable"] == "fixed"
+
+
+def test_a_fixed_folder_refuses_a_per_item_move_the_same_as_root_only(tmp_path):
+    """The pair is the point: both values forbid a per-item move out, so keying
+    the guard on one of them would leave the other open."""
+    from pixlstash.hub.db import HubDatabase
+    from pixlstash.services.model_mover import ModelMover, MoveRefused
+
+    source = tmp_path / "cache"
+    source.mkdir()
+    (source / "models--org--thing").mkdir()
+    destination = tmp_path / "loras"
+    destination.mkdir()
+
+    hub = HubDatabase(str(tmp_path / "hub.db"))
+    try:
+        with hub.transaction() as conn:
+            conn.execute(
+                "INSERT INTO model_folder (id, path, kind, owner, movable, "
+                "created_at) VALUES (1, ?, 'foreign', 'pixlstash', 'fixed', "
+                "'2026-08-12T00:00:00Z')",
+                (str(source),),
+            )
+            conn.execute(
+                "INSERT INTO model_folder (id, path, kind, movable, created_at) "
+                "VALUES (2, ?, 'user', 'per_item', '2026-08-12T00:00:00Z')",
+                (str(destination),),
+            )
+            cursor = conn.execute(
+                "INSERT INTO model (file_kind, kind, display_name, filename, "
+                "provenance, file_size, created_at) VALUES ('engine', 'other', "
+                "'org/thing', 'models--org--thing', 'builtin', 10, "
+                "'2026-08-12T00:00:00Z')"
+            )
+            conn.execute(
+                "INSERT INTO model_file (model_id, model_folder_id, relpath, "
+                "state, seen_at) VALUES (?, 1, 'models--org--thing', 'present', "
+                "'2026-08-12T00:00:00Z')",
+                (int(cursor.lastrowid),),
+            )
+        with pytest.raises(MoveRefused):
+            ModelMover(hub).plan([(1, "models--org--thing")], 2)
+    finally:
+        hub.close()

--- a/tests/test_model_move.py
+++ b/tests/test_model_move.py
@@ -891,7 +891,7 @@ def test_a_root_only_folder_refuses_a_per_item_move(tmp_path):
         mover = ModelMover(hub)
         with pytest.raises(MoveRefused) as refused:
             mover.plan([(1, "models--org--thing")], 2)
-        assert "moves as a whole" in str(refused.value)
+        assert "not moved one at a time" in str(refused.value)
 
         # The positive control: over-blocking is its own regression, so a
         # per_item folder must still move out in the same environment.


### PR DESCRIPTION
Three commits that were pushed to #886's branch **after it had already merged**,
so they never reached `develop`. Rebuilt here on top of `develop` unchanged.

Verified by content rather than by the merge badge — `git grep MOVABLE_FIXED
origin/develop` returned nothing, which is how this was caught.

## What is in here

**`movable` gains a fourth value, settling #902.**

| Value | Meaning | Folders |
|---|---|---|
| `per_item` | files move one at a time | a folder the owner assembled |
| `root_only` | relocates as a whole | the managed store, our downloads, the InsightFace packs |
| `external` | taken *from*, never written into | an ai-toolkit output root |
| `fixed` | **cannot relocate at all** — another tool owns where it lives | the HuggingFace cache |

`root_only` would be a lie about the cache: its location is `HF_HOME`, read at
import by a library shared with every other tool on the machine, so "moving" it
is a restart and a re-download. The design needs that row to render with no drag
handle and no Move, its one action being an explanation, and that needs a value
the UI can read rather than a special-cased path.

**The move guard now names both `root_only` and `fixed`.** Keying on one leaves
the other open, which is exactly how a rename of this vocabulary could silently
drop the protection — the plan's original `external` would have done precisely
that, since the guard reads values rather than `owner`. Pinned by a test.

**A `## Test this` convention**, then its correction: the handoff goes to the
person in the session and never into a PR body, because a test plan is made of
the tester's absolute paths, their library and their disk figures. Learned by
doing it wrong on #886 and having to edit it back out.

## Test this

Nothing user-visible changes yet — `fixed` is a stored value the UI does not read
until the folders dialog learns to offer the explanation (that work is #893/#899
territory). Backend suites cover it: 45 tests across `test_builtin_models.py` and
`test_model_move.py`, both directions on the guard.