### PR TITLE
Show unclaimed model files in the download folder on the shelf

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1308,6 +1308,37 @@ doctrine — detection proposes, it never applies, so nothing here deletes.
 at the top level and inside every subdirectory it fills; that is the tool's, and
 reporting it would train the reader to ignore the list.
 
+**And the readout is declared, which is what makes it reachable (#927).** It
+existed, it was right, and *nothing called it* — so the shelf listed the four
+engines and said nothing about the 339 MB sitting beside them: invisible, and
+therefore impossible to act on. `declare_builtin_models` now appends one entry
+per unclaimed file, and two choices carry the fix:
+
+- **`file_kind='unknown'`, never `engine`.** Every shelf verb refuses an engine
+  row (see *Protected, because they are ours* above), so a leftover declared as
+  ours would be visible and still untouchable — half a fix that reads like a
+  whole one. `unknown` is what the shelf already calls *Unclassified*, and it is
+  the honest reading of "present, and nothing in this build claims it".
+- **Weights only** (`MODEL_SUFFIXES`: `.safetensors .ckpt .pt .pth .bin .onnx
+  .gguf`, wider than the scanner's lone `.safetensors` because this folder is
+  where the other formats land). Every hit is now a row rather than a line in a
+  log, and a shelf that also lists a label CSV and a revision sidecar is one
+  nobody reads closely enough to notice the `.pt`. Bytes are unaffected: the
+  folder's total is read off the disk, not summed from these rows.
+
+**A re-declaration `COALESCE`s rather than restates.** That is a no-op for an
+engine — each declares its kind, role and name, and `PATCH /models` refuses one
+anyway — and it is what stops every server start from resetting a name the owner
+typed onto the one row class here they may curate. `file_kind` needs the same
+care for a sharper reason (`DeclaredEntry.restated_file_kind`): a leftover enters
+with `sha256` NULL, so `CheckpointHashTask` picks it up, and a digest that is
+already registered **merges** the two `model` rows — this folder's `model_file`
+is repointed at the survivor, which is somebody's real adapter. Restating
+`unknown` onto it would drop that adapter out of `/adapters` for its own folder,
+over a second copy the owner happened to leave in the download folder.
+
+Deleting the *file* is not this change and not this module: that is #925.
+
 ### The other two roots: InsightFace packs and the HuggingFace cache
 
 **The built-in folder was never the only place models land, and the other two

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1438,9 +1438,17 @@ undo by accident:
   field stops its own keys, or Arrow, Space and Escape would walk and clear the
   list from under it.
 - **`unknown` is never rendered as a checkpoint.** `file_kind='unknown'` is a
-  first-class stored value with its own glyph and the word "Unclassified". It
-  is in neither list by default and is fetched only from the *adapters* block
-  under `?file_kind=unknown`.
+  first-class stored value with its own glyph and the word "Unclassified". It is
+  never folded into either other list and is fetched only from the *adapters*
+  block under `?file_kind=unknown` — but it **is** fetched by default, for the
+  reason `engines` is: a file nothing could classify is still on the disk the
+  shelf accounts for, and opt-in is how a 339 MB leftover in PixlStash's own
+  download folder stayed invisible once the backend started declaring it
+  (#927, backend §*The unclaimed readout*). `activeCount` therefore counts
+  turning it **off**, the way it counts `checkpoints`. A remembered selection
+  would have defeated the change on exactly the machines that had used the shelf
+  longest, so `pixlstash:modelShelfFilters` gained `FILTERS_SCHEMA_VERSION` and
+  a blob from another `v` is discarded whole — the same trade `storedView` makes.
 
 **The `Assigned to` marks** (`EntityMark.vue`, `assignmentMarks` in
 `utils/modelShelf.js`) draw one bordered thumbnail per attached character or

--- a/frontend/src/components/panels/ShelfShowPanel.vue
+++ b/frontend/src/components/panels/ShelfShowPanel.vue
@@ -76,7 +76,9 @@
       </label>
       <!-- `unknown` is a first-class stored value, never promoted to
            checkpoint and never folded into adapters. It gets its own box and
-           its own word, and it is off by default. -->
+           its own word, and it is ON by default: the leftovers in PixlStash's
+           own download folder land here, and off by default is how they stayed
+           invisible (#927). -->
       <label
         class="tbm-check"
         title="Files we could not identify as an adapter or a checkpoint"

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -16,13 +16,17 @@ const listCheckpoints = vi.fn();
 // result set. Its own double, or every `listAdapters.mockResolvedValue` here
 // would answer it with adapter rows and the shelf would render each one twice.
 const listEngines = vi.fn();
+// And the unclassified block, for the same reason, now that it is on by
+// default (#927): one route, one more result set, its own double.
+const listUnclassified = vi.fn();
 
 vi.mock("../../api/modelShelf", () => ({
   BASE_MODEL_UNASSIGNED: "UNASSIGNED",
-  listAdapters: (...args) =>
-    args[0]?.fileKind === "engine"
-      ? listEngines(...args)
-      : listAdapters(...args),
+  listAdapters: (...args) => {
+    if (args[0]?.fileKind === "engine") return listEngines(...args);
+    if (args[0]?.fileKind === "unknown") return listUnclassified(...args);
+    return listAdapters(...args);
+  },
   listCheckpoints: (...args) => listCheckpoints(...args),
 }));
 
@@ -136,10 +140,11 @@ function adapter(overrides = {}) {
   };
 }
 
-async function mountShelf(rows, checkpoints = []) {
+async function mountShelf(rows, checkpoints = [], unclassified = []) {
   listAdapters.mockResolvedValue(rows);
   listCheckpoints.mockResolvedValue(checkpoints);
   listEngines.mockResolvedValue([]);
+  listUnclassified.mockResolvedValue(unclassified);
   const wrapper = mount(ModelShelf, globalOpts);
   await new Promise((resolve) => setTimeout(resolve, 0));
   await wrapper.vm.$nextTick();
@@ -157,6 +162,7 @@ beforeEach(() => {
   listAdapters.mockReset();
   listCheckpoints.mockReset();
   listEngines.mockReset().mockResolvedValue([]);
+  listUnclassified.mockReset().mockResolvedValue([]);
   listModelFolderDevices.mockReset();
   listModelFolderDevices.mockResolvedValue([]);
   listModelFolders.mockReset();
@@ -324,16 +330,18 @@ describe("renaming a row in place", () => {
 
 describe("file kinds", () => {
   it("never renders an unclassified file as a checkpoint", async () => {
-    // `unknown` is in neither default list (see api/modelShelf.js), so the row
-    // only reaches the shelf when the Unclassified box asks for its block.
+    // `unknown` is in neither of the other two lists (see api/modelShelf.js),
+    // so the row reaches the shelf only through the Unclassified block.
     useModelShelfStore().setFilters({
       adapters: false,
       checkpoints: false,
       unclassified: true,
     });
-    const wrapper = await mountShelf([
-      adapter({ file_kind: "unknown", kind: null, display_name: "aurora" }),
-    ]);
+    const wrapper = await mountShelf(
+      [],
+      [],
+      [adapter({ file_kind: "unknown", kind: null, display_name: "aurora" })],
+    );
     const kind = textOf(wrapper.find(".shelf-row .shelf-col"));
     expect(kind).toContain("Unclassified");
     expect(kind).not.toContain("Checkpoint");

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -27,6 +27,17 @@ import {
 const FILTERS_KEY = "pixlstash:modelShelfFilters";
 
 /**
+ * Bumped when a *default* below changes; a blob from another `v` is discarded.
+ *
+ * A remembered selection outlives the reason it was remembered. `Unclassified`
+ * shipped off by default, so every blob written before this carries
+ * `unclassified: false` whether or not anyone chose it — and a shelf that now
+ * has something real to show under that box would have gone on hiding it from
+ * exactly the people who have been using the screen longest (#927).
+ */
+const FILTERS_SCHEMA_VERSION = 1;
+
+/**
  * Where the view axes are remembered: grouping, sort, and what is collapsed.
  *
  * A second key rather than more fields in {@link FILTERS_KEY}: `resetFilters`
@@ -255,7 +266,11 @@ function defaultFilters() {
     adapters: true,
     adapterKinds: [],
     checkpoints: true,
-    unclassified: false,
+    // On, for the reason `engines` is on: a file nothing can classify is still
+    // taking the disk the shelf exists to account for, and off by default is
+    // how a 339 MB leftover in PixlStash's own download folder stayed invisible
+    // (#927). The box is still there to turn it off.
+    unclassified: true,
     engines: true,
     baseModels: [],
     capabilities: [],
@@ -293,7 +308,10 @@ function writeStored(key, value) {
 /** Read the remembered selection, or null when there is none to trust. */
 function storedFilters() {
   const parsed = readStored(FILTERS_KEY);
-  if (!parsed) return null;
+  // A blob an older build wrote is discarded whole rather than half-applied,
+  // the same trade `storedView` makes: the alternative is carrying every past
+  // default forward forever.
+  if (!parsed || parsed.v !== FILTERS_SCHEMA_VERSION) return null;
   const filters = defaultFilters();
   for (const key of ["adapters", "checkpoints", "unclassified", "engines"]) {
     if (typeof parsed[key] === "boolean") filters[key] = parsed[key];
@@ -370,7 +388,9 @@ function storedCollapsed() {
  */
 function groupsOf(row, axis) {
   if (axis === "feature") {
-    const capabilities = Array.isArray(row.capabilities) ? row.capabilities : [];
+    const capabilities = Array.isArray(row.capabilities)
+      ? row.capabilities
+      : [];
     if (!capabilities.length) {
       // Every scanned adapter and checkpoint lands here, which is most of the
       // shelf: `kind` on those rows is an adapter algorithm, not a capability,
@@ -454,7 +474,7 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
   let epoch = 0;
 
   function remember() {
-    writeStored(FILTERS_KEY, filters);
+    writeStored(FILTERS_KEY, { v: FILTERS_SCHEMA_VERSION, ...filters });
   }
 
   /** Persist the view axes and the collapsed sets as one versioned blob. */
@@ -797,7 +817,10 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
     let n = 0;
     if (!filters.adapters || filters.adapterKinds.length) n += 1;
     if (!filters.checkpoints) n += 1;
-    if (filters.unclassified) n += 1;
+    // Counted the way `checkpoints` is, because it now defaults the same way:
+    // the badge says how far the selection has moved from the default, so the
+    // departure is turning it OFF.
+    if (!filters.unclassified) n += 1;
     if (filters.baseModels.length) n += 1;
     if (filters.capabilities.length) n += 1;
     return n;

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -250,13 +250,12 @@ function defaultView() {
 /**
  * The default `Show` selection, and therefore what "no active filter" means.
  *
- * `unclassified` is off because a file we could not identify is not something
- * to put in front of someone who came to find a LoRA; it is a first-class
- * state with its own checkbox, never folded into either other bucket.
- * `engines` is on for the opposite reason: they are the answer to "where did
- * my disk go", and on a measured machine they are 118 GB against the adapters'
- * few — invisible by default is how they came to be missing from the shelf for
- * three releases while the architecture note claimed they were on it.
+ * `unclassified` is on, and it is a first-class state with its own checkbox,
+ * never folded into either other bucket. `engines` is on for the same reason:
+ * they are the answer to "where did my disk go", and on a measured machine
+ * they are 118 GB against the adapters' few — invisible by default is how they
+ * came to be missing from the shelf for three releases while the architecture
+ * note claimed they were on it.
  * `adapterKinds: []` means *every* kind, not *no* kind — an empty multi-select
  * is unconstrained, the standard convention, and the only reading under which
  * a fresh install shows anything. `capabilities` reads the same way.

--- a/frontend/src/stores/useModelShelfStore.test.js
+++ b/frontend/src/stores/useModelShelfStore.test.js
@@ -15,6 +15,11 @@ const listCheckpoints = vi.fn();
 // below would answer the engines request with adapter rows too, and the store
 // would look like it had duplicated the shelf.
 const listEngines = vi.fn();
+// Same split, same reason, now that `Unclassified` is on by default: it is one
+// more result set behind the one route, and folding it into `listAdapters`
+// would answer the unclassified request with adapter rows and make every list
+// here look duplicated.
+const listUnclassified = vi.fn();
 
 const editModels = vi.fn();
 const forgetModels = vi.fn();
@@ -24,10 +29,11 @@ const clearModelIcons = vi.fn();
 
 vi.mock("../api/modelShelf", () => ({
   BASE_MODEL_UNASSIGNED: "UNASSIGNED",
-  listAdapters: (...args) =>
-    args[0]?.fileKind === "engine"
-      ? listEngines(...args)
-      : listAdapters(...args),
+  listAdapters: (...args) => {
+    if (args[0]?.fileKind === "engine") return listEngines(...args);
+    if (args[0]?.fileKind === "unknown") return listUnclassified(...args);
+    return listAdapters(...args);
+  },
   listCheckpoints: (...args) => listCheckpoints(...args),
   editModels: (...args) => editModels(...args),
   forgetModels: (...args) => forgetModels(...args),
@@ -71,18 +77,21 @@ beforeEach(() => {
   listAdapters.mockReset().mockResolvedValue([]);
   listCheckpoints.mockReset().mockResolvedValue([]);
   listEngines.mockReset().mockResolvedValue([]);
+  listUnclassified.mockReset().mockResolvedValue([]);
 });
 
 describe("defaults", () => {
-  it("shows adapters and checkpoints but not unclassified files", async () => {
-    // `unknown` is first-class, not a bucket to hide things in — but a file we
-    // could not identify is not what someone came to the shelf to find, so it
-    // is opt-in and never folded into either other list.
+  it("shows adapters, checkpoints and unclassified files", async () => {
+    // `unknown` is first-class and never folded into either other list — and it
+    // is asked for by default: a file nothing could classify is still on the
+    // disk the shelf accounts for, and opt-in is how a 339 MB leftover in
+    // PixlStash's own download folder stayed invisible (#927).
     const store = useModelShelfStore();
     await store.fetchRows();
     expect(listAdapters).toHaveBeenCalledTimes(1);
     expect(listAdapters).toHaveBeenCalledWith();
     expect(listCheckpoints).toHaveBeenCalledTimes(1);
+    expect(listUnclassified).toHaveBeenCalledWith({ fileKind: "unknown" });
     expect(store.activeCount).toBe(0);
   });
 
@@ -122,12 +131,18 @@ describe("defaults", () => {
 
   it("asks the adapters block for the unclassified files", async () => {
     const store = useModelShelfStore();
-    await store.setFilters({ unclassified: true }, { refetch: true });
-    expect(listAdapters).toHaveBeenCalledWith({ fileKind: "unknown" });
+    await store.fetchRows();
+    expect(listUnclassified).toHaveBeenCalledWith({ fileKind: "unknown" });
     // Never /checkpoints: an unknown must not render as a checkpoint.
     expect(listCheckpoints).not.toHaveBeenCalledWith(
       expect.objectContaining({ fileKind: "unknown" }),
     );
+  });
+
+  it("stops asking for the unclassified files when the box is unticked", async () => {
+    const store = useModelShelfStore();
+    await store.setFilters({ unclassified: false }, { refetch: true });
+    expect(listUnclassified).not.toHaveBeenCalled();
   });
 });
 
@@ -302,9 +317,9 @@ describe("the badge", () => {
     expect(store.activeCount).toBe(2);
   });
 
-  it("counts turning unclassified on, because off is the default", async () => {
+  it("counts turning unclassified off, because on is the default", async () => {
     const store = useModelShelfStore();
-    await store.setFilters({ unclassified: true }, { refetch: true });
+    await store.setFilters({ unclassified: false }, { refetch: true });
     expect(store.activeCount).toBe(1);
   });
 });
@@ -324,10 +339,10 @@ describe("empty states", () => {
 describe("persistence", () => {
   it("remembers the selection and restores it next visit", () => {
     const store = useModelShelfStore();
-    store.setFilters({ unclassified: true, baseModels: ["UNASSIGNED"] });
+    store.setFilters({ unclassified: false, baseModels: ["UNASSIGNED"] });
     setActivePinia(createPinia());
     const restored = useModelShelfStore();
-    expect(restored.filters.unclassified).toBe(true);
+    expect(restored.filters.unclassified).toBe(false);
     expect(restored.filters.baseModels).toEqual(["UNASSIGNED"]);
   });
 
@@ -335,7 +350,22 @@ describe("persistence", () => {
     window.localStorage.setItem("pixlstash:modelShelfFilters", "{not json");
     const store = useModelShelfStore();
     expect(store.filters.adapters).toBe(true);
-    expect(store.filters.unclassified).toBe(false);
+    expect(store.filters.unclassified).toBe(true);
+  });
+
+  it("discards a blob an older build wrote, so a changed default applies", () => {
+    // The regression this pins is #927 in its second half. `Unclassified`
+    // shipped off, so every blob written before this carries
+    // `unclassified: false` whether or not anyone chose it — and honouring it
+    // would keep the leftovers hidden from precisely the people who have used
+    // the shelf longest.
+    window.localStorage.setItem(
+      "pixlstash:modelShelfFilters",
+      JSON.stringify({ adapters: false, unclassified: false }),
+    );
+    const store = useModelShelfStore();
+    expect(store.filters.unclassified).toBe(true);
+    expect(store.filters.adapters).toBe(true);
   });
 });
 
@@ -625,9 +655,9 @@ describe("the view is remembered", () => {
     // and losing your sort order to it would be a different promise.
     const store = useModelShelfStore();
     store.setView({ sortKey: "name" });
-    store.setFilters({ unclassified: true });
+    store.setFilters({ unclassified: false });
     await store.resetFilters();
-    expect(store.filters.unclassified).toBe(false);
+    expect(store.filters.unclassified).toBe(true);
     expect(store.view.sortKey).toBe("name");
   });
 

--- a/pixlstash/services/builtin_models.py
+++ b/pixlstash/services/builtin_models.py
@@ -24,11 +24,17 @@ Drift here is also self-announcing rather than silent: a renamed file makes its
 declared row go ``missing`` and the real file appear under
 :func:`unclaimed_files`, which is a visible pair, not a quiet wrong answer.
 
-**These rows are protected.** The folder answers 409 to ``DELETE`` and every
-shelf verb refuses them, because they are ours: renaming our own tagger would
-make the shelf lie about it, and assigning a tagger to a character means
+**The engine rows are protected.** The folder answers 409 to ``DELETE`` and
+every shelf verb refuses them, because they are ours: renaming our own tagger
+would make the shelf lie about it, and assigning a tagger to a character means
 nothing. They are on the shelf for completeness — so the owner can see what is
 on their disk and what it costs — not to be curated.
+
+**The unclaimed files in the folder are not**, and that is the point of
+declaring them (#927). They go in as ``file_kind='unknown'``, which is what the
+shelf calls *Unclassified*, so a leftover like ``best.pt`` is visible, carries
+its size, and is an ordinary row the owner can rename or forget rather than one
+the shelf refuses to discuss.
 """
 
 from __future__ import annotations
@@ -41,7 +47,7 @@ from typing import Optional
 from platformdirs import user_data_dir
 
 from pixlstash.pixl_logging import get_logger
-from pixlstash.utils.adapter_header import FILE_ENGINE
+from pixlstash.utils.adapter_header import FILE_ENGINE, FILE_UNKNOWN
 
 logger = get_logger(__name__)
 
@@ -71,6 +77,27 @@ BUILTIN_PROVENANCE = "builtin"
 # HuggingFace's, not ours and not the owner's, so it is neither declared nor
 # reported as unclaimed — it is simply not a model file.
 TOOLING_DIRS = (".cache",)
+
+# What counts as weights, for the unclaimed readout. Wider than the scanner's
+# `MODEL_SUFFIX` (`.safetensors` alone), because this folder is precisely where
+# the other formats land — our own tagger is ONNX and both scorers are `.pth` —
+# and the leftover that prompted #927 is a `.pt`.
+#
+# An allowlist rather than "every file the walk saw", because the readout now
+# writes a shelf row per hit. A label CSV, a revision sidecar or a stray README
+# is a fact about the folder and not a model, and a shelf that lists them
+# teaches the reader to skim past the row that matters. The size still counts:
+# what is skipped here is a row, never a byte of the folder's own total, which
+# the folder list reads off the disk.
+MODEL_SUFFIXES = (
+    ".safetensors",
+    ".ckpt",
+    ".pt",
+    ".pth",
+    ".bin",
+    ".onnx",
+    ".gguf",
+)
 
 
 @dataclass(frozen=True)
@@ -116,8 +143,11 @@ class DeclaredEntry:
 
     Attributes:
         relpath: Location within the folder — `model_file`'s own identity.
-        display_name: What the shelf calls it.
-        role: Stored in ``model.kind``; see :class:`BuiltinEngine.role`.
+        display_name: What the shelf calls it, or None to let the row derive a
+            name from its filename. None for an unclaimed file: we did not put
+            it there and have nothing to call it.
+        role: Stored in ``model.kind``; see :class:`BuiltinEngine.role`. None
+            for an unclaimed file, whose role we do not know.
         size: Bytes, or None when it could not be read. None never overwrites a
             size already recorded.
         present: Whether it is on disk now. False writes ``missing``, which is a
@@ -126,19 +156,42 @@ class DeclaredEntry:
             to ``model_capability``. Empty means "just the role", which is what
             all but one caller means: a model that does one thing does not have
             to say it twice.
+        file_kind: ``engine`` for something PixlStash chose to download, which
+            is what every declaration but one is. ``unknown`` for an unclaimed
+            file, and that is not a formality: every shelf verb refuses an
+            engine row, so declaring a leftover as one would put it on the shelf
+            in the single state that cannot be acted on.
     """
 
     relpath: str
-    display_name: str
-    role: str
+    display_name: Optional[str]
+    role: Optional[str]
     size: Optional[int]
     present: bool
     capabilities: tuple[str, ...] = field(default_factory=tuple)
+    file_kind: str = FILE_ENGINE
 
     @property
     def declared_capabilities(self) -> tuple[str, ...]:
-        """The capability set to write — never empty, `role` first."""
-        return self.capabilities or (self.role,)
+        """The capability set to write — `role` first, empty when there is none."""
+        if self.capabilities:
+            return self.capabilities
+        return (self.role,) if self.role else ()
+
+    @property
+    def restated_file_kind(self) -> Optional[str]:
+        """The ``file_kind`` a re-declaration asserts, or None to leave it alone.
+
+        An engine is ours and its row says what we say. An unclaimed file is
+        not, and the difference is load-bearing rather than tidy: it enters with
+        ``sha256`` NULL, so ``CheckpointHashTask`` picks it up, and if it hashes
+        to a digest already registered the two ``model`` rows **merge** — this
+        folder's ``model_file`` is repointed at the survivor, which is somebody's
+        real adapter. Restating ``unknown`` onto that row on the next start would
+        drop the adapter out of ``/adapters`` for its own folder too, over a
+        second copy the owner happened to leave here.
+        """
+        return self.file_kind if self.file_kind == FILE_ENGINE else None
 
 
 # Mirrors `pixlstash_tagger.PIXLSTASH_TAGGER_FILENAME` /
@@ -322,13 +375,17 @@ def declared_paths() -> set[str]:
 
 
 def unclaimed_files(folder_path: str) -> list[dict]:
-    """Files present in the folder that no declaration accounts for.
+    """Model files present in the folder that no declaration accounts for.
 
     **Not "orphaned".** We know our own manifest; we do not know that a previous
     build, a plugin or the owner did not put a file there deliberately. This
     reports what nothing in *this build* claims, which is a smaller and true
     statement — the same distinction the scan already draws between ``missing``
     (we looked and it was not there) and ``unreachable`` (we could not look).
+
+    **Weights only** (:data:`MODEL_SUFFIXES`). Each hit becomes a row on the
+    model shelf, and a shelf that also lists a label CSV and a revision sidecar
+    is one nobody reads carefully enough to notice the 339 MB `.pt` among them.
 
     Detection proposes and never applies: nothing here deletes.
 
@@ -345,6 +402,8 @@ def unclaimed_files(folder_path: str) -> list[dict]:
     for directory, dirs, files in os.walk(folder_path):
         dirs[:] = [d for d in dirs if d not in TOOLING_DIRS]
         for name in files:
+            if not name.lower().endswith(MODEL_SUFFIXES):
+                continue
             absolute = os.path.join(directory, name)
             relpath = os.path.relpath(absolute, folder_path)
             if relpath in declared:
@@ -375,6 +434,14 @@ def declare_builtin_models(hub, folder_path: str) -> Optional[int]:
     did not see to ``missing``; pointed here it would mark the ONNX tagger and
     both ``.pth`` scorers missing on every pass.
 
+    **The unclaimed files are declared too.** :func:`unclaimed_files` has always
+    known about the leftovers — a 339 MB ``best.pt`` on a measured machine — but
+    nothing called it, so the shelf listed the four engines and said nothing
+    about the file sitting beside them: invisible, and therefore impossible to
+    act on (#927). They go in as ``file_kind='unknown'`` with no role and no
+    capability, which is what the shelf already calls *Unclassified* and is the
+    honest reading of "present, and nothing in this build claims it".
+
     Args:
         hub: The open hub database.
         folder_path: Where PixlStash downloads its engines.
@@ -403,6 +470,20 @@ def declare_builtin_models(hub, folder_path: str) -> Optional[int]:
                 role=engine.role,
                 size=size,
                 present=present,
+            )
+        )
+    for leftover in unclaimed_files(folder_path):
+        # `present` unconditionally: the walk just saw the file. One that goes
+        # away is swept to `missing` by `declare_folder` like any other row,
+        # which is what then lets the owner forget it.
+        entries.append(
+            DeclaredEntry(
+                relpath=leftover["relpath"],
+                display_name=None,
+                role=None,
+                size=leftover["size"],
+                present=True,
+                file_kind=FILE_UNKNOWN,
             )
         )
     return declare_folder(hub, folder_path, entries)
@@ -480,7 +561,7 @@ def declare_folder(
                     "INSERT INTO model (file_kind, kind, display_name, filename, "
                     "provenance, file_size, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
-                        FILE_ENGINE,
+                        entry.file_kind,
                         entry.role,
                         entry.display_name,
                         os.path.basename(entry.relpath),
@@ -497,13 +578,29 @@ def declare_folder(
                 )
             else:
                 model_id = int(existing[0])
-                # The declaration is the authority for what this row IS, so it
-                # is written outright rather than COALESCE'd: unlike a scanned
-                # row there is no owner curation here to preserve.
+                # COALESCE'd on the *declared* value throughout, which changes
+                # nothing for an engine: every one declares its kind, its role
+                # and its name, so the declaration still wins outright — and no
+                # verb lets anyone edit an engine row anyway.
+                #
+                # It is what keeps an unclaimed file honest, which declares only
+                # the first of the three. Written outright, every server start
+                # would reset the name and kind the owner typed onto the one row
+                # class here they are allowed to curate — and `restated_file_kind`
+                # covers the sharper case above, where the row is no longer the
+                # leftover's alone.
                 conn.execute(
-                    "UPDATE model SET file_kind = ?, kind = ?, display_name = ?, "
+                    "UPDATE model SET file_kind = COALESCE(?, file_kind), "
+                    "kind = COALESCE(?, kind), "
+                    "display_name = COALESCE(?, display_name), "
                     "file_size = COALESCE(?, file_size) WHERE id = ?",
-                    (FILE_ENGINE, entry.role, entry.display_name, size, model_id),
+                    (
+                        entry.restated_file_kind,
+                        entry.role,
+                        entry.display_name,
+                        size,
+                        model_id,
+                    ),
                 )
                 conn.execute(
                     "UPDATE model_file SET state = ?, seen_at = ? "

--- a/pixlstash/services/builtin_models.py
+++ b/pixlstash/services/builtin_models.py
@@ -393,9 +393,10 @@ def unclaimed_files(folder_path: str) -> list[dict]:
         folder_path: The built-in folder to inspect.
 
     Returns:
-        ``{"relpath", "size"}`` per unclaimed file, smallest path first. Empty
-        when the folder does not exist, which is the normal state before the
-        first download.
+        ``{"relpath", "size"}`` per unclaimed file, smallest path first, with
+        ``size`` ``None`` when the file could not be sized. Empty when the
+        folder does not exist, which is the normal state before the first
+        download.
     """
     declared = declared_paths()
     found: list[dict] = []
@@ -417,7 +418,12 @@ def unclaimed_files(folder_path: str) -> list[dict]:
                     absolute,
                     exc,
                 )
-                size = 0
+                # `None`, never `0`. The declaration COALESCEs the size onto the
+                # row, so a zero from a transient `stat` failure would overwrite
+                # a size a previous run read correctly — the shelf would then
+                # claim a 339 MB leftover takes no disk. `None` leaves the
+                # stored figure alone and matches "without one".
+                size = None
             found.append({"relpath": relpath, "size": size})
     return sorted(found, key=lambda item: item["relpath"])
 

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -204,6 +204,34 @@ def test_an_unclaimed_file_gets_a_row_the_owner_can_actually_reach(
     assert engines["n"] == len(BUILTIN_ENGINES)
 
 
+def test_a_sizing_failure_leaves_the_size_a_previous_run_read(
+    server_hub, tmp_path, monkeypatch
+):
+    """The size is COALESCE'd onto the row, so an unsizeable file must report
+    `None` and not `0`.
+
+    A zero would win the COALESCE and overwrite a figure a previous start read
+    correctly, and the shelf would then say a 339 MB leftover takes no disk —
+    from a `stat` that failed for a moment on the one folder the downloaders
+    are actively writing into.
+    """
+    (tmp_path / "best.pt").write_bytes(b"y" * 20)
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    real_getsize = os.path.getsize
+
+    def failing_getsize(path):
+        if os.path.basename(path) == "best.pt":
+            raise OSError("file is being replaced")
+        return real_getsize(path)
+
+    monkeypatch.setattr(os.path, "getsize", failing_getsize)
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    row = server_hub.fetchone("SELECT file_size FROM model WHERE filename = 'best.pt'")
+    assert row["file_size"] == 20
+
+
 def test_declaring_again_does_not_wipe_a_name_the_owner_gave_a_leftover(
     server_hub, tmp_path
 ):

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -27,7 +27,7 @@ from pixlstash.services.builtin_caches import (
     declare_huggingface_cache,
     declare_insightface_packs,
 )
-from pixlstash.utils.adapter_header import FILE_ENGINE
+from pixlstash.utils.adapter_header import FILE_ENGINE, FILE_UNKNOWN
 from pixlstash.utils.insightface_model_utils import KNOWN_MODEL_PACKS
 
 
@@ -95,6 +95,21 @@ def test_the_download_tools_own_bookkeeping_is_not_unclaimed(tmp_path):
     assert unclaimed_files(str(tmp_path)) == []
 
 
+def test_only_weights_are_reported_as_unclaimed(tmp_path):
+    """Every hit becomes a shelf row, so the readout is weights or nothing.
+
+    The folder collects a trainer's `results.csv` and the odd README beside the
+    files that matter, and a shelf listing those is one nobody reads carefully
+    enough to notice the 339 MB `.pt` among them.
+    """
+    (tmp_path / "best.pt").write_bytes(b"y" * 20)
+    (tmp_path / "results.csv").write_text("epoch,loss\n")
+    (tmp_path / "README.md").write_text("# notes")
+    (tmp_path / "hub.db").write_bytes(b"SQLite")
+
+    assert [item["relpath"] for item in unclaimed_files(str(tmp_path))] == ["best.pt"]
+
+
 def test_a_folder_that_has_never_been_downloaded_into_reports_nothing(tmp_path):
     """The normal state before the first run, and not an error."""
     assert unclaimed_files(str(tmp_path / "never-created")) == []
@@ -148,6 +163,134 @@ def test_declaring_twice_does_not_duplicate_a_row(server_hub, tmp_path):
         "SELECT COUNT(*) AS n FROM model_file WHERE model_folder_id = ?", (folder_id,)
     )
     assert count["n"] == len(BUILTIN_ENGINES)
+
+
+def test_an_unclaimed_file_gets_a_row_the_owner_can_actually_reach(
+    server_hub, tmp_path
+):
+    """#927: the readout knew about `best.pt` and nothing called it.
+
+    Two halves, and the second is the one that makes the first useful. It has to
+    appear at all — a file that is on the shelf's own folder and not on the
+    shelf is one the owner cannot act on — and it has to appear as `unknown`
+    rather than `engine`, because every shelf verb refuses an engine row. A
+    leftover declared as ours would be visible and still untouchable.
+    """
+    (tmp_path / "best.pt").write_bytes(b"y" * 20)
+
+    folder_id = declare_builtin_models(server_hub, str(tmp_path))
+
+    row = server_hub.fetchone(
+        "SELECT m.file_kind, m.kind, m.display_name, m.filename, m.file_size, "
+        "mf.state FROM model m JOIN model_file mf ON mf.model_id = m.id "
+        "WHERE mf.model_folder_id = ? AND mf.relpath = ?",
+        (folder_id, "best.pt"),
+    )
+    assert row is not None, "the leftover got no row, which is the bug"
+    assert row["file_kind"] == FILE_UNKNOWN
+    assert row["state"] == "present"
+    assert row["file_size"] == 20
+    assert row["filename"] == "best.pt"
+    # No name and no role: we did not put it there and do not know what it is.
+    # The shelf derives a name from the filename, which is honest about who
+    # decided it.
+    assert row["display_name"] is None
+    assert row["kind"] is None
+
+    # And it is not counted among PixlStash's own engines.
+    engines = server_hub.fetchone(
+        "SELECT COUNT(*) AS n FROM model WHERE file_kind = ?", (FILE_ENGINE,)
+    )
+    assert engines["n"] == len(BUILTIN_ENGINES)
+
+
+def test_declaring_again_does_not_wipe_a_name_the_owner_gave_a_leftover(
+    server_hub, tmp_path
+):
+    """The declaration is the authority for an engine, not for a leftover.
+
+    An engine restates its name on every start because nobody may rename one.
+    An unclaimed file declares no name at all, so restating it outright would
+    reset whatever the owner typed on the one row class here they are allowed
+    to curate — every server start, silently.
+    """
+    (tmp_path / "best.pt").write_bytes(b"y" * 20)
+    declare_builtin_models(server_hub, str(tmp_path))
+    with server_hub.transaction() as conn:
+        conn.execute(
+            "UPDATE model SET display_name = 'YOLO detector', kind = 'detector' "
+            "WHERE filename = 'best.pt'"
+        )
+
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    row = server_hub.fetchone(
+        "SELECT display_name, kind FROM model WHERE filename = 'best.pt'"
+    )
+    assert (row["display_name"], row["kind"]) == ("YOLO detector", "detector")
+
+
+def test_a_leftover_merged_into_a_real_model_does_not_drag_it_to_unknown(
+    server_hub, tmp_path
+):
+    """The sharp edge of giving leftovers a row, and the reason `file_kind` is
+    COALESCE'd rather than restated.
+
+    A leftover enters with `sha256` NULL, so `CheckpointHashTask` picks it up,
+    and if it hashes to a digest already registered the two `model` rows MERGE:
+    this folder's `model_file` is repointed at the survivor, which is somebody's
+    real adapter in their own folder. Restating `unknown` onto that row on the
+    next start would drop the adapter out of `/adapters` everywhere, over a
+    second copy the owner happened to leave in the download folder.
+
+    The merge is simulated rather than driven through the hash task: what is
+    under test is the declaration's behaviour once a location it wrote points at
+    a row it did not.
+    """
+    (tmp_path / "stray.safetensors").write_bytes(b"y" * 20)
+    folder_id = declare_builtin_models(server_hub, str(tmp_path))
+
+    with server_hub.transaction() as conn:
+        adapter_id = conn.execute(
+            "INSERT INTO model (file_kind, kind, sha256, display_name, "
+            "provenance, created_at) VALUES ('adapter', 'lora', ?, "
+            "'Cyanwood Style', 'external', '2026-08-01T00:00:00Z')",
+            ("a" * 64,),
+        ).lastrowid
+        # What `CheckpointHashTask._merge` does: the survivor keeps its identity
+        # and takes the other row's locations.
+        conn.execute(
+            "UPDATE model_file SET model_id = ? "
+            "WHERE model_folder_id = ? AND relpath = ?",
+            (adapter_id, folder_id, "stray.safetensors"),
+        )
+
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    row = server_hub.fetchone(
+        "SELECT file_kind, kind, display_name FROM model WHERE id = ?", (adapter_id,)
+    )
+    assert row["file_kind"] == "adapter", "the merged adapter was demoted to unknown"
+    assert (row["kind"], row["display_name"]) == ("lora", "Cyanwood Style")
+
+
+def test_a_leftover_that_is_deleted_outside_pixlstash_goes_missing(
+    server_hub, tmp_path
+):
+    """Which is what then lets the owner forget the row: `POST /models/forget`
+    refuses anything with a copy still `present`."""
+    leftover = tmp_path / "best.pt"
+    leftover.write_bytes(b"y" * 20)
+    folder_id = declare_builtin_models(server_hub, str(tmp_path))
+    os.unlink(leftover)
+
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    state = server_hub.fetchone(
+        "SELECT state FROM model_file WHERE model_folder_id = ? AND relpath = ?",
+        (folder_id, "best.pt"),
+    )
+    assert state["state"] == "missing"
 
 
 def test_claiming_a_path_the_owner_registered_resets_every_column(server_hub, tmp_path):


### PR DESCRIPTION
Closes #927.

## The bug

`unclaimed_files()` in `services/builtin_models.py` has always known about the
leftovers in the download folder — it is implemented, documented and tested, and
`best.pt` is the worked example in `docs/backend_architecture.md`.

**Nothing ever called it.** The declaration wrote a row per engine and stopped
there, so a file sitting beside them got no row, no size and no place on the
shelf — invisible, and therefore impossible to act on.

## What changed

**`declare_builtin_models` declares the unclaimed files too**, one entry each,
and two choices carry the fix:

- **`file_kind='unknown'`, never `engine`.** Every shelf verb refuses an engine
  row, so a leftover declared as ours would be visible and still untouchable —
  half a fix that reads like a whole one. `unknown` is what the shelf already
  calls *Unclassified* and is the honest reading of "present, and nothing in
  this build claims it".
- **Weights only** (`MODEL_SUFFIXES`, wider than the scanner's lone
  `.safetensors` because this folder is where the other formats land). Every hit
  is a row now rather than a line in a log, and a shelf that also lists a label
  CSV and a revision sidecar is one nobody reads closely enough to notice the
  `.pt`. No byte is hidden: the folder's total is read off the disk.

**A re-declaration `COALESCE`s instead of restating.** A no-op for an engine —
each declares its kind, role and name, and `PATCH /models` refuses one anyway —
but without it every server start would reset a name the owner typed onto the
one row class here they are allowed to curate.

`file_kind` needed the same care for a sharper reason, which is the one bug in
here I did not expect to find: a leftover enters with `sha256` NULL, so
`CheckpointHashTask` picks it up, and a digest that is already registered
**merges** the two `model` rows — this folder's `model_file` is repointed at the
survivor, which is somebody's real adapter. Restating `unknown` onto it would
have dropped that adapter out of `/adapters` for its own folder, over a second
copy the owner happened to leave in the download folder.
`DeclaredEntry.restated_file_kind` is what stops it, with a regression test that
simulates the merge.

**Frontend: `Unclassified` is on by default.** A row nobody fetches is still not
seen. This is the same call the `Engines` box already made — off by default is
exactly how the engines stayed invisible while the architecture note said they
were listed — and the reasoning transfers: a file nothing could classify is
still on the disk the shelf exists to account for. `activeCount` now counts
turning it *off*, the way it counts `Checkpoints`, and the box is still there.
A remembered selection would have defeated the change on precisely the machines
that have used the shelf longest, so `pixlstash:modelShelfFilters` gained a
`FILTERS_SCHEMA_VERSION` and an older blob is discarded whole — the same trade
`storedView` already makes.

## Scope

**Deleting the file is not in here.** No shelf verb deletes from disk today, for
any model; that is #925 point 5 ("delete models from folders we provide, not
just forget them"). What this PR does deliver is the half #927 names in its
title — the file is on the shelf, with its size, as an ordinary row that Rename
and Forget can reach.

## Tests

- `tests/test_builtin_models.py`: the row appears and is `unknown` rather than
  `engine`; only weights are reported; a name the owner gives survives the next
  declaration; a merged adapter is not demoted; a deleted leftover goes
  `missing` (which is what then lets Forget take the row).
- `useModelShelfStore.test.js` / `ModelShelf.test.js` updated for the new
  default, plus a case pinning that an older filters blob is discarded.
- Backend: `test_builtin_models`, `test_model_shelf_api`,
  `test_model_folder_scanner`, `test_managed_model_store`, `test_model_move`,
  `test_hub_model_shelf_schema`, `test_model_shelf_scan_invariants`,
  `test_architecture_guardrails`, `test_ci_shards` all green; `ruff format` and
  `ruff check` clean. Frontend: full vitest suite, 3040 passing.
