### PR TITLE
Scope the model shelf's move progress to the panel that is busy

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -657,7 +657,11 @@ Both people modes take the opt-in `allowCreate` prop (default false; set by `Ima
 5-star score widget. Props: `score`, `readonly`. Emits: `set-score`. Used in `ImageOverlay` and `ImageGrid` cells.
 
 #### `ProgressOverlay.vue`
-Task progress overlay, shared by export, plugin runs and smart-score sorts (all three mounted in `ImageGrid`). Props: `visible`, `status`, `message`, `percent`, `count`, `total`, `abortLabel`, `anchor`, `indeterminate`. Emits: `abort`. Terminal statuses: `completed`, `failed`, `cancelled`.
+Task progress overlay, shared by export, plugin runs and smart-score sorts (all three mounted in `ImageGrid`) and by the model shelf's move (§9.1a). Props: `visible`, `status`, `message`, `percent`, `count`, `total`, `abortLabel`, `anchor`, `indeterminate`. Emits: `abort`. Terminal statuses: `completed`, `failed`, `cancelled`.
+
+**The button is gated on the label alone**, terminal status included (#900), so a card *held up* to report a failure can carry its own dismissal rather than needing a second prop for a second word. A caller that wants no button at the end nulls the label, which is what the export already does; the plugin and smart-score callers pass none at all.
+
+**Positioning is the caller's, in practice.** `anchor` only picks `top: 10px` or `bottom: 88px` against the nearest positioned ancestor, and 88px is the grid's bottom bar, not a universal offset. A host whose corner is somewhere else wraps the component in its own absolutely positioned box and resets the card to `position: static` — the shelf's `.shelf-progress` is the worked example. Wrapping (rather than passing a class) is also forced by the multi-root note above.
 
 **Multi-root by design (#758).** The card is behind `v-if="visible"`, but the `role="status"` live region is a second root *outside* it: a live region inserted at the same moment as its first text is not reliably announced, so hosting it inside the `v-if` loses the run's opening line. Consequence for callers: attribute fallthrough does not apply — `class`/`style`/`id` are silently dropped (with a dev-only Vue warning) and `ref.$el` resolves to a text node, not the card. Pass anything positional through props, or wrap the component.
 
@@ -2070,6 +2074,33 @@ happens inside the handler and only for a payload the target takes (#757).
 that is about to be wrong; a veil that only *looks* disabled leaves every row
 clickable and in the tab order, which is worse than none. The toolbar stays
 live, because Show and Sort still answer correctly while files are in flight.
+
+**The panel dims, not the app (#900).** `.shelf-dim` is inside `.shelf-body`
+and `inert` is on the same wrapper, so the sidebar, the title bar and the
+shelf's own toolbar are all untouched — a move concerns one list, and a veil
+over the product would say otherwise. The bar is the third caller of
+`ProgressOverlay` and is pinned to **that panel's** corner: `.shelf` carries
+`position: relative` and `.shelf-progress` is the corner box, at
+`--z-floating` so it clears the veil. Explicitly not a centred modal, and
+explicitly not left to resolve against whichever ancestor happens to be
+positioned (before this it was the grid column's, by accident).
+
+**A failure keeps the card instead of handing its news to a notice.**
+`useModelMovesStore.failure` holds the receipt of any finished run with a
+`failed` item, and the card stays up as `status="failed"` with the bar filled
+to 100% — the abort takes the bar's whole width rather than freezing part-way
+like an interrupted run — with **Dismiss** as its one button. Only a run that
+landed cleanly still pushes a notice. The reason is durability, not aesthetics:
+a `warning` notice clears itself after six seconds, and "some of your models did
+not arrive" is the outcome that must not scroll past while the owner is looking
+elsewhere. Holding it in the *store* is what makes it survive leaving the shelf
+— it is put back in the same corner on every mount until dismissed, and a new
+move clears it so a stale red card can never sit on live progress. A refusal to
+*start* is unchanged: the POST plans the whole batch before the first byte, so a
+4xx is a notice and no job, not a failed one. **Dismiss returns focus to the
+shelf root**, the same landing `closeMove` uses: the button destroys the element
+the keyboard is standing on, and focus falling to `<body>` restarts the next Tab
+at the top of an 1,800-row document.
 
 #### The icon verb, on the shelf
 

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -85,6 +85,7 @@ vi.mock("../../api/pictureSets", async (importOriginal) => ({
 }));
 
 import ModelShelf from "./ModelShelf.vue";
+import { useModelMovesStore } from "../../stores/useModelMovesStore";
 import { useModelShelfStore } from "../../stores/useModelShelfStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
 
@@ -2269,5 +2270,48 @@ describe("what a scan just added", () => {
     await store.fetchRows();
     await wrapper.vm.$nextTick();
     expect(wrapper.find(".shelf-row-new").exists()).toBe(false);
+  });
+});
+
+describe("a long move, in the panel that is running it", () => {
+  it("dims and inerts the list without touching the toolbar", async () => {
+    // #900: the panel dims, not the app. The veil is INSIDE `.shelf-body`, so
+    // Show and Sort still answer while files are in flight, and `inert` is
+    // what actually stops the rows — a veil that only looks disabled leaves
+    // every one of them clickable and in the tab order.
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const moves = useModelMovesStore();
+    expect(wrapper.find(".shelf-dim").exists()).toBe(false);
+
+    moves.job = { status: "running", total: 4, done: 1, results: [] };
+    await wrapper.vm.$nextTick();
+    const body = wrapper.find(".shelf-body");
+    expect(body.find(".shelf-dim").exists()).toBe(true);
+    expect(body.attributes("inert")).toBeDefined();
+    expect(wrapper.find(".shelf-toolbar").attributes("inert")).toBeUndefined();
+  });
+
+  it("anchors the bar in the shelf and leaves the failure in its place", async () => {
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const moves = useModelMovesStore();
+    const card = () => wrapper.find(".shelf-progress progress-overlay-stub");
+    expect(card().attributes("visible")).toBe("false");
+
+    moves.job = { status: "running", total: 4, done: 1, results: [] };
+    await wrapper.vm.$nextTick();
+    expect(card().attributes("visible")).toBe("true");
+    expect(card().attributes("status")).toBe("running");
+    expect(card().attributes("abortlabel")).toBe("Stop");
+
+    // The run ends badly: the card stays where the progress was rather than
+    // handing the news to a notice that clears itself, and the bar fills.
+    moves.job = { status: "finished", total: 4, done: 4, results: [] };
+    moves.failure = "Moved 3 files. 1 file could not be moved and stayed put.";
+    await wrapper.vm.$nextTick();
+    expect(card().attributes("visible")).toBe("true");
+    expect(card().attributes("status")).toBe("failed");
+    expect(card().attributes("percent")).toBe("100");
+    expect(card().attributes("message")).toContain("could not be moved");
+    expect(card().attributes("abortlabel")).toBe("Dismiss");
   });
 });

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -861,16 +861,23 @@
       @close="closeAddFile"
     />
 
-    <ProgressOverlay
-      :visible="moves.running"
-      :status="moves.running ? 'running' : 'idle'"
-      :message="moveProgressMessage"
-      :percent="moves.percent"
-      :count="moves.done"
-      :total="moves.total"
-      :abort-label="moves.cancelRequested ? null : 'Stop'"
-      @abort="moves.cancel()"
-    />
+    <!-- Corner-anchored inside the panel that is busy, never a centred modal:
+         a move concerns THIS list, and a card in the middle of the window
+         claims the whole product for it. This wrapper is the corner and
+         `.shelf` is what it is measured from, because `ProgressOverlay` is
+         multi-root and silently drops a class handed to it. -->
+    <div class="shelf-progress">
+      <ProgressOverlay
+        :visible="moves.running || Boolean(moves.failure)"
+        :status="moveProgressStatus"
+        :message="moves.failure || moveProgressMessage"
+        :percent="moves.failure ? 100 : moves.percent"
+        :count="moves.failure ? null : moves.done"
+        :total="moves.failure ? null : moves.total"
+        :abort-label="moveProgressAction"
+        @abort="moves.failure ? dismissMoveFailure() : moves.cancel()"
+      />
+    </div>
   </div>
 </template>
 
@@ -997,6 +1004,39 @@ const moveProgressMessage = computed(() =>
     ? "Stopping after the file in flight…"
     : "Moving model files…",
 );
+
+/**
+ * What the corner card is saying: progress, or the failure it ended in.
+ *
+ * A failed run keeps the card rather than handing its news to a notice that
+ * clears itself, so the error is read in the place the progress was (#900).
+ * The bar fills to 100% under it, which is what makes the failure take the
+ * bar's whole width instead of freezing part-way like an interrupted run.
+ */
+const moveProgressStatus = computed(() => {
+  if (moves.failure) return "failed";
+  return moves.running ? "running" : "idle";
+});
+
+/** The card's one button: stop a run, or put a read failure away. */
+const moveProgressAction = computed(() => {
+  if (moves.failure) return "Dismiss";
+  return moves.cancelRequested ? null : "Stop";
+});
+
+/**
+ * Put the failure away and catch the focus it was holding.
+ *
+ * Dismiss destroys the element the keyboard is standing on, and focus would
+ * fall to `<body>` — the next Tab restarts at the top of the document, which is
+ * how a user who just cleared a card loses their place in a 1,800-row list. The
+ * shelf root is the same landing the move dialog returns to.
+ */
+async function dismissMoveFailure() {
+  moves.dismissFailure();
+  await nextTick();
+  rootEl.value?.focus();
+}
 
 /**
  * Open the move dialog for a set of rows.
@@ -2177,6 +2217,11 @@ watch(
   flex-direction: column;
   height: 100%;
   min-height: 0;
+  /* The positioning context for `.shelf-progress`. Without it the corner card
+     resolves against whatever ancestor happens to be positioned — today the
+     grid column, tomorrow anything — and a bar that is meant to say "this
+     panel is busy" would be pinned to something else's corner. */
+  position: relative;
   background: rgb(var(--v-theme-background));
   color: rgb(var(--v-theme-on-background));
   outline: none;
@@ -2625,6 +2670,23 @@ watch(
 .shelf-group-btn--drop {
   background: rgba(var(--v-theme-primary), 0.12);
   box-shadow: inset 0 0 0 2px rgba(var(--v-theme-primary), 0.65);
+}
+
+/* The bar's corner. `.shelf` rather than `.shelf-body` is what it hangs from:
+   the body is the scroller, and a card inside it would scroll away from the
+   work it is reporting. --z-floating is "chrome anchored to the content area",
+   which is what this is, and it clears the veil below. */
+.shelf-progress {
+  position: absolute;
+  right: var(--space-4);
+  bottom: var(--space-4);
+  z-index: var(--z-floating);
+}
+
+/* The wrapper owns the corner, so the card lays out in flow inside it rather
+   than re-anchoring to the same ancestor with its own grid-shaped offsets. */
+.shelf-progress :deep(.progress-overlay) {
+  position: static;
 }
 
 /* Paired with `inert` on `.shelf-body`, which is what actually stops the

--- a/frontend/src/components/widgets/ProgressOverlay.test.js
+++ b/frontend/src/components/widgets/ProgressOverlay.test.js
@@ -140,9 +140,40 @@ describe("ProgressOverlay accessibility", () => {
     ).toBe(true);
   });
 
+  it("does not double-punctuate a message that is already a sentence", () => {
+    // The shelf hands over a whole receipt as the title (#900), and the running
+    // message ends in an ellipsis. Both would announce as "\u2026.: failed."
+    const w = mountOverlay({
+      status: "failed",
+      message: "Moved 3 files. 1 file could not be moved and stayed put.",
+    });
+    expect(live(w)).toBe(
+      "Moved 3 files. 1 file could not be moved and stayed put: failed.",
+    );
+  });
+
   it("shows no failure marker while running", () => {
     expect(
       mountOverlay({ percent: 5 }).find(".progress-overlay__failed").exists(),
     ).toBe(false);
+  });
+});
+
+describe("the card's one button", () => {
+  it("is gated on the label alone, so a held failure can be dismissed", () => {
+    // #900: the shelf keeps a failed move's card up in the panel that ran it
+    // and labels the button `Dismiss`. Gating on `!isTerminal` as well would
+    // strand that card with no way out.
+    const w = mountOverlay({ status: "failed", abortLabel: "Dismiss" });
+    const button = w.find(".progress-overlay__abort");
+    expect(button.text()).toBe("Dismiss");
+    button.trigger("click");
+    expect(w.emitted("abort")).toHaveLength(1);
+  });
+
+  it("is absent when the caller drops the label at the end", () => {
+    // What the export does: it nulls the label on every terminal status.
+    const w = mountOverlay({ status: "completed", abortLabel: null });
+    expect(w.find(".progress-overlay__abort").exists()).toBe(false);
   });
 });

--- a/frontend/src/components/widgets/ProgressOverlay.vue
+++ b/frontend/src/components/widgets/ProgressOverlay.vue
@@ -31,7 +31,7 @@
       {{ count }} / {{ total }}
     </div>
     <button
-      v-if="abortLabel && !isTerminal"
+      v-if="abortLabel"
       class="progress-overlay__abort"
       type="button"
       @click="emit('abort')"
@@ -71,7 +71,11 @@
  *   percent    - Progress percentage (0-100).
  *   count      - Processed/current item count (optional).
  *   total      - Total item count (optional).
- *   abortLabel - Label for the abort button. No button rendered if falsy.
+ *   abortLabel - Label for the card's one button. No button rendered if falsy.
+ *                The label alone gates it, terminal status included, so a card
+ *                held up to report a failure can carry its own dismissal. A
+ *                caller that wants no button at the end nulls the label, which
+ *                the export already does.
  *   anchor     - 'top' | 'bottom'. Controls vertical position.
  *   indeterminate - When true, show animated indeterminate progress.
  *
@@ -128,7 +132,11 @@ const clampedPercent = computed(() => {
  * presence, so nothing is re-read until the next run moves it.
  */
 const announcement = computed(() => {
-  const label = props.message || "Progress";
+  // Every branch below appends its own sentence, so a message that already ends
+  // one produces "…stayed put.: failed." The shelf's held failure card carries
+  // a whole receipt as its title, and "Moving model files…" has an ellipsis for
+  // the same reason; both read as one sentence once the tail comes off.
+  const label = (props.message || "").replace(/[.…\s]+$/u, "") || "Progress";
   if (props.status === "failed") return `${label}: failed.`;
   if (props.status === "cancelled") return `${label}: cancelled.`;
   if (props.status === "completed") return `${label}: complete.`;
@@ -249,5 +257,18 @@ const announcement = computed(() => {
 
 .progress-overlay__abort:hover {
   background: rgba(var(--v-theme-error), 0.85);
+}
+
+/* On the failed card the button's own error fill sits on an error background
+   and all but disappears — which would hide the only way out of a card that is
+   held until it is dismissed. A wash of the card's own ink delineates it, and
+   the ink itself is the pair the theme already contrast-checks. */
+.progress-overlay--error .progress-overlay__abort {
+  background: rgba(var(--v-theme-on-error), 0.16);
+  color: rgb(var(--v-theme-on-error));
+}
+
+.progress-overlay--error .progress-overlay__abort:hover {
+  background: rgba(var(--v-theme-on-error), 0.28);
 }
 </style>

--- a/frontend/src/stores/useModelMovesStore.js
+++ b/frontend/src/stores/useModelMovesStore.js
@@ -97,6 +97,17 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
   const job = ref(null);
   const starting = ref(false);
   const error = ref("");
+  /**
+   * The receipt of a finished run that lost files, held until it is dismissed.
+   *
+   * Held HERE rather than pushed as a notice (#900). A `warning` card clears
+   * itself after six seconds, and what it is saying is that some of the
+   * owner's models did not arrive — which is the one outcome that must not
+   * scroll past while they are looking elsewhere. Living in the store, it goes
+   * back into the shelf's corner, where the progress was, every time the shelf
+   * is mounted.
+   */
+  const failure = ref("");
   let pollHandle = null;
   let epoch = 0;
   // Set the moment a job is started or observed running, cleared when its
@@ -166,11 +177,11 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
     if (!watching) return;
     watching = false;
     const results = snapshot?.results || [];
-    const failed = results.some((r) => r.status === "failed");
-    useNoticeStore().push({
-      level: failed ? "warning" : "success",
-      text: moveReceipt(results, Boolean(snapshot?.cancel_requested)),
-    });
+    const receipt = moveReceipt(results, Boolean(snapshot?.cancel_requested));
+    // Two surfaces for two kinds of news: a run that landed says so in passing,
+    // a run that lost files holds the panel until it is read.
+    if (results.some((r) => r.status === "failed")) failure.value = receipt;
+    else useNoticeStore().push({ level: "success", text: receipt });
     await Promise.all([
       useModelShelfStore().fetchRows(),
       useModelFoldersStore().refresh({ quiet: true }),
@@ -194,6 +205,9 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
     const notices = useNoticeStore();
     starting.value = true;
     error.value = "";
+    // The new run owns the corner from here; the last one's failure has had its
+    // chance to be read and must not sit on top of live progress.
+    failure.value = "";
     try {
       job.value = await startModelMove(destinationFolderId, items);
       watching = true;
@@ -229,6 +243,11 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
     }
   }
 
+  /** Put the held failure away. The only way out of it, by design. */
+  function dismissFailure() {
+    failure.value = "";
+  }
+
   /**
    * Pick up a move already running, e.g. one started before a reload.
    *
@@ -256,6 +275,7 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
     job.value = null;
     starting.value = false;
     error.value = "";
+    failure.value = "";
   }
 
   const unsubscribeSessionReset = onSessionReset(resetForSession);
@@ -271,12 +291,14 @@ export const useModelMovesStore = defineStore("modelMoves", () => {
     busy,
     starting,
     error,
+    failure,
     total,
     done,
     percent,
     cancelRequested,
     start,
     cancel,
+    dismissFailure,
     adopt,
     poll,
     resetForSession,

--- a/frontend/src/stores/useModelMovesStore.test.js
+++ b/frontend/src/stores/useModelMovesStore.test.js
@@ -128,6 +128,38 @@ describe("watching one to its end", () => {
     expect(store.running).toBe(true);
   });
 
+  it("holds a run that lost files instead of letting a notice expire", async () => {
+    // #900: the failure is the one outcome that must not clear itself after
+    // six seconds. It is held so the shelf can put it back in the corner the
+    // progress came from, and only a dismissal takes it away.
+    const store = useModelMovesStore();
+    await store.start(2, ITEMS);
+    getModelMoveStatus.mockResolvedValue(
+      snapshot({
+        status: "finished",
+        done: 2,
+        results: [{ status: "moved" }, { status: "failed" }],
+      }),
+    );
+
+    await store.poll();
+    expect(store.failure).toBe(
+      "Moved 1 file. 1 file could not be moved and stayed put.",
+    );
+    expect(useNoticeStore().notices).toHaveLength(0);
+
+    store.dismissFailure();
+    expect(store.failure).toBe("");
+  });
+
+  it("clears a held failure when the next move starts", async () => {
+    // A stale red card on top of live progress would report the wrong run.
+    const store = useModelMovesStore();
+    store.failure = "Moved 1 file. 1 file could not be moved and stayed put.";
+    await store.start(2, ITEMS);
+    expect(store.failure).toBe("");
+  });
+
   it("does not turn a failed poll into a failed move", async () => {
     // The move is still running on the server. Reporting an outcome we never
     // read would be inventing one.


### PR DESCRIPTION
Closes #900.

Two of the three things the issue asks for were already shipped with F4: the
veil is `.shelf-dim` *inside* `.shelf-body` with `inert` on the same wrapper, so
the sidebar, the title bar and the shelf's own toolbar stay live, and the bar is
`ProgressOverlay` rather than a new build. What was missing is the other two.

**The bar is now anchored to the panel.** `.shelf` had no `position`, so the
card resolved against whichever ancestor happened to be positioned — today the
grid column, and `bottom: 88px` is the *grid's* bottom-bar clearance, not a
universal offset. `.shelf` takes `position: relative` and a `.shelf-progress`
box owns the corner at `--z-floating` (which clears the veil); the card lays out
in flow inside it. A wrapper rather than a class because `ProgressOverlay` is
multi-root and drops one.

**A failure keeps the card instead of a notice that expires.**
`useModelMovesStore.failure` holds the receipt of any finished run with a
`failed` item; the card stays as `status="failed"` with the bar filled to 100%,
so the abort takes the bar's whole width rather than freezing part-way like an
interrupted run, and **Dismiss** is its one button. Only a clean run still
pushes a notice.

The reason is durability, not looks: a `warning` notice clears itself after six
seconds, and "some of your models did not arrive" is the outcome that must not
scroll past while the owner is looking elsewhere. Holding it in the *store* is
what makes it survive leaving the shelf — it goes back into the same corner on
every mount until dismissed, and a new move clears it so a stale red card can
never sit on live progress. A refusal to *start* is unchanged: the POST plans
the whole batch before the first byte, so a 4xx stays a notice and no job.

### Also changed, and why

- `ProgressOverlay`'s button is gated on `abortLabel` alone, terminal status
  included — otherwise a card held up to report a failure has no way out. No
  effect on the existing callers: the export already nulls the label on every
  terminal status, and the plugin and smart-score cards pass none.
- On the error card that button used to be `error` on `error` and all but
  vanished; it takes a wash of the card's own ink.
- The live region stripped a trailing `.`/`…` off the message before appending
  its own sentence, or the held receipt announces as "…stayed put.: failed."
- Dismiss returns focus to the shelf root, the landing `closeMove` already uses.
  It destroys the element the keyboard is standing on, and focus falling to
  `<body>` restarts the next Tab at the top of the document.

### Tests

Store: a run that lost files is held rather than notified, dismissal clears it,
and a new move clears it. Shelf: the veil and `inert` land on the body and not
the toolbar; the card is inside `.shelf-progress`, and the failure keeps it with
a filled bar and Dismiss. Widget: the button survives a terminal status, is gone
when the label is dropped, and the announcement is not double-punctuated.

Frontend suite green (3025), build clean. `docs/frontend_architecture.md` §9.1a
and the `ProgressOverlay` entry updated.
