### PR TITLE
Give the shelf's four naming states four treatments

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1388,7 +1388,7 @@ express that. Like Duplicates it is excluded from `selectionOwnsHighlight` in
 `SideBar.vue`, or the underlying picture selection would light a second active
 destination in the rail.
 
-Four rules come from measurement against real adapter folders and are easy to
+These rules come from measurement against real adapter folders and are easy to
 undo by accident:
 
 - **A blank cell is the failure mode, not an edge case.** 37% of real adapters
@@ -1401,12 +1401,38 @@ undo by accident:
   and stops a guess being mistaken for a choice. `deriveModelName` mirrors
   `pixlstash/utils/model_utils.py`; `cleanAssetName` beneath it must not drift,
   because its Python original feeds stored sentence embeddings.
-- **The derived name is marked by type, never by opacity.** `--font-mono` at
-  `--weight-regular` and full strength: §3 gives the mono face to file paths,
-  and a filename-derived name is one. Rank is never opacity
-  (`visual-language.md` §5.1) and a third of the rows faded would be a column
-  of ghosts. A font swap is silent to a screen reader, so the row also carries
-  a `visually-hidden` qualifier.
+- **The name has FOUR states and the row draws each one differently.**
+  `modelName` returns `{text, state}` with `state` one of `named` / `derived` /
+  `from-file` / `needs-a-name`, and naming is the commonest fix on this shelf,
+  so telling them apart is the column's main job (#897):
+  - `named` — somebody chose it. Plain, at `--weight-semibold`.
+  - `derived` — we made a readable string the file does not contain. The **UI**
+    face at `--weight-regular` (mono would claim the string were the file's),
+    plus an outline tag reading `derived`.
+  - `from-file` — nothing survived the strip, so what is shown *is* the
+    filename. `--font-mono` (§3 gives mono to file paths) plus a small **accent**
+    tag reading `from filename`.
+  - `needs-a-name` — no name and no filename. `text` is deliberately **empty**
+    and the row draws an italic `Name this model` prompt with a permanent accent
+    rule and a pencil that never hides. It used to read `no name in file`, which
+    looks like a name and reads as inert, so the row that most needed naming was
+    the one that least invited it.
+  Rank is type, shape and words — **never opacity** (`visual-language.md` §5.1):
+  a third of the rows faded would be a column of ghosts, and the two "nobody has
+  named this" tags carry their meaning in the label so the pair survives
+  greyscale. The empty `text` is already handled by `compareOn`, which sorts a
+  row that cannot answer the key last in both directions.
+- **The name is a field, and the affordance is not hover-only.** The dashed rule
+  and the pencil appear on `.shelf-row:hover` **and** `:focus-within`, or a
+  keyboard reader would have no sign the name is editable. Editing happens
+  **inline** — a bordered input with `--focus-ring`, committed on Enter or on
+  blur, abandoned on Escape, writing through `store.editModelIds(ids, changes)`
+  (the selection-free half of `editSelected`) and taking a stack cover's whole
+  run, since the members share one name. The keyboard path is **F2 on the row**
+  (`aria-keyshortcuts`), not a focusable pencil: the shelf's dialect is that the
+  row is the control, and a pencil per row would be 1,800 new tab stops. The
+  field stops its own keys, or Arrow, Space and Escape would walk and clear the
+  list from under it.
 - **`unknown` is never rendered as a checkpoint.** `file_kind='unknown'` is a
   first-class stored value with its own glyph and the word "Unclassified". It
   is in neither list by default and is fetched only from the *adapters* block

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -220,14 +220,17 @@ describe("the four naming states", () => {
 
   it("draws each of them differently", async () => {
     const rows = (await mountStates()).findAll(".shelf-row");
-    expect(rows.map((row) => row.find(".shelf-row-name").classes()[1])).toEqual(
-      [
-        "shelf-row-name--named",
-        "shelf-row-name--needs-a-name",
-        "shelf-row-name--derived",
-        "shelf-row-name--from-file",
-      ],
-    );
+    const stateClass = (row) =>
+      row
+        .find(".shelf-row-name")
+        .classes()
+        .find((c) => c.startsWith("shelf-row-name--"));
+    expect(rows.map(stateClass)).toEqual([
+      "shelf-row-name--named",
+      "shelf-row-name--needs-a-name",
+      "shelf-row-name--derived",
+      "shelf-row-name--from-file",
+    ]);
   });
 
   it("tells derived from the file's own name without opening anything", async () => {

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -180,9 +180,124 @@ describe("a row with nothing in its header", () => {
     ]);
     const names = wrapper.findAll(".shelf-row-name");
     expect(names[0].classes()).toContain("shelf-row-name--derived");
-    expect(names[1].classes()).not.toContain("shelf-row-name--derived");
-    // ...and the mark is announced, because a font swap is silent.
-    expect(names[0].text()).toContain("name taken from the filename");
+    expect(names[1].classes()).toContain("shelf-row-name--named");
+    // ...and the mark is a WORD, because a font swap is silent to a screen
+    // reader and invisible in greyscale.
+    const rows = wrapper.findAll(".shelf-row");
+    expect(rows[0].find(".shelf-name-tag").text()).toBe("derived");
+    expect(rows[1].find(".shelf-name-tag").exists()).toBe(false);
+  });
+});
+
+describe("the four naming states", () => {
+  /** One row per state, in the order the design lists them. */
+  async function mountStates() {
+    return mountShelf([
+      adapter({ id: 1, display_name: "Clementine" }),
+      adapter({ id: 2, display_name: null, filename: null }),
+      adapter({ id: 3, display_name: null, filename: "Foxglove_Char.st" }),
+      // Nothing survives the strip, so the shown string IS the filename.
+      adapter({ id: 4, display_name: null, filename: "000002750.st" }),
+    ]);
+  }
+
+  it("draws each of them differently", async () => {
+    const rows = (await mountStates()).findAll(".shelf-row");
+    expect(rows.map((row) => row.find(".shelf-row-name").classes()[1])).toEqual(
+      [
+        "shelf-row-name--named",
+        "shelf-row-name--needs-a-name",
+        "shelf-row-name--derived",
+        "shelf-row-name--from-file",
+      ],
+    );
+  });
+
+  it("tells derived from the file's own name without opening anything", async () => {
+    const rows = (await mountStates()).findAll(".shelf-row");
+    // The two "nobody named this" states are different news, and the words are
+    // what carry it: the accent on the from-file tag is a hint on top.
+    expect(rows[2].find(".shelf-name-tag").text()).toBe("derived");
+    expect(rows[3].find(".shelf-name-tag").text()).toBe("from filename");
+    expect(rows[3].find(".shelf-name-tag").classes()).toContain(
+      "shelf-name-tag--from-file",
+    );
+  });
+
+  it("shows an unnamed model an empty field, not inert text", async () => {
+    const rows = (await mountStates()).findAll(".shelf-row");
+    // The row that most needs naming used to read `no name in file`, which
+    // looks like a name and invites nothing. It is a prompt with a persistent
+    // pencil now (#897).
+    expect(rows[1].find(".shelf-row-name").text()).toBe("Name this model");
+    expect(rows[1].find(".shelf-name-pencil").classes()).toContain(
+      "shelf-name-pencil--persistent",
+    );
+    expect(rows[0].find(".shelf-name-pencil").classes()).not.toContain(
+      "shelf-name-pencil--persistent",
+    );
+  });
+});
+
+describe("renaming a row in place", () => {
+  it("opens the field on F2 and commits it on Enter", async () => {
+    // F2 and not a tab stop per row: the affordance has to be reachable by
+    // keyboard, and the shelf's dialect is that the ROW is the control.
+    const wrapper = await mountShelf([adapter({ id: 7, display_name: null })]);
+    const store = useModelShelfStore();
+    const edit = vi.spyOn(store, "editModelIds").mockResolvedValue(true);
+
+    await wrapper.find(".shelf-row").trigger("keydown", { key: "F2" });
+    const field = wrapper.find(".shelf-row-rename");
+    expect(field.exists()).toBe(true);
+    // Seeded EMPTY on a derived row: the derived string is a guess, and
+    // pre-filling it would turn one Enter into somebody having chosen it.
+    expect(field.element.value).toBe("");
+
+    await field.setValue("Cyanwood");
+    await field.trigger("keydown", { key: "Enter" });
+    expect(edit).toHaveBeenCalledWith([7], { display_name: "Cyanwood" });
+    expect(wrapper.find(".shelf-row-rename").exists()).toBe(false);
+  });
+
+  it("writes nothing on Escape", async () => {
+    const wrapper = await mountShelf([adapter({ id: 7 })]);
+    const store = useModelShelfStore();
+    const edit = vi.spyOn(store, "editModelIds").mockResolvedValue(true);
+
+    await wrapper.find(".shelf-row").trigger("keydown", { key: "F2" });
+    await wrapper.find(".shelf-row-rename").setValue("Nope");
+    await wrapper
+      .find(".shelf-row-rename")
+      .trigger("keydown", { key: "Escape" });
+    expect(edit).not.toHaveBeenCalled();
+    expect(wrapper.find(".shelf-row-rename").exists()).toBe(false);
+  });
+
+  it("keeps the field's keys off the list underneath", async () => {
+    // Arrow walks the rows, Space picks and Escape clears the selection, so a
+    // name could not be typed with any of them still live under the field.
+    const wrapper = await mountShelf([adapter({ id: 7 }), adapter({ id: 8 })]);
+    const store = useModelShelfStore();
+    await wrapper.find(".shelf-row").trigger("keydown", { key: "F2" });
+    await wrapper.find(".shelf-row-rename").trigger("keydown", { key: " " });
+    expect(store.selectedRows).toHaveLength(0);
+  });
+
+  it("renames every member of a run, because they share one name", async () => {
+    const wrapper = await mountShelf([
+      adapter({ id: 1, stack_id: 5, display_name: null, training_step: 250 }),
+      adapter({ id: 2, stack_id: 5, display_name: null, training_step: 500 }),
+    ]);
+    const store = useModelShelfStore();
+    const edit = vi.spyOn(store, "editModelIds").mockResolvedValue(true);
+
+    await wrapper.find(".shelf-row").trigger("keydown", { key: "F2" });
+    await wrapper.find(".shelf-row-rename").setValue("Cyanwood");
+    await wrapper
+      .find(".shelf-row-rename")
+      .trigger("keydown", { key: "Enter" });
+    expect(edit).toHaveBeenCalledWith([1, 2], { display_name: "Cyanwood" });
   });
 });
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -446,9 +446,10 @@
                   row.memberCount > 1 ? isStackOpen(row.stack_id) : undefined
                 "
                 :aria-selected="store.isSelected(row.id)"
+                aria-keyshortcuts="F2"
                 :tabindex="row.rowKey === rovingRowKey ? 0 : -1"
                 :data-row-key="row.rowKey"
-                :draggable="canDrag(row)"
+                :draggable="canDrag(row) && editingRowKey !== row.rowKey"
                 @click="pickRow(row, $event)"
                 @keydown="onRowKeydown(row, $event)"
                 @focus="focusedRowKey = row.rowKey"
@@ -483,14 +484,56 @@
                   <ModelMark :row="row" />
                 </span>
                 <span role="gridcell" class="shelf-row-label">
-                  <span
-                    class="shelf-row-name"
-                    :class="{ 'shelf-row-name--derived': row.name.derived }"
-                    >{{ row.name.text
-                    }}<span v-if="row.name.derived" class="visually-hidden">
-                      (name taken from the filename)</span
-                    ></span
-                  >
+                  <!-- The name is a FIELD, and it has four states, because
+                       naming is the commonest fix on this shelf and the reader
+                       has to be able to tell "somebody chose this" from "we
+                       guessed" from "there is nothing here" without opening
+                       anything. Rendering all four as one string is what made
+                       an unnamed row look inert, and an inert row never gets
+                       named (#897). The tag beside the name is the carrier;
+                       the type and the accent are hints on top of it, so the
+                       distinction survives greyscale. -->
+                  <input
+                    v-if="editingRowKey === row.rowKey"
+                    v-model="editingName"
+                    class="shelf-row-rename"
+                    type="text"
+                    :placeholder="row.name.text || 'Name this model'"
+                    :aria-label="`Name for ${row.filename || 'this model'}`"
+                    @click.stop
+                    @keydown="onRenameKeydown"
+                    @blur="commitRename"
+                  />
+                  <template v-else>
+                    <span
+                      class="shelf-row-name"
+                      :class="`shelf-row-name--${row.name.state}`"
+                      >{{ row.name.text || "Name this model" }}</span
+                    >
+                    <span
+                      v-if="NAME_TAG[row.name.state]"
+                      class="shelf-name-tag"
+                      :class="`shelf-name-tag--${row.name.state}`"
+                      :title="NAME_TAG[row.name.state].title"
+                      >{{ NAME_TAG[row.name.state].label }}</span
+                    >
+                    <!-- Decorative, and deliberately not focusable: the row is
+                         the control on this grid, so the keyboard path is F2 on
+                         the row (announced by `aria-keyshortcuts`) rather than
+                         a tab stop per row across 1,800 of them. -->
+                    <v-icon
+                      class="shelf-name-pencil"
+                      :class="{
+                        'shelf-name-pencil--persistent':
+                          row.name.state === 'needs-a-name',
+                      }"
+                      size="14"
+                      title="Rename (F2)"
+                      aria-hidden="true"
+                      @click.stop="startRename(row)"
+                      >mdi-pencil-outline</v-icon
+                    >
+                  </template>
                   <!-- The step, on any row that is not a stack cover.
                        `deriveModelName` strips the trailing step from the
                        filename on the stated grounds that "the step is parsed
@@ -1319,6 +1362,15 @@ function onRowKeydown(row, event) {
     }
     return;
   }
+  // The keyboard half of the pencil. F2 is the rename key everywhere a list has
+  // one, and it keeps the affordance off the tab order: the shelf's dialect is
+  // that the ROW is the control, so a focusable pencil per row would be 1,800
+  // new tab stops for the gesture one key already covers.
+  if (event.key === "F2") {
+    event.preventDefault();
+    startRename(row);
+    return;
+  }
   if (event.key === " " || event.key === "Enter") {
     event.preventDefault();
     store.selectFromClick(
@@ -1333,6 +1385,92 @@ function onRowKeydown(row, event) {
   // after a click — rather than only while a row holds the roving tab stop,
   // which is what it used to mean and is not what a reader expects from
   // "Escape clears the selection".
+}
+
+/**
+ * What the two "nobody has named this" states say out loud.
+ *
+ * Words, not colour: the accent on the from-file chip is a hint and the label
+ * is what carries the meaning, so the pair still reads in greyscale. They are
+ * different news — one string is the file's own and one is ours — and the whole
+ * point of #897 is that a reader can tell which without opening the row.
+ */
+const NAME_TAG = {
+  derived: {
+    label: "derived",
+    title:
+      "PixlStash made this name from the file. Nobody has named this model.",
+  },
+  "from-file": {
+    label: "from filename",
+    title: "This is the file's own name. Nobody has named this model.",
+  },
+};
+
+// Inline rename. One row at a time, held by row key: the field is what makes
+// the dashed rule and the pencil honest — an affordance that opened a dialog
+// would be advertising a field the row does not have.
+const editingRowKey = ref("");
+const editingName = ref("");
+let editingRow = null;
+
+/** Put the field on a row, seeded with the GIVEN name, not the shown one. */
+function startRename(row) {
+  editingRow = row;
+  editingRowKey.value = row.rowKey;
+  // Seeded from `display_name`, so opening the field on a derived row offers an
+  // empty box: the derived string is a guess and pre-filling it would turn one
+  // Enter into somebody having chosen it.
+  editingName.value = row.display_name || "";
+  nextTick(() => {
+    const el = rootEl.value?.querySelector(".shelf-row-rename");
+    el?.focus();
+    el?.select();
+  });
+}
+
+function endRename() {
+  editingRow = null;
+  editingRowKey.value = "";
+  editingName.value = "";
+}
+
+/**
+ * Commit the field, on Enter or on losing focus.
+ *
+ * Closes BEFORE it writes, so the blur the unmount fires finds nothing to do
+ * and the row cannot be written twice. An empty box clears the name back to
+ * `NULL`, which is what puts the model back on the backend's naming queue.
+ */
+async function commitRename() {
+  const row = editingRow;
+  if (!row) return;
+  const next = editingName.value.trim();
+  endRename();
+  if (next === String(row.display_name || "").trim()) return;
+  // A cover stands for every member of the run, and they share one name.
+  await store.editModelIds(row.memberIds ?? [row.id], {
+    display_name: next || null,
+  });
+}
+
+/**
+ * The field's own keys.
+ *
+ * Everything is stopped from reaching the row and the shelf root: Arrow walks
+ * the list, Space and Enter pick, and Escape clears the selection, so a name
+ * could not be typed with any of them live underneath.
+ */
+function onRenameKeydown(event) {
+  event.stopPropagation();
+  if (event.key !== "Enter" && event.key !== "Escape") return;
+  event.preventDefault();
+  const key = editingRowKey.value;
+  if (event.key === "Enter") commitRename();
+  else endRename();
+  // Focus goes back to the row it came from: the field is gone and a keyboard
+  // reader would otherwise be dropped at the top of the document.
+  nextTick(() => focusDrawnRow(key));
 }
 
 /**
@@ -2003,12 +2141,40 @@ watch(
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* Reserved on every state, so the rule appearing under the pointer cannot
+     shift the row's baseline by a pixel as the reader scans down it. */
+  border-bottom: 1px dashed transparent;
 }
 
-/* The unnamed third. Mono at regular weight, at FULL strength: §3 gives the
-   mono face to file paths, and a filename-derived name is one — so this says
-   what the string is rather than demoting it. Rank is never opacity (§5.1),
-   and 37% of rows faded would be a column of ghosts. */
+/* The editable rule, on hover AND on the tab stop. Hover alone is the defect:
+   a keyboard reader would have no sign the name is a field at all, and
+   `:focus-within` on the row covers both the row itself and the field it
+   opens. Not on `--needs-a-name`, which carries its own accent rule always and
+   must not be quieted down to this one while the pointer is over it. */
+.shelf-row:hover .shelf-row-name:not(.shelf-row-name--needs-a-name),
+.shelf-row:focus-within .shelf-row-name:not(.shelf-row-name--needs-a-name) {
+  border-bottom-color: rgba(var(--v-theme-on-background), 0.45);
+}
+
+/* An EMPTY FIELD inviting a name, never disabled-looking text — the one
+   distinction #897 says decides whether these rows ever get fixed. So: full
+   ink, an accent rule that is always there, and a pencil that never hides.
+   Italic because rank is style and not another step down in contrast, the same
+   call `.shelf-col-none` makes one column over. */
+.shelf-row-name--needs-a-name {
+  font-style: italic;
+  font-weight: var(--weight-regular);
+  border-bottom-color: rgb(var(--v-theme-accent));
+}
+
+/* A readable name we generated. The UI face, because this string is OURS and
+   is not in the file — mono would claim it were. Regular weight, so it does
+   not carry the authority of a title somebody chose; the tag beside it says
+   the rest. */
+.shelf-row-name--derived {
+  font-weight: var(--weight-regular);
+}
+
 /* Quiet beside the name, in the same slot the stack count uses: it qualifies
    the identity rather than being part of it. Tabular figures so a column of
    steps lines up when several members of a run sit together. */
@@ -2025,9 +2191,82 @@ watch(
   color: rgba(var(--v-theme-on-background), 0.7);
 }
 
-.shelf-row-name--derived {
+/* The file's own string, shown because nothing survived the strip. Mono at
+   regular weight, at FULL strength: §3 gives the mono face to file paths, and
+   this IS one — so the face says what the string is rather than demoting it.
+   Rank is never opacity (§5.1), and 37% of rows faded would be a column of
+   ghosts. (The comment used to sit above `.shelf-row-at-step`, two rules from
+   the one it describes.) */
+.shelf-row-name--from-file {
   font-family: var(--font-mono);
   font-weight: var(--weight-regular);
+}
+
+/* The two "nobody has named this" tags. Both are shapes with words in them, so
+   which is which survives greyscale (§4): the accent is a hint on the
+   from-file one, never the thing carrying the meaning. */
+.shelf-name-tag {
+  flex: none;
+  padding: 0 var(--space-2);
+  border: 1px solid rgba(var(--v-theme-on-background), 0.35);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  white-space: nowrap;
+  /* 0.7 and not 0.6: at 11px the lower alpha misses the contrast floor (#836). */
+  color: rgba(var(--v-theme-on-background), 0.7);
+}
+
+.shelf-name-tag--from-file {
+  border-color: rgba(var(--v-theme-accent), 0.6);
+  background: rgba(var(--v-theme-accent), 0.14);
+  /* The surface's own ink on a 14% wash, NOT `on-accent`: that pairing is for a
+     solid fill and measures near-invisible over a tint (§4, §11). */
+  color: rgb(var(--v-theme-on-background));
+}
+
+/* The affordance itself. Opacity rather than `display`, so it holds its own
+   width and the name never reflows out from under the pointer. */
+.shelf-name-pencil {
+  flex: none;
+  opacity: 0;
+  cursor: pointer;
+  color: rgba(var(--v-theme-on-background), 0.7);
+  transition: opacity var(--dur-2) var(--ease-standard);
+}
+
+.shelf-row:hover .shelf-name-pencil,
+.shelf-row:focus-within .shelf-name-pencil,
+.shelf-name-pencil--persistent {
+  opacity: 1;
+}
+
+/* On the row that has no name, the pencil is the ask and wears the accent with
+   the rule under the placeholder. */
+.shelf-name-pencil--persistent {
+  color: rgb(var(--v-theme-accent));
+}
+
+/* Editing: a real bordered field, in the app's one focus language (§11). Sized
+   to the text it replaces so committing does not jump the row. */
+.shelf-row-rename {
+  min-width: 0;
+  flex: 1 1 auto;
+  padding: 0 var(--space-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: rgb(var(--v-theme-on-background));
+  background: rgba(var(--v-theme-on-background), 0.06);
+  border: 1px solid rgb(var(--v-theme-border));
+  border-radius: var(--radius-sm);
+}
+
+.shelf-row-rename:focus {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 /* No `margin-left` any more: the status glyph is a column of its own now, and

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -545,7 +545,9 @@
                       }"
                       size="14"
                       title="Rename (F2)"
-                      aria-hidden="true"
+                      role="button"
+                      tabindex="-1"
+                      aria-label="Rename (F2)"
                       @click.stop="startRename(row)"
                       >mdi-pencil-outline</v-icon
                     >

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -875,8 +875,21 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
    * @returns {Promise<boolean>} true when the write landed.
    */
   async function editSelected(changes) {
+    return editModelIds(selectedModelIds.value, changes);
+  }
+
+  /**
+   * The same write, against ids the caller names rather than the selection.
+   *
+   * The row's inline rename needs it: naming a model is a gesture on ONE row
+   * and must not disturb, or depend on, whatever is selected elsewhere.
+   *
+   * @param {number[]} ids - model ids. A stack cover passes its members.
+   * @param {Object} changes - as {@link editSelected}.
+   * @returns {Promise<boolean>} true when the write landed.
+   */
+  async function editModelIds(ids, changes) {
     const notices = useNoticeStore();
-    const ids = selectedModelIds.value;
     if (!ids.length) return false;
     try {
       const body = await editModels(ids, changes);
@@ -1038,7 +1051,10 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
       await fetchRows();
       notices.push({
         level: "success",
-        text: `Set the icon on ${row.name.text}.`,
+        // A row in the `needs-a-name` state has no name to say, by design —
+        // its `text` is empty so the shelf can draw it as a field. The receipt
+        // still has to name something the reader can recognise.
+        text: `Set the icon on ${row.name.text || row.filename || "the model"}.`,
       });
       return true;
     } catch (err) {
@@ -1132,6 +1148,7 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
     selectVisible,
     clearSelection,
     editSelected,
+    editModelIds,
     forgetSelected,
     setIconOnSelected,
     clearIconsOnSelected,

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -57,24 +57,36 @@ export function deriveModelName(filename) {
 }
 
 /**
- * Resolve what a row is called, and whether anybody chose it.
+ * Resolve what a row is called, and WHO decided it.
  *
- * The chain is: the name the user gave, else one derived from the filename,
- * else the filename itself. `derived` is what the row uses to mark the name as
- * a fact about the file rather than a title someone wrote.
+ * The chain is: the name the user gave, else a readable one we made from the
+ * filename, else the filename itself, else nothing. `state` is the whole point
+ * — the row draws each of the four differently, because "somebody named this"
+ * and "we guessed" and "there is nothing here to read" are three different
+ * things to a reader deciding what to fix, and the shelf used to render all of
+ * them as one string.
+ *
+ * The last state returns an EMPTY string on purpose. A row with no filename
+ * used to read `no name in file`, which looks like a name, sorts like a name
+ * and reads as inert — so the one row that most needs naming was the one that
+ * least invited it. The row renders the empty case as a field.
  *
  * @param {Object} model - a row from `/adapters` or `/checkpoints`.
- * @returns {{text: string, derived: boolean}}
+ * @returns {{text: string, state: "named"|"derived"|"from-file"|"needs-a-name"}}
  */
 export function modelName(model) {
   const given = String(model?.display_name || "").trim();
-  if (given) return { text: given, derived: false };
+  if (given) return { text: given, state: "named" };
   const filename = String(model?.filename || "").trim();
   const derived = deriveModelName(filename);
-  if (derived) return { text: derived, derived: true };
+  // A real readable name, and OURS: `deriveModelName` rewrote the file's own
+  // string, so nothing on disk says this. It must not be mistaken for a title.
+  if (derived) return { text: derived, state: "derived" };
   // Nothing survived the strip (a file called `000002750.safetensors`). The
-  // raw filename is the only honest thing left to show.
-  return { text: filename || "no name in file", derived: true };
+  // raw filename is the only honest thing left to show — and it is the file's
+  // string verbatim, which is what the row says out loud.
+  if (filename) return { text: filename, state: "from-file" };
+  return { text: "", state: "needs-a-name" };
 }
 
 /**

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -63,7 +63,7 @@ describe("deriveModelName", () => {
 describe("modelName", () => {
   it("prefers the name somebody gave it, and says nobody did", () => {
     expect(modelName({ display_name: "Clementine", filename: "x.st" })).toEqual(
-      { text: "Clementine", derived: false },
+      { text: "Clementine", state: "named" },
     );
   });
 
@@ -75,18 +75,23 @@ describe("modelName", () => {
         display_name: null,
         filename: "Foxglove_Char_000000250.safetensors",
       }),
-    ).toEqual({ text: "Foxglove Char", derived: true });
+    ).toEqual({ text: "Foxglove Char", state: "derived" });
   });
 
-  it("falls back to the raw filename rather than to a blank", () => {
+  it("separates the file's own string from one we made", () => {
+    // Nothing survived the strip, so what is shown IS the filename — a
+    // different piece of news from `derived`, and the row says which.
     expect(modelName({ filename: "000002750.safetensors" })).toEqual({
       text: "000002750.safetensors",
-      derived: true,
+      state: "from-file",
     });
   });
 
-  it("never returns an empty string", () => {
-    expect(modelName({}).text).not.toBe("");
+  it("returns nothing to show when there is nothing to show", () => {
+    // Deliberately empty rather than the old `no name in file`, which looked
+    // like a name, sorted like one and read as inert. The row draws this state
+    // as a field asking to be filled (#897).
+    expect(modelName({})).toEqual({ text: "", state: "needs-a-name" });
   });
 });
 


### PR DESCRIPTION
Closes #897. Part of #904.

**Based on `develop`, not `main`:** the model shelf does not exist on `main`, and
every sibling conformance PR (#907, #909, #910) merged into `develop`.

## What was wrong

`modelName` returned two states — "somebody named it" and "everything else" —
and the row drew the second one as mono text. So a model with a readable derived
name, a model showing its raw filename, and a model with nothing at all were one
rendering. The last of those read `no name in file`: a string that looks like a
name, sorts like a name and invites nothing, which is the issue's point about why
unnamed rows never get named.

## What changed

`modelName` now returns `{text, state}` with four states, and the row draws each:

| State | Treatment |
|---|---|
| `named` | plain, `--weight-semibold`; dashed rule + pencil on hover **and** focus |
| `derived` | the **UI** face at regular weight (the string is ours, not the file's) + an outline `DERIVED` tag |
| `from-file` | `--font-mono` (§3 gives mono to paths — this string *is* one) + a small accent `FROM FILENAME` tag |
| `needs-a-name` | `text` is empty; the row draws an italic *Name this model* prompt with a permanent accent rule and a pencil that never hides |

The two "nobody has named this" states carry their meaning in the **word** on the
tag; the accent and the type are hints on top, so the pair survives greyscale
(§4). Nothing is faded — rank is type and shape, never opacity (§5.1), and a
third of a real shelf is unnamed.

**The name is now an actual field.** Clicking the pencil, or pressing **F2** on
the focused row, swaps in a bordered input with `--focus-ring`; Enter and blur
commit, Escape abandons, and focus returns to the row. Emptying the box clears
`display_name` back to `NULL`, which is what puts the model back on the backend's
naming queue. Renaming a stack cover renames its whole run, since the members
share one name.

The pencil is deliberately **not** focusable and the keyboard path is F2
(`aria-keyshortcuts` on the row). The shelf's dialect is that the row is the
control — a focusable pencil would be 1,800 new tab stops for a gesture one key
already covers. The field stops its own keys, or Arrow/Space/Escape would walk
and clear the list from underneath it.

Store: `editSelected` now delegates to a new `editModelIds(ids, changes)`, so a
one-row rename neither depends on nor disturbs the selection.

## Notes for the reviewer

- All the visual treatments come from the design table quoted in #897 and use
  only existing tokens — no new colours, spacing or radii. I did not route it
  through `lead-designer`/`ui-ux-expert` for that reason; say the word if you
  want their pass anyway.
- `text: ""` for `needs-a-name` needs no sort change: `compareOn` already treats
  `""` as "cannot answer this key" and sorts it last in both directions.
- The one place that read `row.name.text` into prose (the set-icon receipt) now
  falls back to the filename, since that state has no name to quote.
- 2963 frontend tests pass. New coverage: the four states render distinctly, the
  derived/from-file tags say which is which, the unnamed row is a prompt with a
  persistent pencil, and F2 → type → Enter writes (and Escape does not), including
  across a run's members.
