### PR TITLE
Model shelf: make the capacity meter the drop target, showing projected usage

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1619,6 +1619,49 @@ models is thirty-six headers. Under `Folder` the second level is spent on the
   `mdi-alert-outline` glyph and semibold figures, with the warning hue additive
   on top; so it survives greyscale, and it gets no live region, because it is
   true of several bands at once and would fire a burst on every device refresh.
+- **The meter is the drop target, and it projects the consequence before the
+  drop commits (#894).** A drag over a band draws a **fourth, hatched segment**
+  carved *out of* the free one — `bandProjection` returns a replacement for
+  `bandUsage`'s object with `freePct` already reduced, so the four still sum to
+  100 and the flex row and the no-clamp guarantee both survive untouched. The
+  hatch is the point: three segments are things that were *measured* and this
+  one is a thing that *has not happened*, and a fourth flat colour would have
+  said it was already on the disk. It is the same 45° texture the sidebar's
+  `.not-droppable` and the grid's ghosted tiles use, at 2px/4px because the
+  track is 6px tall.
+  - **The projection nets out copies already on that drive.** A move inside one
+    drive is a rename — the server reports `bytes_to_copy` of zero for it — so
+    `movableCopies` returns `bytesByFolderId` alongside `items`, and the band
+    sums only the copies whose `bandKeyFor` differs from its own. Without that
+    a drive refuses a move onto itself that costs nothing. `bytesByFolderId` is
+    deliberately **not** on `items`, which is posted to `/model-moves` verbatim.
+  - **A band that has no room refuses, and so does every folder header on it.**
+    The refusal belongs to the *disk*: `dropFits` is checked in both handlers
+    and drawn in one place, the band, so the reader is told why while the
+    pointer is still down rather than by a message after the release. Refusing
+    is simply not calling `preventDefault()`, so the browser's own "no drop
+    here" cursor lands on a band already in the error treatment.
+  - **An unmeasurable drive does not refuse.** `bandProjection` returns `null`
+    and `dropFits` answers *true*: "we cannot say" must not be drawn as "does
+    not fit". The band still highlights as a target (`bandDropState` keys on the
+    pointer and the fit, never on a projection existing) — it simply has no
+    ghost and no outcome to state. The server checks before it copies.
+  - **A band drop resolves to the first folder on that drive a move may go to.**
+    A band is a disk and a move needs a folder, so one has to be chosen.
+    Choosing is safe because a drop still does not move on release — the dialog
+    states the destination and its select corrects it — and it is kinder than
+    refusing a drive holding two eligible folders, which would be a refusal the
+    reject treatment does not mean.
+  - **The outcome is stated in words** under the band ("100.0 GB fits · 300.0 GB
+    free after", "100.0 GB will not fit · 60.0 GB short", "Already on this drive
+    · nothing to copy"). The hatch and the hue are neither readable aloud nor in
+    greyscale; this is the half that is. It states the *outcome* rather than the
+    new total, because the reader is deciding whether to let go.
+  - **The drag's weight is held in the component for the drag's lifetime.**
+    `dataTransfer`'s *data* is unreadable during `dragover` — only `types` is —
+    and the projection has to be drawn while the pointer is down. `dragstart`
+    records it and `dragend` clears it, which is a hand-off between two of this
+    component's own handlers rather than a guess about the payload.
 - **The bands are decoration and fail alone.** `refreshDevices` is unawaited and
   swallows its own error into a `console.warn`, never into the folder store's
   `error`: the route stats the filesystem, so an offline mount can make it slow
@@ -1996,12 +2039,14 @@ same-drive move, because those are renames — a byte-based bar would sit at 0%
 through the entire fastest case and then jump.
 
 **Two ways in, one dialog, and a drop does not move on release.** The selection
-bar's Move button and a drag onto a folder header both resolve to the same list
-of copies and both open `ShelfMoveDialog`, which states the move in files, bytes
-and rename-versus-copy before anything starts. There is no undo behind a move,
-so a 438 GB copy across a USB drive must never be one slip of the pointer away.
-A drop seeds the destination it was aimed at; the select still lets it be
-corrected.
+bar's Move button and a drag onto a folder header **or onto a drive band's
+capacity meter** all resolve to the same list of copies and all open
+`ShelfMoveDialog`, which states the move in files, bytes and rename-versus-copy
+before anything starts. There is no undo behind a move, so a 438 GB copy across
+a USB drive must never be one slip of the pointer away. A drop seeds the
+destination it was aimed at; the select still lets it be corrected — which is
+also what makes a band drop safe, since a band is a disk and the folder on it
+has to be picked for the user (§9.1a, the meter as drop target).
 
 **`movableCopies` is the single gate**, per COPY rather than per model, because
 `model_file`'s key is `(folder_id, relpath)` and a model catalogued in three

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -1407,24 +1407,24 @@ describe("a registered folder holding no models", () => {
   });
 });
 
+/** A DataTransfer stand-in: jsdom's drag events carry none. */
+function transfer(types = []) {
+  return {
+    types,
+    setData: vi.fn(function (type) {
+      this.types = [...this.types, type];
+    }),
+    effectAllowed: "",
+    dropEffect: "",
+  };
+}
+
 describe("dragging models onto a folder", () => {
   const FOLDERS = [
     { id: 1, path: "/models/loras", kind: "user", movable: "per_item" },
     { id: 2, path: "/models/store", kind: "managed", movable: "root_only" },
     { id: 3, path: "/runs", kind: "source", movable: "per_item" },
   ];
-
-  /** A DataTransfer stand-in: jsdom's drag events carry none. */
-  function transfer(types = []) {
-    return {
-      types,
-      setData: vi.fn(function (type) {
-        this.types = [...this.types, type];
-      }),
-      effectAllowed: "",
-      dropEffect: "",
-    };
-  }
 
   async function shelfWithFolders(rows) {
     listModelFolders.mockResolvedValue(FOLDERS);
@@ -1573,6 +1573,193 @@ describe("dragging models onto a folder", () => {
     expect(dialog.props("open")).toBe(true);
     expect(dialog.props("destinationFolderId")).toBe(2);
     expect(dialog.props("items")).toEqual([{ folder_id: 1, relpath: "a" }]);
+  });
+});
+
+describe("dropping onto the capacity meter", () => {
+  const GB = 1024 ** 3;
+  const FOLDERS = [
+    { id: 1, path: "/mnt/fast/loras", kind: "user", movable: "per_item" },
+    { id: 2, path: "/mnt/slow/store", kind: "managed", movable: "root_only" },
+  ];
+
+  /**
+   * One 100 GB adapter on the Fast drive, and an empty folder on Slow.
+   *
+   * `slowFree` is the whole point of the fixture: it is what decides whether
+   * the drop fits, and every test here differs only in that number.
+   */
+  async function twoDrives({ slowFree, devices } = {}) {
+    listModelFolders.mockResolvedValue(FOLDERS);
+    listModelFolderDevices.mockResolvedValue(
+      devices ?? [
+        {
+          device_id: "fast",
+          mount_point: "/mnt/fast",
+          label: "Fast",
+          total_bytes: 4000 * GB,
+          free_bytes: 2000 * GB,
+          shelf_bytes: 500 * GB,
+          folder_ids: [1],
+        },
+        {
+          device_id: "slow",
+          mount_point: "/mnt/slow",
+          label: "Slow",
+          total_bytes: 1000 * GB,
+          free_bytes: slowFree,
+          shelf_bytes: 100 * GB,
+          folder_ids: [2],
+        },
+      ],
+    );
+    const wrapper = await mountShelf([
+      adapter({
+        id: 1,
+        file_size: 100 * GB,
+        locations: [
+          {
+            state: "present",
+            folder_id: 1,
+            folder_path: "/mnt/fast/loras",
+            relpath: "a.st",
+          },
+        ],
+      }),
+    ]);
+    const store = useModelShelfStore();
+    store.setView({ groupBy: "folder", folderLayout: "drive" });
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+    return wrapper;
+  }
+
+  function bandFor(wrapper, label) {
+    return wrapper
+      .findAll(".shelf-band-heading")
+      .find((band) => band.text().includes(label));
+  }
+
+  /** Pick the row up, then hold the pointer over a band. */
+  async function dragOnto(wrapper, label, type = "dragover") {
+    const dt = transfer();
+    await wrapper.find(".shelf-row").trigger("dragstart", { dataTransfer: dt });
+    const event = Object.assign(new Event(type, { cancelable: true }), {
+      dataTransfer: dt,
+    });
+    bandFor(wrapper, label).element.dispatchEvent(event);
+    await wrapper.vm.$nextTick();
+    return event;
+  }
+
+  it("projects the drop as a hatched segment cut out of the free space", async () => {
+    // The consequence, drawn before the drop commits. Four segments now, still
+    // summing to the drive: 100 GB on the shelf, 500 GB of other files, the
+    // 100 GB ghost, and the 300 GB that would be left.
+    const wrapper = await twoDrives({ slowFree: 400 * GB });
+    const event = await dragOnto(wrapper, "Slow");
+    expect(event.defaultPrevented).toBe(true);
+
+    const band = bandFor(wrapper, "Slow");
+    expect(band.classes()).toContain("shelf-band-heading--drop");
+    expect(
+      band.findAll(".shelf-band-seg").map((s) => s.attributes("style")),
+    ).toEqual(["width: 10%;", "width: 50%;", "width: 10%;", "width: 30%;"]);
+    // Hatched rather than a fourth flat colour: a projection is provisional
+    // and a measurement is not, and the two must not be one reading apart.
+    expect(band.find(".shelf-band-seg--ghost").exists()).toBe(true);
+    expect(band.find(".shelf-band-seg--ghost-reject").exists()).toBe(false);
+    // The half that survives greyscale and is readable out loud.
+    expect(textOf(band)).toContain("100.0 GB fits · 300.0 GB free after");
+
+    // And only the band under the pointer: the other drive still reads as
+    // measured, because nothing is being dropped on it.
+    expect(bandFor(wrapper, "Fast").findAll(".shelf-band-seg")).toHaveLength(3);
+  });
+
+  it("refuses the drop while the pointer is still down, not after it", async () => {
+    // The honest place to refuse a move. `preventDefault()` is what ACCEPTS a
+    // drop, so not calling it leaves the browser's own "no drop here" cursor
+    // over a band already drawn in the error treatment.
+    const wrapper = await twoDrives({ slowFree: 40 * GB });
+    const event = await dragOnto(wrapper, "Slow");
+    expect(event.defaultPrevented).toBe(false);
+
+    const band = bandFor(wrapper, "Slow");
+    expect(band.classes()).toContain("shelf-band-heading--reject");
+    expect(band.classes()).not.toContain("shelf-band-heading--drop");
+    expect(band.find(".shelf-band-seg--ghost-reject").exists()).toBe(true);
+    expect(textOf(band)).toContain("100.0 GB will not fit · 60.0 GB short");
+  });
+
+  it("does not open the dialog for a drop the band refused", async () => {
+    const wrapper = await twoDrives({ slowFree: 40 * GB });
+    await dragOnto(wrapper, "Slow", "drop");
+    expect(
+      wrapper.findComponent({ name: "ShelfMoveDialog" }).props("open"),
+    ).toBe(false);
+  });
+
+  it("resolves a band drop to the first folder on that drive a move may go to", async () => {
+    // A band is a disk and a move needs a folder, so one is chosen — safely,
+    // because the drop does not move on release: the dialog states the
+    // destination and its select corrects it.
+    const wrapper = await twoDrives({ slowFree: 400 * GB });
+    await dragOnto(wrapper, "Slow", "drop");
+
+    const dialog = wrapper.findComponent({ name: "ShelfMoveDialog" });
+    expect(dialog.props("open")).toBe(true);
+    expect(dialog.props("destinationFolderId")).toBe(2);
+    expect(dialog.props("items")).toEqual([{ folder_id: 1, relpath: "a.st" }]);
+  });
+
+  it("counts a move within one drive as nothing to copy", async () => {
+    // Those are renames — the server reports `bytes_to_copy` of zero for them
+    // — so projecting 100 GB onto the disk the bytes are already on would
+    // refuse a move that costs nothing.
+    const wrapper = await twoDrives({ slowFree: 400 * GB });
+    await dragOnto(wrapper, "Fast");
+
+    const band = bandFor(wrapper, "Fast");
+    expect(band.classes()).toContain("shelf-band-heading--drop");
+    expect(textOf(band)).toContain("Already on this drive · nothing to copy");
+  });
+
+  it("refuses a folder header on a full drive too, not only its band", async () => {
+    // The refusal belongs to the DISK. A folder whose drive has no room cannot
+    // take the files either, so the header stops highlighting and the band
+    // above it is where the reader is told why.
+    const wrapper = await twoDrives({ slowFree: 40 * GB });
+    const dt = transfer();
+    await wrapper.find(".shelf-row").trigger("dragstart", { dataTransfer: dt });
+    const event = Object.assign(new Event("dragover", { cancelable: true }), {
+      dataTransfer: dt,
+    });
+    wrapper
+      .findAll(".shelf-group-btn")
+      .find((b) => b.text().includes("/mnt/slow/store"))
+      .element.dispatchEvent(event);
+    await wrapper.vm.$nextTick();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(wrapper.find(".shelf-group-btn--drop").exists()).toBe(false);
+    expect(bandFor(wrapper, "Slow").classes()).toContain(
+      "shelf-band-heading--reject",
+    );
+  });
+
+  it("does not refuse a drive it could not measure", async () => {
+    // "We cannot say" must not be drawn as "does not fit". The band takes the
+    // drop and highlights for it; it simply has no ghost and no outcome to
+    // state, and the server still checks before it copies.
+    const wrapper = await twoDrives({ devices: [] });
+    const event = await dragOnto(wrapper, "/mnt/slow/store");
+    expect(event.defaultPrevented).toBe(true);
+
+    const band = bandFor(wrapper, "/mnt/slow/store");
+    expect(band.classes()).toContain("shelf-band-heading--drop");
+    expect(band.find(".shelf-band-seg--ghost").exists()).toBe(false);
+    expect(textOf(band)).toContain("Capacity unknown");
   });
 });
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -320,10 +320,23 @@
                inside a row and not inside a header. Drawn on the first group of
                each band, never as a wrapper element, so the sticky folder
                headers below keep scrolling under it in one flow. -->
+          <!-- And the drop target for a move (#894). `dragover` carries no
+               `.prevent` here either — calling preventDefault() is what ACCEPTS
+               a drop, so a band with no room simply never calls it and the
+               browser draws its own refusal cursor over a band already in the
+               error treatment. -->
           <h3
             v-if="group.bandStart"
             class="shelf-band-heading"
-            :class="{ 'shelf-band-heading--unknown': !group.band.measured }"
+            :class="{
+              'shelf-band-heading--unknown': !group.band.measured,
+              'shelf-band-heading--drop': bandDropState(group.band) === 'drop',
+              'shelf-band-heading--reject':
+                bandDropState(group.band) === 'reject',
+            }"
+            @dragover="onBandDragOver(group.band, $event)"
+            @dragleave="onBandDragLeave(group.band)"
+            @drop="onBandDrop(group.band, $event)"
           >
             <span class="shelf-band-label" :title="group.band.mountPoint">
               <v-icon size="16" class="shelf-band-icon">mdi-harddisk</v-icon>
@@ -351,27 +364,51 @@
             >
               <span
                 class="shelf-band-seg shelf-band-seg--shelf"
-                :style="{ width: `${usage(group.band).shelfPct}%` }"
+                :style="{ width: `${meter(group.band).shelfPct}%` }"
               ></span>
               <span
                 class="shelf-band-seg shelf-band-seg--other"
-                :style="{ width: `${usage(group.band).otherPct}%` }"
+                :style="{ width: `${meter(group.band).otherPct}%` }"
+              ></span>
+              <!-- The ghost: what a drop would add, carved out of the free
+                   segment rather than laid over it, so the four still sum to
+                   the drive. Hatched, never a solid, because a projection is
+                   provisional and a measurement is not — and the two must not
+                   be one reading apart. -->
+              <span
+                v-if="projection(group.band)"
+                class="shelf-band-seg shelf-band-seg--ghost"
+                :class="{
+                  'shelf-band-seg--ghost-reject': !projection(group.band).fits,
+                }"
+                :style="{ width: `${projection(group.band).addedPct}%` }"
               ></span>
               <span
                 class="shelf-band-seg shelf-band-seg--free"
-                :style="{ width: `${usage(group.band).freePct}%` }"
+                :style="{ width: `${meter(group.band).freePct}%` }"
               ></span>
             </span>
             <span
               class="shelf-band-figures"
               :class="{
-                'shelf-band-figures--low': usage(group.band)?.lowFree,
+                'shelf-band-figures--low':
+                  !projection(group.band) && usage(group.band)?.lowFree,
+                'shelf-band-figures--reject':
+                  bandDropState(group.band) === 'reject',
               }"
             >
-              <!-- The non-colour half of the low state. Colour is additive
-                   here, never the carrier: the distinction has to survive
-                   greyscale, and the glyph and the word "Only" both do. -->
-              <v-icon v-if="usage(group.band)?.lowFree" size="16"
+              <!-- The non-colour half of the low and reject states. Colour is
+                   additive here, never the carrier: the distinction has to
+                   survive greyscale, and the glyph and the words ("Only", "will
+                   not fit") both do. A drop that fits gets the tray glyph
+                   rather than none, so the label under a hatched meter is
+                   marked as being about the drag and not about the disk. -->
+              <v-icon v-if="projection(group.band)" size="16">{{
+                projection(group.band).fits
+                  ? "mdi-tray-arrow-down"
+                  : "mdi-alert-circle-outline"
+              }}</v-icon>
+              <v-icon v-else-if="usage(group.band)?.lowFree" size="16"
                 >mdi-alert-outline</v-icon
               >
               <span>{{ meterLabel(group.band) }}</span>
@@ -394,7 +431,8 @@
             <button
               class="ps-row shelf-group-btn"
               :class="{
-                'shelf-group-btn--drop': dropTargetKey === group.key,
+                'shelf-group-btn--drop':
+                  dropTargetKey === group.key && dropFits(group.band),
                 'shelf-group-btn--offline': group.offline,
               }"
               :style="groupStyle(group)"
@@ -552,7 +590,7 @@
                 @keydown="onRowKeydown(row, $event)"
                 @focus="focusedRowKey = row.rowKey"
                 @dragstart="onRowDragStart(row, $event)"
-                @dragend="dropTargetKey = ''"
+                @dragend="clearDropState()"
               >
                 <!-- Column 1 stays the reserved glyph slot. The selection shows
                    as the row's own wash and a tick here, not as a checkbox: a
@@ -864,6 +902,8 @@ import { isModelFileDrag, setInternalDragPayload } from "../../utils/media";
 import {
   assignmentMarks,
   bandGroups,
+  bandKeyFor,
+  bandProjection,
   bandUsage,
   withEmptyFolders,
   withFolderSignals,
@@ -933,6 +973,17 @@ const moveItems = ref([]);
 const moveBytes = ref(0);
 /** The group header the pointer is currently over, for the drop affordance. */
 const dropTargetKey = ref("");
+/** The band the pointer is currently over, for its meter's projection (#894). */
+const dropBandKey = ref("");
+/**
+ * The dragged bytes, by the folder they are in NOW.
+ *
+ * Kept for the length of the drag because `dataTransfer`'s DATA is unreadable
+ * during `dragover` — only `types` is — and the projection has to be drawn
+ * while the pointer is still down. The drag always starts in this component, so
+ * this is a hand-off between two of its own handlers and not a guess.
+ */
+const dragBytesByFolder = shallowRef(new Map());
 const moveInvoker = shallowRef(null);
 
 /** `model_folder.id` to the folder row, for `movableCopies`' folder rules. */
@@ -1020,13 +1071,107 @@ function onRowDragStart(row, event) {
   if (!store.isSelected(row.id)) {
     store.selectFromClick(row.id, {}, orderedRowIds.value);
   }
-  const { items } = movableCopies(store.selectedRows, foldersById.value);
+  const { items, bytesByFolderId } = movableCopies(
+    store.selectedRows,
+    foldersById.value,
+  );
   if (!items.length) {
     event.preventDefault();
     return;
   }
+  dragBytesByFolder.value = bytesByFolderId;
   event.dataTransfer.effectAllowed = "move";
   setInternalDragPayload(event.dataTransfer, { type: "model-files", items });
+}
+
+/** Everything the pointer was saying, cleared however the drag ended. */
+function clearDropState() {
+  dropTargetKey.value = "";
+  dropBandKey.value = "";
+  dragBytesByFolder.value = new Map();
+}
+
+/**
+ * The bytes this drag would ADD to a drive.
+ *
+ * Copies already on it are excluded, because a move within one drive is a
+ * rename: the server reports `bytes_to_copy` of zero for exactly that case, and
+ * a meter projecting 438 GB onto the disk those bytes are already sitting on
+ * would refuse a move that costs nothing.
+ */
+function bytesLandingOn(band) {
+  if (!band) return 0;
+  let bytes = 0;
+  for (const [folderId, size] of dragBytesByFolder.value) {
+    if (bandKeyFor(folderId, foldersStore.deviceByFolderId) !== band.key) {
+      bytes += size;
+    }
+  }
+  return bytes;
+}
+
+/**
+ * The projection for the band under the pointer, and only for that one.
+ *
+ * A computed rather than a per-band call, so the arithmetic runs once per drag
+ * position however many times the template asks for it — the heading reads it
+ * for its own state, for the ghost segment, for the glyph and for the label.
+ */
+const dropProjection = computed(() => {
+  if (!dropBandKey.value) return null;
+  const group = shownGroups.value.find(
+    (item) => item.bandStart && item.band?.key === dropBandKey.value,
+  );
+  if (!group) return null;
+  return bandProjection(group.band, bytesLandingOn(group.band));
+});
+
+/** The projection if this band is the one being dragged over, else null. */
+function projection(band) {
+  return band && band.key === dropBandKey.value ? dropProjection.value : null;
+}
+
+/**
+ * Whether a drop aimed at this drive has room for it.
+ *
+ * A drive we could not measure answers **true**: "we cannot say" must not read
+ * as "does not fit", and refusing a drop on an unplugged-then-replugged disk
+ * because its capacity never came back would be a refusal with no cause the
+ * reader can see. The server still checks before it copies.
+ */
+function dropFits(band) {
+  const projected = bandProjection(band, bytesLandingOn(band));
+  return projected ? projected.fits : true;
+}
+
+/**
+ * What this band is saying to the drag right now: nothing, that it takes the
+ * drop, or that it refuses it.
+ *
+ * Keyed on the pointer and the fit rather than on the projection, so a drive
+ * whose capacity we could not read still highlights as a target. It has no
+ * ghost to draw and no outcome to state, but it does accept the drop — and a
+ * target that accepts without saying so is the one gap a projection-gated
+ * highlight would open.
+ */
+function bandDropState(band) {
+  if (!band || band.key !== dropBandKey.value) return "";
+  return dropFits(band) ? "drop" : "reject";
+}
+
+/**
+ * The folder a drop on the BAND resolves to: the first on that drive a move may
+ * be sent to, in the order the headers are drawn.
+ *
+ * A band is a disk and a move needs a folder, so one of them has to be chosen.
+ * Choosing the first is safe because a drop does not move on release — the
+ * dialog states the destination and its select corrects it — and it is kinder
+ * than refusing a drive holding two eligible folders, which would be a refusal
+ * the reject treatment does not mean.
+ */
+function bandDropFolderId(band) {
+  const group = (band?.groups || []).find((item) => isDropTarget(item));
+  return group ? Number(group.folderId) : null;
 }
 
 /** True when this group is a folder a move may be sent to. */
@@ -1050,20 +1195,75 @@ function isDropTarget(group) {
  */
 function onGroupDragOver(group, event) {
   if (!isModelFileDrag(event.dataTransfer) || !isDropTarget(group)) return;
+  // Recorded BEFORE the fit is judged, so a refused header still has something
+  // for `dragleave` to clear and the band above it keeps projecting for exactly
+  // as long as the pointer is there. The highlight is what the fit gates.
+  dropTargetKey.value = group.key;
+  dropBandKey.value = group.band?.key || "";
+  // A folder on a full drive cannot take the files either — the refusal belongs
+  // to the disk, not to the header, which is why the check lives here as well
+  // and the band above is where it is drawn.
+  if (!dropFits(group.band)) return;
   event.preventDefault();
   event.dataTransfer.dropEffect = "move";
-  dropTargetKey.value = group.key;
 }
 
 function onGroupDragLeave(group) {
-  if (dropTargetKey.value === group.key) dropTargetKey.value = "";
+  // Only when the pointer really left: moving header to header inside one band
+  // fires this AFTER `dragover` on the new one, so the key has already moved on
+  // and clearing here would blink the projection off between two targets.
+  if (dropTargetKey.value !== group.key) return;
+  dropTargetKey.value = "";
+  dropBandKey.value = "";
 }
 
 function onGroupDrop(group, event) {
-  dropTargetKey.value = "";
+  const fits = dropFits(group.band);
+  clearDropState();
   if (!isModelFileDrag(event.dataTransfer) || !isDropTarget(group)) return;
+  if (!fits) return;
   event.preventDefault();
   openMove(store.selectedRows, Number(group.folderId));
+}
+
+/**
+ * The meter is the drop target (#894).
+ *
+ * It is where "which disk has room" stops being informational, and it is the
+ * honest place to refuse: a drop that will not fit is refused while the pointer
+ * is still down, next to the projection saying why, rather than as a message
+ * after the release. The band is still marked as the target while it refuses —
+ * `preventDefault()` is simply not called, so the browser draws its own "no
+ * drop here" cursor over a band already in the error treatment.
+ */
+function onBandDragOver(band, event) {
+  if (!isModelFileDrag(event.dataTransfer)) return;
+  // Nothing on this drive takes a drop at all. No projection either: it would
+  // promise an outcome for a gesture that has no destination to resolve to.
+  if (bandDropFolderId(band) === null) return;
+  dropTargetKey.value = "";
+  dropBandKey.value = band.key;
+  if (!dropFits(band)) return;
+  event.preventDefault();
+  event.dataTransfer.dropEffect = "move";
+}
+
+function onBandDragLeave(band) {
+  // `dropTargetKey` set means the pointer moved from the band DOWN onto one of
+  // its own folder headers, which is still inside this band's projection.
+  if (dropBandKey.value === band.key && !dropTargetKey.value) {
+    dropBandKey.value = "";
+  }
+}
+
+function onBandDrop(band, event) {
+  const folderId = bandDropFolderId(band);
+  const fits = dropFits(band);
+  clearDropState();
+  if (!isModelFileDrag(event.dataTransfer) || folderId === null) return;
+  if (!fits) return;
+  event.preventDefault();
+  openMove(store.selectedRows, folderId);
 }
 
 /**
@@ -1733,6 +1933,18 @@ function usage(band) {
 }
 
 /**
+ * The figures the meter draws: the projection while a drag is over this band,
+ * the measurement otherwise.
+ *
+ * One object either way, because `bandProjection` returns a REPLACEMENT for
+ * `bandUsage`'s — its `freePct` is already reduced by the ghost — so the three
+ * measured segments need no branch of their own and the row still sums to 100.
+ */
+function meter(band) {
+  return projection(band) || bandUsage(band);
+}
+
+/**
  * The meter's key, in the segments' own left-to-right order.
  *
  * The wording borrows `meterLabel`'s, so the key and the figures under it are
@@ -1758,6 +1970,8 @@ const showsBandLegend = computed(() =>
  * zero, which would draw an empty meter for a drive that may well be full.
  */
 function meterLabel(band) {
+  const projected = projection(band);
+  if (projected) return projectionLabel(projected);
   const use = bandUsage(band);
   if (!use) return "Capacity unknown";
   const free = formatModelSize(band.freeBytes);
@@ -1768,6 +1982,24 @@ function meterLabel(band) {
   // gets no action — the same register as the offline banner.
   const lead = use.lowFree ? "Only " : "";
   return `${lead}${free} free of ${total} · ${shelf} on the shelf`;
+}
+
+/**
+ * What a drop on this drive would do, said in words.
+ *
+ * The hatch says "provisional" and the colour says "refused", and neither is
+ * readable aloud or in greyscale — this is the half that is. It states the
+ * OUTCOME rather than the new total: the reader is deciding whether to release
+ * the pointer, and "8.1 GB short" answers that where "1.9 TB used" does not.
+ */
+function projectionLabel(projected) {
+  if (!projected.addedBytes) return "Already on this drive · nothing to copy";
+  const added = formatModelSize(projected.addedBytes);
+  if (!projected.fits) {
+    const short = formatModelSize(-projected.freeAfter);
+    return `${added} will not fit · ${short} short`;
+  }
+  return `${added} fits · ${formatModelSize(projected.freeAfter)} free after`;
 }
 
 /**
@@ -2135,6 +2367,30 @@ watch(
   font-style: italic;
 }
 
+/* The drop affordance, in the same inset ring the folder header below uses:
+   the shelf has one drop treatment and a second dialect on the outer level
+   would read as a different kind of target rather than the same one. The
+   radius is on the heading here because, unlike the header, the band is not
+   the full-bleed sticky strip. */
+.shelf-band-heading--drop,
+.shelf-band-heading--reject {
+  border-radius: var(--radius-sm);
+}
+
+.shelf-band-heading--drop {
+  background: rgba(var(--v-theme-primary), 0.12);
+  box-shadow: inset 0 0 0 2px rgba(var(--v-theme-primary), 0.65);
+}
+
+/* The refusal, while the pointer is still down. `no-drop` is the same cursor
+   `.not-droppable` uses in the sidebar, and it is the third carrier after the
+   hue and the hatch — the state has to survive greyscale and forced-colors. */
+.shelf-band-heading--reject {
+  background: rgba(var(--v-theme-error), 0.1);
+  box-shadow: inset 0 0 0 2px rgba(var(--v-theme-error), 0.65);
+  cursor: no-drop;
+}
+
 .shelf-band-label {
   display: inline-flex;
   align-items: center;
@@ -2198,6 +2454,35 @@ watch(
   background: var(--band-meter-free);
 }
 
+/* The projection. HATCHED, never a solid: the other three segments are things
+   that were measured and this one is a thing that has not happened, and a
+   fourth flat colour would have said "this is also on the disk". The same 45°
+   texture the sidebar's `.not-droppable` and the grid's ghosted tiles use, at
+   2px/4px because the track is 6px tall and the family's usual 4px/8px would
+   put barely one stripe in a narrow segment.
+
+   Both stops carry a visible alpha rather than one of them being transparent:
+   a hatch that let the free track show through would read as a lighter free
+   segment on a nearly-empty drive rather than as a texture. */
+.shelf-band-seg--ghost {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(var(--v-theme-primary), 0.9) 0 var(--space-1),
+    rgba(var(--v-theme-primary), 0.4) var(--space-1) var(--space-2)
+  );
+}
+
+/* Does not fit. The segment is clamped to the free space it is drawing into —
+   a bar cannot run past its own track — so the hue and the hatch are what say
+   the drop was refused, and the label says by how much. */
+.shelf-band-seg--ghost-reject {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(var(--v-theme-error), 0.9) 0 var(--space-1),
+    rgba(var(--v-theme-error), 0.4) var(--space-1) var(--space-2)
+  );
+}
+
 /* Track as well as segment, so a sub-pixel seam between two segments cannot
    show the neutral track through an amber bar. */
 .shelf-band-meter--low,
@@ -2217,6 +2502,17 @@ watch(
    dark, both over the 3:1 UI floor. */
 .shelf-band-figures--low .v-icon {
   color: rgb(var(--v-theme-warning));
+}
+
+/* Same split as `--low` and for the same measurement: weight on the --text-xs
+   body text, hue reserved for the 16px glyph, which is non-text and answers to
+   the 3:1 UI floor rather than the 4.5:1 body one. */
+.shelf-band-figures--reject {
+  font-weight: var(--weight-semibold);
+}
+
+.shelf-band-figures--reject .v-icon {
+  color: rgb(var(--v-theme-error));
 }
 
 .shelf-band-figures {

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -453,6 +453,23 @@ export function withFolderSignals(
  * @returns {Array<Object>} the same groups, reordered, each with `band` and
  *   `bandStart` (true on the first group of each band).
  */
+/**
+ * The band a folder belongs to.
+ *
+ * The drive when one was measured, the folder itself when none was — the same
+ * rule {@link bandGroups} keys on, exported so a caller asking "is this copy
+ * already on that drive?" cannot answer it with a second, drifting copy of the
+ * rule.
+ *
+ * @param {number} folderId - `model_folder.id`.
+ * @param {Map<number, Object>} deviceByFolderId - from `useModelFoldersStore`.
+ * @returns {string} the band key.
+ */
+export function bandKeyFor(folderId, deviceByFolderId) {
+  const device = deviceByFolderId?.get?.(Number(folderId)) || null;
+  return device?.device_id ? `d:${device.device_id}` : `f:${Number(folderId)}`;
+}
+
 export function bandGroups(groups, deviceByFolderId) {
   const byBand = new Map();
   // Not every folder group names a folder. A model whose folders have all been
@@ -467,7 +484,7 @@ export function bandGroups(groups, deviceByFolderId) {
     const folderId = Number(group.folderId);
     const device = deviceByFolderId?.get?.(folderId) || null;
     // Unmeasured folders band alone, keyed by folder rather than by device.
-    const key = device?.device_id ? `d:${device.device_id}` : `f:${folderId}`;
+    const key = bandKeyFor(folderId, deviceByFolderId);
     let band = byBand.get(key);
     if (!band) {
       band = {
@@ -571,6 +588,52 @@ export function bandUsage(band) {
     freePct: (free / total) * 100,
     usedPct: (used / total) * 100,
     lowFree: free < LOW_FREE_BYTES,
+  };
+}
+
+/**
+ * What a drive would hold after a drop, and whether the drop fits.
+ *
+ * The meter is the drop target (#894), so the consequence has to be drawable
+ * *before* the pointer is released — which means a fourth segment carved out of
+ * the free one rather than a fifth number in the label. `freePct` is therefore
+ * already reduced by the projection and the four still sum to exactly 100, so
+ * the caller lays them out in the same flex row with no rounding sliver at the
+ * right-hand end and needs no per-segment clamp. That is the whole reason this
+ * returns a REPLACEMENT for `bandUsage`'s object rather than something to draw
+ * alongside it.
+ *
+ * `added` is clamped into the free space for the SEGMENT, because a bar cannot
+ * draw past its own track; `fits` is decided on the unclamped figure, so the
+ * over-full case is a full-width hatch in the error treatment and not a bar
+ * that quietly stops looking wrong at 100%. `freeAfter` goes negative in that
+ * case, which is how far short the drive is.
+ *
+ * A drive that could not be measured returns `null`, exactly as `bandUsage`
+ * does: a projection onto an unknown capacity is a guess, and the caller must
+ * read that as "cannot say" rather than as "does not fit".
+ *
+ * @param {Object} band - a band from {@link bandGroups}.
+ * @param {number} addedBytes - bytes the drop would ADD to this drive. Copies
+ *   already on it are renames and add nothing, so the caller nets them out.
+ * @returns {{shelfPct: number, otherPct: number, addedPct: number,
+ *   freePct: number, usedPct: number, lowFree: boolean, addedBytes: number,
+ *   freeAfter: number, fits: boolean}|null}
+ */
+export function bandProjection(band, addedBytes) {
+  const use = bandUsage(band);
+  if (!use) return null;
+  const total = Number(band.totalBytes);
+  const free = Math.min(Number(band.freeBytes), total);
+  const added = Math.max(0, Number(addedBytes) || 0);
+  const drawn = Math.min(added, free);
+  return {
+    ...use,
+    addedPct: (drawn / total) * 100,
+    freePct: ((free - drawn) / total) * 100,
+    addedBytes: added,
+    freeAfter: free - added,
+    fits: added <= free,
   };
 }
 
@@ -715,10 +778,22 @@ export function importReceipt(report) {
  * @param {Map<number, Object>|null} foldersById - `model_folder.id` to the
  *   folder row, for the two folder-level exclusions. Omitted, only the
  *   `present` rule applies.
- * @returns {{items: Array<{folder_id: number, relpath: string}>, totalBytes: number}}
+ * `bytesByFolderId` is the same weight split by where the bytes are NOW, which
+ * is what the capacity projection needs: a copy moved between two folders on
+ * one drive is a rename and adds nothing to it, so the drive a drop is aimed at
+ * has to net out the copies already sitting on it (#894). It is deliberately
+ * kept off `items`, which is posted to `/model-moves` verbatim.
+ *
+ * @param {Array<Object>} rows - shelf rows, each with `locations`.
+ * @param {Map<number, Object>|null} foldersById - `model_folder.id` to the
+ *   folder row, for the two folder-level exclusions. Omitted, only the
+ *   `present` rule applies.
+ * @returns {{items: Array<{folder_id: number, relpath: string}>,
+ *   totalBytes: number, bytesByFolderId: Map<number, number>}}
  */
 export function movableCopies(rows, foldersById = null) {
   const items = [];
+  const bytesByFolderId = new Map();
   let totalBytes = 0;
   for (const row of Array.isArray(rows) ? rows : []) {
     for (const loc of row?.locations || []) {
@@ -726,11 +801,17 @@ export function movableCopies(rows, foldersById = null) {
       const folder = foldersById?.get(Number(loc.folder_id));
       if (folder?.owner === "pixlstash") continue;
       if (folder?.movable === "external") continue;
+      const bytes = Number(row.file_size) || 0;
+      const folderId = Number(loc.folder_id);
       items.push({ folder_id: loc.folder_id, relpath: loc.relpath });
-      totalBytes += Number(row.file_size) || 0;
+      bytesByFolderId.set(
+        folderId,
+        (bytesByFolderId.get(folderId) || 0) + bytes,
+      );
+      totalBytes += bytes;
     }
   }
-  return { items, totalBytes };
+  return { items, totalBytes, bytesByFolderId };
 }
 
 /**

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -609,6 +609,15 @@ export function bandUsage(band) {
  * that quietly stops looking wrong at 100%. `freeAfter` goes negative in that
  * case, which is how far short the drive is.
  *
+ * **Every** derived field is projected, not just the segments. `usedPct` and
+ * `lowFree` are recomputed from the free space that would be LEFT, because a
+ * replacement carrying two fields measured before the drop is a trap: they sit
+ * on the same object as segments drawn from after it, and the first caller to
+ * read `meter(band).lowFree` next to a projected bar gets an answer about a
+ * different drive state than the one on screen. Nothing reads them off this
+ * object today — the band's low treatment deliberately goes through `bandUsage`
+ * — and that is exactly why the inconsistency would be found late.
+ *
  * A drive that could not be measured returns `null`, exactly as `bandUsage`
  * does: a projection onto an unknown capacity is a guess, and the caller must
  * read that as "cannot say" rather than as "does not fit".
@@ -627,12 +636,19 @@ export function bandProjection(band, addedBytes) {
   const free = Math.min(Number(band.freeBytes), total);
   const added = Math.max(0, Number(addedBytes) || 0);
   const drawn = Math.min(added, free);
+  const freeAfter = free - added;
   return {
     ...use,
     addedPct: (drawn / total) * 100,
     freePct: ((free - drawn) / total) * 100,
+    // The drawn figure, so this stays `shelfPct + otherPct + addedPct` and the
+    // bar cannot claim to be more than full.
+    usedPct: ((total - free + drawn) / total) * 100,
+    // The unclamped one, so a drop that overruns the drive reports low rather
+    // than reporting the zero free space it was clamped to.
+    lowFree: freeAfter < LOW_FREE_BYTES,
     addedBytes: added,
-    freeAfter: free - added,
+    freeAfter,
     fits: added <= free,
   };
 }

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -422,6 +422,47 @@ describe("bandProjection", () => {
     expect(projected.freeAfter).toBe(200);
   });
 
+  it("projects every derived field, not only the segments", () => {
+    // The object REPLACES `bandUsage`'s, so a field measured before the drop
+    // riding along on it is a trap: it would be read next to segments drawn
+    // from after the drop and answer about a different drive state.
+    const GB = 1024 ** 3;
+    const projected = bandProjection(
+      { totalBytes: 1000 * GB, freeBytes: 400 * GB, shelfBytes: 300 * GB },
+      380 * GB,
+    );
+    // 20 GB left is well under the 50 GiB floor, though the drive was not low
+    // before the drop and `bandUsage` still says so.
+    expect(projected.lowFree).toBe(true);
+    expect(
+      bandUsage({
+        totalBytes: 1000 * GB,
+        freeBytes: 400 * GB,
+        shelfBytes: 300 * GB,
+      }).lowFree,
+    ).toBe(false);
+    // `usedPct` is what the three filled segments add up to, or a caller could
+    // read a fullness that contradicts the bar beside it.
+    expect(projected.usedPct).toBeCloseTo(
+      projected.shelfPct + projected.otherPct + projected.addedPct,
+      10,
+    );
+    expect(projected.usedPct + projected.freePct).toBeCloseTo(100, 10);
+  });
+
+  it("reports a drop that overruns the drive as low, not as freshly empty", () => {
+    // `freePct` is clamped to zero because a bar cannot draw past its track;
+    // `lowFree` must read the UNCLAMPED figure or the most over-full case on
+    // the shelf would be the one that stops reporting low.
+    const projected = bandProjection(
+      { totalBytes: 1000, freeBytes: 100, shelfBytes: 0 },
+      400,
+    );
+    expect(projected.freePct).toBe(0);
+    expect(projected.usedPct).toBe(100);
+    expect(projected.lowFree).toBe(true);
+  });
+
   it("clamps the bar but not the verdict when the drop does not fit", () => {
     // A bar cannot draw past its own track, so the segment stops at the free
     // space — but `fits` is decided on the unclamped figure, or an over-full

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -8,6 +8,7 @@ import { SET_COLORS } from "./setAppearance";
 import {
   assignmentMarks,
   bandGroups,
+  bandProjection,
   bandUsage,
   baseModelKey,
   collapseStacks,
@@ -396,6 +397,75 @@ describe("bandUsage", () => {
     });
     expect(usage.shelfPct).toBe(usage.usedPct);
     expect(usage.otherPct).toBe(0);
+  });
+});
+
+describe("bandProjection", () => {
+  it("carves the ghost out of the free segment rather than laying it over", () => {
+    // Four segments still summing to one track, which is what lets the caller
+    // keep the same flex row and the same no-clamp guarantee `bandUsage` has.
+    const projected = bandProjection(
+      { totalBytes: 1000, freeBytes: 400, shelfBytes: 300 },
+      200,
+    );
+    expect(projected.shelfPct).toBe(30);
+    expect(projected.otherPct).toBe(30);
+    expect(projected.addedPct).toBe(20);
+    expect(projected.freePct).toBe(20);
+    expect(
+      projected.shelfPct +
+        projected.otherPct +
+        projected.addedPct +
+        projected.freePct,
+    ).toBe(100);
+    expect(projected.fits).toBe(true);
+    expect(projected.freeAfter).toBe(200);
+  });
+
+  it("clamps the bar but not the verdict when the drop does not fit", () => {
+    // A bar cannot draw past its own track, so the segment stops at the free
+    // space — but `fits` is decided on the unclamped figure, or an over-full
+    // drop would quietly stop looking wrong at exactly 100%.
+    const projected = bandProjection(
+      { totalBytes: 1000, freeBytes: 100, shelfBytes: 0 },
+      400,
+    );
+    expect(projected.addedPct).toBe(10);
+    expect(projected.freePct).toBe(0);
+    expect(projected.fits).toBe(false);
+    // How far short the drive is, which is what the label states.
+    expect(projected.freeAfter).toBe(-300);
+  });
+
+  it("treats a drop that exactly fills the drive as fitting", () => {
+    const projected = bandProjection(
+      { totalBytes: 1000, freeBytes: 250, shelfBytes: 0 },
+      250,
+    );
+    expect(projected.fits).toBe(true);
+    expect(projected.freeAfter).toBe(0);
+    expect(projected.freePct).toBe(0);
+  });
+
+  it("says nothing changes when the drop adds no bytes", () => {
+    // Every copy already on this drive: the move is a rename and the server
+    // reports `bytes_to_copy` of zero for it.
+    const projected = bandProjection(
+      { totalBytes: 1000, freeBytes: 400, shelfBytes: 300 },
+      0,
+    );
+    expect(projected.addedPct).toBe(0);
+    expect(projected.freePct).toBe(40);
+    expect(projected.fits).toBe(true);
+  });
+
+  it("cannot say for a drive it could not measure, which is not a refusal", () => {
+    // Null rather than `fits: false`. "We do not know" must not be drawn as
+    // "does not fit" — the drop is left to the server to judge.
+    expect(bandProjection({ totalBytes: null, freeBytes: null }, 100)).toBe(
+      null,
+    );
+    expect(bandProjection(undefined, 100)).toBe(null);
   });
 });
 
@@ -940,6 +1010,29 @@ describe("movableCopies", () => {
     );
     expect(items).toHaveLength(2);
     expect(totalBytes).toBe(1000);
+  });
+
+  it("splits the weight by where the bytes are now, for the projection", () => {
+    // A copy moved between two folders on one drive is a rename and adds
+    // nothing to it, so the drive a drop is aimed at nets out the copies
+    // already sitting on it (#894). Kept off `items`, which goes to the server
+    // verbatim.
+    const { items, bytesByFolderId } = movableCopies(
+      [
+        locRow([{ folder_id: 1, relpath: "a.st", state: "present" }], 500),
+        locRow(
+          [
+            { folder_id: 1, relpath: "b.st", state: "present" },
+            { folder_id: 4, relpath: "b.st", state: "present" },
+          ],
+          200,
+        ),
+      ],
+      folders,
+    );
+    expect(bytesByFolderId.get(1)).toBe(700);
+    expect(bytesByFolderId.get(4)).toBe(200);
+    expect(items.every((item) => !("bytes" in item))).toBe(true);
   });
 
   it("leaves PixlStash's own engines where they are", () => {


### PR DESCRIPTION
Closes #894. Built on #893's three-segment meter, so this targets `develop`
where that landed — not `main`.

## What changed

The drive band's capacity meter was decorative; a move could only be dropped on
a folder group header, and whether the disk had room for it was something you
found out afterwards. Now the band **is** a drop target, and it draws the
consequence while the pointer is still down.

- **A fourth, hatched segment** projects what the drop would add, carved *out
  of* the free segment rather than laid over it. `bandProjection` returns a
  replacement for `bandUsage`'s object with `freePct` already reduced, so the
  four segments still sum to exactly 100% and the existing flex row and
  no-per-segment-clamp guarantee are untouched.
- **Hatched, not solid.** Three segments are things that were measured and this
  one is a thing that has not happened; a fourth flat colour would have read as
  "already on the disk". It reuses the 45° texture the sidebar's
  `.not-droppable` and the grid's ghosted tiles already use, at 2px/4px because
  the track is only 6px tall.
- **A drop that will not fit is refused while the pointer is down**, next to a
  projection saying by how much, rather than as a message after release. The
  band takes the error treatment and `preventDefault()` is simply not called, so
  the browser's own "no drop here" cursor lands on it.
- **The refusal belongs to the disk, not to one header.** `dropFits` is checked
  in the folder-header handler too, so a folder on a full drive stops
  highlighting as well — the band above it is where the reason is drawn.
- **The outcome is stated in words** under the band: "100.0 GB fits · 300.0 GB
  free after", "100.0 GB will not fit · 60.0 GB short", "Already on this drive ·
  nothing to copy". The hatch and the hue are readable neither aloud nor in
  greyscale; this is the half that is.

## Two things worth a reviewer's attention

**A same-drive move adds nothing.** Those are renames — the server reports
`bytes_to_copy` of zero for them — so a band nets out the copies already sitting
on it before projecting. Without that, a drive would refuse a move onto itself
that costs no space at all. `movableCopies` now returns `bytesByFolderId`
alongside `items`; it is deliberately kept **off** `items`, which is posted to
`/model-moves` verbatim. `bandKeyFor` is factored out of `bandGroups` so
"is this copy already on that drive?" is answered by the one rule that builds
the bands, not by a second copy of it.

**A band is a disk, but a move needs a folder.** A band drop resolves to the
first folder on that drive a move may go to. That is safe because a drop still
does not move on release — the dialog states the destination and its select
corrects it — and it is kinder than refusing a drive that happens to hold two
eligible folders, which would be a refusal the reject treatment does not mean.

An **unmeasurable** drive does not refuse: `bandProjection` returns `null` and
`dropFits` answers true, because "we cannot say" must not be drawn as "does not
fit". The band still highlights as a target — it just has no ghost and no
outcome to state — and the server checks before it copies.

## Tests

13 new: `bandProjection`'s arithmetic (the four segments summing to one track,
the bar clamping while the verdict does not, the exact-fill boundary, the
unmeasured null), `movableCopies`' per-folder byte split, and seven component
tests covering the projection, the in-flight refusal, a refused drop not opening
the dialog, the destination a band drop resolves to, the same-drive case, the
folder header refusing on a full drive, and the unmeasured drive still
accepting.

`npx vitest run` — 3016 passed, 167 files. `npm run build` clean, eslint clean
(the one `KIND_ICON` warning is pre-existing), prettier formatted.
`docs/frontend_architecture.md` §9.1a updated for the meter-as-drop-target rules
and the move section's "two ways in" corrected to three.