### PR TITLE
Restore foreign keys after clean_db wipes (#712)

### DIFF
--- a/tests/test_metadata_hash.py
+++ b/tests/test_metadata_hash.py
@@ -15,8 +15,7 @@ import json
 import tempfile
 
 import pytest
-from sqlalchemy import text
-from sqlmodel import delete, select
+from sqlmodel import select
 
 from pixlstash.db_models import (
     Character,
@@ -30,6 +29,7 @@ from pixlstash.db_models import (
 from pixlstash.db_models.tag import Tag
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.server import Server
+from tests.utils import wipe_tables
 
 
 @pytest.fixture(scope="module")
@@ -44,21 +44,20 @@ def server():
 
 @pytest.fixture(autouse=True)
 def clean_db(server):
-    def _wipe(session):
-        session.exec(text("PRAGMA foreign_keys = OFF"))
-        session.exec(delete(Snapshot))
-        session.exec(delete(Tag))
-        session.exec(delete(Face))
-        session.exec(delete(PictureSetMember))
-        session.exec(delete(PictureProjectMember))
-        session.exec(delete(PictureSet))
-        session.exec(delete(Project))
-        session.exec(delete(Character))
-        session.exec(delete(Picture))
-        session.exec(text("PRAGMA foreign_keys = ON"))
-        session.commit()
-
-    server.vault.db.run_task(_wipe)
+    server.vault.db.run_task(
+        wipe_tables,
+        [
+            Snapshot,
+            Tag,
+            Face,
+            PictureSetMember,
+            PictureProjectMember,
+            PictureSet,
+            Project,
+            Character,
+            Picture,
+        ],
+    )
     yield
 
 

--- a/tests/test_metadata_hash_batching.py
+++ b/tests/test_metadata_hash_batching.py
@@ -35,8 +35,7 @@ from datetime import datetime
 
 import numpy as np
 import pytest
-from sqlalchemy import event, inspect as sa_inspect, select as sa_select, text
-from sqlmodel import delete
+from sqlalchemy import event, inspect as sa_inspect, select as sa_select
 
 from pixlstash.database import (
     _HASH_SKIP_COLS,
@@ -55,6 +54,7 @@ from pixlstash.db_models import (
 from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.db_models.tag import Tag
 from pixlstash.server import Server
+from tests.utils import wipe_tables
 
 
 # ---------------------------------------------------------------------------
@@ -150,21 +150,20 @@ def server():
 
 @pytest.fixture(autouse=True)
 def clean_db(server):
-    def _wipe(session):
-        session.exec(text("PRAGMA foreign_keys = OFF"))
-        session.exec(delete(Snapshot))
-        session.exec(delete(Tag))
-        session.exec(delete(Face))
-        session.exec(delete(PictureSetMember))
-        session.exec(delete(PictureProjectMember))
-        session.exec(delete(PictureSet))
-        session.exec(delete(Project))
-        session.exec(delete(Character))
-        session.exec(delete(Picture))
-        session.exec(text("PRAGMA foreign_keys = ON"))
-        session.commit()
-
-    server.vault.db.run_task(_wipe)
+    server.vault.db.run_task(
+        wipe_tables,
+        [
+            Snapshot,
+            Tag,
+            Face,
+            PictureSetMember,
+            PictureProjectMember,
+            PictureSet,
+            Project,
+            Character,
+            Picture,
+        ],
+    )
     yield
 
 

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -44,6 +44,7 @@ from pixlstash.utils.snapshot_compression import (
     compress_snapshot,
     materialize_snapshot,
 )
+from tests.utils import delete_characters, delete_projects, wipe_tables
 
 
 @pytest.fixture(scope="module")
@@ -62,32 +63,31 @@ def server():
 def clean_db(server):
     """Wipe all relevant tables and snapshot files before each test."""
 
-    def _wipe(session):
-        session.exec(text("PRAGMA foreign_keys = OFF"))
-        session.exec(delete(Snapshot))
-        # Likeness pipeline rows are populated by restore_full (via
-        # ensure_all), so they accumulate across tests. Without an
-        # explicit wipe — FKs are OFF here, so CASCADE doesn't fire —
-        # they orphan and collide with the next test's replay.
-        session.exec(delete(PictureLikeness))
-        session.exec(delete(PictureLikenessQueue))
-        session.exec(delete(PictureLikenessFrontier))
-        session.exec(delete(PictureProjectMember))
-        session.exec(delete(CharacterProjectMember))
-        session.exec(delete(PictureSetProjectMember))
-        session.exec(delete(PictureSetMember))
-        session.exec(delete(Face))
-        session.exec(delete(Tag))
-        session.exec(delete(DeletedFileLog))
-        session.exec(delete(Picture))
-        session.exec(delete(ReferenceFolder))
-        session.exec(delete(PictureSet))
-        session.exec(delete(Project))
-        session.exec(delete(Character))
-        session.exec(text("PRAGMA foreign_keys = ON"))
-        session.commit()
-
-    server.vault.db.run_task(_wipe)
+    server.vault.db.run_task(
+        wipe_tables,
+        [
+            Snapshot,
+            # Likeness pipeline rows are populated by restore_full (via
+            # ensure_all), so they accumulate across tests. Without an
+            # explicit wipe — FKs are OFF for the wipe, so CASCADE doesn't
+            # fire — they orphan and collide with the next test's replay.
+            PictureLikeness,
+            PictureLikenessQueue,
+            PictureLikenessFrontier,
+            PictureProjectMember,
+            CharacterProjectMember,
+            PictureSetProjectMember,
+            PictureSetMember,
+            Face,
+            Tag,
+            DeletedFileLog,
+            Picture,
+            ReferenceFolder,
+            PictureSet,
+            Project,
+            Character,
+        ],
+    )
 
     cp_dir = os.path.join(server.vault.image_root, "snapshots")
     if os.path.isdir(cp_dir):
@@ -727,16 +727,7 @@ def test_root_entity_membership_projects_are_restore_dependencies(server):
     char_id, project_id = server.vault.db.run_task(_setup)
     cp = server.vault.snapshot_service.create_snapshot("MANUAL")
 
-    def _delete_project(session):
-        session.exec(
-            delete(CharacterProjectMember).where(
-                CharacterProjectMember.character_id == char_id
-            )
-        )
-        session.exec(delete(Project).where(Project.id == project_id))
-        session.commit()
-
-    server.vault.db.run_task(_delete_project)
+    server.vault.db.run_task(delete_projects, [project_id])
 
     with pytest.raises(MissingDependenciesError) as exc_info:
         server.vault.restore_service.restore_resource(cp.id, "character", char_id)
@@ -1213,13 +1204,9 @@ def test_restore_resource_picture_with_missing_character_raises_without_confirm(
     alice_id = server.vault.db.run_task(_setup_snapshot_state)
     cp = server.vault.snapshot_service.create_snapshot("MANUAL")
 
-    # Live: user deletes the character (Face.character_id cascades to NULL
-    # in the live DB but the snapshot still has the reference).
-    def _delete_char(session):
-        session.exec(delete(Character).where(Character.id == alice_id))
-        session.commit()
-
-    server.vault.db.run_task(_delete_char)
+    # Live: user deletes the character (the delete route nulls Face.character_id
+    # in the live DB, but the snapshot still has the reference).
+    server.vault.db.run_task(delete_characters, [alice_id])
 
     # Default call refuses with MissingDependenciesError.
     with pytest.raises(MissingDependenciesError) as exc_info:
@@ -1267,11 +1254,7 @@ def test_restore_resource_picture_confirm_restores_missing_character(server):
     bob_id = server.vault.db.run_task(_setup_snapshot_state)
     cp = server.vault.snapshot_service.create_snapshot("MANUAL")
 
-    def _delete_char(session):
-        session.exec(delete(Character).where(Character.id == bob_id))
-        session.commit()
-
-    server.vault.db.run_task(_delete_char)
+    server.vault.db.run_task(delete_characters, [bob_id])
 
     report = server.vault.restore_service.restore_resource(
         cp.id,
@@ -1338,11 +1321,7 @@ def test_restore_batch_unions_missing_dependencies_across_items(server):
     c1_id, c2_id = server.vault.db.run_task(_setup)
     cp = server.vault.snapshot_service.create_snapshot("MANUAL")
 
-    def _delete_both(session):
-        session.exec(delete(Character))
-        session.commit()
-
-    server.vault.db.run_task(_delete_both)
+    server.vault.db.run_task(delete_characters)
 
     resources = [
         {"type": "picture", "id": pa.id},
@@ -1397,11 +1376,7 @@ def test_restore_batch_confirm_restores_all_missing_parents_once(server):
     c1_id, c2_id = server.vault.db.run_task(_setup)
     cp = server.vault.snapshot_service.create_snapshot("MANUAL")
 
-    def _delete_both(session):
-        session.exec(delete(Character))
-        session.commit()
-
-    server.vault.db.run_task(_delete_both)
+    server.vault.db.run_task(delete_characters)
 
     resources = [
         {"type": "picture", "id": pc.id},
@@ -1920,11 +1895,7 @@ def test_missing_deps_refusal_emits_started_then_failed(server):
     char_id = server.vault.db.run_task(_setup)
     cp = server.vault.snapshot_service.create_snapshot("MANUAL")
 
-    def _del(session):
-        session.exec(delete(Character).where(Character.id == char_id))
-        session.commit()
-
-    server.vault.db.run_task(_del)
+    server.vault.db.run_task(delete_characters, [char_id])
 
     events = _capture_restore_events(server)
     with pytest.raises(MissingDependenciesError):
@@ -3931,16 +3902,7 @@ def test_restore_resource_rebuilds_entity_project_membership(server):
     char_id, project_ids = server.vault.db.run_task(_setup_snapshot_state)
     cp = server.vault.snapshot_service.create_snapshot("MANUAL")
 
-    def _delete_char(session):
-        session.exec(
-            delete(CharacterProjectMember).where(
-                CharacterProjectMember.character_id == char_id
-            )
-        )
-        session.exec(delete(Character).where(Character.id == char_id))
-        session.commit()
-
-    server.vault.db.run_task(_delete_char)
+    server.vault.db.run_task(delete_characters, [char_id])
 
     report = server.vault.restore_service.restore_resource(
         cp.id,

--- a/tests/test_scrapheap_retention.py
+++ b/tests/test_scrapheap_retention.py
@@ -24,8 +24,8 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from PIL import Image
 from fastapi.testclient import TestClient
-from sqlmodel import Session, delete, select
-from sqlalchemy import event, text
+from sqlmodel import Session, select
+from sqlalchemy import event
 
 from pixlstash.db_models import (
     DeletedFileLog,
@@ -47,6 +47,7 @@ from pixlstash.tasks.scrapheap_retention_purge_finder import (
 from pixlstash.tasks.scrapheap_retention_purge_task import ScrapheapRetentionPurgeTask
 from pixlstash.utils.image_processing.image_utils import ImageUtils
 from tests.authz_guard import no_spa_fallback  # noqa: F401
+from tests.utils import wipe_tables
 
 # The SPA catch-all answers unmatched GETs with 200, so a wrong URL can make a
 # positive assertion vacuous. See tests/authz_guard.py.
@@ -100,20 +101,13 @@ def server():
 def reset_vault(server):
     """Wipe pictures/folders/ledger and reset retention config between tests."""
 
-    def _wipe(session: Session):
-        session.exec(text("PRAGMA foreign_keys = OFF"))
-        for model in _RESET_TABLES:
-            session.exec(delete(model))
-        session.commit()
-        session.exec(text("PRAGMA foreign_keys = ON"))
-
     def _wipe_identity(session: Session):
         session.exec(delete(User))
         session.commit()
 
     # Two databases now: pictures and the ledger live in the vault, the user
     # lives in the hub.
-    server.vault.db.run_task(_wipe)
+    server.vault.db.run_task(wipe_tables, _RESET_TABLES)
     server.hub_engine.run_task(_wipe_identity)
     image_root = server.vault.image_root
     db_basenames = {"vault.db", "vault.db-wal", "vault.db-shm", "vault.db-journal"}

--- a/tests/test_scrapheap_retention.py
+++ b/tests/test_scrapheap_retention.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from PIL import Image
 from fastapi.testclient import TestClient
-from sqlmodel import Session, select
+from sqlmodel import Session, delete, select
 from sqlalchemy import event
 
 from pixlstash.db_models import (

--- a/tests/test_server_simple.py
+++ b/tests/test_server_simple.py
@@ -27,8 +27,7 @@ from io import BytesIO
 import pytest
 from PIL import Image
 from fastapi.testclient import TestClient
-from sqlmodel import Session, delete, select
-from sqlalchemy import text
+from sqlmodel import Session, select
 
 from pixlstash.db_models import (
     Character,
@@ -57,6 +56,7 @@ from pixlstash.db_models import (
 from pixlstash.pixl_logging import get_logger
 from pixlstash.server import Server
 from pixlstash.utils.image_processing.image_utils import ImageUtils
+from tests.utils import wipe_tables
 
 logger = get_logger(__name__)
 
@@ -124,16 +124,9 @@ def reset_vault(server):
     - Reset auth in-memory caches.
     """
 
-    def _wipe(session: Session):
-        # Disable FK enforcement so wipe order doesn't matter; the test
-        # leaves the DB empty so referential integrity is preserved overall.
-        session.exec(text("PRAGMA foreign_keys = OFF"))
-        for model in _RESET_TABLES:
-            session.exec(delete(model))
-        session.commit()
-        session.exec(text("PRAGMA foreign_keys = ON"))
-
-    server.vault.db.run_task(_wipe)
+    # FK enforcement is off for the wipe so table order doesn't matter; the
+    # DB is left empty, so referential integrity is preserved overall.
+    server.vault.db.run_task(wipe_tables, _RESET_TABLES)
 
     image_root = server.vault.image_root
     db_basenames = {"vault.db", "vault.db-wal", "vault.db-shm", "vault.db-journal"}

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -8,8 +8,6 @@ import tempfile
 from contextlib import closing, contextmanager
 
 import pytest
-from sqlalchemy import text
-from sqlmodel import delete
 
 from pixlstash.db_models import Picture, User
 from pixlstash.db_models.picture_likeness import (
@@ -21,6 +19,7 @@ from pixlstash.db_models.snapshot import Snapshot
 from pixlstash.server import Server
 from pixlstash.services.snapshot_service import GFS_KEEP_MONTHLY, GFS_KEEP_WEEKLY
 from pixlstash.utils.snapshot_compression import materialize_snapshot
+from tests.utils import wipe_tables
 
 
 @contextmanager
@@ -57,17 +56,16 @@ def server():
 def clean_db(server):
     """Wipe DB rows and snapshot files before each test."""
 
-    def _wipe(session):
-        session.exec(text("PRAGMA foreign_keys = OFF"))
-        session.exec(delete(Snapshot))
-        session.exec(delete(PictureLikeness))
-        session.exec(delete(PictureLikenessQueue))
-        session.exec(delete(PictureLikenessFrontier))
-        session.exec(delete(Picture))
-        session.exec(text("PRAGMA foreign_keys = ON"))
-        session.commit()
-
-    server.vault.db.run_task(_wipe)
+    server.vault.db.run_task(
+        wipe_tables,
+        [
+            Snapshot,
+            PictureLikeness,
+            PictureLikenessQueue,
+            PictureLikenessFrontier,
+            Picture,
+        ],
+    )
 
     cp_dir = os.path.join(server.vault.image_root, "snapshots")
     if os.path.isdir(cp_dir):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -8,6 +8,7 @@ import tempfile
 from contextlib import closing, contextmanager
 
 import pytest
+from sqlalchemy import text
 
 from pixlstash.db_models import Picture, User
 from pixlstash.db_models.picture_likeness import (

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,14 +1,89 @@
 import time
 
-from sqlalchemy import func
-from sqlmodel import delete, select
+from sqlalchemy import func, update
+from sqlmodel import delete, select, text
 
+from pixlstash.db_models.character import Character
+from pixlstash.db_models.face import Face
 from pixlstash.db_models.picture import Picture
 from pixlstash.db_models.picture_likeness import PictureLikeness, PictureLikenessQueue
+from pixlstash.db_models.picture_set import PictureSet
+from pixlstash.db_models.project import Project
 
 API_PREFIX = "/api/v1"
 
 _DEFAULT_TIMEOUT_S = 180
+
+
+def wipe_tables(session, models):
+    """Delete every row of ``models`` with FK enforcement off, then restore it.
+
+    Pass this straight to ``db.run_task``, which supplies the session::
+
+        server.vault.db.run_task(wipe_tables, [Snapshot, Tag, Picture])
+
+    ``PRAGMA foreign_keys`` is a no-op while a transaction is pending, so the
+    restoring ``ON`` must come *after* the commit. Issued before it (the shape
+    every ``clean_db`` fixture used to have) it is silently ignored and the
+    connection goes back to the pool with foreign keys off, for whichever test
+    picks it up next — see issue #712. The assertion is there because the
+    failure mode is that the restore *looks* like it happened.
+
+    Args:
+        session: SQLModel Session, as handed to ``db.run_task``.
+        models: Table models to delete. FKs are off for the deletes, so the
+            order is for readability only.
+    """
+    session.exec(text("PRAGMA foreign_keys = OFF"))
+    for model in models:
+        session.exec(delete(model))
+    session.commit()
+    session.exec(text("PRAGMA foreign_keys = ON"))
+    assert session.exec(text("PRAGMA foreign_keys")).one()[0] == 1, (
+        "PRAGMA foreign_keys = ON no-opped; this connection would return to "
+        "the pool with foreign key enforcement off"
+    )
+
+
+def delete_characters(session, character_ids=None):
+    """Delete characters the way ``DELETE /characters/{id}`` does.
+
+    ``face.character_id`` is a plain FK with no ``ON DELETE`` action, so the
+    live route nulls every referencing face before removing the row
+    (``routes/characters.py::clear_character_and_nullify_faces``). Deleting the
+    row straight out raises ``IntegrityError`` — it only ever worked in tests
+    while FK enforcement was leaking off (#712). ``CharacterProjectMember``
+    rows cascade on their own.
+
+    Args:
+        session: SQLModel Session, as handed to ``db.run_task``.
+        character_ids: Ids to delete, or ``None`` for every character.
+    """
+    faces = update(Face).values(character_id=None)
+    characters = delete(Character)
+    if character_ids is not None:
+        faces = faces.where(Face.character_id.in_(character_ids))
+        characters = characters.where(Character.id.in_(character_ids))
+    session.exec(faces)
+    session.exec(characters)
+    session.commit()
+
+
+def delete_projects(session, project_ids):
+    """Delete projects the way ``DELETE /projects/{id}`` does.
+
+    Pictures, picture sets and characters carry a plain ``project_id`` FK, so
+    the live route nulls those pointers before removing the project; only the
+    membership tables cascade. See :func:`delete_characters` and #712.
+    """
+    for model in (Picture, PictureSet, Character):
+        session.exec(
+            update(model)
+            .where(model.project_id.in_(project_ids))
+            .values(project_id=None)
+        )
+    session.exec(delete(Project).where(Project.id.in_(project_ids)))
+    session.commit()
 
 
 def poll_until_zero(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,34 +26,50 @@ def wipe_tables(session, models):
     restoring ``ON`` must come *after* the commit. Issued before it (the shape
     every ``clean_db`` fixture used to have) it is silently ignored and the
     connection goes back to the pool with foreign keys off, for whichever test
-    picks it up next — see issue #712. The assertion is there because the
-    failure mode is that the restore *looks* like it happened.
+    picks it up next — see issue #712. The restore runs in a ``finally`` so a
+    delete that raises mid-wipe cannot leak enforcement off either, and it
+    raises rather than asserts because the whole point of the check is that a
+    no-opped pragma is silent (``python -O`` would drop an ``assert``).
 
     Args:
         session: SQLModel Session, as handed to ``db.run_task``.
         models: Table models to delete. FKs are off for the deletes, so the
             order is for readability only.
+
+    Raises:
+        RuntimeError: If foreign key enforcement is still off afterwards.
     """
-    session.exec(text("PRAGMA foreign_keys = OFF"))
-    for model in models:
-        session.exec(delete(model))
-    session.commit()
-    session.exec(text("PRAGMA foreign_keys = ON"))
-    assert session.exec(text("PRAGMA foreign_keys")).one()[0] == 1, (
-        "PRAGMA foreign_keys = ON no-opped; this connection would return to "
-        "the pool with foreign key enforcement off"
-    )
+    try:
+        session.exec(text("PRAGMA foreign_keys = OFF"))
+        for model in models:
+            session.exec(delete(model))
+        session.commit()
+    finally:
+        # The pragma needs no transaction pending: the commit above ends it on
+        # the happy path, this rollback ends a half-done wipe on the unhappy
+        # one (and is a no-op after a successful commit).
+        session.rollback()
+        session.exec(text("PRAGMA foreign_keys = ON"))
+        if session.exec(text("PRAGMA foreign_keys")).one()[0] != 1:
+            raise RuntimeError(
+                "PRAGMA foreign_keys = ON no-opped; this connection would "
+                "return to the pool with foreign key enforcement off"
+            )
 
 
 def delete_characters(session, character_ids=None):
-    """Delete characters the way ``DELETE /characters/{id}`` does.
+    """Remove characters, nulling the faces that reference them first.
 
-    ``face.character_id`` is a plain FK with no ``ON DELETE`` action, so the
-    live route nulls every referencing face before removing the row
-    (``routes/characters.py::clear_character_and_nullify_faces``). Deleting the
-    row straight out raises ``IntegrityError`` — it only ever worked in tests
-    while FK enforcement was leaking off (#712). ``CharacterProjectMember``
-    rows cascade on their own.
+    ``face.character_id`` is a plain FK with no ``ON DELETE`` action, so
+    deleting the character row on its own raises ``IntegrityError``; it only
+    ever worked in tests while FK enforcement was leaking off (#712). The live
+    route nulls those faces for the same reason
+    (``routes/characters.py::clear_character_and_nullify_faces``).
+    ``CharacterProjectMember`` rows cascade on their own.
+
+    This is only the FK-relevant part of ``DELETE /characters/{id}`` — it does
+    not delete the character's reference picture set, which the route also
+    does. Callers that need the full route semantics should call the route.
 
     Args:
         session: SQLModel Session, as handed to ``db.run_task``.
@@ -70,11 +86,18 @@ def delete_characters(session, character_ids=None):
 
 
 def delete_projects(session, project_ids):
-    """Delete projects the way ``DELETE /projects/{id}`` does.
+    """Remove projects, nulling the ``project_id`` pointers that reference them.
 
     Pictures, picture sets and characters carry a plain ``project_id`` FK, so
-    the live route nulls those pointers before removing the project; only the
-    membership tables cascade. See :func:`delete_characters` and #712.
+    it has to be nulled before the project row can go; only the membership
+    tables cascade. See :func:`delete_characters` and #712.
+
+    This is only the FK-relevant part of ``DELETE /projects/{id}``. The route
+    additionally re-derives each entity's primary ``project_id`` from the
+    memberships that survive, since an entity may belong to several projects
+    (#125); this helper nulls unconditionally, which is the same thing only
+    when every project the entity belongs to is being deleted. That holds for
+    its callers here, which delete the entity's sole project.
     """
     for model in (Picture, PictureSet, Character):
         session.exec(


### PR DESCRIPTION
Fixes #712.

## What was wrong

`PRAGMA foreign_keys` is a no-op while a transaction is pending. Every `clean_db`
fixture issued the restoring `ON` after its `DELETE`s, so it was silently ignored
and the connection went back to the pool with FK enforcement off — for the rest of
its life, and for whichever test drew it next.

Six fixtures had the bug, two more than the issue lists: `test_snapshots.py`,
`test_restore.py`, `test_metadata_hash.py`, `test_metadata_hash_batching.py`,
`test_server_simple.py` and `test_scrapheap_retention.py`.

## What changed

One shared `wipe_tables(session, models)` helper in `tests/utils.py`, passed
straight to `db.run_task`, replaces all six copies of the pragma dance. It commits
before restoring the pragma, restores in a `finally` so a delete that raises
mid-wipe cannot leak enforcement off either, and raises `RuntimeError` if the
restore did not take — the failure mode here was that it looked like it had, so the
check must not be droppable by `python -O`.

In `test_scrapheap_retention.py` only the vault wipe goes through the helper; the
hub database's identity wipe issues no pragma and is left as it is.

The other `PRAGMA foreign_keys = OFF` sites (`test_migrations.py`,
`test_picture_is_video.py`) are on short-lived raw `sqlite3` connections that are
closed immediately, not on the pool, so they are left alone.

## Fallout: 7 tests were relying on the leak

With FK enforcement genuinely on, seven `test_restore.py` tests failed. Each has a
helper that simulates "the user deleted this character/project" by deleting the row
directly, which violates `face.character_id` / `picture.project_id` /
`pictureset.project_id` / `character.project_id` — plain FKs with no `ON DELETE`
action. The production routes null those pointers first
(`routes/characters.py::clear_character_and_nullify_faces`,
`routes/projects.py::delete_project`); the tests only ever passed because
enforcement was off. One comment even asserted the wrong mechanism
("Face.character_id cascades to NULL"), now corrected.

Added `delete_characters` / `delete_projects` to `tests/utils.py` covering the
FK-relevant part of what those routes do, and pointed the six call sites at them.
Their docstrings name what they deliberately leave out (the reference picture set;
the #125 primary-project re-derivation, which differs only when the entity belongs
to another surviving project). No production code changed — this is the
weakened-test class the issue predicted, surfacing on contact.

## Verification

All six affected files plus `test_ci_shards.py`: 371 passed. `ruff check` clean.
`test_server_simple.py::test_scrapheap_delete_forever_upgrades_stale_kept_flag`
fails, but fails identically on a clean `develop` checkout — it is pre-existing and
untouched by this branch.

No new test file, so no CI shard-list change is needed — the guard inside
`wipe_tables` runs in every one of those fixtures, on every test.
