### PR TITLE
Give the drive band three segments, a legend and a low-free state

### DIFF
--- a/docs/design/visual-language.md
+++ b/docs/design/visual-language.md
@@ -378,6 +378,37 @@ Findings to honour:
   4.90 / 5.30. All clear the 3:1 UI floor. Light `success` and `info` were Material
   500s until 2026-07 and measured 2.64 / 2.97 — **below the floor** — which is the
   reason they were deepened to `#2e7d32` and `#1a6ec4`.
+- **A multi-segment meter steps its neutral to the extreme *away* from the canvas**,
+  never to a mid-grey between the accent and the track. The range between the accent
+  and the canvas is not wide enough for two 3:1 steps; the range *past* the accent is.
+  Proven on the model shelf's drive band (#893), whose three segments are `ours` /
+  `other` / `free` and therefore have two adjacencies to keep readable. Composited over
+  `background`, light on `#faf9f7` / dark on `#1b1f24`:
+
+  | pair | light | dark |
+  |---|---|---|
+  | `ours` `#567309` : `other` (`#1c160c` / `#d4c9c1`) | **3.29** | **3.36** |
+  | `other` : `free` (`#e5e3e1` / `#121518`) | **14.03** | **11.28** |
+  | `free` : canvas | 1.22 | 1.11 — *drawn*, not inferred (see below) |
+
+  Three things this pins down, each of which was got wrong first:
+  **(a)** The neutral is what steps per theme, not the accent — `primary` stays the
+  "ours" colour in both, because a legend swatch that is orange in one theme and olive
+  in the other is not one system. **(b)** Dark is stepped *independently*, never a
+  flipped alpha: on a dark canvas an ink alpha can only lighten, so the neutral cannot
+  pass below the olive, and the shipped `rgba(ink, .28)` measured **1.34:1** — the
+  deuteranopia failure that opened the issue. The neutral goes light and the *track*
+  takes the dark end via a `scrim` tint. **(c)** In light the neutral must go past the
+  ink itself: `on-background` tops out at L .0153 and measures 2.95, just under the
+  floor, so the fill is `shadow` `#1c160c` (L .0085).
+  Separating the segments with a hairline instead was rejected: the issue's requirement
+  is a *luminance* separation, and a drawn line is not one — with a quiet mid-grey
+  neutral the pair measures 1.73:1, so in greyscale you would see two segments and be
+  unable to tell which was which.
+  The track is only 1.22 / 1.11 against the canvas, which would make a nearly-empty
+  drive a ghost, so it carries a 1px `outline` at 4.24 / 5.67 rather than relying on a
+  colour step. A meter's own frame is a legitimate substitute for a fill boundary; a
+  line *between two fills* is not.
 - **The eight `on-<status>` values, on their solid fill:** light `on-error` #ffffff
   4.86 · `on-warning` #23211d 4.95 · `on-success` #ffffff 5.13 · `on-info` #ffffff
   5.16; dark, all four `#1b1b1b`: `on-error` 4.68 · `on-warning` 5.53 · `on-success`

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1592,11 +1592,33 @@ models is thirty-six headers. Under `Folder` the second level is spent on the
   thereby one drive) and sorts after every measured band. Its meter is omitted
   rather than drawn empty, because an empty bar reads as a drive with nothing on
   it. `bandUsage` returns `null` for exactly this.
-- **The meter is one track with two fills, and free space leads the label.** The
-  shelf's share is *part* of what is used, so two separate bars could sum past
-  the drive; and free is the number that decides whether the next 24 GB
-  checkpoint fits. `shelf_bytes` counts `present` copies only, so a `missing`
-  row never reports space the drive does not agree is in use.
+- **The meter is one track with three segments, and free space leads the label.**
+  `ours | other | free`, laid end to end. The shelf's share is *part* of what is
+  used, so `other` is the *rest* of the used space and the three sum to exactly
+  100% by construction — which is what lets them be a flex row with no rounding
+  sliver at the right-hand end. They were originally two *overlaid* fills, which
+  summed correctly but meant a reader could see a boundary without being able to
+  tell which of the meter's two questions — "how full is this drive" and "how
+  much of that is ours" — it answered (#893). Free leads the label because it is
+  the number that decides whether the next 24 GB checkpoint fits. `shelf_bytes`
+  counts `present` copies only, so a `missing` row never reports space the drive
+  does not agree is in use.
+- **The key is drawn once for the view; the meters carry no ARIA.** Three
+  segments need naming, but naming them per band would cost more room than the
+  meters themselves, so the legend renders once and only when a *measured* band
+  is actually on screen (an unmeasured band has no meter to key). Each meter is
+  `aria-hidden`: `.shelf-band-figures` already states the identical string as
+  visible text in the same heading, so labelling the meter made every band
+  announce its figures twice. `role="meter"` is wrong here for a different
+  reason — it carries a single `aria-valuenow`, and this is three numbers.
+- **Low free space is a fact about a disk, not an event.** `bandUsage` flags it
+  from an absolute floor (`LOW_FREE_BYTES`, 50 GiB) and never a percentage: the
+  question is "does the next checkpoint fit", 10% of a 4 TB model drive is
+  400 GB and would cry wolf, and 10% of a 256 GB SSD is 25 GB — but so is 60 GB
+  free on that same disk. It is carried by the word "Only" leading the label, a
+  `mdi-alert-outline` glyph and semibold figures, with the warning hue additive
+  on top; so it survives greyscale, and it gets no live region, because it is
+  true of several bands at once and would fire a burst on every device refresh.
 - **The bands are decoration and fail alone.** `refreshDevices` is unawaited and
   swallows its own error into a `console.warn`, never into the folder store's
   `error`: the route stats the filesystem, so an offline mount can make it slow

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -806,7 +806,133 @@ describe("drive bands", () => {
     // Free leads: it is the number that decides whether the next checkpoint
     // fits, and the meter is read at a glance rather than computed from.
     expect(textOf(bands[0])).toContain("512.0 GB free of 1.0 TB");
-    expect(wrapper.findAll(".shelf-band-fill")).toHaveLength(2);
+
+    // Three segments carving up the track, in the legend's order, and their
+    // widths add to the whole drive. Two overlaid fills could not say which of
+    // "how full is the disk" and "how much is ours" a boundary marked (#893).
+    const segs = wrapper.findAll(".shelf-band-seg");
+    expect(segs).toHaveLength(3);
+    expect(segs.map((s) => s.attributes("style"))).toEqual([
+      "width: 25%;", // 256 GB on the shelf
+      "width: 25%;", // 256 GB belonging to anything else
+      "width: 50%;", // 512 GB free
+    ]);
+    // The meter is decorative: the same figures are already visible text in
+    // this heading, so labelling it made every band announce them twice.
+    expect(wrapper.find(".shelf-band-meter").attributes("aria-hidden")).toBe(
+      "true",
+    );
+    expect(
+      wrapper.find(".shelf-band-meter").attributes("role"),
+    ).toBeUndefined();
+  });
+
+  it("keys the meter once for the view, not once per band", async () => {
+    listModelFolderDevices.mockResolvedValue([
+      {
+        device_id: "9",
+        mount_point: "/mnt/fast",
+        label: "FastModels",
+        total_bytes: 1024 ** 4,
+        free_bytes: 512 * 1024 ** 3,
+        shelf_bytes: 256 * 1024 ** 3,
+        folder_ids: [1],
+      },
+      {
+        device_id: "10",
+        mount_point: "/mnt/slow",
+        label: "SlowModels",
+        total_bytes: 1024 ** 4,
+        free_bytes: 512 * 1024 ** 3,
+        shelf_bytes: 128 * 1024 ** 3,
+        folder_ids: [2],
+      },
+    ]);
+    const wrapper = await mountShelf([
+      inFolder(1, 1, "/mnt/fast/loras"),
+      inFolder(2, 2, "/mnt/slow/checkpoints"),
+    ]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "drive" });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findAll(".shelf-band-heading")).toHaveLength(2);
+    expect(wrapper.findAll(".shelf-band-legend")).toHaveLength(1);
+    expect(textOf(wrapper.find(".shelf-band-legend"))).toContain(
+      "On the shelf",
+    );
+    expect(textOf(wrapper.find(".shelf-band-legend"))).toContain("Other files");
+    expect(textOf(wrapper.find(".shelf-band-legend"))).toContain("Free");
+  });
+
+  it("draws no key when no meter is on screen to key", async () => {
+    // An unmeasured drive renders no meter, so a shelf of only offline drives
+    // would otherwise print a key to a picture nobody can see.
+    listModelFolderDevices.mockResolvedValue([
+      {
+        device_id: null,
+        mount_point: "/net/models",
+        total_bytes: null,
+        free_bytes: null,
+        shelf_bytes: 0,
+        folder_ids: [7],
+      },
+    ]);
+    const wrapper = await mountShelf([inFolder(1, 7, "/net/models/loras")]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "drive" });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".shelf-band-heading").exists()).toBe(true);
+    expect(wrapper.find(".shelf-band-legend").exists()).toBe(false);
+  });
+
+  it("warns when a drive has no room for the next checkpoint", async () => {
+    listModelFolderDevices.mockResolvedValue([
+      {
+        device_id: "9",
+        mount_point: "/mnt/fast",
+        label: "FastModels",
+        total_bytes: 1024 ** 4,
+        free_bytes: 8 * 1024 ** 3,
+        shelf_bytes: 512 * 1024 ** 3,
+        folder_ids: [1],
+      },
+    ]);
+    const wrapper = await mountShelf([inFolder(1, 1, "/mnt/fast/loras")]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "drive" });
+    await wrapper.vm.$nextTick();
+
+    // The word carries the state in greyscale, and in a screen reader, without
+    // a live region: this is a standing fact about a disk, not an event.
+    expect(textOf(wrapper.find(".shelf-band-heading"))).toContain(
+      "Only 8.0 GB free of 1.0 TB",
+    );
+    expect(wrapper.find(".shelf-band-meter--low").exists()).toBe(true);
+    expect(wrapper.find(".shelf-band-figures--low").exists()).toBe(true);
+    expect(wrapper.find(".shelf-band-heading").attributes("role")).not.toBe(
+      "alert",
+    );
+  });
+
+  it("leaves a roomy drive unwarned however full it looks", async () => {
+    // 400 GB left is a tenth of this drive. A percentage rule would cry wolf
+    // here, on exactly the hardware people keep models on.
+    listModelFolderDevices.mockResolvedValue([
+      {
+        device_id: "9",
+        mount_point: "/mnt/fast",
+        label: "FastModels",
+        total_bytes: 4000 * 1024 ** 3,
+        free_bytes: 400 * 1024 ** 3,
+        shelf_bytes: 1024 ** 3,
+        folder_ids: [1],
+      },
+    ]);
+    const wrapper = await mountShelf([inFolder(1, 1, "/mnt/fast/loras")]);
+    useModelShelfStore().setView({ groupBy: "folder", folderLayout: "drive" });
+    await wrapper.vm.$nextTick();
+
+    expect(textOf(wrapper.find(".shelf-band-heading"))).not.toContain("Only");
+    expect(wrapper.find(".shelf-band-meter--low").exists()).toBe(false);
   });
 
   it("says a drive is unknown rather than drawing it empty", async () => {

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -290,6 +290,30 @@
            stops too, so Tab still moves group to group when nothing inside is
            reached. -->
       <template v-else>
+        <!-- The key to the meters, said ONCE for the view rather than once per
+             band: it is the same three segments every time, and repeating it
+             down the list would cost more room than the meters themselves.
+             Drawn only when a measured meter is actually on screen — an
+             unmeasured band renders no meter at all, so a shelf of offline
+             drives would otherwise key a picture nobody can see.
+
+             No ARIA and no `aria-describedby` back from the bands: each
+             heading already states its figures in words, so this is redundant
+             to a screen reader, and wiring it up would re-read all three
+             labels on every heading. -->
+        <p v-if="showsBandLegend" class="shelf-band-legend">
+          <span
+            v-for="item in BAND_LEGEND"
+            :key="item.key"
+            class="shelf-band-legend-item"
+          >
+            <span
+              class="shelf-band-swatch"
+              :class="`shelf-band-seg--${item.key}`"
+            ></span>
+            <span>{{ item.label }}</span>
+          </span>
+        </p>
         <div v-for="group in shownGroups" :key="group.key" class="shelf-group">
           <!-- The drive band: the OUTER of the two levels the plan allows, and
                the second one is spent here rather than on stacks, which nest
@@ -305,25 +329,53 @@
               <v-icon size="16" class="shelf-band-icon">mdi-harddisk</v-icon>
               <span>{{ group.band.label }}</span>
             </span>
-            <!-- Two fills in one track, not two bars: the shelf's share is a
-                 part of what is used, so drawing it separately would let the
-                 two add up past the drive. -->
+            <!-- Three segments carving up one track, not fills stacked on top
+                 of each other. The shelf's share is a PART of what is used, so
+                 `other` is the REST of the used space: laid end to end the
+                 three are the drive, and no boundary is ambiguous. Overlaying
+                 them was the original shape and it meant a reader could see a
+                 boundary without being able to tell which of the two questions
+                 — "how full is this disk" and "how much of that is us" — it
+                 answered (#893).
+
+                 `aria-hidden`, and no `role="img"`: `.shelf-band-figures`
+                 below already renders the identical string as visible text in
+                 this same heading, so labelling the meter made every band
+                 announce its figures twice. `role="meter"` would be worse —
+                 it carries one `aria-valuenow` and this is three numbers. -->
             <span
               v-if="usage(group.band)"
               class="shelf-band-meter"
-              role="img"
-              :aria-label="meterLabel(group.band)"
+              :class="{ 'shelf-band-meter--low': usage(group.band).lowFree }"
+              aria-hidden="true"
             >
               <span
-                class="shelf-band-fill"
-                :style="{ width: `${usage(group.band).usedPct}%` }"
-              ></span>
-              <span
-                class="shelf-band-fill shelf-band-fill--shelf"
+                class="shelf-band-seg shelf-band-seg--shelf"
                 :style="{ width: `${usage(group.band).shelfPct}%` }"
               ></span>
+              <span
+                class="shelf-band-seg shelf-band-seg--other"
+                :style="{ width: `${usage(group.band).otherPct}%` }"
+              ></span>
+              <span
+                class="shelf-band-seg shelf-band-seg--free"
+                :style="{ width: `${usage(group.band).freePct}%` }"
+              ></span>
             </span>
-            <span class="shelf-band-figures">{{ meterLabel(group.band) }}</span>
+            <span
+              class="shelf-band-figures"
+              :class="{
+                'shelf-band-figures--low': usage(group.band)?.lowFree,
+              }"
+            >
+              <!-- The non-colour half of the low state. Colour is additive
+                   here, never the carrier: the distinction has to survive
+                   greyscale, and the glyph and the word "Only" both do. -->
+              <v-icon v-if="usage(group.band)?.lowFree" size="16"
+                >mdi-alert-outline</v-icon
+              >
+              <span>{{ meterLabel(group.band) }}</span>
+            </span>
           </h3>
 
           <!-- The header IS the button, on the same four-column grid as the
@@ -1590,6 +1642,24 @@ function usage(band) {
 }
 
 /**
+ * The meter's key, in the segments' own left-to-right order.
+ *
+ * The wording borrows `meterLabel`'s, so the key and the figures under it are
+ * visibly the same vocabulary. Not "PixlStash" and not "used by other apps":
+ * the shelf knows which bytes are its own and knows nothing whatever about
+ * what put the rest there.
+ */
+const BAND_LEGEND = [
+  { key: "shelf", label: "On the shelf" },
+  { key: "other", label: "Other files" },
+  { key: "free", label: "Free" },
+];
+
+const showsBandLegend = computed(() =>
+  shownGroups.value.some((group) => group.bandStart && usage(group.band)),
+);
+
+/**
  * What a band's meter says in words.
  *
  * Free space leads, because it is the number that decides whether the next
@@ -1597,11 +1667,16 @@ function usage(band) {
  * zero, which would draw an empty meter for a drive that may well be full.
  */
 function meterLabel(band) {
-  if (!bandUsage(band)) return "Capacity unknown";
+  const use = bandUsage(band);
+  if (!use) return "Capacity unknown";
   const free = formatModelSize(band.freeBytes);
   const total = formatModelSize(band.totalBytes);
   const shelf = formatModelSize(band.shelfBytes);
-  return `${free} free of ${total} · ${shelf} on the shelf`;
+  // One word for the low state, and it states the fact and stops. Nothing is
+  // broken and there is nothing to click, so this is not the error voice and
+  // gets no action — the same register as the offline banner.
+  const lead = use.lowFree ? "Only " : "";
+  return `${lead}${free} free of ${total} · ${shelf} on the shelf`;
 }
 
 /**
@@ -1985,32 +2060,116 @@ watch(
   flex: none;
 }
 
-/* One track, two fills, the wider drawn first: the shelf's share is PART of
-   what is used, so two separate bars could add up past the drive. */
+/* One track, three segments laid end to end. They sum to exactly 100% by
+   construction in `bandUsage`, so the row needs no arithmetic here and no
+   sliver of bare track can open at the right-hand end.
+
+   The ROUNDING lives on the track and nowhere else, which is the point of
+   `overflow: hidden`: the outer ends curve because the track clips them, while
+   every inner boundary stays square. A radius on a segment would put a curve
+   mid-stack where the data has no end, and a rounded edge reads as "the bar
+   stops here" when the next segment carries straight on (#893). */
 .shelf-band-meter {
-  position: relative;
+  display: flex;
   height: 6px;
   border-radius: var(--radius-sm);
-  background: rgba(var(--v-theme-on-panel), 0.08);
+  background: var(--band-meter-free);
+  /* `outline`, not `border` or an inset shadow: both of those would eat 2 of
+     the 6 track pixels. An outline draws outside the box, costs no layout and
+     follows the radius. It exists because the track against the canvas is only
+     1.22:1 (light) / 1.11:1 (dark) — a nearly-empty drive would otherwise draw
+     a meter you cannot find. */
+  outline: 1px solid var(--band-meter-edge);
   overflow: hidden;
 }
 
-.shelf-band-fill {
-  position: absolute;
-  top: 0;
-  left: 0;
+.shelf-band-seg {
   height: 100%;
-  border-radius: var(--radius-sm);
-  background: rgba(var(--v-theme-on-panel), 0.28);
+  /* Never rounded, never shrunk: a segment is the width it was given, and
+     flex would otherwise take space back off the small ones. */
+  border-radius: 0;
+  flex: none;
 }
 
-.shelf-band-fill--shelf {
+/* The three fills. Separated by LUMINANCE, not hue, so the meter survives
+   greyscale and deuteranopia: the ramp runs .0085 → .1426 → .7687 in light and
+   .1426 → .5962 → .0073 in dark, and no pair depends on colour vision.
+   Measurements and the per-theme reasoning live in style.css. */
+.shelf-band-seg--shelf {
   background: rgb(var(--v-theme-primary));
 }
 
+.shelf-band-seg--other {
+  background: var(--band-meter-other);
+}
+
+.shelf-band-seg--free {
+  background: var(--band-meter-free);
+}
+
+/* Track as well as segment, so a sub-pixel seam between two segments cannot
+   show the neutral track through an amber bar. */
+.shelf-band-meter--low,
+.shelf-band-meter--low .shelf-band-seg--free {
+  background: var(--band-meter-free-low);
+}
+
+/* The figures do NOT take the warning hue: they are --text-xs body text, and
+   light `warning` measures 3.09:1 on the canvas — the 3:1 UI floor, not the
+   4.5:1 body floor this size needs. Weight carries the rank instead, the same
+   way `--unknown` above ranks by style. */
+.shelf-band-figures--low {
+  font-weight: var(--weight-semibold);
+}
+
+/* The glyph is non-text at 16px, so it may carry the hue: 3.09 light, 6.72
+   dark, both over the 3:1 UI floor. */
+.shelf-band-figures--low .v-icon {
+  color: rgb(var(--v-theme-warning));
+}
+
 .shelf-band-figures {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
   font-size: var(--text-xs);
   white-space: nowrap;
+}
+
+/* The key, once for the view. Wraps rather than scrolls: three short pairs at
+   a narrow width belong on two lines, not behind a scrollbar. */
+.shelf-band-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  margin: 0 0 var(--space-2);
+  padding: 0 var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: rgba(var(--v-theme-on-background), 0.7);
+}
+
+.shelf-band-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+/* Square, deliberately: `--radius-sm` is 4px and would turn an 8px swatch into
+   a dot, which is a second kind of mark. A square chip reads as a piece cut
+   out of the bar, which is what it is meant to identify. */
+.shelf-band-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 0;
+  flex: none;
+}
+
+/* The "Free" swatch is a chip of bare track sitting on the canvas at 1.22:1,
+   so it needs the frame the meter gets from its outline. `inset` here rather
+   than `outline`, because a legend chip has no overflow to protect. */
+.shelf-band-legend .shelf-band-seg--free {
+  box-shadow: inset 0 0 0 1px var(--band-meter-edge);
 }
 
 /* ── Group headers ─────────────────────────────────────────────────────────

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -67,6 +67,35 @@ body {
      light-theme claim about a dark-theme rule; light already reads
      `on-surface` (10.84:1) and needs no change either. */
   --active-text: rgb(var(--v-theme-on-primary));
+
+  /* Drive-band capacity meter (#893). Three segments, so TWO adjacencies to
+     keep readable: ours|other and other|free. `ours` is `primary` in both
+     themes; it is the NEUTRAL that steps per theme.
+
+     STEPPED INDEPENDENTLY, NOT A FLIPPED ALPHA. On a dark canvas an ink alpha
+     can only LIGHTEN, and the olive sits at L .1426 with the canvas floor at
+     L .0134 — so a neutral cannot pass below the accent, and today's
+     rgba(ink, .28) lands at 1.34:1 against it. The neutral therefore goes to
+     the light extreme and the TRACK takes the dark end via a scrim tint.
+
+     The general rule this established: in a multi-segment meter the neutral
+     goes to the extreme AWAY from the canvas, never between the accent and the
+     track. The range between accent and canvas is not wide enough for two 3:1
+     steps; the range past the accent is. Measured, over #1b1f24:
+       ours #567309 : other #d4c9c1  = 3.36
+       other        : free  #121518  = 11.28
+     Full table and the rejected alternatives: visual-language.md §4. */
+  --band-meter-other: rgba(var(--v-theme-on-background), 0.86);
+  --band-meter-free: rgba(var(--v-theme-scrim), 0.32);
+  /* Additive only — the alert glyph and the word "Only" carry the low state in
+     greyscale. A SOLID `warning` free segment is impossible here: dark
+     `warning` against this neutral is 1.52:1, and no neutral can clear 3:1
+     from both the olive (needs L ≥ .528) and `warning` (needs L ≤ .092). The
+     55% tint is the value that clears both. other:free 3.45. */
+  --band-meter-free-low: rgba(var(--v-theme-warning), 0.55);
+  /* The track against the canvas is only 1.11:1, so a nearly-empty drive would
+     draw a ghost. This frames it instead of inferring the edge. 5.67:1. */
+  --band-meter-edge: rgba(var(--v-theme-on-background), 0.6);
 }
 .v-theme--pixlStashLight {
   /* See the note on the dark theme above. */
@@ -74,9 +103,32 @@ body {
   /* Selection reads warm (accent) on the light theme instead of the olive `primary`
      green, which clashes with the warm palette. Dark keeps the green convention. */
   --hover-wash: rgba(var(--v-theme-accent), 0.14);
-  --active-wash: rgba(var(--v-theme-accent), 0.20);
+  --active-wash: rgba(var(--v-theme-accent), 0.2);
   --active-bar: rgb(var(--v-theme-accent));
   --active-text: rgb(var(--v-theme-on-surface));
+
+  /* Drive-band capacity meter (#893) — see the dark block above for the rule.
+     Here the canvas is near-white, so the neutral goes to the DARK extreme,
+     and it has to go past the ink to get there: `on-background` tops out at
+     L .0153 and measures 2.95 against the olive, just under the floor.
+     `shadow` #1c160c (L .0085) measures 3.29.
+
+     `shadow` is documented as an elevation colour, and using it as a FILL is a
+     role stretch. It is the light theme's warm near-black extreme and the only
+     on-token value that clears 3:1; `scrim` (#000000) clears at 3.85 but is
+     cold black on a warm palette (visual-language.md §4). If that stretch is
+     rejected in review, the swap is a named `meter-neutral` key in main.js
+     (#1c160c light / #d4c9c1 dark) — identical pixels, cleaner semantics.
+
+     Measured, over #faf9f7:
+       ours #567309 : other #1c160c  = 3.29
+       other        : free  #e5e3e1  = 14.03 */
+  --band-meter-other: rgb(var(--v-theme-shadow));
+  --band-meter-free: rgba(var(--v-theme-on-background), 0.1);
+  /* other:free 9.57 — the fill level stays readable under the tint. */
+  --band-meter-free-low: rgba(var(--v-theme-warning), 0.55);
+  /* Track against canvas is 1.22:1 here. Frame, don't infer. 4.24:1. */
+  --band-meter-edge: rgba(var(--v-theme-on-background), 0.6);
 }
 
 /* ---------------------------------------------------------------------------

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -348,14 +348,44 @@ export function bandGroups(groups, deviceByFolderId) {
 }
 
 /**
- * How full a drive is, as a percentage of its size.
+ * When a drive is close enough to full to say so.
  *
- * `used`, not `free`, because a meter fills from empty. Returns `null` when the
- * drive could not be measured, which the caller must draw as "unknown" rather
- * than as an empty bar: an empty bar reads as a drive with nothing on it.
+ * Bytes, not a proportion, because the question the band answers is "does the
+ * next checkpoint fit" and that is answered in bytes. A full SDXL or Flux
+ * checkpoint is 6–24 GB, so 50 GiB is two or three more files: close enough to
+ * warn, far enough not to nag.
+ *
+ * A percentage is wrong in both directions on exactly the hardware this
+ * feature targets. Ten per cent of a 4 TB model drive is 400 GB, which is not a
+ * problem and would cry wolf on the drive people actually keep models on; ten
+ * per cent of a 256 GB SSD is 25 GB, which IS a problem — but so is 60 GB free
+ * on that same disk, and the fraction calls that fine.
+ */
+export const LOW_FREE_BYTES = 50 * 1024 ** 3;
+
+/**
+ * How a drive's space divides into the three things a reader asks about.
+ *
+ * The meter answers two questions at once — "how full is this disk" and "how
+ * much of that is us" — and it can only answer the second if the shelf's share
+ * is drawn as its OWN segment rather than as a fill overlaid on the used one.
+ * Overlaying was the original shape and it made the two questions the same
+ * pixel: a reader could see one boundary and had no way to know which of the
+ * two it marked.
+ *
+ * The three add to exactly 100 by construction (`shelf + (used - shelf) + free
+ * === total`), which is what lets the caller lay them out in a row without a
+ * rounding sliver opening at the right-hand end. Clamping the shelf to `used`
+ * keeps that identity true when a mid-scan `shelf_bytes` briefly exceeds what
+ * the disk reports as used.
+ *
+ * Returns `null` when the drive could not be measured, which the caller must
+ * draw as "unknown" rather than as an empty bar: an empty bar reads as a drive
+ * with nothing on it.
  *
  * @param {Object} band - a band from {@link bandGroups}.
- * @returns {{usedPct: number, shelfPct: number}|null}
+ * @returns {{shelfPct: number, otherPct: number, freePct: number,
+ *   usedPct: number, lowFree: boolean}|null}
  */
 export function bandUsage(band) {
   const total = Number(band?.totalBytes);
@@ -365,8 +395,11 @@ export function bandUsage(band) {
   const used = Math.max(0, total - free);
   const shelf = Math.max(0, Math.min(used, Number(band?.shelfBytes) || 0));
   return {
-    usedPct: Math.min(100, (used / total) * 100),
-    shelfPct: Math.min(100, (shelf / total) * 100),
+    shelfPct: (shelf / total) * 100,
+    otherPct: ((used - shelf) / total) * 100,
+    freePct: (free / total) * 100,
+    usedPct: (used / total) * 100,
+    lowFree: free < LOW_FREE_BYTES,
   };
 }
 

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -375,9 +375,18 @@ export const LOW_FREE_BYTES = 50 * 1024 ** 3;
  *
  * The three add to exactly 100 by construction (`shelf + (used - shelf) + free
  * === total`), which is what lets the caller lay them out in a row without a
- * rounding sliver opening at the right-hand end. Clamping the shelf to `used`
- * keeps that identity true when a mid-scan `shelf_bytes` briefly exceeds what
- * the disk reports as used.
+ * rounding sliver opening at the right-hand end. That identity is the whole
+ * reason the segments need no per-segment clamp, so BOTH inputs are clamped
+ * into range before it is relied on:
+ *
+ *   * `free` to `total`, because the two are separate reads of the device and
+ *     a filesystem can genuinely report more free than it holds — thin
+ *     provisioning and transparent compression (ZFS, btrfs) do it by design,
+ *     and a network mount's `statvfs` can simply be wrong. Unclamped that
+ *     yields `freePct > 100` and a segment running off the end of the track.
+ *   * `shelf` to `used`, because `shelf_bytes` is counted from the hub and the
+ *     capacity from the disk, so a scan mid-flight can briefly make the first
+ *     exceed the second.
  *
  * Returns `null` when the drive could not be measured, which the caller must
  * draw as "unknown" rather than as an empty bar: an empty bar reads as a drive
@@ -389,10 +398,11 @@ export const LOW_FREE_BYTES = 50 * 1024 ** 3;
  */
 export function bandUsage(band) {
   const total = Number(band?.totalBytes);
-  const free = Number(band?.freeBytes);
+  const reportedFree = Number(band?.freeBytes);
   if (!Number.isFinite(total) || total <= 0) return null;
-  if (!Number.isFinite(free) || free < 0) return null;
-  const used = Math.max(0, total - free);
+  if (!Number.isFinite(reportedFree) || reportedFree < 0) return null;
+  const free = Math.min(reportedFree, total);
+  const used = total - free;
   const shelf = Math.max(0, Math.min(used, Number(band?.shelfBytes) || 0));
   return {
     shelfPct: (shelf / total) * 100,

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -287,17 +287,61 @@ describe("bandGroups", () => {
 });
 
 describe("bandUsage", () => {
-  it("reports the shelf's share as part of what is used, never beside it", () => {
-    // Two fills in one track: if the shelf's share were measured against free
-    // space the two could sum past the drive.
+  it("splits the drive into three segments that carve up what is used", () => {
+    // The shelf's share is a PART of what is used, so `other` is the rest of
+    // the used space and not the whole of it. Drawing `used` and `shelf` as
+    // two overlaid fills was the original shape and it left the reader unable
+    // to tell which of the two a given boundary marked.
     const usage = bandUsage({
       totalBytes: 1000,
       freeBytes: 250,
       shelfBytes: 500,
     });
-    expect(usage.usedPct).toBe(75);
     expect(usage.shelfPct).toBe(50);
-    expect(usage.shelfPct).toBeLessThanOrEqual(usage.usedPct);
+    expect(usage.otherPct).toBe(25);
+    expect(usage.freePct).toBe(25);
+    expect(usage.usedPct).toBe(75);
+  });
+
+  it("keeps the three segments summing to exactly one full track", () => {
+    // Laid out in a row rather than overlaid, so anything short of 100 opens a
+    // sliver of bare track at the right-hand end that reads as free space.
+    for (const band of [
+      { totalBytes: 3, freeBytes: 1, shelfBytes: 1 },
+      { totalBytes: 1024 ** 4, freeBytes: 7, shelfBytes: 123456789 },
+      { totalBytes: 1000, freeBytes: 1000, shelfBytes: 0 },
+      { totalBytes: 1000, freeBytes: 0, shelfBytes: 1000 },
+    ]) {
+      const usage = bandUsage(band);
+      expect(usage.shelfPct + usage.otherPct + usage.freePct).toBeCloseTo(
+        100,
+        10,
+      );
+      expect(usage.otherPct).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("measures low space in checkpoints that would fit, not in percentages", () => {
+    const GB = 1024 ** 3;
+    // 400 GB left on a 4 TB drive is a tenth of it, and dozens more models.
+    // The fraction rule would warn here, which is the cry-wolf case.
+    expect(
+      bandUsage({ totalBytes: 4000 * GB, freeBytes: 400 * GB, shelfBytes: 0 })
+        .lowFree,
+    ).toBe(false);
+    // The same drive with room for two more checkpoints IS worth saying, even
+    // though it is only 1% and no fraction rule set for the small disk would
+    // have caught it.
+    expect(
+      bandUsage({ totalBytes: 4000 * GB, freeBytes: 40 * GB, shelfBytes: 0 })
+        .lowFree,
+    ).toBe(true);
+    // And 60 GB on a small SSD is nearly half of it but still not low, which
+    // is the direction a fraction rule gets backwards.
+    expect(
+      bandUsage({ totalBytes: 128 * GB, freeBytes: 60 * GB, shelfBytes: 0 })
+        .lowFree,
+    ).toBe(false);
   });
 
   it("refuses to draw a meter for a drive it could not measure", () => {
@@ -311,12 +355,15 @@ describe("bandUsage", () => {
   it("never lets a stale shelf figure overflow the track", () => {
     // `shelf_bytes` is counted from the hub and the capacity from the disk, so
     // a scan mid-flight can make the first exceed the second for a moment.
+    // `other` must absorb the clamp and stay at zero rather than going
+    // negative, which would draw a segment growing leftwards.
     const usage = bandUsage({
       totalBytes: 1000,
       freeBytes: 900,
       shelfBytes: 5000,
     });
     expect(usage.shelfPct).toBe(usage.usedPct);
+    expect(usage.otherPct).toBe(0);
   });
 });
 

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -357,6 +357,23 @@ describe("bandUsage", () => {
     ).toBe(false);
   });
 
+  it("never lets a drive report more free space than it holds", () => {
+    // Thin provisioning and transparent compression (ZFS, btrfs) report this
+    // by design, and a network mount's statvfs can simply be wrong. `free` and
+    // `total` are two separate reads, so nothing upstream reconciles them.
+    // Unclamped this gives freePct 150 and a segment running off the track.
+    const usage = bandUsage({
+      totalBytes: 1000,
+      freeBytes: 1500,
+      shelfBytes: 0,
+    });
+    expect(usage.freePct).toBe(100);
+    expect(usage.usedPct).toBe(0);
+    expect(usage.otherPct).toBe(0);
+    expect(usage.shelfPct).toBe(0);
+    expect(usage.shelfPct + usage.otherPct + usage.freePct).toBe(100);
+  });
+
   it("refuses to draw a meter for a drive it could not measure", () => {
     // Null rather than zero: an empty bar reads as a drive with nothing on it,
     // which is the opposite of "we do not know".


### PR DESCRIPTION
Closes #893.

The drive band's meter was two overlaid fills with no key, so a reader could see a boundary without being able to tell which of the meter's two questions — "how full is this drive" and "how much of that is ours" — it marked. This makes it three segments and names them.

## What changed

**Three segments instead of two fills.** `bandUsage` now returns `shelfPct` / `otherPct` / `freePct`, where `other` is the *rest* of the used space rather than all of it. They sum to exactly 100% by construction, which is what lets them be a plain flex row with no rounding sliver opening at the right-hand end. Rounding lives on the track and nowhere else — `overflow: hidden` clips the outer ends and every inner boundary stays square, so no curve appears mid-stack where the data has no end.

**A legend, once per view.** Rendered only when a *measured* band is actually on screen: an unmeasured drive draws no meter, so a shelf of only offline drives would otherwise print a key to a picture nobody can see.

**A low-free state.** Triggered on an absolute floor (`LOW_FREE_BYTES`, 50 GiB), never a percentage — the question is "does the next checkpoint fit", and a percentage is wrong in both directions on this hardware: 10% of a 4 TB model drive is 400 GB and cries wolf, while 10% of a 256 GB SSD is 25 GB — but so is 60 GB free on that same disk. It is carried by the word "Only" leading the label, an alert glyph and semibold figures, with the warning hue additive on top, so it survives greyscale. No live region: it is a standing fact about a disk, can be true of several bands at once, and would otherwise fire a burst on every device refresh.

## The contrast work, which was the substance of this

The issue asks for a measured separation in both themes, with dark stepped independently. That turned out to be forced by arithmetic rather than a matter of taste, and what ships today fails:

| pair | light (today → new) | dark (today → new) |
|---|---|---|
| `ours` : `other` | 2.90 → **3.29** | **1.34** → **3.36** |
| `other` : `free` | 1.53 → **14.03** | 1.84 → **11.28** |

The dark **1.34:1** is the deuteranopia failure the issue describes: the same alpha flipped from light gives a neutral almost exactly as luminous as the olive, so in greyscale the two segments merge. The issue also only names the `ours`/`other` pair, but `other`/`free` — the boundary that answers "how full is this drive" — measured 1.53 and 1.84 and was arguably the worse of the two.

Three findings worth a reviewer's attention:

- **The neutral is what steps per theme, not the accent.** `primary` stays "ours" in both themes; a legend swatch that is orange in light and olive in dark is not one system.
- **Dark cannot be a flipped alpha.** On a dark canvas an ink alpha can only *lighten*, so the neutral cannot pass below the olive. It goes light instead and the *track* takes the dark end via a `scrim` tint.
- **In light the neutral has to go past the ink itself.** `on-background` tops out at L .0153 and measures 2.95 — just under the floor — so the fill is `shadow` `#1c160c`.

Separating the segments with a hairline instead was considered and rejected: the requirement is a *luminance* separation and a drawn line is not one, so with a quiet mid-grey neutral the pair still measures 1.73:1 and greyscale still merges them.

The track itself is only 1.22 / 1.11 against the canvas, which would make a nearly-empty drive a ghost, so it carries a 1px `outline` at 4.24 / 5.67. A meter's own frame is a fair substitute for a fill boundary; a line between two fills is not.

Measurements are recorded in `docs/design/visual-language.md` §4 as a reusable rule — *in a multi-segment meter the neutral goes to the extreme away from the canvas* — since this is the first meter the design system has had.

## One judgement call to confirm

`shadow` is documented as an elevation colour and using it as a **fill** is a role stretch. It is the light theme's warm near-black extreme and the only on-token value that clears 3:1 (`scrim` clears at 3.85 but is cold black on a warm palette). If that is rejected, the swap is a named `meter-neutral` theme key — identical pixels, cleaner semantics — and it is localised to one line per theme in `style.css`.

## Notes

- **This targets `develop`, not `main`.** The model shelf does not exist on `main`; #868, which shipped the band, merged to `develop`.
- The meters lost their `role="img"` and `aria-label`. `.shelf-band-figures` already renders the identical string as visible text in the same heading, so every band was announcing its figures twice. `role="meter"` would be wrong for a separate reason — one `aria-valuenow`, three numbers.
- `ModelShelf.test.js > a run's disclosure > keeps the count a drawn figure and not a second control` fails on this branch. **It is not from this change** — it fails on `develop` too. #897's rename pencil carries `role="button" tabindex="-1"`, which the test's `[tabindex], [role="button"]` selector matches even though `tabindex="-1"` is not a tab stop. Left alone as out of scope; worth a follow-up on whether the selector or the pencil is wrong.
