### PR TITLE
Build the Assigned to marks on the model shelf

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1412,6 +1412,40 @@ undo by accident:
   is in neither list by default and is fetched only from the *adapters* block
   under `?file_kind=unknown`.
 
+**The `Assigned to` marks** (`EntityMark.vue`, `assignmentMarks` in
+`utils/modelShelf.js`) draw one bordered thumbnail per attached character or
+set. `attachments` carries `entity_type` and `entity_id` and no names, so the
+names, colours and thumbnails come from `useEntityListsStore` — the two list
+reads the sidebar already makes, shared and cached, never a lookup per
+attachment; the thumbnail is an `<img src>` from `characterThumbnailUrl` /
+`pictureSetThumbnailUrl` rather than a blob, so one response is cached however
+many rows name that character. Four rules hold it together and are each easy to
+undo:
+
+- **Colour is a grouping hint and never the meaning.** Every mark carries the
+  entity's thumbnail (or its initials when the entity has no picture) and an
+  accessible name saying its type, so the column reads in greyscale (WCAG
+  1.4.1). Distinguishing a character from a set *by colour* is explicitly
+  rejected. The hue is the entity's own where it has one, so a character wears
+  the same colour here as in the sidebar, and a hash of its id otherwise —
+  never its position in the fan, which would repaint every mark when one
+  attachment is removed.
+- **One radius for every entity mark.** `--radius-sm`, because §6 reserves
+  `--radius-pill` for avatar rings and half of these are picture sets. Type
+  lives in the label, never in the shape.
+- **Unassigned is a dashed outline, not a blank cell**, so "assigned to
+  nothing" reads as a state rather than as a rendering gap.
+- **The fan is capped at three with an explicit z-order.** Three marks at a
+  half-mark overlap land exactly on the two-mark track, so a fourth would step
+  every column right of it sideways; beyond that the last slot becomes a `+N`
+  counter whose title names the entities it stands for. `assignmentMarks`
+  stamps `z` descending, so the fan paints front-to-back rather than the last
+  attachment covering the first.
+
+An attachment whose entity the lists do not answer still gets a mark, reading
+`#12`: the vault is the authority on what is attached, and dropping the mark
+would say "not assigned", which is a different and wrong fact.
+
 Rows are built on the shared row system (`SideBar.global.css`, §5.1) through
 the neutral `.ps-row` / `.ps-row-glyph` aliases, so the shelf consumes those
 rules rather than keeping a second copy of them. Column 1 is reserved and empty

--- a/frontend/src/api/characters.js
+++ b/frontend/src/api/characters.js
@@ -8,7 +8,7 @@
 //
 // See docs/frontend_architecture.md §8 ("The `src/api/` resource layer").
 
-import { apiClient} from "../utils/apiClient";
+import { apiClient, appendShareToken} from "../utils/apiClient";
 import { unwrap } from "../utils/unwrap";
 
 /**
@@ -18,6 +18,28 @@ import { unwrap } from "../utils/unwrap";
  */
 function charactersUrl(path = "") {
   return `/characters${path}`;
+}
+
+/**
+ * The URL of a character's thumbnail, for an `<img src>`.
+ *
+ * The other half of {@link getCharacterThumbnail}, for callers that draw MANY
+ * of them: a blob costs a request and an object URL per character, while a
+ * `src` lets the browser fetch and cache one response however many marks name
+ * that character (the model shelf's `Assigned to` column, #892). The blob form
+ * stays for the sidebar, which wants the failure as a rejection.
+ *
+ * The route is cookie-authenticated, so a share token has to ride in the query
+ * — an `<img>` sends no header.
+ *
+ * @param {number|string} id
+ * @returns {string}
+ */
+export function characterThumbnailUrl(id) {
+  const base = apiClient.defaults.baseURL || "";
+  return appendShareToken(
+    `${base}${charactersUrl(`/${encodeURIComponent(id)}/thumbnail`)}`,
+  );
 }
 
 /**

--- a/frontend/src/api/pictureSets.js
+++ b/frontend/src/api/pictureSets.js
@@ -4,7 +4,7 @@
 // (`/picture_sets/{id}/members/{pictureId}`), so bulk actions are the caller's
 // loop over these calls, not a bulk endpoint.
 
-import { apiClient} from "../utils/apiClient";
+import { apiClient, appendShareToken} from "../utils/apiClient";
 import { unwrap } from "../utils/unwrap";
 
 /**
@@ -14,6 +14,27 @@ import { unwrap } from "../utils/unwrap";
  */
 function setsUrl(path = "") {
   return `/picture_sets${path}`;
+}
+
+/**
+ * The URL of a set's thumbnail, for an `<img src>`.
+ *
+ * The list row carries a `thumbnail_url` too, and the sidebar uses that because
+ * it also wants the row's `top_picture_ids` as a cache-versioning key. This is
+ * the plain form for a caller that has only an id — the model shelf's
+ * `Assigned to` marks, which resolve from an attachment rather than a row.
+ *
+ * The route is cookie-authenticated, so a share token has to ride in the query
+ * — an `<img>` sends no header.
+ *
+ * @param {number|string} id
+ * @returns {string}
+ */
+export function pictureSetThumbnailUrl(id) {
+  const base = apiClient.defaults.baseURL || "";
+  return appendShareToken(
+    `${base}${setsUrl(`/${encodeURIComponent(id)}/thumbnail`)}`,
+  );
 }
 
 /**

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -69,6 +69,21 @@ vi.mock("../../api/modelFolders", async (importOriginal) => ({
   listModelFolders: (...args) => listModelFolders(...args),
 }));
 
+// The names, colours and thumbnails behind the `Assigned to` marks (#892).
+// Mocked for the same reason the folder reads are: unmocked they reach the
+// network from `onMounted`, and the rejection lands in a `console.warn` from a
+// promise no test awaits — which is the teardown race noted above.
+const listCharacters = vi.fn();
+const listPictureSets = vi.fn();
+vi.mock("../../api/characters", async (importOriginal) => ({
+  ...(await importOriginal()),
+  listCharacters: (...args) => listCharacters(...args),
+}));
+vi.mock("../../api/pictureSets", async (importOriginal) => ({
+  ...(await importOriginal()),
+  listPictureSets: (...args) => listPictureSets(...args),
+}));
+
 import ModelShelf from "./ModelShelf.vue";
 import { useModelShelfStore } from "../../stores/useModelShelfStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
@@ -151,6 +166,8 @@ beforeEach(() => {
   getModelMoveStatus.mockReset();
   getModelMoveStatus.mockResolvedValue({ status: "idle", results: [] });
   addModelFile.mockReset();
+  listCharacters.mockReset().mockResolvedValue([]);
+  listPictureSets.mockReset().mockResolvedValue([]);
 });
 
 describe("a row with nothing in its header", () => {
@@ -168,7 +185,7 @@ describe("a row with nothing in its header", () => {
     // is the guaranteed anchor when all else is null, and an absent base model
     // says so in words rather than leaving a cell that reads as a gap.
     const cells = row.findAll(".shelf-col").map((s) => textOf(s));
-    expect(cells).toEqual(["LoRA", "Not set", "—Not assigned", "342.1 MB"]);
+    expect(cells).toEqual(["LoRA", "Not set", "Not assigned", "342.1 MB"]);
   });
 
   it("marks the derived name by type, not by fading it", async () => {
@@ -1285,6 +1302,78 @@ describe("a run's disclosure", () => {
         "Status",
       ]);
     }
+  });
+});
+
+describe("the Assigned to marks (#892)", () => {
+  it("names every attached entity, and never by colour alone", async () => {
+    listCharacters.mockResolvedValue([
+      { id: 7, name: "Ada", character_color: "#e91e63" },
+    ]);
+    listPictureSets.mockResolvedValue([
+      { id: 3, name: "Beach", set_color: "#3f51b5" },
+    ]);
+    const wrapper = await mountShelf([
+      adapter({
+        attachments: [
+          { entity_type: "character", entity_id: 7 },
+          { entity_type: "set", entity_id: 3 },
+        ],
+      }),
+    ]);
+    const cell = wrapper.find(".shelf-col--assigned");
+    const marks = cell.findAll(".emark");
+    expect(marks).toHaveLength(2);
+    // The accessible name is on the cell whether or not anything is hovered,
+    // and it says the TYPE — which is what keeps the mark off colour and off
+    // shape as the only carrier of what it is (WCAG 1.4.1).
+    expect(textOf(cell)).toBe("Character: Ada. Set: Beach.");
+    expect(marks[0].attributes("title")).toBe("Character: Ada");
+    expect(marks[1].attributes("title")).toBe("Set: Beach");
+    // Front-to-back: the first attachment paints over the ones behind it.
+    const z = marks.map((m) => Number(m.attributes("style").match(/\d+/)[0]));
+    expect(z[0]).toBeGreaterThan(z[1]);
+  });
+
+  it("counts the overflow rather than widening the column", async () => {
+    listCharacters.mockResolvedValue(
+      [1, 2, 3, 4].map((id) => ({ id, name: `Char ${id}` })),
+    );
+    const wrapper = await mountShelf([
+      adapter({
+        attachments: [1, 2, 3, 4].map((id) => ({
+          entity_type: "character",
+          entity_id: id,
+        })),
+      }),
+    ]);
+    const cell = wrapper.find(".shelf-col--assigned");
+    expect(cell.findAll(".emark")).toHaveLength(3);
+    // The counter names what it stands for: those marks cannot be hovered.
+    const last = cell.findAll(".emark")[2];
+    expect(last.text()).toContain("+2");
+    expect(last.attributes("title")).toBe(
+      "Character: Char 3, Character: Char 4",
+    );
+  });
+
+  it("shows an outlined slot for a model assigned to nothing", async () => {
+    const wrapper = await mountShelf([adapter({ attachments: [] })]);
+    const cell = wrapper.find(".shelf-col--assigned");
+    // A state, not a gap: the slot is drawn and the reader is told which it is.
+    expect(cell.find(".shelf-assigned-none").exists()).toBe(true);
+    expect(textOf(cell)).toBe("Not assigned");
+  });
+
+  it("still marks an attachment whose entity the lists do not answer", async () => {
+    // The vault is the authority on what is attached. Dropping the mark would
+    // say "not assigned", which is a different and wrong fact.
+    const wrapper = await mountShelf([
+      adapter({ attachments: [{ entity_type: "character", entity_id: 42 }] }),
+    ]);
+    const cell = wrapper.find(".shelf-col--assigned");
+    expect(cell.findAll(".emark")).toHaveLength(1);
+    expect(textOf(cell)).toBe("Character: #42.");
   });
 });
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -553,20 +553,28 @@
                   <span v-if="row.base_model">{{ row.base_model }}</span>
                   <span v-else class="shelf-col-none">Not set</span>
                 </span>
-                <!-- The column exists here; the marks that belong in it are
-                     #892. Until then it states the fact `row.attachments`
-                     already carries — how many characters and sets a model is
-                     assigned to — rather than sitting blank under a header
-                     that promises something. `attachments` holds ids and no
-                     names, so naming the entities is not available without the
-                     lookup that issue owns. -->
+                <!-- One bordered mark per attached character or set, fanned
+                     with a fixed half-mark overlap (#892). The z-order is
+                     explicit and reversed against document order — see
+                     `assignmentMarks`, which stamps it — so the fan reads
+                     front-to-back rather than the last attachment painting on
+                     top of the first.
+
+                     Not assigned is a dashed outline rather than an empty cell,
+                     because a blank under a header that promises something
+                     reads as a rendering gap rather than as a state. -->
                 <span role="gridcell" class="shelf-col shelf-col--assigned">
-                  <template v-if="attachedCount(row)">
-                    {{ attachedCount(row)
-                    }}<span class="visually-hidden"> assigned</span>
+                  <template v-if="row.attachments?.length">
+                    <EntityMark
+                      v-for="mark in assignedMarks(row)"
+                      :key="mark.key"
+                      :mark="mark"
+                      class="shelf-assigned-mark"
+                      :style="{ zIndex: mark.z }"
+                    />
                   </template>
                   <template v-else>
-                    <span aria-hidden="true">—</span>
+                    <span class="shelf-assigned-none" aria-hidden="true"></span>
                     <span class="visually-hidden">Not assigned</span>
                   </template>
                 </span>
@@ -675,12 +683,14 @@ import ModelFoldersDialog from "../panels/ModelFoldersDialog.vue";
 import ModelImportDialog from "../panels/ModelImportDialog.vue";
 import ShelfStackProposalsDialog from "../panels/ShelfStackProposalsDialog.vue";
 import FolderBrowser from "../editors/FolderBrowser.vue";
+import EntityMark from "../widgets/EntityMark.vue";
 import ModelMark from "../widgets/ModelMark.vue";
 import ProgressOverlay from "../widgets/ProgressOverlay.vue";
 import StackEdgeTicks from "../widgets/StackEdgeTicks.vue";
 import { useConfirm } from "../../composables/useConfirm";
 import { addModelFile } from "../../api/modelFiles";
 import { createStack } from "../../api/modelStacks";
+import { useEntityListsStore } from "../../stores/useEntityListsStore";
 import { useModelShelfStore } from "../../stores/useModelShelfStore";
 import { useModelFoldersStore } from "../../stores/useModelFoldersStore";
 import { useModelMovesStore } from "../../stores/useModelMovesStore";
@@ -688,6 +698,7 @@ import { useNoticeStore } from "../../stores/useNoticeStore";
 import { errorDetail } from "../../utils/apiError";
 import { isModelFileDrag, setInternalDragPayload } from "../../utils/media";
 import {
+  assignmentMarks,
   bandGroups,
   bandUsage,
   withEmptyFolders,
@@ -701,6 +712,7 @@ import {
 } from "../../utils/modelShelf";
 
 const store = useModelShelfStore();
+const entityLists = useEntityListsStore();
 const foldersStore = useModelFoldersStore();
 const moves = useModelMovesStore();
 const rootEl = ref(null);
@@ -1336,14 +1348,17 @@ function onRowKeydown(row, event) {
 }
 
 /**
- * How many characters and sets a model is assigned to.
+ * The marks the `Assigned to` column draws for one row (#892).
  *
- * The count only, because `attachments` carries `entity_type` and `entity_id`
- * and no names: saying WHICH ones needs the character and set stores, which is
- * what #892 brings when it replaces this cell with marks.
+ * The lists are read from the shared entity store rather than fetched per row:
+ * `attachments` comes back on the list read already, so the whole shelf costs
+ * the two list reads the sidebar makes anyway, not one lookup per attachment.
  */
-function attachedCount(row) {
-  return (row.attachments ?? []).length;
+function assignedMarks(row) {
+  return assignmentMarks(row.attachments, {
+    characters: entityLists.characters,
+    sets: entityLists.pictureSets,
+  });
 }
 
 /**
@@ -1508,6 +1523,12 @@ onMounted(() => {
   // Unawaited already means it does not hold up the shelf.
   foldersStore.refreshDevices();
   foldersStore.refresh();
+  // The names, colours and thumbnails behind the `Assigned to` marks. Cached
+  // and shared with the sidebar, so on a warm cache this repaints the marks
+  // without a request; unawaited, because a row whose marks read `#12` for a
+  // moment is a better shelf than one that waits for two list reads to draw.
+  entityLists.refresh("characters");
+  entityLists.refresh("sets");
   // A move is machine-wide and outlives this component, so one may already be
   // running: started before a reload, or from another tab. Adopting it is what
   // puts the progress back rather than leaving the list live over files that
@@ -1943,9 +1964,41 @@ watch(
   white-space: nowrap;
 }
 
+/* The fan. `overflow: visible` against `.shelf-col`'s hidden, because the marks
+   are the content rather than text to ellipsise, and `assignmentMarks` already
+   caps them at what the track holds. */
 .shelf-col--assigned {
-  text-align: center;
-  font-variant-numeric: tabular-nums;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  overflow: visible;
+}
+
+/* The fixed overlap: half a mark, so three fit the two-mark track exactly and a
+   fan of two still shows a whole mark and a half. The `z-index` bound on each
+   mark takes effect because `.emark` is positioned; without that the stacking
+   order would fall back to document order and the fan would read back-to-front. */
+.shelf-assigned-mark + .shelf-assigned-mark {
+  margin-left: calc(var(--entity-thumb) / -2);
+}
+
+/* Assigned to nothing, as a state rather than as a gap: the same footprint a
+   mark has, outlined dashed so it reads as an empty slot and not as a mark that
+   failed to load. Dashed and not merely faint, because the distinction has to
+   survive greyscale as well as a glance. */
+.shelf-assigned-none {
+  display: inline-block;
+  box-sizing: border-box;
+  width: var(--entity-thumb);
+  height: var(--entity-thumb);
+  /* 0.5, not the fainter alpha this would like to be: the outline is the only
+     visible carrier of the state, so it is a non-text UI component and owes
+     3:1 (WCAG 1.4.11). Measured with the shipped `contrastRatio`: 0.35 gives
+     2.13:1 on the light canvas and 0.5 gives 3.15:1 (4.36:1 dark). Not
+     `divider` either — that is a hairline BETWEEN things, and far below the
+     floor for something that has to be seen on its own. */
+  border: 1px dashed rgba(var(--v-theme-on-background), 0.5);
+  border-radius: var(--radius-sm);
 }
 
 .shelf-col--size {

--- a/frontend/src/components/widgets/EntityMark.vue
+++ b/frontend/src/components/widgets/EntityMark.vue
@@ -1,0 +1,152 @@
+<template>
+  <!-- One attachment, as one mark. `title` names it on hover; the
+       `visually-hidden` span names it unconditionally, so the cell's accessible
+       name lists the entities whether or not anything can be hovered. Both,
+       because `title` is invisible to a screen reader on a non-interactive
+       element and the hidden span is invisible to a mouse. -->
+  <span
+    class="emark"
+    :class="{ 'emark--more': mark.more }"
+    :style="ring"
+    :title="mark.label"
+  >
+    <img
+      v-if="thumbnailUrl && !failed"
+      class="emark-img"
+      :src="thumbnailUrl"
+      alt=""
+      loading="lazy"
+      @error="failed = true"
+    />
+    <!-- The same "unset is never blank" rule the model's own mark follows: a
+         character with no reference face and a set with no pictures both 404
+         their thumbnail, and an empty square would read as a broken mark rather
+         than as an entity without a picture. -->
+    <span
+      v-else-if="!mark.more"
+      class="emark-fill"
+      :style="{ backgroundColor: mark.tile, color: mark.ink }"
+      >{{ mark.initials }}</span
+    >
+    <span v-else class="emark-fill emark-fill--more">+{{ mark.more }}</span>
+    <!-- The full stop is load-bearing: the cell's accessible name is the
+         concatenation of its marks' text, and without a separator two of them
+         run together as "Character: AdaSet: Beach". -->
+    <span class="visually-hidden">{{ mark.label }}. </span>
+  </span>
+</template>
+
+<script setup>
+// One mark in the shelf's `Assigned to` column (#892).
+//
+// The thumbnail is addressed by URL rather than fetched as a blob, so the
+// browser caches one response however many rows attach the same character —
+// which is the common case, a style adapter being assigned across a cast. Both
+// routes are cookie-authenticated GETs, and `appendShareToken` covers the
+// share-token session that an `<img>` cannot carry a header for.
+//
+// Shape carries nothing: character and set take one radius, and the type is in
+// the label. Colour carries nothing either — see `assignmentMarks`.
+
+import { computed, ref, watch } from "vue";
+
+import { characterThumbnailUrl } from "../../api/characters";
+import { pictureSetThumbnailUrl } from "../../api/pictureSets";
+
+const props = defineProps({
+  /** One descriptor from `assignmentMarks`. */
+  mark: { type: Object, required: true },
+});
+
+/** entity type → the resource module that addresses its thumbnail. */
+const THUMBNAIL_URL = {
+  character: characterThumbnailUrl,
+  set: pictureSetThumbnailUrl,
+};
+
+const failed = ref(false);
+
+// A recycled mark (the same DOM node reused for a different row's attachment)
+// would otherwise keep the previous entity's failure and never try its own
+// thumbnail.
+watch(
+  () => props.mark?.key,
+  () => {
+    failed.value = false;
+  },
+);
+
+const thumbnailUrl = computed(() => {
+  const build = THUMBNAIL_URL[props.mark?.type];
+  return build && props.mark?.id != null ? build(props.mark.id) : "";
+});
+
+// Bound inline because the hue is per-entity data, not a state of this
+// component; everything that is a decision rather than a datum is in the
+// stylesheet below.
+const ring = computed(() =>
+  props.mark?.hue ? { borderColor: props.mark.hue } : {},
+);
+</script>
+
+<style scoped>
+/* `--radius-sm` for every mark: §6 reserves the pill for avatar rings, and half
+   of these are picture sets rather than faces. The border is the "bordered
+   thumbnail" of the design — it is what separates two marks in a fan when the
+   pictures behind them are similar, and it is 2px because a hairline is lost
+   against a photograph. */
+.emark {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Stated rather than inherited: the fan's overlap is half of
+     `--entity-thumb`, and a content-box mark would be 4px wider than the token
+     says and would push the last one out of the two-mark track. */
+  box-sizing: border-box;
+  width: var(--entity-thumb);
+  height: var(--entity-thumb);
+  flex: 0 0 auto;
+  border: 2px solid rgb(var(--v-theme-divider));
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  /* The fan overlaps, so a mark has to be opaque over its neighbour rather than
+     letting the row's wash show through the gap between border and image. The
+     row canvas is `background`, not `surface`; the two differ by a hair and it
+     is the corner radius that would show it. */
+  background: rgb(var(--v-theme-background));
+}
+
+.emark-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Tile and ink arrive as a pair from `markBackground`/`markForeground`, which
+   pin the lightness precisely so white initials clear AA on all 48 hues; they
+   are bound together inline so one cannot drift from the other. */
+.emark-fill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.02em;
+}
+
+/* The counter is not an entity, so it takes no identity hue — it is chrome, and
+   a hue here would imply a fifth character. */
+.emark--more {
+  border-color: rgb(var(--v-theme-divider));
+}
+
+.emark-fill--more {
+  background: rgba(var(--v-theme-on-background), 0.08);
+  color: rgba(var(--v-theme-on-background), 0.87);
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -674,3 +674,100 @@ export function generatedMark(row) {
     initials: initialsOf(name.text),
   };
 }
+
+/**
+ * How many marks the `Assigned to` column fans before it starts counting.
+ *
+ * Three, because the column is two marks wide and the overlap is half a mark:
+ * 24 + 12 + 12 lands exactly on `calc(var(--entity-thumb) * 2)`. A fourth would
+ * push the column wide and step every column right of it sideways, which is the
+ * alignment #891 exists to hold.
+ */
+const ASSIGNMENT_FAN_MAX = 3;
+
+/** Which entity list answers an attachment's `entity_type`. */
+const ATTACHMENT_KIND = {
+  character: {
+    list: "characters",
+    noun: "Character",
+    colorKey: "character_color",
+  },
+  set: { list: "sets", noun: "Set", colorKey: "set_color" },
+};
+
+/**
+ * The marks the `Assigned to` column draws for one row (#892).
+ *
+ * `attachments` carries `entity_type` and `entity_id` and nothing else, so the
+ * names, colours and thumbnails come from the shared entity lists the sidebar
+ * already fetches. An id the lists do not answer still gets a mark — the vault
+ * is the authority on what is attached, and dropping the mark would say "not
+ * assigned", which is a different and wrong fact. It reads `#12` until the list
+ * lands, which is a loading state rather than a lie.
+ *
+ * **Colour is a grouping hint and never the meaning.** Every mark carries the
+ * entity's thumbnail or its initials and an accessible name, so the row still
+ * reads in greyscale (WCAG 1.4.1); the hue only helps the eye tell two
+ * overlapping marks apart. It is the entity's OWN colour where it has one, so a
+ * character wears the same hue here as in the sidebar, and a hash of its id
+ * otherwise — never the position in the fan, which would repaint every mark
+ * when one attachment is removed.
+ *
+ * **Type is never carried by shape.** A character and a set take one radius;
+ * which is which lives in the label (`Character: Ada` / `Set: Beach`).
+ *
+ * @param {Array<{entity_type: string, entity_id: number}>} attachments
+ * @param {Object} [lists]
+ * @param {Array<Object>} [lists.characters] - `useEntityListsStore().characters`.
+ * @param {Array<Object>} [lists.sets] - `useEntityListsStore().pictureSets`.
+ * @returns {Array<Object>} up to {@link ASSIGNMENT_FAN_MAX} descriptors, the
+ *   last of which is a `{more}` counter when there were more than that. Each
+ *   carries `label`, `z`, and either `initials` + `tile` + `ink`, or `more`.
+ */
+export function assignmentMarks(
+  attachments,
+  { characters = [], sets = [] } = {},
+) {
+  const byId = {
+    characters: new Map((characters || []).map((row) => [String(row.id), row])),
+    sets: new Map((sets || []).map((row) => [String(row.id), row])),
+  };
+  const marks = (attachments ?? []).map((att) => {
+    const type = att.entity_type === "character" ? "character" : "set";
+    const kind = ATTACHMENT_KIND[type];
+    const entity = byId[kind.list].get(String(att.entity_id));
+    const name = entity?.name || `#${att.entity_id}`;
+    const hex =
+      entity?.[kind.colorKey] ||
+      SET_COLORS[hash32(`${type}:${att.entity_id}`) % SET_COLORS.length].value;
+    return {
+      key: `${type}:${att.entity_id}`,
+      type,
+      id: att.entity_id,
+      label: `${kind.noun}: ${name}`,
+      hue: hex,
+      tile: markBackground(hex),
+      ink: markForeground(),
+      initials: initialsOf(name),
+    };
+  });
+  let fan = marks;
+  if (marks.length > ASSIGNMENT_FAN_MAX) {
+    const rest = marks.slice(ASSIGNMENT_FAN_MAX - 1);
+    fan = [
+      ...marks.slice(0, ASSIGNMENT_FAN_MAX - 1),
+      {
+        key: "more",
+        more: rest.length,
+        // The counter names what it stands for rather than only saying "+4":
+        // the reader cannot hover the marks that are not there.
+        label: rest.map((mark) => mark.label).join(", "),
+      },
+    ];
+  }
+  // Painted front-to-back, which is the reverse of document order: the first
+  // attachment is the whole mark and the ones behind it show the sliver that
+  // says how many there are. Stamped here rather than in the template so the
+  // order is one decision with one test, not an expression in a `v-for`.
+  return fan.map((mark, index) => ({ ...mark, z: fan.length - index }));
+}

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import { contrastRatio } from "./contrastAudit.js";
 import { SET_COLORS } from "./setAppearance";
 import {
+  assignmentMarks,
   bandGroups,
   bandUsage,
   baseModelKey,
@@ -657,5 +658,65 @@ describe("movableCopies", () => {
       locRow([{ folder_id: 2, relpath: "tagger.onnx", state: "present" }]),
     ]);
     expect(items).toHaveLength(1);
+  });
+});
+
+describe("assignmentMarks", () => {
+  const attach = (type, id) => ({ entity_type: type, entity_id: id });
+
+  it("takes the entity's own colour, so a character is one hue app-wide", () => {
+    const [mark] = assignmentMarks([attach("character", 7)], {
+      characters: [{ id: 7, name: "Ada", character_color: "#e91e63" }],
+    });
+    expect(mark.hue).toBe("#e91e63");
+    expect(mark.label).toBe("Character: Ada");
+    expect(mark.initials).toBe("AD");
+  });
+
+  it("keys a colourless entity on its id, never on its place in the fan", () => {
+    // Positional colour would repaint every remaining mark when one attachment
+    // is removed, which is the failure `generatedMark` documents for models.
+    const lists = {
+      sets: [
+        { id: 4, name: "Beach" },
+        { id: 9, name: "Studio" },
+      ],
+    };
+    const pair = assignmentMarks([attach("set", 4), attach("set", 9)], lists);
+    const alone = assignmentMarks([attach("set", 9)], lists);
+    expect(alone[0].hue).toBe(pair[1].hue);
+    expect(SET_COLORS.map((c) => c.value)).toContain(alone[0].hue);
+  });
+
+  it("gives every mark an identity beside its colour", () => {
+    // The greyscale test, as arithmetic: strip the hue and each mark still
+    // carries a name and a glyph, so nothing is distinguished by colour alone.
+    const marks = assignmentMarks(
+      [attach("character", 1), attach("set", 1)],
+      {},
+    );
+    expect(marks.map((m) => m.label)).toEqual(["Character: #1", "Set: #1"]);
+    expect(marks.every((m) => m.initials)).toBe(true);
+    // The type is in the noun, never in the hue — two entities can and do
+    // collide on a colour, which is exactly why colour is only a hint.
+    expect(marks.every((m) => SET_COLORS.some((c) => c.value === m.hue))).toBe(
+      true,
+    );
+  });
+
+  it("fans three and then counts, front-to-back", () => {
+    const marks = assignmentMarks(
+      [1, 2, 3, 4, 5].map((id) => attach("character", id)),
+      {},
+    );
+    expect(marks).toHaveLength(3);
+    expect(marks[2].more).toBe(3);
+    expect(marks[2].label).toBe("Character: #3, Character: #4, Character: #5");
+    expect(marks.map((m) => m.z)).toEqual([3, 2, 1]);
+  });
+
+  it("returns nothing for a model assigned to nothing", () => {
+    expect(assignmentMarks([], {})).toEqual([]);
+    expect(assignmentMarks(undefined)).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #892.

`Assigned to` was a headed column with nothing in it but a count — `row.attachments`
was never rendered. It now draws the marks the design calls for.

### What it does

Each attachment renders as a bordered mark: the character's or set's thumbnail,
falling back to a coloured initials tile when the entity has no picture (a
character with no reference face and an empty set both 404 their thumbnail).
Hovering names the entity; the name is also in the cell's accessible name
unconditionally, so a reader gets it without hovering.

- **Colour is a grouping hint and never the meaning.** Every mark carries a
  thumbnail-or-initials and a name that says its type, so nothing is
  distinguished by colour alone (WCAG 1.4.1) and the column survives greyscale.
  The hue is the entity's own (`character_color` / `set_color`) where it has one
  — so a character wears the same colour here as in the sidebar — and a hash of
  its id otherwise. Never its position in the fan, which would repaint every
  remaining mark when one attachment is removed.
- **One radius for every mark.** `--radius-sm`; §6 reserves `--radius-pill` for
  avatar rings and half of these are picture sets. The type is in the label,
  never in the shape.
- **Unassigned is a dashed outline**, not a blank cell, so it reads as a state
  rather than a rendering gap. At `on-background` 0.5 rather than something
  fainter: the outline is the only visible carrier of that state, so it owes
  3:1 as a non-text component (measured 3.15:1 light, 4.36:1 dark; 0.35 was
  2.13:1).
- **The fan is capped at three, with an explicit z-order.** Three marks at a
  half-mark overlap land exactly on the existing two-mark track, so a fourth
  would step every column right of it sideways — beyond three the last slot is
  a `+N` counter whose title names the entities it stands for. The z-index is
  stamped descending in `assignmentMarks`, so the fan paints front-to-back
  instead of the last attachment covering the first.

### How it resolves the entities

`attachments` carries `entity_type` and `entity_id` and no names, so the names,
colours and thumbnails come from `useEntityListsStore` — the two list reads the
sidebar already makes, cached and shared, rather than a lookup per attachment.
The thumbnails are `<img src>` (new `characterThumbnailUrl` /
`pictureSetThumbnailUrl` in the api layer) rather than blobs, so the browser
fetches and caches one response however many rows name the same character; the
sidebar keeps its blob form, which wants the failure as a rejection.

An attachment whose entity the lists do not answer still gets a mark, reading
`#12`. The vault is the authority on what is attached, and dropping the mark
would say "not assigned" — a different and wrong fact.

### Base branch

**Opened against `develop`, not `main`, because the model shelf does not exist
on `main` at all** — `ModelShelf.vue`, the store, the routes and every sibling
file are develop-only, and #891 (the columns this column lives in) also merged
to `develop`. A PR against `main` would carry 432 unrelated commits. Please
retarget if that reading is wrong.

Note also that #892 and its parent checkbox in #904 were both already marked
shipped, but the placeholder cell and its `#892` comment were still on
`develop` — the work had not in fact landed.

### Tests

Nine new cases: four in `ModelShelf.test.js` covering the rendered marks, the
overflow counter, the unassigned slot and an unresolved entity; five unit cases
in `modelShelf.test.js` covering the colour source, id-keyed stability, the
identity-beside-colour invariant, the cap and the z-order. Full frontend suite
green (2965). `docs/frontend_architecture.md` §9.1a documents the four rules.
