### PR TITLE
Give model shelf folder headers a drive, a tier and a reachability signal

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1606,6 +1606,62 @@ models is thirty-six headers. Under `Folder` the second level is spent on the
 F5's stacks nest inside a *row*, not inside a header, so they do not want a
 third level.
 
+#### What a folder header states (#899)
+
+A folder header used to carry a path and a count, so "which disk is this on",
+"is this one PixlStash writes to" and "is this drive even plugged in" were
+answerable only by opening the folders dialog. All three are properties of the
+registry the shelf already holds, so none of them costs a request:
+`withFolderSignals()` (pure, in `utils/modelShelf.js`) decorates the drawn
+groups with `tier`, `icon`, `chip`, `drive`, `offline` and `nested`.
+
+- **Every distinction survives greyscale.** The drive is a hue on the rail *and*
+  a chip naming the volume; the tier is a glyph *shape* and a *word*; offline is
+  a **dashed** rail plus muted ink. Nothing here is carried by hue alone, which
+  is the same rule "the two kinds of absence" below states for rows.
+- **The rail's colour is a grouping hint, never an identity.** It says "these
+  folders are on one disk"; the chip or the band above says *which*. Drives are
+  numbered in a stable order (sorted `device_id`), not in the order the groups
+  arrive in, or plugging a disk in would repaint every other folder's rail.
+  `driveRailColor` keeps a `SET_COLORS` entry's **hue** and pins saturation and
+  lightness, the same renormalisation `markBackground` does and for the same
+  reason — a colour picked for identity is not automatically one that reads as a
+  3px line. The palette is deliberately interleaved, so neighbouring indices are
+  far apart in hue.
+- **An unmeasured drive gets no rail colour.** We do not know which disk the
+  folder is on, and a colour there would claim a grouping nothing measured.
+- **The drive chip is drawn only where no band names the drive already.** Under
+  `Drive, then folder` the band *is* the chip, and repeating it on every folder
+  under it is noise rather than a second signal. The rail still runs down each
+  header, which is what holds the grouping together once the band has scrolled
+  off.
+- **The tier's glyph is the folders dialog's own.** `FOLDER_TIERS` lives in
+  `utils/modelShelf.js` and `ModelFoldersDialog.vue` reads its `KIND_ICON` out
+  of it: the header and the dialog row are two views of one registry, and two
+  copies of the map would be two vocabularies for one fact. It is also why the
+  glyph is an mdi folder like every other — an earlier mock hand-drew one from a
+  `div` plus a `::before` tab, which is a second icon family by construction.
+  `managed` takes the home glyph and `foreign` the lock, because `foreign` is
+  the only kind the owner can neither scan nor forget. `user` is the **unmarked**
+  case: chipping every header would hide the two that matter.
+- **Offline swaps the glyph and drops the drive hue.** The disconnected mark is
+  the shape half of the treatment, and the rail goes dashed-and-muted rather
+  than dashed-in-the-drive-colour — a coloured rail says "this is which disk",
+  and we cannot see the disk. Never the error colour, for the reason the offline
+  *row* is not the error colour either.
+- **Nesting is one level and never two.** A folder registered inside another
+  registered folder takes one `--depth` step, the shared row system's own indent
+  (§5.1) rather than a private padding. The question the indent answers is a yes
+  or a no; a registry three deep would otherwise walk the headers off the panel.
+  The prefix test is on a **separator boundary**, so `/models` does not swallow
+  `/models-old`.
+- **A group that is not a folder is left alone.** "No registered copy" has no
+  `folderId`, no disk and no tier — the same reason `bandGroups` leaves it
+  unbanded.
+- **The rail and the chips have accessible equivalents.** A rail has no
+  accessible name and a hue has none either, so the header's `aria-label` states
+  the tier, the drive and the offline state alongside the path and the count.
+
 #### The two kinds of absence (#898)
 
 `locationState()` reduces a row's copies to one word, and the shelf renders

--- a/frontend/src/components/panels/ModelFoldersDialog.vue
+++ b/frontend/src/components/panels/ModelFoldersDialog.vue
@@ -203,7 +203,7 @@ import {
   useModelFoldersStore,
 } from "../../stores/useModelFoldersStore";
 import { relativeDate } from "../../utils/snapshots";
-import { formatModelSize } from "../../utils/modelShelf";
+import { FOLDER_TIERS, formatModelSize } from "../../utils/modelShelf";
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -239,17 +239,13 @@ const DOCKER_REASON =
   "Adding a folder needs its path on the host, which PixlStash cannot ask for from inside Docker. Add it from the command line for now.";
 
 // One folder family, so the column reads as "which kind of folder" rather than
-// as four unrelated marks.
-const KIND_ICON = {
-  managed: "mdi-folder-home-outline",
-  user: "mdi-folder-outline",
-  source: "mdi-folder-cog-outline",
-  // The only kind the owner can neither scan nor forget, so it is the only one
-  // that gets the lock. `managed` is not locked — it holds no association to
-  // dissolve, but it is scannable and relocatable, which is why it keeps the
-  // home glyph rather than joining this one.
-  foreign: "mdi-folder-lock-outline",
-};
+// as four unrelated marks — and ONE copy of it, shared with the shelf's folder
+// headers (#899), which state the same tier about the same registry. `managed`
+// is not locked: it holds no association to dissolve, but it is scannable and
+// relocatable, which is why it keeps the home glyph rather than the lock.
+const KIND_ICON = Object.fromEntries(
+  Object.entries(FOLDER_TIERS).map(([kind, tier]) => [kind, tier.icon]),
+);
 
 const browseOpen = ref(false);
 const expanded = ref(new Set());

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -854,6 +854,144 @@ describe("drive bands", () => {
   });
 });
 
+describe("what a folder header says about its folder (#899)", () => {
+  const inFolder = (id, folderId, path, state = "present") =>
+    adapter({
+      id,
+      sha256: String(id).repeat(64).slice(0, 64),
+      locations: [
+        { state, folder_id: folderId, folder_path: path, relpath: "a.st" },
+      ],
+    });
+
+  async function mountFolders(rows, { folders = [], devices = [] } = {}) {
+    listModelFolders.mockResolvedValue(folders);
+    listModelFolderDevices.mockResolvedValue(devices);
+    const wrapper = await mountShelf(rows);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "alpha" });
+    await wrapper.vm.$nextTick();
+    return wrapper;
+  }
+
+  it("rails the folders on one drive in one colour, and names the volume", async () => {
+    const wrapper = await mountFolders(
+      [
+        inFolder(1, 1, "/mnt/fast/loras"),
+        inFolder(2, 2, "/mnt/fast/ckpt"),
+        inFolder(3, 3, "/ext/loras"),
+      ],
+      {
+        folders: [
+          { id: 1, path: "/mnt/fast/loras", kind: "user", file_count: 1 },
+          { id: 2, path: "/mnt/fast/ckpt", kind: "user", file_count: 1 },
+          { id: 3, path: "/ext/loras", kind: "user", file_count: 1 },
+        ],
+        devices: [
+          { device_id: "9", label: "FastModels", folder_ids: [1, 2] },
+          { device_id: "12", label: "Archive", folder_ids: [3] },
+        ],
+      },
+    );
+    // Alphabetical by path under this layout: /ext/loras, then the two on
+    // /mnt/fast.
+    const headers = wrapper.findAll(".shelf-group-btn");
+    const rails = headers.map((btn) => btn.attributes("style") || "");
+    expect(rails[1]).toContain("border-left-color");
+    // Same disk, same rail; a different disk, a different one.
+    expect(rails[2]).toBe(rails[1]);
+    expect(rails[0]).not.toBe(rails[1]);
+    // ...and the identity is a WORD, because the hue is only a grouping hint.
+    expect(textOf(headers[1])).toContain("FastModels");
+    expect(textOf(headers[0])).toContain("Archive");
+  });
+
+  it("leaves the drive chip to the band when there is a band", async () => {
+    // Under `Drive, then folder` the band above IS the chip. Repeating it on
+    // every folder under it would be noise rather than a second signal.
+    listModelFolders.mockResolvedValue([
+      { id: 1, path: "/mnt/fast/loras", kind: "user", file_count: 1 },
+    ]);
+    listModelFolderDevices.mockResolvedValue([
+      { device_id: "9", label: "FastModels", folder_ids: [1] },
+    ]);
+    const wrapper = await mountShelf([inFolder(1, 1, "/mnt/fast/loras")]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "drive" });
+    await wrapper.vm.$nextTick();
+
+    expect(textOf(wrapper.find(".shelf-band-heading"))).toContain("FastModels");
+    expect(textOf(wrapper.find(".shelf-group-btn"))).not.toContain(
+      "FastModels",
+    );
+    // The rail still runs down the header: it is what says the two folders
+    // under one band belong together once the band has scrolled away.
+    expect(wrapper.find(".shelf-group-btn").attributes("style")).toContain(
+      "border-left-color",
+    );
+  });
+
+  it("states the tier in a word and a glyph, on the header itself", async () => {
+    const wrapper = await mountFolders(
+      [
+        inFolder(1, 1, "/store"),
+        inFolder(2, 2, "/hf"),
+        inFolder(3, 3, "/mine"),
+      ],
+      {
+        folders: [
+          { id: 1, path: "/store", kind: "managed", file_count: 1 },
+          { id: 2, path: "/hf", kind: "foreign", file_count: 1 },
+          { id: 3, path: "/mine", kind: "user", file_count: 1 },
+        ],
+      },
+    );
+    const headers = wrapper.findAll(".shelf-group-btn");
+    const chips = headers.map((h) =>
+      h.findAll(".shelf-group-chip").map((c) => textOf(c)),
+    );
+    // Alphabetical by path: /hf, /mine, /store.
+    expect(chips[0]).toEqual(["Locked"]);
+    expect(chips[1]).toEqual([]);
+    expect(chips[2]).toEqual(["Managed"]);
+    // The reader who never opens the header still hears all three.
+    expect(headers[2].attributes("aria-label")).toBe(
+      "/store, Managed, 1 model",
+    );
+  });
+
+  it("marks an offline folder without ever using the error treatment", async () => {
+    const wrapper = await mountFolders(
+      [inFolder(1, 1, "/ext/loras", "unreachable")],
+      {
+        folders: [{ id: 1, path: "/ext/loras", kind: "user", file_count: 1 }],
+      },
+    );
+    const header = wrapper.find(".shelf-group-btn");
+    expect(header.classes()).toContain("shelf-group-btn--offline");
+    // A word as well as the dashed rail, so nothing here is carried by colour.
+    expect(textOf(header)).toContain("Offline");
+    expect(header.attributes("aria-label")).toContain("offline");
+    // The dashed rail replaces the drive hue rather than joining it: we cannot
+    // see the disk, so nothing on this header may claim which one it is.
+    expect(header.attributes("style") || "").not.toContain("border-left-color");
+  });
+
+  it("indents a folder registered inside another registered folder", async () => {
+    const wrapper = await mountFolders(
+      [inFolder(1, 1, "/models"), inFolder(2, 2, "/models/loras")],
+      {
+        folders: [
+          { id: 1, path: "/models", kind: "user", file_count: 1 },
+          { id: 2, path: "/models/loras", kind: "user", file_count: 1 },
+        ],
+      },
+    );
+    const [parent, child] = wrapper.findAll(".shelf-group-btn");
+    // `--depth` is the shared row system's own indent, not a private padding.
+    expect(parent.attributes("style") || "").not.toContain("--depth");
+    expect(child.attributes("style")).toContain("--depth: 1");
+  });
+});
+
 describe("the group header's reserved column", () => {
   it("carries the axis glyph rather than an empty gap", async () => {
     // The width is reserved either way so the header's label lines up with the

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -341,10 +341,14 @@
                  a payload this target takes (#757). -->
             <button
               class="ps-row shelf-group-btn"
-              :class="{ 'shelf-group-btn--drop': dropTargetKey === group.key }"
+              :class="{
+                'shelf-group-btn--drop': dropTargetKey === group.key,
+                'shelf-group-btn--offline': group.offline,
+              }"
+              :style="groupStyle(group)"
               type="button"
               :aria-expanded="!store.isCollapsed(group.key)"
-              :aria-label="`${group.label}, ${modelCount(group.rows.length)}`"
+              :aria-label="groupLabel(group)"
               @click="store.toggleGroup(group.key)"
               @dragover="onGroupDragOver(group, $event)"
               @dragleave="onGroupDragLeave(group)"
@@ -361,17 +365,43 @@
               <!-- Column 2 carries the axis glyph rather than sitting empty:
                    the reserved width is there either way, and a folder header
                    with a gap where the row thumbnails are reads as a missing
-                   image rather than as alignment. -->
+                   image rather than as alignment. Under `Folder` the glyph is
+                   the TIER's — one mdi folder family, never a hand-drawn box —
+                   and an unreachable folder wears the disconnected mark
+                   instead, which is the shape half of the offline treatment. -->
               <span class="shelf-group-mark">
                 <v-icon size="18">{{
-                  GROUP_BY_LABELS[store.view.groupBy].icon
+                  group.icon || GROUP_BY_LABELS[store.view.groupBy].icon
                 }}</v-icon>
               </span>
-              <span
-                class="shelf-group-label"
-                :class="`shelf-group-label--${group.labelKind}`"
-                >{{ group.label }}</span
-              >
+              <!-- Column 3 holds the label and everything that qualifies it.
+                   The chips are WORDS on purpose: the rail's hue groups the
+                   folders on one disk and the tier's glyph gives it a shape,
+                   but neither survives greyscale on its own, and only the chip
+                   is readable out loud. -->
+              <span class="shelf-group-id">
+                <span
+                  class="shelf-group-label"
+                  :class="`shelf-group-label--${group.labelKind}`"
+                  >{{ group.label }}</span
+                >
+                <span v-if="group.chip" class="shelf-group-chip">{{
+                  group.chip
+                }}</span>
+                <!-- Only where no band names the drive already: under `Drive,
+                     then folder` the band above IS this chip, and repeating it
+                     on every folder under it is noise rather than a signal. -->
+                <span
+                  v-if="!group.band && group.drive"
+                  class="shelf-group-chip"
+                >
+                  <v-icon size="12">mdi-harddisk</v-icon>
+                  {{ group.drive.label }}
+                </span>
+                <span v-if="group.offline" class="shelf-group-chip"
+                  >Offline</span
+                >
+              </span>
               <span class="shelf-group-count">{{
                 modelCount(group.rows.length)
               }}</span>
@@ -776,6 +806,7 @@ import {
   bandGroups,
   bandUsage,
   withEmptyFolders,
+  withFolderSignals,
   formatModelSize,
   GROUP_BY_LABELS,
   movableCopies,
@@ -1565,9 +1596,15 @@ function modelCount(n) {
   return `${n.toLocaleString()} ${n === 1 ? "model" : "models"}`;
 }
 
+/** The folders every copy of which is unreachable, for the headers' rails. */
+const offlineFolderIds = computed(
+  () => new Set(store.offlineMounts.map((mount) => mount.folderId)),
+);
+
 /**
  * The groups as drawn: banded by drive under `Folder` + `Drive, then folder`,
- * and the store's own order on every other axis.
+ * and the store's own order on every other axis, each folder group carrying
+ * what its header states about the folder (#899).
  *
  * Banded HERE rather than in the store because the drives are the folder
  * store's data and the folder store already imports the shelf store; reaching
@@ -1581,9 +1618,55 @@ const shownGroups = computed(() => {
   // default destination for a drop or an import — which it cannot be while the
   // owner has no way to see it.
   const groups = withEmptyFolders(store.groups, foldersStore.folders);
-  if (store.view.folderLayout !== "drive") return groups;
-  return bandGroups(groups, foldersStore.deviceByFolderId);
+  const arranged =
+    store.view.folderLayout === "drive"
+      ? bandGroups(groups, foldersStore.deviceByFolderId)
+      : groups;
+  // Last, so it decorates what is actually drawn under either layout. The
+  // offline set comes off the SHELF store rather than the registry: "wholly out
+  // of reach" is a fact about the copies, and the registry only knows a path.
+  return withFolderSignals(arranged, {
+    folders: foldersStore.folders,
+    deviceByFolderId: foldersStore.deviceByFolderId,
+    offlineFolderIds: offlineFolderIds.value,
+  });
 });
+
+/**
+ * The rail, and the one step of nesting.
+ *
+ * Both ride machinery that is already there: `.ps-row`'s rail is always present
+ * and always transparent (§5.1), so only its colour changes and a header that
+ * gains a drive does not move a pixel; `--depth` is the shared row system's own
+ * indent and is what every nested row in the sidebar uses.
+ */
+function groupStyle(group) {
+  const style = {};
+  // Not on an offline header: that rail is muted and dashed, and a drive hue
+  // on it would say the disk is there.
+  if (group.drive && !group.offline) style.borderLeftColor = group.drive.rail;
+  if (group.nested) style["--depth"] = 1;
+  return style;
+}
+
+/**
+ * What a folder header says out loud.
+ *
+ * The same three facts the chips and the rail carry, because a rail has no
+ * accessible name and a hue has none either: the tier, the drive and whether
+ * the folder can be reached at all.
+ */
+function groupLabel(group) {
+  return [
+    group.label,
+    group.chip,
+    group.drive?.label,
+    group.offline ? "offline" : "",
+    modelCount(group.rows.length),
+  ]
+    .filter(Boolean)
+    .join(", ");
+}
 
 function usage(band) {
   return bandUsage(band);
@@ -2131,6 +2214,50 @@ watch(
   font-weight: var(--weight-semibold);
   letter-spacing: var(--tracking-label);
   text-transform: uppercase;
+}
+
+/* Column 3: the label and the marks that qualify it, on one baseline. The
+   label is the only thing allowed to shrink — a chip that ellipsised would be
+   an unreadable word rather than a shorter one. */
+.shelf-group-id {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* The tier, the drive and the offline state, each as a WORD. The outline pill
+   at label weight, the same shape `.mf-chip` gives the folders dialog: this is
+   the same fact in a second place, and a second shape for it would read as a
+   second kind of thing. Never a filled pill — that one is the picture count's. */
+.shelf-group-chip {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-2);
+  border: 1px solid rgb(var(--v-theme-divider));
+  border-radius: var(--radius-sm);
+  font-size: var(--text-2xs);
+  color: rgba(var(--v-theme-on-background), 0.7);
+  white-space: nowrap;
+}
+
+/* ── The folder header's own two kinds of absence ──────────────────────────
+   OFFLINE is the folder-level twin of `.shelf-row--offline`, and takes the
+   same treatment for the same reason: a dashed rail and muted ink, and
+   deliberately NEVER the error colour, because an unplugged disk is not a
+   fault and nothing under it is lost. The drive hue is dropped rather than
+   dashed in colour — a coloured rail says "this is which disk", and we cannot
+   see the disk. */
+.shelf-group-btn--offline {
+  border-left-style: dashed;
+  border-left-color: rgba(var(--v-theme-on-background), 0.7);
+}
+
+.shelf-group-btn--offline .shelf-group-label,
+.shelf-group-btn--offline .shelf-group-mark {
+  color: rgba(var(--v-theme-on-background), 0.7);
 }
 
 /* A folder header's label is a literal filesystem path. §3 gives the mono face

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -272,6 +272,167 @@ export const FOLDER_LAYOUT_LABELS = {
 };
 
 /**
+ * What each folder tier is marked with, in ONE icon family.
+ *
+ * Shared with `ModelFoldersDialog`, which is where these glyphs started: the
+ * shelf header and the dialog row are two views of the same registry, and two
+ * copies of the map would be two vocabularies for one fact. Nothing here is
+ * hand-drawn — the header used to have no tier mark at all, and the mock that
+ * proposed one built a folder out of a div and a `::before` tab, which is a
+ * second icon family by construction.
+ *
+ * `chip` is the WORD the tier is stated in, and it is what makes the tier
+ * survive greyscale together with the glyph's shape. `user` has none: a folder
+ * the owner registered is the unmarked case, and chipping every header would
+ * make the two that matter invisible among them.
+ */
+export const FOLDER_TIERS = {
+  managed: {
+    icon: "mdi-folder-home-outline",
+    chip: "Managed",
+    note: "PixlStash keeps its own models here.",
+  },
+  // The only kind the owner can neither scan nor forget, so it is the only one
+  // that gets the lock — the same rule the folders dialog's glyph column uses.
+  foreign: {
+    icon: "mdi-folder-lock-outline",
+    chip: "Locked",
+    note: "Owned by another tool. PixlStash reads it and never writes to it.",
+  },
+  source: {
+    icon: "mdi-folder-cog-outline",
+    chip: "ai-toolkit",
+    note: "Training output. Models are imported from here, not catalogued in place.",
+  },
+  user: { icon: "mdi-folder-outline", chip: "", note: "" },
+};
+
+/** The glyph a folder whose drive is not plugged in wears, instead of its tier's. */
+const OFFLINE_ICON = "mdi-lan-disconnect";
+
+// The rail keeps its palette entry's HUE and pins saturation and lightness, the
+// same renormalisation `markBackground` does and for the same reason: a colour
+// picked for identity is not automatically a colour that reads as a 3px line.
+// Mid lightness rather than the mark's 30%, because this line sits on the
+// canvas in BOTH themes and nothing is ever written on it.
+const RAIL_SATURATION = 60;
+const RAIL_LIGHTNESS = 50;
+
+/**
+ * The rail colour a drive gets, by its position in the drive order.
+ *
+ * A grouping hint and never the identity: the chip (or the band above) names
+ * the volume, and the palette repeats after 48 drives. `SET_COLORS` is
+ * deliberately interleaved so neighbouring indices are far apart in hue, which
+ * is what makes "these two folders are on one disk" readable at a glance.
+ *
+ * @param {number} index - position in the drive order.
+ * @returns {string} an `hsl()` colour.
+ */
+export function driveRailColor(index) {
+  const entry = SET_COLORS[index % SET_COLORS.length].value;
+  return `hsl(${hueOf(entry)} ${RAIL_SATURATION}% ${RAIL_LIGHTNESS}%)`;
+}
+
+/**
+ * True when `path` sits inside `parent`, one registered folder inside another.
+ *
+ * String comparison on a separator boundary, which is what keeps `/models` from
+ * swallowing `/models-old`. Both separators, because a registry written on
+ * Windows holds backslashes.
+ */
+function isInside(path, parent) {
+  if (!path || !parent || path === parent) return false;
+  const head = parent.replace(/[/\\]+$/, "");
+  const rest = path.slice(head.length);
+  return path.startsWith(head) && /^[/\\]/.test(rest);
+}
+
+/**
+ * Tell each folder header what drive it is on, what tier it is and whether it
+ * can be reached (#899).
+ *
+ * A header used to carry a path and a count and nothing else, so the answer to
+ * "which disk is this on", "is this one PixlStash writes to" and "is this drive
+ * even plugged in" lived only in the folders dialog. All three are properties
+ * of the folder registry, which the shelf already holds; none of them needed a
+ * request.
+ *
+ * **Every distinction here survives greyscale.** The drive is a hue on the rail
+ * AND a chip that names the volume; the tier is a glyph shape AND a word; the
+ * offline state is a DASHED rail and muted ink — never the error colour, for
+ * the reason the offline row treatment is not the error colour either. Nothing
+ * is carried by hue alone.
+ *
+ * Drives are numbered in a stable order (by device id) rather than by the order
+ * the groups happen to arrive in, or plugging a disk in would repaint every
+ * other folder's rail. A folder whose drive could not be measured gets NO rail
+ * colour: we do not know what disk it is on, and inventing a colour for it
+ * would claim a grouping nothing measured.
+ *
+ * @param {Array<Object>} groups - folder groups, each carrying `folderId`.
+ * @param {Object} context
+ * @param {Array<Object>} context.folders - rows from `GET /model-folders`.
+ * @param {Map<number, Object>} [context.deviceByFolderId] - from the folder store.
+ * @param {Set<number>} [context.offlineFolderIds] - folders wholly out of reach.
+ * @returns {Array<Object>} the same groups, each with `tier`, `icon`, `chip`,
+ *   `drive` (`{label, rail}` or null), `offline` and `nested`.
+ */
+export function withFolderSignals(
+  groups,
+  { folders = [], deviceByFolderId = null, offlineFolderIds = null } = {},
+) {
+  const byId = new Map(
+    (folders || []).map((folder) => [Number(folder.id), folder]),
+  );
+  const paths = (folders || []).map((folder) => String(folder.path || ""));
+  // Drive order, fixed before anything is drawn. Sorted by device id so it is
+  // the same on every render and the same for every reader.
+  const driveIndex = new Map(
+    [
+      ...new Set(
+        [...(deviceByFolderId?.values?.() || [])]
+          .map((device) => device?.device_id)
+          .filter(Boolean)
+          .map(String),
+      ),
+    ]
+      .sort()
+      .map((id, index) => [id, index]),
+  );
+  return (groups || []).map((group) => {
+    const folderId = Number(group.folderId);
+    const folder = Number.isInteger(folderId) ? byId.get(folderId) : null;
+    const device = Number.isInteger(folderId)
+      ? deviceByFolderId?.get?.(folderId) || null
+      : null;
+    const tier = FOLDER_TIERS[folder?.kind] ? folder.kind : "user";
+    const offline = Boolean(offlineFolderIds?.has?.(folderId));
+    const deviceId = device?.device_id ? String(device.device_id) : "";
+    return {
+      ...group,
+      tier: folder ? tier : null,
+      icon: offline ? OFFLINE_ICON : FOLDER_TIERS[tier].icon,
+      chip: folder ? FOLDER_TIERS[tier].chip : "",
+      note: folder ? FOLDER_TIERS[tier].note : "",
+      drive: deviceId
+        ? {
+            label: device.label || device.mount_point || "",
+            rail: driveRailColor(driveIndex.get(deviceId) ?? 0),
+          }
+        : null,
+      offline,
+      // One level, never two: nesting here says "this folder lives inside
+      // another registered one", which is a yes or a no. A registry three deep
+      // would otherwise walk the headers off the left edge of the panel.
+      nested: paths.some((other) =>
+        isInside(String(folder?.path || ""), other),
+      ),
+    };
+  });
+}
+
+/**
  * Arrange folder groups into drive bands.
  *
  * Two levels, which is what the plan allows and no more: the band is the drive

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -25,6 +25,8 @@ import {
   offlineFolders,
   stackReceipt,
   trainingStep,
+  withFolderSignals,
+  FOLDER_TIERS,
 } from "./modelShelf";
 
 describe("cleanAssetName", () => {
@@ -414,6 +416,159 @@ describe("withEmptyFolders", () => {
     expect(withEmptyFolders(groups, [{ id: 1, path: "/models/loras" }])).toBe(
       groups,
     );
+  });
+});
+
+describe("withFolderSignals", () => {
+  const group = (folderId, path) => ({
+    key: path,
+    label: path,
+    labelKind: "path",
+    folderId,
+    rows: [],
+  });
+
+  const devices = (entries) => {
+    const byFolder = new Map();
+    for (const device of entries) {
+      for (const id of device.folder_ids) byFolder.set(id, device);
+    }
+    return byFolder;
+  };
+
+  it("gives folders on one drive one rail colour, and two drives two", () => {
+    // The whole point of the hue: "these are on the same physical disk" read
+    // off the header, without opening the folders dialog.
+    const [a, b, c] = withFolderSignals(
+      [
+        group(1, "/mnt/fast/loras"),
+        group(2, "/mnt/fast/ckpt"),
+        group(3, "/ext"),
+      ],
+      {
+        folders: [
+          { id: 1, path: "/mnt/fast/loras", kind: "user" },
+          { id: 2, path: "/mnt/fast/ckpt", kind: "user" },
+          { id: 3, path: "/ext", kind: "user" },
+        ],
+        deviceByFolderId: devices([
+          { device_id: "9", label: "FastModels", folder_ids: [1, 2] },
+          { device_id: "12", label: "Archive", folder_ids: [3] },
+        ]),
+      },
+    );
+    expect(a.drive.rail).toBe(b.drive.rail);
+    expect(c.drive.rail).not.toBe(a.drive.rail);
+    // The chip carries the identity; the colour is only a grouping hint.
+    expect(a.drive.label).toBe("FastModels");
+    expect(c.drive.label).toBe("Archive");
+  });
+
+  it("numbers the drives by device id, not by the order groups arrive in", () => {
+    // A group order that decided the colours would repaint every folder's rail
+    // when a filter emptied a group or a new disk was plugged in.
+    const context = {
+      folders: [
+        { id: 1, path: "/a", kind: "user" },
+        { id: 2, path: "/b", kind: "user" },
+      ],
+      deviceByFolderId: devices([
+        { device_id: "aaa", folder_ids: [1] },
+        { device_id: "bbb", folder_ids: [2] },
+      ]),
+    };
+    const forward = withFolderSignals(
+      [group(1, "/a"), group(2, "/b")],
+      context,
+    );
+    const reversed = withFolderSignals(
+      [group(2, "/b"), group(1, "/a")],
+      context,
+    );
+    expect(reversed[1].drive.rail).toBe(forward[0].drive.rail);
+    expect(reversed[0].drive.rail).toBe(forward[1].drive.rail);
+  });
+
+  it("gives an unmeasured drive no rail colour rather than inventing one", () => {
+    // We do not know which disk this is on, and a colour would claim a grouping
+    // nothing measured.
+    const [only] = withFolderSignals([group(7, "/net/models")], {
+      folders: [{ id: 7, path: "/net/models", kind: "user" }],
+      deviceByFolderId: devices([{ device_id: null, folder_ids: [7] }]),
+    });
+    expect(only.drive).toBe(null);
+  });
+
+  it("states each tier in a shape and a word, never in a colour", () => {
+    const [managed, locked, plain] = withFolderSignals(
+      [group(1, "/store"), group(2, "/hf"), group(3, "/mine")],
+      {
+        folders: [
+          { id: 1, path: "/store", kind: "managed" },
+          { id: 2, path: "/hf", kind: "foreign" },
+          { id: 3, path: "/mine", kind: "user" },
+        ],
+      },
+    );
+    expect(managed.icon).toBe(FOLDER_TIERS.managed.icon);
+    expect(managed.chip).toBe("Managed");
+    expect(locked.icon).toBe(FOLDER_TIERS.foreign.icon);
+    expect(locked.chip).toBe("Locked");
+    // The unmarked case: chipping every header would hide the two that matter.
+    expect(plain.icon).toBe(FOLDER_TIERS.user.icon);
+    expect(plain.chip).toBe("");
+  });
+
+  it("marks an unreachable folder offline, and keeps its tier chip", () => {
+    const [only] = withFolderSignals([group(2, "/hf")], {
+      folders: [{ id: 2, path: "/hf", kind: "foreign" }],
+      offlineFolderIds: new Set([2]),
+    });
+    expect(only.offline).toBe(true);
+    // A different GLYPH, so the reachability survives greyscale — and the tier
+    // is still stated, because a locked folder is locked whether or not the
+    // disk is plugged in.
+    expect(only.icon).toBe("mdi-lan-disconnect");
+    expect(only.chip).toBe("Locked");
+  });
+
+  it("nests a folder that sits inside another registered one, one level only", () => {
+    const [parent, child, sibling, deeper] = withFolderSignals(
+      [
+        group(1, "/models"),
+        group(2, "/models/loras"),
+        group(3, "/models-old"),
+        group(4, "/models/loras/flux"),
+      ],
+      {
+        folders: [
+          { id: 1, path: "/models", kind: "user" },
+          { id: 2, path: "/models/loras", kind: "user" },
+          { id: 3, path: "/models-old", kind: "user" },
+          { id: 4, path: "/models/loras/flux", kind: "user" },
+        ],
+      },
+    );
+    expect(parent.nested).toBe(false);
+    expect(child.nested).toBe(true);
+    // A prefix that is not a path boundary is a different folder, not a child.
+    expect(sibling.nested).toBe(false);
+    // Two registered folders above it, still one step: the indent says "inside
+    // another folder", which is a yes or a no.
+    expect(deeper.nested).toBe(true);
+  });
+
+  it("leaves a group that is not a folder alone", () => {
+    // "No registered copy" has no folder id, no disk and no tier — decorating
+    // it would put a drive rail over the one group that exists because there is
+    // no drive.
+    const [only] = withFolderSignals([{ key: "none", label: "x", rows: [] }], {
+      folders: [{ id: 1, path: "/models", kind: "user" }],
+    });
+    expect(only.tier).toBe(null);
+    expect(only.drive).toBe(null);
+    expect(only.chip).toBe("");
+    expect(only.nested).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #899.

A folder header carried a path and a count, so "which disk is this on", "is
this one PixlStash writes to" and "is this drive even plugged in" were
answerable only by opening the folders dialog. All three are properties of the
registry the shelf already holds, so none of them costs a request.

**Base is `develop`, not `main`.** `ModelShelf.vue` does not exist on `main`
(443 commits behind), and #891/#892/#896/#897/#898 all merged to `develop`.

### What a header states now

`withFolderSignals()` — pure, in `utils/modelShelf.js` — decorates the drawn
groups with `tier`, `icon`, `chip`, `drive`, `offline` and `nested`.

- **A drive rail** down the header's leading edge, cycling colour per drive, so
  the folders on one disk read as a set. It rides `.ps-row`'s existing rail
  (always present, always transparent, §5.1), so a header that gains a drive
  does not move a pixel. Drives are numbered by sorted `device_id`, not by the
  order groups arrive in, or plugging a disk in would repaint every other rail.
  `driveRailColor` keeps a `SET_COLORS` entry's hue and pins saturation and
  lightness, the same renormalisation `markBackground` already does.
- **A drive chip** naming the volume — but only where no band names it already.
  Under `Drive, then folder` the band above *is* the chip; repeating it on every
  folder under it is noise rather than a second signal. The rail still runs down
  each header, which is what holds the grouping once the band has scrolled off.
- **Tier**, as a glyph shape and a word: the managed store takes the home glyph
  and `Managed`, a folder owned by another tool takes the lock and `Locked`, and
  a folder the owner registered stays unmarked — chipping every header would
  hide the two that matter.
- **Offline** takes the dashed rail and muted ink of the absence rules, the
  disconnected glyph, and the word `Offline`. Never the error colour, for the
  reason the offline *row* is not the error colour either. The drive hue is
  dropped rather than dashed in colour: a coloured rail says which disk, and we
  cannot see the disk.
- **Nesting**, one level, for a folder registered inside another registered one.
  It is one `--depth` step — the shared row system's own indent, not a private
  padding — and the prefix test is on a separator boundary, so `/models` does
  not swallow `/models-old`.

**Every distinction survives greyscale**, which is the issue's acceptance
condition: the drive is a hue *and* a chip, the tier is a shape *and* a word,
offline is a dash *and* a word. Nothing is carried by hue alone. The rail and
the chips also have no accessible name of their own, so the header's
`aria-label` states the tier, the drive and the offline state alongside the path
and the count.

### Reuse rather than a second vocabulary

The tier glyphs were `KIND_ICON` inside `ModelFoldersDialog.vue`. They are now
`FOLDER_TIERS` in `utils/modelShelf.js` and the dialog reads its map out of
them: the header and the dialog row are two views of one registry, and two
copies would be two vocabularies for one fact. It is also why the glyph is an
mdi folder like everything else — the mock referenced in the issue hand-drew one
from a `div` plus a `::before` tab, which is a second icon family by
construction.

### Checks

- Full frontend suite green (167 files, 2999 tests) except the one test #916 is
  already fixing: `keeps the count a drawn figure and not a second control` is
  red on `develop` today, from #914's autofix, and is untouched here on purpose
  so the two branches do not collide. Merged locally against #916's head: clean
  merge, and both shelf suites pass on the merged tree.
- 6 new unit tests for `withFolderSignals` and 5 new component tests covering
  the rail, the band's chip suppression, the tier, the offline treatment and the
  nesting indent.
- `npm run build` clean; Prettier and ESLint clean on the changed files (the one
  remaining ESLint warning, an unused `KIND_ICON` in `ModelShelf.vue`, predates
  this branch and belongs to the row's file-kind map, not the folder tiers).

### Not covered by the suite

The colours themselves. The rail hues are asserted only as "same drive, same
value; different drive, a different one" — whether they read well against both
themes at 3px, and whether a nested header's indent looks right beside a band,
want an eye on a real library.
