### PR TITLE
Address review comments on the model shelf PRs (#912-#915)

### DIFF
--- a/frontend/src/api/characters.js
+++ b/frontend/src/api/characters.js
@@ -8,7 +8,7 @@
 //
 // See docs/frontend_architecture.md §8 ("The `src/api/` resource layer").
 
-import { apiClient, appendShareToken} from "../utils/apiClient";
+import { apiClient, appendShareToken } from "../utils/apiClient";
 import { unwrap } from "../utils/unwrap";
 
 /**
@@ -49,10 +49,9 @@ export function characterThumbnailUrl(id) {
  * @returns {Promise<Array<Object>>} the character list (the response body).
  */
 export async function listCharacters({ params } = {}) {
-  return unwrap(apiClient.get(
-    charactersUrl(""),
-    params ? { params } : undefined,
-  ));
+  return unwrap(
+    apiClient.get(charactersUrl(""), params ? { params } : undefined),
+  );
 }
 
 /**
@@ -104,9 +103,11 @@ export async function deleteCharacter(id) {
  *   the only subset an assignment can ever apply to.
  */
 export async function getCharacterMembership(pictureIds) {
-  return unwrap(apiClient.post(charactersUrl("/membership"), {
-    picture_ids: pictureIds,
-  }));
+  return unwrap(
+    apiClient.post(charactersUrl("/membership"), {
+      picture_ids: pictureIds,
+    }),
+  );
 }
 
 /**
@@ -116,9 +117,11 @@ export async function getCharacterMembership(pictureIds) {
  * @returns {Promise<Object>} the response body.
  */
 export async function addCharacterFaces(id, pictureIds) {
-  return unwrap(apiClient.post(charactersUrl(`/${id}/faces`), {
-    picture_ids: pictureIds,
-  }));
+  return unwrap(
+    apiClient.post(charactersUrl(`/${id}/faces`), {
+      picture_ids: pictureIds,
+    }),
+  );
 }
 
 /**
@@ -132,9 +135,11 @@ export async function addCharacterFaces(id, pictureIds) {
  * @returns {Promise<Object>} the response body.
  */
 export async function removeCharacterFaces(id, pictureIds) {
-  return unwrap(apiClient.delete(charactersUrl(`/${id}/faces`), {
-    data: { picture_ids: pictureIds },
-  }));
+  return unwrap(
+    apiClient.delete(charactersUrl(`/${id}/faces`), {
+      data: { picture_ids: pictureIds },
+    }),
+  );
 }
 
 /**
@@ -171,17 +176,16 @@ export async function getCharacterName(id) {
  *   HTTP cache after the thumbnail has been regenerated.
  * @returns {Promise<Blob>} the image data.
  */
-export async function getCharacterThumbnail(
-  id,
-  { cacheBuster } = {},
-) {
+export async function getCharacterThumbnail(id, { cacheBuster } = {}) {
   const path =
     cacheBuster != null
       ? `/${id}/thumbnail?cb=${cacheBuster}`
       : `/${id}/thumbnail`;
-  return unwrap(apiClient.get(charactersUrl(path), {
-    responseType: "blob",
-  }));
+  return unwrap(
+    apiClient.get(charactersUrl(path), {
+      responseType: "blob",
+    }),
+  );
 }
 
 /**
@@ -191,9 +195,11 @@ export async function getCharacterThumbnail(
  * @returns {Promise<Object>} the response body.
  */
 export async function addCharacterFacesByFaceId(id, faceIds) {
-  return unwrap(apiClient.post(charactersUrl(`/${id}/faces`), {
-    face_ids: faceIds,
-  }));
+  return unwrap(
+    apiClient.post(charactersUrl(`/${id}/faces`), {
+      face_ids: faceIds,
+    }),
+  );
 }
 
 /**
@@ -203,9 +209,11 @@ export async function addCharacterFacesByFaceId(id, faceIds) {
  * between review and assignment.
  */
 export async function addCharacterFaceAssignments(id, faceAssignments) {
-  return unwrap(apiClient.post(charactersUrl(`/${id}/faces`), {
-    face_assignments: faceAssignments,
-  }));
+  return unwrap(
+    apiClient.post(charactersUrl(`/${id}/faces`), {
+      face_assignments: faceAssignments,
+    }),
+  );
 }
 
 /**
@@ -221,10 +229,12 @@ export async function addCharacterFaceAssignments(id, faceAssignments) {
  *   number of pictures in scope.
  */
 export async function getCharacterSummary(id, params) {
-  return unwrap(apiClient.get(
-    charactersUrl(`/${id}/summary`),
-    params ? { params } : undefined,
-  ));
+  return unwrap(
+    apiClient.get(
+      charactersUrl(`/${id}/summary`),
+      params ? { params } : undefined,
+    ),
+  );
 }
 
 /**
@@ -239,9 +249,11 @@ export async function getCharacterSummary(id, params) {
  * @returns {Promise<Object>} the response body.
  */
 export async function removeCharacterFacesByFaceId(id, faceIds) {
-  return unwrap(apiClient.delete(charactersUrl(`/${id}/faces`), {
-    data: { face_ids: faceIds },
-  }));
+  return unwrap(
+    apiClient.delete(charactersUrl(`/${id}/faces`), {
+      data: { face_ids: faceIds },
+    }),
+  );
 }
 
 /**
@@ -251,7 +263,5 @@ export async function removeCharacterFacesByFaceId(id, faceIds) {
  *   `reference_picture_ids` is the ordered list.
  */
 export async function getReferencePictures(id) {
-  return unwrap(apiClient.get(
-    charactersUrl(`/${id}/reference_pictures`),
-  ));
+  return unwrap(apiClient.get(charactersUrl(`/${id}/reference_pictures`)));
 }

--- a/frontend/src/api/pictureSets.js
+++ b/frontend/src/api/pictureSets.js
@@ -4,7 +4,7 @@
 // (`/picture_sets/{id}/members/{pictureId}`), so bulk actions are the caller's
 // loop over these calls, not a bulk endpoint.
 
-import { apiClient, appendShareToken} from "../utils/apiClient";
+import { apiClient, appendShareToken } from "../utils/apiClient";
 import { unwrap } from "../utils/unwrap";
 
 /**
@@ -48,10 +48,7 @@ export function pictureSetThumbnailUrl(id) {
  * @returns {Promise<Array<Object>>} the picture-set list (the response body).
  */
 export async function listPictureSets({ params } = {}) {
-  return unwrap(apiClient.get(
-    setsUrl(""),
-    params ? { params } : undefined,
-  ));
+  return unwrap(apiClient.get(setsUrl(""), params ? { params } : undefined));
 }
 
 /**
@@ -105,10 +102,12 @@ export async function getPictureSetMembership(
   pictureIds,
   { includeDeleted = false } = {},
 ) {
-  return unwrap(apiClient.post(setsUrl("/membership"), {
-    picture_ids: pictureIds,
-    include_deleted: includeDeleted,
-  }));
+  return unwrap(
+    apiClient.post(setsUrl("/membership"), {
+      picture_ids: pictureIds,
+      include_deleted: includeDeleted,
+    }),
+  );
 }
 
 /**
@@ -118,9 +117,7 @@ export async function getPictureSetMembership(
  * @returns {Promise<Object>} the response body.
  */
 export async function addPictureToSet(setId, pictureId) {
-  return unwrap(apiClient.post(
-    setsUrl(`/${setId}/members/${pictureId}`),
-  ));
+  return unwrap(apiClient.post(setsUrl(`/${setId}/members/${pictureId}`)));
 }
 
 /**
@@ -130,9 +127,7 @@ export async function addPictureToSet(setId, pictureId) {
  * @returns {Promise<Object>} the response body.
  */
 export async function removePictureFromSet(setId, pictureId) {
-  return unwrap(apiClient.delete(
-    setsUrl(`/${setId}/members/${pictureId}`),
-  ));
+  return unwrap(apiClient.delete(setsUrl(`/${setId}/members/${pictureId}`)));
 }
 
 /**

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -1338,10 +1338,21 @@ describe("a run's disclosure", () => {
     // tag-name-only assertion let that mutant through when this was checked.
     // `[tabindex]` is on the row itself, so the search is for descendants.
     expect(
-      row.findAll(
-        'button, a[href], input, select, textarea, [tabindex], [role="button"]',
-      ),
+      row
+        .findAll(
+          'button, a[href], input, select, textarea, [tabindex], [role="button"]',
+        )
+        // The rename pencil is the one exception, and it is a different ACTION
+        // rather than a second way into the run: voice control ("click Rename")
+        // and the AT element list both need a named target, so it carries a
+        // role and a label (#914 review). It is exempt from the count above and
+        // held to the rule that actually matters on the next line.
+        .filter((el) => !el.classes().includes("shelf-name-pencil")),
     ).toHaveLength(0);
+    // ...which is that it is not a TAB STOP. `tabindex="-1"` is what keeps the
+    // keyboard path F2 on the row rather than a stop per row across 1,800 of
+    // them, and it is the assertion the exemption above would otherwise drop.
+    expect(row.find(".shelf-name-pencil").attributes("tabindex")).toBe("-1");
     expect(row.find(".shelf-row-steps").exists()).toBe(true);
   });
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -533,10 +533,18 @@
                       :title="NAME_TAG[row.name.state].title"
                       >{{ NAME_TAG[row.name.state].label }}</span
                     >
-                    <!-- Decorative, and deliberately not focusable: the row is
-                         the control on this grid, so the keyboard path is F2 on
-                         the row (announced by `aria-keyshortcuts`) rather than
-                         a tab stop per row across 1,800 of them. -->
+                    <!-- Named but deliberately not a tab stop: the row is the
+                         control on this grid, so the keyboard path is F2 on the
+                         row (announced by `aria-keyshortcuts`) rather than a
+                         tab stop per row across 1,800 of them.
+
+                         `tabindex="-1"` is what buys that, NOT `aria-hidden`,
+                         which is what this used to carry. Hiding a click target
+                         from the accessibility tree is invalid ARIA and it cost
+                         something real: voice control ("click Rename") and the
+                         AT element list both need a role and a name, and a
+                         pointer-free-but-sighted user had no way to reach the
+                         pencil at all. -->
                     <v-icon
                       class="shelf-name-pencil"
                       :class="{

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -490,7 +490,7 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
         ...results.flat(),
       ];
       // Cleared on every ordinary fetch, so the badge is exactly "what the scan
-      // you just ran added" and never a stale mark from one three refreshes ago.
+      // you just ran added" and never a stale mark from three refreshes ago.
       newIds.value = markNew
         ? new Set(
             rows.value.map((row) => row.id).filter((id) => !before.has(id)),

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -407,7 +407,9 @@ export function locationState(locations) {
  *
  * @param {Array<Object>} rows - shelf rows, each with `locations`.
  * @returns {Array<{folderId: number, path: string, count: number}>} sorted by
- *   path, so the banner reads the same on every render.
+ *   path, so the banner reads the same on every render — under the shelf's one
+ *   collation, numeric and case-insensitive, so `/mnt/2` precedes `/mnt/10`
+ *   here as it does in every other list on the screen.
  */
 export function offlineFolders(rows) {
   const byFolder = new Map();
@@ -437,7 +439,12 @@ export function offlineFolders(rows) {
   return [...byFolder.values()]
     .filter((folder) => folder.offline && folder.count)
     .map(({ folderId, path, count }) => ({ folderId, path, count }))
-    .sort((a, b) => a.path.localeCompare(b.path));
+    .sort((a, b) =>
+      a.path.localeCompare(b.path, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      }),
+    );
 }
 
 /**
@@ -749,6 +756,28 @@ export function generatedMark(row) {
  */
 const ASSIGNMENT_FAN_MAX = 3;
 
+/**
+ * `id -> row` for an entity list, built once per list rather than once per row.
+ *
+ * `assignmentMarks` is called from a `v-for` over the whole shelf, so rebuilding
+ * the maps inside it made the column cost rows x entities — 1,800 rows against a
+ * few hundred characters, on every render. Keyed on the ARRAY, which the entity
+ * store replaces wholesale on every refresh (`lists.value = { ...lists.value }`)
+ * and never mutates in place, so a new list is a new key and the cache cannot go
+ * stale. A `WeakMap` because the entry should die with the list it indexes.
+ */
+const ID_INDEX = new WeakMap();
+
+function indexById(list) {
+  if (!Array.isArray(list)) return new Map();
+  let index = ID_INDEX.get(list);
+  if (!index) {
+    index = new Map(list.map((row) => [String(row.id), row]));
+    ID_INDEX.set(list, index);
+  }
+  return index;
+}
+
 /** Which entity list answers an attachment's `entity_type`. */
 const ATTACHMENT_KIND = {
   character: {
@@ -793,8 +822,8 @@ export function assignmentMarks(
   { characters = [], sets = [] } = {},
 ) {
   const byId = {
-    characters: new Map((characters || []).map((row) => [String(row.id), row])),
-    sets: new Map((sets || []).map((row) => [String(row.id), row])),
+    characters: indexById(characters),
+    sets: indexById(sets),
   };
   const marks = (attachments ?? []).map((att) => {
     const type = att.entity_type === "character" ? "character" : "set";

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -203,6 +203,19 @@ describe("offlineFolders", () => {
       "/mnt/zed",
     ]);
   });
+
+  it("counts numerically, so /mnt/2 is not filed after /mnt/10", () => {
+    // The shelf's other lists already collate this way; a bare `localeCompare`
+    // here read `/mnt/10, /mnt/2` and made the banner disagree with the rows.
+    const rows = [
+      { id: 1, locations: [at(1, "unreachable", "/mnt/disk10")] },
+      { id: 2, locations: [at(2, "unreachable", "/mnt/Disk2")] },
+    ];
+    expect(offlineFolders(rows).map((f) => f.path)).toEqual([
+      "/mnt/Disk2",
+      "/mnt/disk10",
+    ]);
+  });
 });
 
 describe("bandGroups", () => {
@@ -794,5 +807,19 @@ describe("assignmentMarks", () => {
   it("returns nothing for a model assigned to nothing", () => {
     expect(assignmentMarks([], {})).toEqual([]);
     expect(assignmentMarks(undefined)).toEqual([]);
+  });
+
+  it("does not serve a stale name after the entity list is replaced", () => {
+    // The id maps are cached per LIST REFERENCE, because this is called once
+    // per shelf row and rebuilding them there cost rows x entities (#915
+    // review). The entity store replaces the array on every refresh rather than
+    // mutating it, so a rename must come through on the next render.
+    const before = [{ id: 7, name: "Ada" }];
+    const after = [{ id: 7, name: "Ada Lovelace" }];
+    const marks = (characters) =>
+      assignmentMarks([attach("character", 7)], { characters })[0].label;
+    expect(marks(before)).toBe("Character: Ada");
+    expect(marks(before)).toBe("Character: Ada");
+    expect(marks(after)).toBe("Character: Ada Lovelace");
   });
 });

--- a/pixlstash/services/model_features.py
+++ b/pixlstash/services/model_features.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import os
+from functools import lru_cache
 from typing import Optional
 
 from pixlstash.pixl_logging import get_logger
@@ -59,7 +60,7 @@ FEATURE_OTHER = "other"
 # Repo ids PixlStash's own code fetches, and what each is for. Restated rather
 # than imported for the reason `builtin_models` restates filenames: joycaption,
 # florence2 and wd14 import torch and onnxruntime at module level, and this runs
-# at start-up. `tests/test_model_features.py` imports the real constants, where
+# at start-up. `tests/test_builtin_models.py` imports the real constants, where
 # the cost is free, and asserts the two agree.
 OUR_REPOS: dict[str, str] = {
     # `joycaption._MODEL_NAME`
@@ -120,14 +121,20 @@ _PIPELINE_MARKER = "model_index.json"
 _CONFIG_MARKER = "config.json"
 
 
-def _base_model_aliases() -> set[str]:
-    """Every HuggingFace repo id the known-base-models table already names."""
+@lru_cache(maxsize=1)
+def _base_model_aliases() -> frozenset[str]:
+    """Every HuggingFace repo id the known-base-models table already names.
+
+    Cached: `KNOWN_BASE_MODELS` is a shipped constant, and the caller runs once
+    per cached repo at start-up, so rebuilding the set per repo is 43 entries
+    walked for nothing on every one of them.
+    """
     aliases = set()
     for meta in KNOWN_BASE_MODELS.values():
         for alias in meta.get("aliases", ()):  # type: ignore[union-attr]
             if "/" in alias:
                 aliases.add(alias.lower())
-    return aliases
+    return frozenset(aliases)
 
 
 def _snapshot_dirs(repo) -> list[str]:
@@ -175,8 +182,9 @@ def _feature_from_files(snapshot: str) -> Optional[str]:
             data = json.load(handle)
     except (OSError, ValueError, UnicodeDecodeError) as exc:
         logger.info(
-            "Could not read %s (%s); the repo will be labelled `other` rather "
-            "than guessed at.",
+            "Could not read %s (%s); this snapshot answers nothing, so the repo "
+            "falls through to its other revisions and then to its name, and is "
+            "labelled `other` if neither answers rather than guessed at.",
             config,
             exc,
         )


### PR DESCRIPTION
Follow-up to the reviews on #912, #913, #914 and #915. Ten Copilot comments
across the four; two of #914's were already fixed on `develop` by the autofix
commit, and the other eight are here — plus the test that autofix broke.

**Base is `develop`, not `main`.** All four PRs merged to `develop`, and the
code these comments are about does not exist on `main` (443 commits behind), so
a PR against `main` would either be empty or drag the whole branch in.

### #912 — `pixlstash/services/model_features.py`

- The comment pointed at `tests/test_model_features.py`, which does not exist.
  The classifier tests live in `tests/test_builtin_models.py`, which really does
  import the real constants and assert they agree with `OUR_REPOS`.
- `_base_model_aliases()` rebuilt a 43-entry table on every `feature_for_repo()`
  call, and the caller runs once per cached repo at start-up. `@lru_cache` on a
  shipped constant; it returns a `frozenset` now so nothing can mutate the cached
  value out from under the next caller.
- The "could not read the config" log claimed the repo *will* be labelled
  `other`, but the function returns `None` there and the caller still has the
  repo's other revisions and then `_NAME_HINTS` to try. It says that now — an
  operational log that overstates an outcome is worse than no log.

### #913

- `offlineFolders()` sorted with a bare `localeCompare`, so the banner filed
  `/mnt/10` before `/mnt/2` while every other list on the shelf used
  `{ numeric: true, sensitivity: "base" }`. Same collation as the rest now, with
  a test.
- Typo in a store comment ("from one three refreshes ago"), worded to match the
  same sentence in `ModelShelf.vue`.

### #914 — both already fixed, but the fix was red

The autofix that replaced the rename pencil's `aria-hidden="true"` with
`role="button" tabindex="-1" aria-label` broke
`keeps the count a drawn figure and not a second control`, a rule from #881's
review that forbids a second control in a shelf row. `develop` is red on it now.

Kept the aria fix — it is the right call, since voice control ("click Rename")
and the AT element list both need a named target, and the pencil had no
non-mouse path at all before. Exempted it from that assertion by name and
replaced the coverage it dropped with an explicit check that it is not a *tab
stop*, which is what the rule is actually protecting (the keyboard path is F2
on the row, not a stop per row across 1,800 rows). The `<!-- Decorative -->`
comment above it was left behind by the autofix and said the opposite of what
the markup now does; it explains the `tabindex="-1"`/`aria-hidden` distinction
instead.

### #915

- `assignmentMarks()` rebuilt both entity id maps on every call, and it is
  called once per rendered row, so the `Assigned to` column cost rows x entities
  on every render. Indexed once per list through a `WeakMap` keyed on the array.
  Safe because the entity store replaces those arrays wholesale on refresh and
  never mutates them in place, so a new list is a new key — there is a test that
  a rename comes through rather than being served from the cache.
- `import { apiClient, appendShareToken}` in `characters.js` and
  `pictureSets.js`. Ran Prettier over both files, which also picked up some
  pre-existing wrapping in the same files; that part is formatting only, no
  tokens changed (`git diff -w` is the smaller diff).

### Checks

Full frontend suite green (167 files, 2984 tests). `ruff format` clean on the
Python file. The backend suite needs deps this worktree does not have, so the
classifier was exercised directly instead: the cache holds, and ours / base
model / name hint / unknown still classify as `face` / `checkpoint` / `search` /
`other`.
