### PR TITLE
Address review comments on #929

### DIFF
--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -250,13 +250,12 @@ function defaultView() {
 /**
  * The default `Show` selection, and therefore what "no active filter" means.
  *
- * `unclassified` is off because a file we could not identify is not something
- * to put in front of someone who came to find a LoRA; it is a first-class
- * state with its own checkbox, never folded into either other bucket.
- * `engines` is on for the opposite reason: they are the answer to "where did
- * my disk go", and on a measured machine they are 118 GB against the adapters'
- * few — invisible by default is how they came to be missing from the shelf for
- * three releases while the architecture note claimed they were on it.
+ * `unclassified` is on, and it is a first-class state with its own checkbox,
+ * never folded into either other bucket. `engines` is on for the same reason:
+ * they are the answer to "where did my disk go", and on a measured machine
+ * they are 118 GB against the adapters' few — invisible by default is how they
+ * came to be missing from the shelf for three releases while the architecture
+ * note claimed they were on it.
  * `adapterKinds: []` means *every* kind, not *no* kind — an empty multi-select
  * is unconstrained, the standard convention, and the only reading under which
  * a fresh install shows anything. `capabilities` reads the same way.

--- a/pixlstash/services/builtin_models.py
+++ b/pixlstash/services/builtin_models.py
@@ -393,9 +393,10 @@ def unclaimed_files(folder_path: str) -> list[dict]:
         folder_path: The built-in folder to inspect.
 
     Returns:
-        ``{"relpath", "size"}`` per unclaimed file, smallest path first. Empty
-        when the folder does not exist, which is the normal state before the
-        first download.
+        ``{"relpath", "size"}`` per unclaimed file, smallest path first, with
+        ``size`` ``None`` when the file could not be sized. Empty when the
+        folder does not exist, which is the normal state before the first
+        download.
     """
     declared = declared_paths()
     found: list[dict] = []
@@ -417,7 +418,12 @@ def unclaimed_files(folder_path: str) -> list[dict]:
                     absolute,
                     exc,
                 )
-                size = 0
+                # `None`, never `0`. The declaration COALESCEs the size onto the
+                # row, so a zero from a transient `stat` failure would overwrite
+                # a size a previous run read correctly — the shelf would then
+                # claim a 339 MB leftover takes no disk. `None` leaves the
+                # stored figure alone and matches "without one".
+                size = None
             found.append({"relpath": relpath, "size": size})
     return sorted(found, key=lambda item: item["relpath"])
 

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -204,6 +204,34 @@ def test_an_unclaimed_file_gets_a_row_the_owner_can_actually_reach(
     assert engines["n"] == len(BUILTIN_ENGINES)
 
 
+def test_a_sizing_failure_leaves_the_size_a_previous_run_read(
+    server_hub, tmp_path, monkeypatch
+):
+    """The size is COALESCE'd onto the row, so an unsizeable file must report
+    `None` and not `0`.
+
+    A zero would win the COALESCE and overwrite a figure a previous start read
+    correctly, and the shelf would then say a 339 MB leftover takes no disk —
+    from a `stat` that failed for a moment on the one folder the downloaders
+    are actively writing into.
+    """
+    (tmp_path / "best.pt").write_bytes(b"y" * 20)
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    real_getsize = os.path.getsize
+
+    def failing_getsize(path):
+        if os.path.basename(path) == "best.pt":
+            raise OSError("file is being replaced")
+        return real_getsize(path)
+
+    monkeypatch.setattr(os.path, "getsize", failing_getsize)
+    declare_builtin_models(server_hub, str(tmp_path))
+
+    row = server_hub.fetchone("SELECT file_size FROM model WHERE filename = 'best.pt'")
+    assert row["file_size"] == 20
+
+
 def test_declaring_again_does_not_wipe_a_name_the_owner_gave_a_leftover(
     server_hub, tmp_path
 ):


### PR DESCRIPTION
Addresses the two review comments on #929. Based on that PR's branch, so the
diff here is only the fixes; merge it into `pw/927-…` before #929 lands.

## The size a failed `stat` would have erased

`unclaimed_files()` fell back to `size = 0` when `os.path.getsize` raised, and
the declaration writes the size with `file_size = COALESCE(?, file_size)`. Zero
wins that COALESCE, so a transient failure on the one folder the downloaders are
actively writing into would overwrite a size an earlier start had read correctly
— and the shelf would then say a 339 MB leftover takes no disk. The log line
already said "reporting it without one"; the value did not agree with it.

Now `None`, which loses the COALESCE and leaves the stored figure standing. On a
first sighting it inserts `file_size` NULL, which is the same state a
declared-but-absent engine already writes, so nothing downstream is new. The
docstring's `Returns:` says so.

`test_a_sizing_failure_leaves_the_size_a_previous_run_read` declares once with
the file readable, then makes `getsize` raise for that name and declares again;
it fails on the old `size = 0` and passes now.

## A doc comment that outlived its default

The block above `defaultFilters()` still opened with "`unclassified` is off
because…" while the value below it had become `true`. Rewritten to state the
default it actually has, keeping the first-class-state point and folding the
reason into the one `engines` already gives.

## Tests

`tests/test_builtin_models.py` 44 passed; `useModelShelfStore.test.js` 74
passed. `ruff format` and `ruff check` clean.
