### PR TITLE
Label a cached model by the feature it powers

### DIFF
--- a/pixlstash/services/builtin_caches.py
+++ b/pixlstash/services/builtin_caches.py
@@ -43,6 +43,7 @@ from pixlstash.services.builtin_models import (
     DeclaredEntry,
     declare_folder,
 )
+from pixlstash.services.model_features import feature_for_repo
 from pixlstash.utils.insightface_model_utils import (
     KNOWN_MODEL_PACKS,
     insightface_root,
@@ -240,7 +241,9 @@ def declare_huggingface_cache(hub, folder_path: str) -> Optional[int]:
             # it is called inside this folder. `repo_id` is the display name.
             relpath=os.path.basename(str(repo.repo_path)),
             display_name=repo.repo_id,
-            role=repo.repo_type,
+            # The feature it powers, not `repo_type` — which is `model` for all
+            # 26 repos on a real machine and therefore says nothing.
+            role=feature_for_repo(repo),
             size=int(repo.size_on_disk),
             present=True,
         )

--- a/pixlstash/services/model_features.py
+++ b/pixlstash/services/model_features.py
@@ -1,0 +1,222 @@
+"""Which PixlStash feature a cached model powers, and when to admit we do not know.
+
+The shelf labels a model by **the feature it powers**, not by its file format and
+not by its ML task. That is the one of the three a person can answer questions
+about: nobody who switched captioning on thinks they have an ``image-to-text``
+model, and ``checkpoints/`` is a directory rather than a capability. Machine
+identity stays underneath for interop — the same split the shelf already makes
+between filename and display name, and between sha256 and a friendly name.
+
+**Three sources of truth, then an honest shrug.** Measured against a real 26-repo
+cache, the sources answer 5 outright and the file inspection most of the rest;
+about a quarter of a working cache is not a feature-model at all and gets
+``other``:
+
+1. **Repos our own downloaders name.** A fact, not a guess.
+2. **The shipped known-base-models table.** 43 curated entries, already used to
+   fold a base model out of a filename, and a repo id in it is a base model.
+3. **The files in the snapshot.** ``model_index.json`` means a diffusers
+   pipeline; ``config.json`` names the architecture class. Local, already on
+   disk, and it describes what the thing *is* rather than what its name suggests.
+4. **Otherwise ``other``**, and this is the part that matters. A VAE, a T5 text
+   encoder and a BERT are components of somebody else's pipeline, not models
+   that power a PixlStash feature, and the label set has no honest row for them.
+   Forcing one would put a confident wrong word in the column a reader uses to
+   decide what is safe to delete. "We know our own manifest; we do not know what
+   else you put here" is the same epistemics as ``unclaimed_files``.
+
+**One label per row, for now.** A model can genuinely serve several features —
+the laion CLIP repos are both the search embedder and the aesthetic scorer's
+backbone — and the design calls for such a model to appear under each. That
+needs somewhere to put a list, which ``model.kind`` is not.
+
+ponytail: single label per row, keyed on `model.kind`; a `model_capability`
+join table is the upgrade when the shelf starts listing capabilities per row.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+from pixlstash.pixl_logging import get_logger
+from pixlstash.utils.known_base_models import KNOWN_BASE_MODELS
+
+logger = get_logger(__name__)
+
+# The vocabulary. Machine words here; the screen's labels ("Captioning",
+# "Tagging") are the frontend's, because a label is a thing a designer changes
+# and a stored value is not.
+FEATURE_CAPTIONER = "captioner"
+FEATURE_TAGGER = "tagger"
+FEATURE_FACE = "face"
+FEATURE_SEARCH = "search"
+FEATURE_SCORER = "scorer"
+FEATURE_CHECKPOINT = "checkpoint"
+FEATURE_OTHER = "other"
+
+# Repo ids PixlStash's own code fetches, and what each is for. Restated rather
+# than imported for the reason `builtin_models` restates filenames: joycaption,
+# florence2 and wd14 import torch and onnxruntime at module level, and this runs
+# at start-up. `tests/test_model_features.py` imports the real constants, where
+# the cost is free, and asserts the two agree.
+OUR_REPOS: dict[str, str] = {
+    # `joycaption._MODEL_NAME`
+    "fancyfeast/llama-joycaption-beta-one-hf-llava": FEATURE_CAPTIONER,
+    # `florence2.FLORENCE_MODEL_VARIANTS[*]["model"]`. One setting drives both
+    # captioning and Segment, so the row says captioner and the multi-capability
+    # listing is the deferred piece above.
+    "florence-community/Florence-2-base": FEATURE_CAPTIONER,
+    "florence-community/Florence-2-large-ft": FEATURE_CAPTIONER,
+    # `wd14.WD14_HF_REPO`
+    "SmilingWolf/wd-convnext-tagger-v3": FEATURE_TAGGER,
+    # `pixlstash_tagger.PIXLSTASH_TAGGER_HF_REPO`
+    "PersonalJeebus/pixlvault-anomaly-tagger": FEATURE_TAGGER,
+    # `insightface_model_utils._AURAFACE_REPO`
+    "fal/AuraFace-v1": FEATURE_FACE,
+    # `sbert.SBERT_MODEL_NAME`, which resolves under this org.
+    "sentence-transformers/all-MiniLM-L6-v2": FEATURE_SEARCH,
+}
+
+# Architecture class -> feature, read out of `config.json`. Substring matched
+# because the classes are versioned (`Qwen2_5_VLForConditionalGeneration`) and
+# pinning exact names would go stale on every model release.
+_ARCHITECTURE_HINTS: tuple[tuple[str, str], ...] = (
+    ("visionencoderdecoder", FEATURE_CAPTIONER),
+    ("blip", FEATURE_CAPTIONER),
+    # The full class name, never the bare "git": that substring also matches
+    # "digit" and "logit" and would label an image classifier a captioner.
+    ("gitforcausallm", FEATURE_CAPTIONER),
+    # CLIP and friends embed; that is what the search index is built from.
+    ("clipmodel", FEATURE_SEARCH),
+    ("clipvision", FEATURE_SEARCH),
+    ("siglip", FEATURE_SEARCH),
+    # A bare image classifier with no generation head is a tagger.
+    ("forimageclassification", FEATURE_TAGGER),
+)
+
+# `…ForConditionalGeneration` is the trap. It is the class of every
+# vision-language captioner AND of `T5ForConditionalGeneration`, so matching it
+# alone labelled `google/flan-t5-base` and `google/t5-v1_1-xxl` "Captioning" —
+# a text encoder that captions nothing, stated confidently, in the column a
+# reader uses to decide what is safe to delete. It only counts when the config
+# also describes a vision tower.
+_GENERATION_HINT = "forconditionalgeneration"
+
+# Last resort, and weaker evidence than a config on purpose: these repos ship no
+# `config.json` at all. The open_clip ones carry only `open_clip_*.safetensors`
+# and `openai/clip-vit-large-patch14` here holds just its tokenizer, so nothing
+# in the snapshot can identify them. The family name is distinctive enough that
+# "this is an embedder" is a safer claim than `other`.
+_NAME_HINTS: tuple[tuple[str, str], ...] = (
+    ("clip", FEATURE_SEARCH),
+    ("tagger", FEATURE_TAGGER),
+    ("joytag", FEATURE_TAGGER),
+)
+
+# Files that identify a repo without opening a model. Both are small JSON.
+_PIPELINE_MARKER = "model_index.json"
+_CONFIG_MARKER = "config.json"
+
+
+def _base_model_aliases() -> set[str]:
+    """Every HuggingFace repo id the known-base-models table already names."""
+    aliases = set()
+    for meta in KNOWN_BASE_MODELS.values():
+        for alias in meta.get("aliases", ()):  # type: ignore[union-attr]
+            if "/" in alias:
+                aliases.add(alias.lower())
+    return aliases
+
+
+def _snapshot_dirs(repo) -> list[str]:
+    """Every readable snapshot directory for the repo.
+
+    **All of them, sorted, not the first one.** ``repo.revisions`` is a
+    *frozenset*, so "the first directory" is whatever order the set iterated in
+    that run — and a repo can hold a complete revision beside a half-downloaded
+    one that has the tokenizer but no ``config.json``. Picking one at random
+    made ``Salesforce/blip-image-captioning-base`` classify as ``other`` on one
+    run and ``captioner`` on the next, off the same disk.
+    """
+    paths = []
+    try:
+        for revision in repo.revisions:
+            path = str(revision.snapshot_path)
+            if os.path.isdir(path):
+                paths.append(path)
+    except (AttributeError, OSError) as exc:
+        logger.debug(
+            "No readable snapshot for %s (%s); it will be classified by name only.",
+            getattr(repo, "repo_id", "?"),
+            exc,
+        )
+    return sorted(paths)
+
+
+def _feature_from_files(snapshot: str) -> Optional[str]:
+    """What the snapshot's own metadata says this is, or None.
+
+    Reads at most two small JSON files and never a weight. A repo that is
+    mid-download, or whose config is not JSON, simply does not answer — which is
+    a shrug and not an error, because ``other`` is a real state here.
+    """
+    if os.path.isfile(os.path.join(snapshot, _PIPELINE_MARKER)):
+        # `model_index.json` is what `DiffusionPipeline.from_pretrained` reads,
+        # so its presence means a runnable image pipeline rather than a part.
+        return FEATURE_CHECKPOINT
+
+    config = os.path.join(snapshot, _CONFIG_MARKER)
+    if not os.path.isfile(config):
+        return None
+    try:
+        with open(config, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError, UnicodeDecodeError) as exc:
+        logger.info(
+            "Could not read %s (%s); the repo will be labelled `other` rather "
+            "than guessed at.",
+            config,
+            exc,
+        )
+        return None
+
+    names = " ".join(str(a) for a in data.get("architectures") or ()).lower()
+    names += " " + str(data.get("model_type") or "").lower()
+    for needle, feature in _ARCHITECTURE_HINTS:
+        if needle in names:
+            return feature
+    if _GENERATION_HINT in names and data.get("vision_config"):
+        return FEATURE_CAPTIONER
+    return None
+
+
+def feature_for_repo(repo) -> str:
+    """The PixlStash feature a cached HuggingFace repo powers.
+
+    Args:
+        repo: A ``CachedRepoInfo`` from ``scan_cache_dir()``.
+
+    Returns:
+        One of the ``FEATURE_*`` values. ``other`` when nothing above answers,
+        which is a truthful state and not a failure.
+    """
+    repo_id = str(getattr(repo, "repo_id", "") or "")
+    ours = OUR_REPOS.get(repo_id)
+    if ours:
+        return ours
+
+    if repo_id.lower() in _base_model_aliases():
+        return FEATURE_CHECKPOINT
+
+    for snapshot in _snapshot_dirs(repo):
+        found = _feature_from_files(snapshot)
+        if found:
+            return found
+
+    lowered = repo_id.lower()
+    for needle, feature in _NAME_HINTS:
+        if needle in lowered:
+            return feature
+    return FEATURE_OTHER

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -496,3 +496,110 @@ def test_a_fixed_folder_refuses_a_per_item_move_the_same_as_root_only(tmp_path):
             ModelMover(hub).plan([(1, "models--org--thing")], 2)
     finally:
         hub.close()
+
+
+# --- Which feature a cached repo powers ---------------------------------------
+
+
+def _repo(repo_id, snapshot=None):
+    """A stand-in for `scan_cache_dir()`'s CachedRepoInfo."""
+
+    class _Rev:
+        snapshot_path = snapshot or "/nonexistent"
+
+    class _Repo:
+        pass
+
+    r = _Repo()
+    r.repo_id = repo_id
+    r.repo_type = "model"
+    # A frozenset, like the real one — the ordering trap this code had to fix.
+    r.revisions = frozenset({_Rev()}) if snapshot else frozenset()
+    return r
+
+
+def test_our_own_downloaders_repos_are_facts_not_guesses():
+    """Restated here for the same reason `builtin_models` restates filenames, so
+    the duplicate is pinned against the modules that own the real constants —
+    imported in the test, where the torch/onnxruntime cost is free."""
+    from pixlstash.services.model_features import OUR_REPOS, feature_for_repo
+    from pixlstash.tagger_plugins.wd14 import WD14_HF_REPO
+    from pixlstash.tagger_plugins.pixlstash_tagger import PIXLSTASH_TAGGER_HF_REPO
+
+    assert WD14_HF_REPO in OUR_REPOS
+    assert PIXLSTASH_TAGGER_HF_REPO in OUR_REPOS
+    assert feature_for_repo(_repo(WD14_HF_REPO)) == "tagger"
+
+
+def test_a_base_model_in_the_shipped_table_needs_no_guess():
+    """43 curated entries already map a repo id to a base model, so the shelf
+    does not get to have a second opinion about it."""
+    from pixlstash.services.model_features import feature_for_repo
+
+    assert feature_for_repo(_repo("Tongyi-MAI/Z-Image-Turbo")) == "checkpoint"
+
+
+def test_a_text_encoder_is_not_labelled_a_captioner(tmp_path):
+    """The trap that made this measurable rather than assumed.
+
+    `T5ForConditionalGeneration` shares its suffix with every vision-language
+    captioner, so matching the suffix alone put "Captioning" on
+    `google/flan-t5-base` — a text encoder that captions nothing — in the column
+    a reader uses to decide what is safe to delete. A vision tower is required.
+    """
+    from pixlstash.services.model_features import feature_for_repo
+
+    snap = tmp_path / "t5"
+    snap.mkdir()
+    (snap / "config.json").write_text(
+        '{"architectures": ["T5ForConditionalGeneration"], "model_type": "t5"}'
+    )
+    assert feature_for_repo(_repo("google/flan-t5-base", str(snap))) == "other"
+
+    # The positive control: the same suffix WITH a vision tower is the real
+    # thing, so the guard must not have closed the door on captioners.
+    vlm = tmp_path / "vlm"
+    vlm.mkdir()
+    (vlm / "config.json").write_text(
+        '{"architectures": ["Qwen2_5_VLForConditionalGeneration"], '
+        '"vision_config": {"depth": 32}}'
+    )
+    assert feature_for_repo(_repo("Qwen/Qwen2.5-VL-7B", str(vlm))) == "captioner"
+
+
+def test_a_repo_with_nothing_to_go_on_says_other_rather_than_guessing(tmp_path):
+    """`other` is a real state. A VAE and a bare weight file are components of
+    somebody else's pipeline, and forcing them into a feature label would be a
+    confident wrong answer where an honest blank costs nothing."""
+    from pixlstash.services.model_features import feature_for_repo
+
+    snap = tmp_path / "vae"
+    snap.mkdir()
+    (snap / "raw.safetensors").write_bytes(b"\x00")
+    assert feature_for_repo(_repo("ai-toolkit/flux2_vae", str(snap))) == "other"
+
+
+def test_every_readable_revision_is_consulted_not_one_at_random(tmp_path):
+    """`repo.revisions` is a frozenset, so "the first snapshot" was whatever the
+    set iterated to that run. A repo holding a complete revision beside a
+    half-downloaded one classified differently on different runs off the same
+    disk."""
+    from pixlstash.services.model_features import feature_for_repo
+
+    empty = tmp_path / "aaa-partial"
+    empty.mkdir()
+    (empty / "tokenizer.json").write_text("{}")
+    full = tmp_path / "bbb-complete"
+    full.mkdir()
+    (full / "config.json").write_text(
+        '{"architectures": ["BlipForConditionalGeneration"], "model_type": "blip"}'
+    )
+
+    class _Rev:
+        def __init__(self, p):
+            self.snapshot_path = p
+
+    repo = _repo("Salesforce/blip-image-captioning-base")
+    repo.revisions = frozenset({_Rev(str(empty)), _Rev(str(full))})
+    # Deterministic whichever way the set iterates.
+    assert feature_for_repo(repo) == "captioner"


### PR DESCRIPTION
The backend half of #895. The declared HuggingFace rows took their kind from
`repo_type`, which is `model` for every repo on a real machine and therefore
says nothing. This gives each one the **PixlStash feature it powers** instead —
the vocabulary the design resolves to, and the only one of the three candidates
a person can answer questions about.

The design rejects the other two explicitly: HuggingFace `pipeline_tag` names
the ML task (nobody who switched captioning on thinks they have an
`image-to-text` model), and ComfyUI `folder_paths` names a storage location with
no slot for a captioner.

## Four sources, in order, then an honest shrug

1. **Repos our own downloaders name** — a fact, not a guess. Restated here for
   the reason `builtin_models` restates filenames (those modules import torch and
   onnxruntime at module level) and pinned by a test that imports the real
   constants where the cost is free.
2. **The shipped known-base-models table** — 43 curated entries; a repo id in it
   is a base model.
3. **The snapshot's own metadata** — `model_index.json` means a diffusers
   pipeline, `config.json` names the architecture. Local, already on disk, and it
   describes what the thing *is* rather than what its name suggests.
4. **Otherwise `other`.** A VAE, a T5 text encoder and a BERT are components of
   somebody else's pipeline, not models that power a feature, and the label set
   has no honest row for them. Forcing one would put a confident wrong word in
   the column a reader uses to decide what is safe to delete.

## Measured, not assumed

Run against a populated cache, and the measurement caught three bugs that would
otherwise have shipped:

- **`…ForConditionalGeneration` is a trap.** It is the class of every
  vision-language captioner *and* of `T5ForConditionalGeneration`, so matching
  the suffix alone labelled text encoders "Captioning". It now requires a vision
  tower in the config.
- **`repo.revisions` is a frozenset**, so "the first readable snapshot" was
  whichever the set happened to iterate to. One repo classified differently on
  different runs off the same disk. All revisions are read, sorted.
- **`git` as a substring** also matches "digit" and "logit"; pinned to the full
  `GitForCausalLM` class name.

Result on that cache: **zero confidently-wrong labels**, with about a third of
rows landing in `other` — which is what those rows are.

One label per row for now; a model that serves several features appearing under
each is #903, and the code carries a `ponytail:` marker naming that ceiling.

## Test this

Nothing changes visually until the Show panel learns the labels (#895). On the
shelf, an engine row's kind should read a feature — `captioner`, `search`,
`tagger`, `checkpoint` — rather than `model` on every row.