### PR TITLE
Stop the shelf calling an undownloaded engine a missing file

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1280,8 +1280,8 @@ files as module constants, but those modules import onnxruntime, torch, cv2 and
 PIL at module level and start-up must not pay that to learn two strings. The
 duplicate is pinned by `tests/test_builtin_models.py`, which imports the real
 constants where the cost is free. Drift is self-announcing rather than silent: a
-renamed file makes its declared row go `missing` *and* the real file appear in
-the unclaimed readout, which is a visible pair.
+renamed file makes its declared row go `not_downloaded` *and* the real file
+appear in the unclaimed readout, which is a visible pair.
 
 **Protected, because they are ours.** `DELETE` on the folder answers 409 (the
 caller is authorized; what refuses is what the target is), and every verb refuses
@@ -1293,9 +1293,20 @@ speaks — and the check runs *inside* the delete transaction, alongside the sta
 gate, rather than as a route-level read that would break the one-critical-section
 invariant.
 
-**Declared-but-absent is normal.** `sac+logos+ava1-l14-linearMSE.pth` is fetched
-only for the CLIP model that needs it, so about half of these are `missing` on
-any given machine. That is a state, not a warning.
+**Declared-but-absent is normal, and it has its own word.**
+`sac+logos+ava1-l14-linearMSE.pth` is fetched only for the CLIP model that needs
+it, so about half of these are absent on any given machine. That is a state, not
+a warning — which is why `declare_folder` writes **`not_downloaded`** and never
+`missing`. `missing` is the *scanner's* word for a registered file that was in a
+readable folder and is not in it any more, and the shelf draws it as a fault
+(error rail, error glyph, "The file is not where it was"): a false alarm on a
+healthy machine, which is what #926 reported. Everything declared here is
+re-fetched the moment something needs it, so the softer word is also right for a
+file that WAS here and is gone. The **sweep** at the end of `declare_folder` is
+the one exception and still writes `missing`: a row the declaration no longer
+*names* — `antelopev2` deleted out of the InsightFace store, a repo dropped by
+`huggingface-cli delete-cache` — is gone rather than pending, because nothing
+will fetch it back.
 
 **The unclaimed readout.** `unclaimed_files()` reports what is present and *not*
 declared — on a measured machine, `best.pt` at 339 MB, which nothing in the tree

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1746,6 +1746,13 @@ fault teaches the reader to ignore the fault as well.
   is not plugged in. The row takes a **dashed rail and muted ink**, and
   **deliberately never the error colour**. Nothing is lost and nothing needs
   fixing; the models come back when the drive does.
+- **Not downloaded** (`not_downloaded`) is not either, and is the third thing
+  #926 found the shelf calling a fault. It is one of PixlStash's own declared
+  engines that nothing has needed yet — the normal state of about half of them —
+  so it takes **no rail at all**, muted ink and a download glyph rather than a
+  broken-file one. Only an ALL-`not_downloaded` row reports it: one genuinely
+  `missing` copy still states the fault, and a state this build does not know
+  falls through to `missing` rather than being quietly reported as fine.
 
 **They are told apart in greyscale**, which is what makes this a treatment
 rather than a hue: solid rail, dashed rail, no rail, plus two different glyphs.

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -1600,9 +1600,14 @@ const KIND_ICON = {
 // `unreachable` is the absence of one (we could not look). Only the fact wears
 // a status colour — claiming a hue for "we do not know" would assert knowledge
 // we do not have. `present` reserves its slot and shows nothing.
+//
+// `not_downloaded` is a fourth thing and wears no status colour either: it is
+// one of PixlStash's own engines that nothing has needed yet, which is the
+// normal state of about half of them. A download glyph, not a broken-file one.
 const LOC_ICON = {
   present: "mdi-check",
   missing: "mdi-file-remove-outline",
+  not_downloaded: "mdi-cloud-download-outline",
   unreachable: "mdi-help-circle-outline",
   forgotten: "mdi-folder-off-outline",
 };
@@ -1610,6 +1615,8 @@ const LOC_ICON = {
 const LOC_TITLE = {
   present: "",
   missing: "The file is not where it was",
+  not_downloaded:
+    "Not downloaded — PixlStash fetches this when something needs it",
   // Not "the drive is unplugged", however common that is: a subdirectory the
   // scan could not list lands here too, and naming a cause we did not observe
   // is the same overclaim the muted glyph exists to avoid.
@@ -3154,7 +3161,10 @@ watch(
   color: rgb(var(--v-theme-error));
 }
 
-.shelf-row-loc--unreachable {
+/* Muted, never the error colour, and 0.7 like every other muted figure on this
+   screen — nothing is wrong with a row that simply has not been fetched. */
+.shelf-row-loc--unreachable,
+.shelf-row-loc--not_downloaded {
   color: rgba(var(--v-theme-on-background), 0.7);
 }
 </style>

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -696,14 +696,22 @@ export function bandProjection(band, addedBytes) {
  * `unreachable` is the absence of one (we could not look). They must not read
  * the same, and one present copy makes both moot — the file is usable.
  *
+ * `not_downloaded` is neither: it is a file PixlStash declares and fetches on
+ * demand, which nothing has needed yet. Only an ALL-`not_downloaded` row reports
+ * it, so a model with one genuinely missing copy still states the fault, and any
+ * state this build does not know still falls through to `missing` rather than
+ * being quietly reported as fine.
+ *
  * @param {Array<Object>} locations - the row's `locations` array.
- * @returns {"present"|"missing"|"unreachable"|"forgotten"}
+ * @returns {"present"|"missing"|"not_downloaded"|"unreachable"|"forgotten"}
  */
 export function locationState(locations) {
   const list = Array.isArray(locations) ? locations : [];
   if (!list.length) return "forgotten";
   if (list.some((loc) => loc?.state === "present")) return "present";
   if (list.some((loc) => loc?.state === "unreachable")) return "unreachable";
+  if (list.every((loc) => loc?.state === "not_downloaded"))
+    return "not_downloaded";
   return "missing";
 }
 

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -136,6 +136,19 @@ describe("locationState", () => {
     expect(locationState([])).toBe("forgotten");
     expect(locationState(undefined)).toBe("forgotten");
   });
+
+  it("does not call an engine nobody has needed yet a fault", () => {
+    // #926: a declared engine that was never fetched used to reach the shelf as
+    // `missing` — error rail, "The file is not where it was" — on a machine
+    // with nothing wrong with it.
+    expect(locationState([{ state: "not_downloaded" }])).toBe("not_downloaded");
+    // One genuinely missing copy still states the fault...
+    expect(
+      locationState([{ state: "not_downloaded" }, { state: "missing" }]),
+    ).toBe("missing");
+    // ...and so does a state this build has never heard of.
+    expect(locationState([{ state: "banana" }])).toBe("missing");
+  });
 });
 
 describe("offlineFolders", () => {

--- a/pixlstash/hub/schema.py
+++ b/pixlstash/hub/schema.py
@@ -365,7 +365,11 @@ CREATE TABLE IF NOT EXISTS model_file (
     model_id         INTEGER NOT NULL REFERENCES model(id),
     model_folder_id  INTEGER NOT NULL REFERENCES model_folder(id),
     relpath          TEXT NOT NULL,
-    state            TEXT NOT NULL,   -- 'present' | 'missing' | 'unreachable'
+    -- 'present' | 'missing' | 'unreachable' | 'not_downloaded'. The first three
+    -- are the scanner's (see model_folder_scanner); the fourth belongs to the
+    -- roots PixlStash declares rather than scans, where an absent file is one we
+    -- have not fetched yet and never one that wandered off.
+    state            TEXT NOT NULL,
     seen_at          TEXT,
     -- st_mtime_ns of this copy at the last scan. Paired with model.file_size it
     -- is what lets a sweep skip re-hashing 1,800 unchanged adapters, without

--- a/pixlstash/routes/model_shelf.py
+++ b/pixlstash/routes/model_shelf.py
@@ -125,10 +125,13 @@ class ModelLocation(BaseModel):
     relpath: str = Field(description="Path of this copy relative to the folder.")
     state: str = Field(
         description=(
-            "``present``, ``missing`` or ``unreachable``. ``missing`` is a fact "
-            "(the folder was readable and the file was not in it); "
-            "``unreachable`` is the absence of one (we could not look), and only "
-            "``missing`` is something a forget/cleanup action may act on."
+            "``present``, ``missing``, ``unreachable`` or ``not_downloaded``. "
+            "``missing`` is a fact (the folder was readable and the file was "
+            "not in it); ``unreachable`` is the absence of one (we could not "
+            "look), and only ``missing`` is something a forget/cleanup action "
+            "may act on. ``not_downloaded`` belongs to the folders PixlStash "
+            "declares rather than scans: one of its own engines that nothing "
+            "has needed yet, which is normal and not a fault."
         )
     )
     file_mtime: Optional[int] = Field(

--- a/pixlstash/services/builtin_models.py
+++ b/pixlstash/services/builtin_models.py
@@ -21,7 +21,7 @@ pay that to learn two strings. They are duplicated here and pinned by
 two agree. The same trade the 48-hex ``SET_COLORS`` list already makes.
 
 Drift here is also self-announcing rather than silent: a renamed file makes its
-declared row go ``missing`` and the real file appear under
+declared row go :data:`STATE_NOT_DOWNLOADED` and the real file appear under
 :func:`unclaimed_files`, which is a visible pair, not a quiet wrong answer.
 
 **These rows are protected.** The folder answers 409 to ``DELETE`` and every
@@ -65,6 +65,23 @@ MOVABLE_FIXED = "fixed"
 
 # Everything in this folder arrived because PixlStash fetched it.
 BUILTIN_PROVENANCE = "builtin"
+
+# What a declared file that is not on disk gets, and deliberately NOT `missing`.
+#
+# `missing` is the SCANNER's word for a registered file that was in a readable
+# folder and is not in it any more, and the shelf draws it as a fault: error
+# rail, error glyph, "The file is not where it was". Nothing declared here is
+# ever that. Every file this module and `builtin_caches` declare is one
+# PixlStash fetches on demand — the ViT-L/14 scorer arrives only with the CLIP
+# model that needs it, an InsightFace pack only when face detection first runs —
+# so absence means "not fetched yet", on a perfectly healthy machine, for about
+# half of these. Saying a file wandered off when nobody ever asked for it is a
+# false alarm, and a false alarm teaches the reader to ignore the real one
+# (#926).
+#
+# It is also the right word for a file that WAS here and is gone: we re-fetch it
+# the moment something needs it, so the owner has nothing to do either way.
+STATE_NOT_DOWNLOADED = "not_downloaded"
 
 # `hf_hub_download(local_dir=...)` leaves its own bookkeeping beside the files it
 # writes, at the top level and again inside every subdirectory it fills. It is
@@ -120,8 +137,9 @@ class DeclaredEntry:
         role: Stored in ``model.kind``; see :class:`BuiltinEngine.role`.
         size: Bytes, or None when it could not be read. None never overwrites a
             size already recorded.
-        present: Whether it is on disk now. False writes ``missing``, which is a
-            normal state here and not a warning.
+        present: Whether it is on disk now. False writes
+            :data:`STATE_NOT_DOWNLOADED`, which is a normal state here and not a
+            warning.
         capabilities: Every feature these weights serve, primary first, written
             to ``model_capability``. Empty means "just the role", which is what
             all but one caller means: a model that does one thing does not have
@@ -460,11 +478,12 @@ def declare_folder(
 
         for entry in entries:
             size = entry.size
-            state = "present" if entry.present else "missing"
+            state = "present" if entry.present else STATE_NOT_DOWNLOADED
             # An engine that has not been downloaded yet is NOT an error and not
             # a warning: the ViT-L/14 scorer is fetched only for the CLIP model
             # that needs it, so "declared and absent" is the normal state for
-            # about half of these on any given machine.
+            # about half of these on any given machine. See
+            # :data:`STATE_NOT_DOWNLOADED` for why that is not `missing`.
             #
             # Identity is the LOCATION — `model_file`'s own primary key — not a
             # hash we would have to read 339 MB to compute, and not `run_key`,
@@ -556,6 +575,13 @@ def declare_folder(
         # left behind would otherwise claim its bytes are still on the disk
         # forever — inflating the very `present_bytes` figure the folder list
         # reports.
+        #
+        # `missing` here and not :data:`STATE_NOT_DOWNLOADED`, which is the one
+        # place in this module the distinction bites: a row the declaration no
+        # longer NAMES is one nothing will fetch back — `antelopev2` deleted out
+        # of the InsightFace store is not in `KNOWN_MODEL_PACKS`, so it is gone
+        # rather than pending. A declared entry that is merely absent goes
+        # through the loop above and gets the softer word.
         #
         # `seen_at <` the run's own stamp rather than `!=`, the same predicate
         # the scanner uses, so a concurrent declaration that stamped a later

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -104,9 +104,10 @@ def test_declaring_writes_a_row_per_engine_and_states_which_are_present(
     server_hub, tmp_path
 ):
     """No parsing and no hashing: an engine that is on disk is `present`, one
-    that has not been fetched yet is `missing` — which is the normal state for
-    about half of them, since the ViT-L/14 scorer arrives only with the CLIP
-    model that needs it."""
+    that has not been fetched yet is `not_downloaded` — which is the normal state
+    for about half of them, since the ViT-L/14 scorer arrives only with the CLIP
+    model that needs it, and NEVER `missing`, which the shelf draws as a fault
+    (#926)."""
     (tmp_path / "pixlstash-anomaly-tagger.safetensors").write_bytes(b"x" * 32)
 
     folder_id = declare_builtin_models(server_hub, str(tmp_path))
@@ -135,7 +136,7 @@ def test_declaring_writes_a_row_per_engine_and_states_which_are_present(
         "present",
     )
     assert tagger["file_size"] == 32
-    assert rows["Aesthetic scorer (ViT-L/14)"]["state"] == "missing"
+    assert rows["Aesthetic scorer (ViT-L/14)"]["state"] == "not_downloaded"
 
 
 def test_declaring_twice_does_not_duplicate_a_row(server_hub, tmp_path):
@@ -177,8 +178,13 @@ def test_claiming_a_path_the_owner_registered_resets_every_column(server_hub, tm
     assert row["movable"] == "root_only"
 
 
-def test_a_file_that_disappears_flips_its_row_to_missing(server_hub, tmp_path):
-    """Declared, not scanned — but the state still has to tell the truth."""
+def test_a_file_that_disappears_stops_claiming_to_be_present(server_hub, tmp_path):
+    """Declared, not scanned — but the state still has to tell the truth.
+
+    `not_downloaded` rather than `missing` even here: we re-fetch a declared
+    engine the moment something needs it, so a deleted one is pending, not lost,
+    and the owner has nothing to do about it either way.
+    """
     weights = tmp_path / "sa_0_4_vit_b_32_linear.pth"
     weights.write_bytes(b"z" * 8)
     folder_id = declare_builtin_models(server_hub, str(tmp_path))
@@ -190,7 +196,7 @@ def test_a_file_that_disappears_flips_its_row_to_missing(server_hub, tmp_path):
         "AND mf.relpath = ?",
         (folder_id, "sa_0_4_vit_b_32_linear.pth"),
     )
-    assert state["state"] == "missing"
+    assert state["state"] == "not_downloaded"
 
 
 def test_the_checkpoint_hash_worker_never_picks_up_an_engine(server_hub, tmp_path):
@@ -249,9 +255,10 @@ def test_insightface_declares_what_is_on_disk_and_what_we_know_about(
     assert rows["InsightFace antelopev2"]["state"] == "present"
     assert rows["InsightFace antelopev2"]["file_size"] == 64
     assert rows["InsightFace antelopev2"]["kind"] == "face"
-    # Known but not downloaded: `missing` is a state, not a warning.
+    # Known but not downloaded: a state, not a warning — and it has to be said
+    # with a word the shelf does not draw as a fault (#926).
     for pack in KNOWN_MODEL_PACKS:
-        assert rows[f"InsightFace {pack}"]["state"] == "missing"
+        assert rows[f"InsightFace {pack}"]["state"] == "not_downloaded"
 
 
 def test_the_zip_insightface_downloaded_a_pack_from_is_not_a_pack(server_hub, tmp_path):
@@ -414,7 +421,7 @@ def test_a_repo_deleted_from_the_cache_stops_claiming_its_bytes(
 def test_the_sweep_does_not_touch_a_declared_engine_that_is_simply_absent(
     server_hub, tmp_path
 ):
-    """`missing` for a declared engine is decided by the existence check, not by
+    """A declared engine's state is decided by the existence check, not by
     the sweep: the built-in entry set is fixed and always names every row, so a
     re-declaration must leave a present engine present."""
     (tmp_path / "sa_0_4_vit_b_32_linear.pth").write_bytes(b"z" * 8)

--- a/tests/test_insightface_relocation.py
+++ b/tests/test_insightface_relocation.py
@@ -370,10 +370,12 @@ def test_relocating_the_packs_moves_them_and_repoints_every_caller(face_env):
         (relocated_id,),
     )
     assert {row["relpath"]: row["state"] for row in rows} == {
-        # Declared and absent is a normal state for a pack nobody has fetched.
-        # It carries across rather than being dropped with the old row: it is a
-        # tombstone, and the packs moving is not news about whether it came back.
-        "auraface": "missing",
+        # Declared and absent is a normal state for a pack nobody has fetched,
+        # which is why it is `not_downloaded` and not `missing` — the shelf draws
+        # `missing` as a fault (#926). It carries across rather than being
+        # dropped with the old row: it is a tombstone, and the packs moving is
+        # not news about whether it came back.
+        "auraface": "not_downloaded",
         "buffalo_l": "present",
     }
     assert (


### PR DESCRIPTION
Closes #926.

## What was wrong

The shelf drew PixlStash's own optional engines as broken files. `services/builtin_models.py` declares what we download — the two aesthetic scorers, the taggers, the InsightFace packs, the HuggingFace cache — and wrote `state = 'missing'` for any of them that was not on disk. `missing` is the **scanner's** word: a registered file that was in a readable folder and is not in it any more. The shelf renders it as a fault — error rail, error-coloured glyph, "The file is not where it was".

But the ViT-L/14 scorer is fetched only for the CLIP model that needs it, and an InsightFace pack only when face detection first runs, so "declared and absent" is the normal state of about half of these on a machine with nothing wrong with it. The code already knew this — the comment beside the write said so — but said it with a word that means the opposite.

## The change

`declare_folder` writes a fourth state, `not_downloaded`, for a declared entry that is absent. It is also the right word for one that *was* here and is gone: everything declared here is re-fetched the moment something needs it, so the owner has nothing to do either way.

The sweep at the end of `declare_folder` still writes `missing`, and that is the one place the distinction bites: a row the declaration no longer *names* — `antelopev2` deleted out of the InsightFace store, a repo dropped by `huggingface-cli delete-cache` — is gone rather than pending, because nothing will fetch it back.

On the shelf, `not_downloaded` takes no rail, muted ink (0.7, the alpha every other muted figure here carries) and a download glyph rather than a broken-file one. `locationState()` only reports it when **every** copy is `not_downloaded`, so a model with one genuinely missing copy still states the fault, and a state this build has never heard of still falls through to `missing` rather than being quietly reported as fine.

No migration: `model_file.state` is plain TEXT with no CHECK, and the declaration re-runs at every start-up, so existing rows flip on the next boot.

## Files

- `pixlstash/services/builtin_models.py` — `STATE_NOT_DOWNLOADED`, written in place of `missing`; the sweep left alone, with why.
- `pixlstash/routes/model_shelf.py`, `pixlstash/hub/schema.py` — the state vocabulary restated where it is documented.
- `frontend/src/utils/modelShelf.js` — `locationState()` reports the new state.
- `frontend/src/components/views/ModelShelf.vue` — glyph, tooltip, muted treatment; deliberately **not** added to `BROKEN_STATES`.
- `docs/backend_architecture.md`, `docs/frontend_architecture.md` — both sections that named `missing` for this case.

## Tests

`tests/test_builtin_models.py` asserts the new state for an unfetched engine, for an unfetched InsightFace pack and for a file that disappears; `modelShelf.test.js` covers the reporting rule including the unknown-state fallback. Backend shelf suites (`test_builtin_models`, `test_model_shelf_api`, `test_model_folder_scanner`, `test_model_shelf_scan_invariants`, `test_insightface_model_pack`, `test_managed_model_store`, `test_model_move`, `test_architecture_guardrails`) and the full frontend suite (3039 tests) pass; ruff and `render_backend_architecture.py --check` are clean.

Based on `develop` and opened against it: the model shelf does not exist on `main`.
