### PR TITLE
Give the model shelf its thumbnails back

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1383,12 +1383,15 @@ Modules are seeded as their first call site migrates, so a module can legitimate
 
 - **URL strings exist only here.** No `apiClient.<verb>('/url')` outside `src/api/**`, and this is enforced: a `no-restricted-imports` ESLint rule makes importing the `apiClient` named export outside this directory an **error**, as is importing `axios` anywhere but the singleton's own definition. The exemptions are `src/utils/apiClient.js` itself and `*.test.js` files, which import it to mock the transport.
 - **Reuse the `apiClient` singleton; never import `axios` directly.** All the cross-cutting behaviour above (the `/api/v1` prefix, share-token injection, `X-Client-Id`, global 401 → logout) lives in the singleton's interceptors, so a module that re-creates an Axios instance silently loses every one of them.
+- **A URL the BROWSER loads is built from `API_BASE_URL`, never from `apiClient.defaults.baseURL`.** `defaults.baseURL` is the backend *origin*; the `/api/v1` prefix is added by the request interceptor, which only Axios requests go through. An `<img src>` or a download built from `defaults` therefore misses the prefix and lands on the SPA fallback, which answers **200 with HTML** rather than an error — so it fails silently. This cost the model shelf every mark it draws, and a `no-restricted-properties` ESLint rule on `apiClient.defaults` now flags it in this directory. Note the rule runs in editors and `npm run lint`; the frontend CI job runs `npm test` only, so it does not block a PR.
 - **Every function returns `response.data`,** not the Axios envelope. Where a caller genuinely needs response metadata (e.g. the `content-disposition` filename on an export download), the module parses it and returns a structured value such as `{ blob, filename }`, so the envelope still does not escape the layer.
 - **Modules are pure transport:** no Pinia imports, no Vue reactivity, no notice/snackbar side effects. Callers own state and error presentation.
 - **Non-JSON responses stay explicit:** blob endpoints (thumbnails, overlays, exports) forward `{ responseType: "blob" }` from inside the module.
 - **Failures propagate.** A module never swallows an error into a benign-looking empty value. This is the natural home for the integration-§13 error-shape normalisation once it lands.
 
 **Testing:** each module gets a co-located `.test.js` that mocks `../utils/apiClient` and asserts verb, URL, params/body, and that the function returns the body rather than the envelope. `api/config.test.js` is the pattern.
+
+The one deliberate exception is `api/imageUrls.test.js`, which is neither co-located nor mocked, and both for the same reason: it covers the URL builders the browser loads itself, and the bug it guards lives precisely in what a mocked `../utils/apiClient` cannot see. The suite stayed green through that bug because the two thumbnail builders had no assertion at all, and the mocks standing in for the other two hardcode the correctly-prefixed string — neither form can fail when the real base is wrong, and those mocks are still there, since mocking the transport is the right thing for the component tests that use them. Centralising the URL assertions here, against the real module, is what makes them able to fail at all.
 
 **Barrel:** there is deliberately no `src/api` barrel. Import the concrete module (`import { getUserConfig } from "@/api/config"`), which keeps imports tree-shakeable and matches the co-located-test convention. A barrel that re-exported `apiClient` would also be a hole in the lint guard above.
 
@@ -1594,8 +1597,14 @@ shared and cached, never a lookup per attachment.
   and the ring around it is already her colour, so the halves say one thing;
   failing that the generated mark. Thumbnails are `<img src>` from
   `characterThumbnailUrl` / `pictureSetThumbnailUrl` rather than blobs, so one
-  response is cached however many rows borrow that face, and a 404 falls back
-  to the initials rather than drawing an empty square.
+  response is cached however many rows borrow that face. **Each step is skipped
+  once its own URL has failed**, so the chain runs all the way down: a model
+  pointing at an icon whose file is gone falls to the assigned face and then to
+  the initials, rather than sitting on a broken image. `ModelMark` therefore
+  records the URLs that 404ed, not one "it failed" flag — and clears that record
+  on a *string* of the row's icon and ring identity, because the shelf builds a
+  fresh ring object on every render and an identity comparison would reset the
+  chain on every keystroke in the filter box.
 - **The FIRST attachment owns the ring and the label names them all.** A mark
   has one edge, and four rings around a 24px square is a mark that is mostly
   ring. The count and every name ride in the mark's `title` and in a

--- a/docs/integration_architecture.md
+++ b/docs/integration_architecture.md
@@ -445,7 +445,7 @@ On `401 Unauthorized`, the client calls `logout()` automatically — **except**:
 - The probe endpoint `/users/me/auth` (used to test credentials without side-effects).
 - Requests made under a share token (a 401 just means that endpoint is outside the token's scope).
 
-All frontend code **must** route HTTP traffic through this client; bypassing it skips auth, share-token injection, and 401 handling. The only legitimate bypass is direct `<img src>`, which uses `appendShareToken()` to preserve the share token.
+All frontend code **must** route HTTP traffic through this client; bypassing it skips auth, share-token injection, and 401 handling. The only legitimate bypass is direct `<img src>`. Such a URL **must** be built from `API_BASE_URL`, since the `/api/v1` prefix is added by the request interceptor that only Axios requests reach; without it the request lands on the SPA fallback, which answers 200 with HTML rather than an error. It also passes through `appendShareToken()` wherever the resource is reachable under a share token — which is most of them, but not the shelf's own (a model icon is `OWNER_ONLY`, a training-run sample `LOCAL_OWNER_ONLY`), where a share token could never resolve anyway.
 
 ---
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -44,6 +44,26 @@ export default [
     },
   },
   {
+    // `apiClient.defaults.baseURL` is the backend ORIGIN. The `/api/v1` prefix
+    // is added by the request interceptor, which only Axios requests go
+    // through — so a URL built from `defaults` and handed to an `<img src>`
+    // misses the prefix, hits the SPA fallback and quietly returns HTML. That
+    // is what left the model shelf's marks blank. `API_BASE_URL` is the base
+    // for anything the browser fetches on its own.
+    files: ["src/api/**/*.js"],
+    rules: {
+      "no-restricted-properties": [
+        "error",
+        {
+          object: "apiClient",
+          property: "defaults",
+          message:
+            "Use API_BASE_URL for URLs the browser loads itself (<img src>, downloads); apiClient.defaults.baseURL has no /api/v1 prefix.",
+        },
+      ],
+    },
+  },
+  {
     // Backend URL strings live only in src/api/ (frontend_architecture.md §8).
     // Importing the raw `apiClient` verb-caller anywhere else is how inline
     // URLs creep back in, so it is an ERROR outside that directory. The rest of

--- a/frontend/src/api/characters.js
+++ b/frontend/src/api/characters.js
@@ -8,7 +8,7 @@
 //
 // See docs/frontend_architecture.md §8 ("The `src/api/` resource layer").
 
-import { apiClient, appendShareToken } from "../utils/apiClient";
+import { API_BASE_URL, apiClient, appendShareToken } from "../utils/apiClient";
 import { unwrap } from "../utils/unwrap";
 
 /**
@@ -36,9 +36,10 @@ function charactersUrl(path = "") {
  * @returns {string}
  */
 export function characterThumbnailUrl(id) {
-  const base = apiClient.defaults.baseURL || "";
+  // An <img src> never reaches the apiClient interceptor, so the API base has
+  // to be spelled out here rather than left for axios to prepend.
   return appendShareToken(
-    `${base}${charactersUrl(`/${encodeURIComponent(id)}/thumbnail`)}`,
+    `${API_BASE_URL}${charactersUrl(`/${encodeURIComponent(id)}/thumbnail`)}`,
   );
 }
 

--- a/frontend/src/api/imageUrls.test.js
+++ b/frontend/src/api/imageUrls.test.js
@@ -1,0 +1,53 @@
+// The URLs the BROWSER loads by itself — an `<img src>`, a download — rather
+// than through Axios.
+//
+// Deliberately NOT co-located per resource module, and deliberately UNMOCKED,
+// because the bug it guards lives in exactly the gap a per-module test with a
+// mocked `../utils/apiClient` cannot see: `/api/v1` is added by the request
+// interceptor, so a URL built from `apiClient.defaults.baseURL` is missing it
+// and lands on the SPA fallback, which answers 200 with HTML. Every existing
+// mock of these builders hardcodes the prefixed string, which is why the suite
+// stayed green while the model shelf drew no marks at all. Here the real
+// module computes the base, so the assertion can fail.
+
+import { describe, it, expect } from "vitest";
+
+import { characterThumbnailUrl } from "./characters";
+import { modelIconUrl } from "./modelIcons";
+import { runSampleUrl } from "./modelImports";
+import { pictureSetThumbnailUrl } from "./pictureSets";
+import { pictureThumbnailUrl } from "./pictures";
+import { API_BASE_URL } from "../utils/apiClient";
+
+describe("browser-loaded URLs carry the API prefix", () => {
+  const cases = [
+    [
+      "characterThumbnailUrl",
+      characterThumbnailUrl(12),
+      "/characters/12/thumbnail",
+    ],
+    [
+      "pictureSetThumbnailUrl",
+      pictureSetThumbnailUrl(5),
+      "/picture_sets/5/thumbnail",
+    ],
+    ["modelIconUrl", modelIconUrl("abc123"), "/model-icons/abc123"],
+    [
+      "runSampleUrl",
+      runSampleUrl(3, "run one", "s.png"),
+      "/model-folders/3/runs/run%20one/samples/s.png",
+    ],
+    // The one that was already right, kept here as the positive control: if the
+    // prefix ever moves, this fails alongside the others rather than leaving
+    // the failure looking like a quirk of the shelf's four.
+    [
+      "pictureThumbnailUrl",
+      pictureThumbnailUrl(7),
+      "/pictures/thumbnails/7.webp",
+    ],
+  ];
+
+  it.each(cases)("%s", (_name, url, path) => {
+    expect(url).toBe(`${API_BASE_URL}${path}`);
+  });
+});

--- a/frontend/src/api/modelIcons.js
+++ b/frontend/src/api/modelIcons.js
@@ -4,7 +4,7 @@
 // sample, which is what a model produces. The store is content-addressed, so
 // forty models given one logo share one file and one cached response.
 
-import { apiClient } from "../utils/apiClient";
+import { API_BASE_URL, apiClient } from "../utils/apiClient";
 import { unwrap } from "../utils/unwrap";
 
 /**
@@ -18,8 +18,9 @@ import { unwrap } from "../utils/unwrap";
  * @returns {string}
  */
 export function modelIconUrl(sha256) {
-  const base = apiClient.defaults.baseURL || "";
-  return `${base}/model-icons/${encodeURIComponent(sha256)}`;
+  // An <img src> never reaches the apiClient interceptor, so the API base has
+  // to be spelled out here rather than left for axios to prepend.
+  return `${API_BASE_URL}/model-icons/${encodeURIComponent(sha256)}`;
 }
 
 /**

--- a/frontend/src/api/modelImports.js
+++ b/frontend/src/api/modelImports.js
@@ -11,7 +11,7 @@
 // verify by SHA-256, register the row and commit, then unlink. It shares the
 // move's single job slot, so a move already running makes it a 409.
 
-import { apiClient } from "../utils/apiClient";
+import { API_BASE_URL, apiClient } from "../utils/apiClient";
 import { unwrap } from "../utils/unwrap";
 
 /**
@@ -42,9 +42,10 @@ export async function listRuns(folderId) {
  * @returns {string}
  */
 export function runSampleUrl(folderId, runName, filename) {
-  const base = apiClient.defaults.baseURL || "";
+  // An <img src> never reaches the apiClient interceptor, so the API base has
+  // to be spelled out here rather than left for axios to prepend.
   return (
-    `${base}/model-folders/${folderId}/runs` +
+    `${API_BASE_URL}/model-folders/${folderId}/runs` +
     `/${encodeURIComponent(runName)}/samples/${encodeURIComponent(filename)}`
   );
 }

--- a/frontend/src/api/pictureSets.js
+++ b/frontend/src/api/pictureSets.js
@@ -4,7 +4,7 @@
 // (`/picture_sets/{id}/members/{pictureId}`), so bulk actions are the caller's
 // loop over these calls, not a bulk endpoint.
 
-import { apiClient, appendShareToken } from "../utils/apiClient";
+import { API_BASE_URL, apiClient, appendShareToken } from "../utils/apiClient";
 import { unwrap } from "../utils/unwrap";
 
 /**
@@ -31,9 +31,10 @@ function setsUrl(path = "") {
  * @returns {string}
  */
 export function pictureSetThumbnailUrl(id) {
-  const base = apiClient.defaults.baseURL || "";
+  // An <img src> never reaches the apiClient interceptor, so the API base has
+  // to be spelled out here rather than left for axios to prepend.
   return appendShareToken(
-    `${base}${setsUrl(`/${encodeURIComponent(id)}/thumbnail`)}`,
+    `${API_BASE_URL}${setsUrl(`/${encodeURIComponent(id)}/thumbnail`)}`,
   );
 }
 

--- a/frontend/src/components/widgets/ModelMark.test.js
+++ b/frontend/src/components/widgets/ModelMark.test.js
@@ -4,14 +4,20 @@
 // sample by construction, and 37% of real adapters carry no title, so the
 // generated mark is the common path rather than the fallback.
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
+import { defineComponent, ref } from "vue";
 
-vi.mock("../../api/modelIcons", () => ({
-  modelIconUrl: (sha) => `/api/v1/model-icons/${sha}`,
-}));
+// The api modules are deliberately NOT mocked. A mock would hardcode the
+// prefixed string, which is exactly the shape that let the shelf ship with
+// marks that drew nothing: every one of them agreed on a URL the real code did
+// not produce. Here the real builders compute it.
+import { API_BASE_URL } from "../../utils/apiClient";
 
 import ModelMark from "./ModelMark.vue";
+
+const ADA_FACE = `${API_BASE_URL}/characters/4/thumbnail`;
+const icon = (sha) => `${API_BASE_URL}/model-icons/${sha}`;
 
 function row(overrides = {}) {
   return {
@@ -28,7 +34,9 @@ const mountMark = (props) => mount(ModelMark, { props: { row: row(props) } });
 describe("ModelMark", () => {
   it("draws the icon when there is one", () => {
     const wrapper = mountMark({ icon_sha256: "a".repeat(64) });
-    expect(wrapper.find("img").attributes("src")).toContain("a".repeat(64));
+    // The whole URL, not a substring: `toContain("model-icons")` passes just
+    // as happily against a base with no `/api/v1` in it, which is the bug.
+    expect(wrapper.find("img").attributes("src")).toBe(icon("a".repeat(64)));
     expect(wrapper.find(".mmark-initials").exists()).toBe(false);
   });
 
@@ -78,6 +86,111 @@ describe("ModelMark", () => {
     const mark = mountMark();
     expect(mark.find(".mmark-face").attributes("aria-hidden")).toBe("true");
     expect(mark.find(".mmark").attributes("aria-hidden")).toBeUndefined();
+  });
+
+  // The fallback chain. Each step is only reachable when the one above it has
+  // actually failed, so the test drives the `error` event rather than asserting
+  // on a flag: a missing icon FILE and a person with no reference face are both
+  // ordinary states, and a mark that stopped at the first 404 would be the same
+  // blank square the shelf was reported as showing.
+  const RING = { type: "character", id: 4, style: "dashed", label: "Ada" };
+
+  it("borrows the assigned person's face when the row has no icon", () => {
+    const wrapper = mount(ModelMark, { props: { row: row(), ring: RING } });
+    expect(wrapper.find("img").attributes("src")).toBe(ADA_FACE);
+  });
+
+  it("falls from a missing icon to that face, and then to the mark", async () => {
+    const wrapper = mount(ModelMark, {
+      props: { row: row({ icon_sha256: "b".repeat(64) }), ring: RING },
+    });
+    expect(wrapper.find("img").attributes("src")).toBe(icon("b".repeat(64)));
+
+    await wrapper.find("img").trigger("error");
+    expect(wrapper.find("img").attributes("src")).toBe(ADA_FACE);
+
+    await wrapper.find("img").trigger("error");
+    expect(wrapper.find("img").exists()).toBe(false);
+    expect(wrapper.find(".mmark-initials").text()).toBe("CS");
+  });
+
+  // Two errors in ONE task, both from the icon's element. The DOM only catches
+  // up on the next tick, so a handler that read the *computed* URL would take
+  // the second event as a verdict on Ada's face — a picture it had not yet
+  // asked the browser for — and skip straight to the initials.
+  it("blames only the load that failed when two errors arrive at once", async () => {
+    const wrapper = mount(ModelMark, {
+      props: { row: row({ icon_sha256: "b".repeat(64) }), ring: RING },
+    });
+    const img = wrapper.find("img").element;
+    img.dispatchEvent(new Event("error"));
+    img.dispatchEvent(new Event("error"));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find("img").attributes("src")).toBe(ADA_FACE);
+  });
+
+  // A late error from the load that has already been replaced. The `:key` is
+  // what makes this harmless: the failed URL got its own element, which keeps
+  // that URL as its `src`, so the late event re-reports a failure already on
+  // the list and is swallowed as a duplicate. Sharing one element would hand
+  // this event the NEW src instead and blacklist a face that never failed.
+  // Dispatched on the captured node, because that is exactly what an in-flight
+  // request does when it resolves late.
+  it("ignores an error from a load it has already moved on from", async () => {
+    const wrapper = mount(ModelMark, {
+      props: { row: row({ icon_sha256: "b".repeat(64) }), ring: RING },
+    });
+    const stale = wrapper.find("img").element;
+    await wrapper.find("img").trigger("error");
+    expect(wrapper.find("img").attributes("src")).toBe(ADA_FACE);
+
+    stale.dispatchEvent(new Event("error"));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find("img").attributes("src")).toBe(ADA_FACE);
+  });
+
+  // The other half of the reset: a recycled mark (the same instance handed a
+  // different row) must forget the previous row's failures. The icon store is
+  // content-addressed, so rows genuinely share a hash — the URL that failed for
+  // one row is the URL the next row wants tried.
+  it("tries a failed URL again once it is a different row's", async () => {
+    const wrapper = mount(ModelMark, {
+      props: { row: row({ icon_sha256: "b".repeat(64) }), ring: RING },
+    });
+    await wrapper.find("img").trigger("error");
+    expect(wrapper.find("img").attributes("src")).toBe(ADA_FACE);
+
+    await wrapper.setProps({ ring: { ...RING, id: 9, label: "Bo" } });
+    expect(wrapper.find("img").attributes("src")).toBe(icon("b".repeat(64)));
+  });
+
+  // Through a PARENT that re-renders, because that is the only way this bug is
+  // visible: the shelf calls `ringFor(row)` inline in its `v-for`, so every
+  // render hands the mark a new-but-identical ring object, and a reset keyed on
+  // object identity would put the mark straight back on the URL that 404ed —
+  // on every keystroke in the filter box. Mounting ModelMark alone with a
+  // stable prop cannot see it.
+  it("keeps the fallback when the parent re-renders with an equal ring", async () => {
+    const tick = ref(0);
+    const parent = mount(
+      defineComponent({
+        components: { ModelMark },
+        setup: () => ({ tick, row: row({ icon_sha256: "b".repeat(64) }) }),
+        // A fresh object literal every render, exactly as `ringFor(row)` is.
+        template: `<div :data-tick="tick">
+          <ModelMark :row="row"
+            :ring="{ type: 'character', id: 4, style: 'dashed', label: 'Ada' }" />
+        </div>`,
+      }),
+    );
+
+    await parent.find("img").trigger("error");
+    expect(parent.find("img").attributes("src")).toBe(ADA_FACE);
+
+    tick.value += 1;
+    await parent.vm.$nextTick();
+    expect(parent.find("img").attributes("src")).toBe(ADA_FACE);
   });
 
   it("draws no ring at all where nothing hands it one", () => {

--- a/frontend/src/components/widgets/ModelMark.vue
+++ b/frontend/src/components/widgets/ModelMark.vue
@@ -10,13 +10,23 @@
        gone (#904). -->
   <span class="mmark" :class="ringClass" :title="ring?.label || undefined">
     <span class="mmark-face" aria-hidden="true">
+      <!-- KEYED on the URL, so each candidate in the fallback chain gets its
+           own element. Reusing one element across two srcs is what makes an
+           `error` impossible to attribute: the handler cannot tell which load
+           failed, and blacklisting the wrong one drops a face that was never
+           even requested. Keyed, the element that failed keeps its own `src`
+           for as long as it exists, so a late error from it re-reports the
+           failure already recorded and `dropFace` swallows it as a duplicate.
+           (The listener does NOT die with the replaced node — Vue leaves it
+           attached — which is exactly why the frozen `src` is what matters.) -->
       <img
         v-if="faceUrl"
+        :key="faceUrl"
         class="mmark-img"
         :src="faceUrl"
         alt=""
         loading="lazy"
-        @error="faceFailed = true"
+        @error="dropFace"
       />
       <span
         v-else
@@ -84,14 +94,36 @@ const iconUrl = computed(() =>
   props.row?.icon_sha256 ? modelIconUrl(props.row.icon_sha256) : "",
 );
 
-const faceFailed = ref(false);
+// The candidates that 404ed, not a single "it failed" flag: the chain below
+// has two steps, and a flag set by the first one would take the second down
+// with it — a model whose icon file is missing would draw nothing rather than
+// falling through to the face of whoever it is assigned to.
+const failed = ref([]);
+
+// Read off the element that failed, never off `faceUrl`: that computed updates
+// the moment `failed` is written, while the DOM catches up a tick later, so two
+// errors arriving in one task would blacklist the SECOND candidate on the
+// strength of the first one's failure. The `:key` above is what makes
+// `event.target` unambiguous.
+function dropFace(event) {
+  const src = event.target.getAttribute("src");
+  if (src && !failed.value.includes(src)) {
+    failed.value = [...failed.value, src];
+  }
+}
 
 // A recycled mark (the same DOM node reused for a different row) would
-// otherwise keep the previous row's failure and never try its own picture.
+// otherwise keep the previous row's failures and never try its own pictures.
+//
+// The source is a STRING, deliberately. `ringFor(row)` is called inline in the
+// shelf's `v-for` (ModelShelf.vue), so every parent render hands this component
+// a new-but-identical ring object; a getter returning an array or the object
+// itself compares unequal each time, and the reset would fire on every keystroke
+// in the filter box — putting the mark back on the URL that just 404ed.
 watch(
-  () => [iconUrl.value, props.ring?.type, props.ring?.id],
+  () => `${iconUrl.value}|${props.ring?.type}|${props.ring?.id}`,
   () => {
-    faceFailed.value = false;
+    failed.value = [];
   },
 );
 
@@ -107,15 +139,22 @@ watch(
  *    pictures both 404 their thumbnail, and an empty square would read as a
  *    broken mark rather than as an entity without a picture.
  *
+ * Each step is skipped once its own URL has failed, so the chain runs all the
+ * way down: a model pointing at an icon whose file is gone falls to the
+ * assigned face, and then to the mark, rather than sitting on a broken image.
+ *
  * Addressed by URL rather than fetched as a blob, so the browser caches one
  * response however many rows borrow the same face — which is the common case,
  * a cast of characters across 1,800 adapters.
  */
 const faceUrl = computed(() => {
-  if (iconUrl.value) return iconUrl.value;
-  if (faceFailed.value) return "";
   const build = ENTITY_THUMBNAIL[props.ring?.type];
-  return build && props.ring?.id != null ? build(props.ring.id) : "";
+  const entityUrl = build && props.ring?.id != null ? build(props.ring.id) : "";
+  return (
+    [iconUrl.value, entityUrl].find(
+      (url) => url && !failed.value.includes(url),
+    ) || ""
+  );
 });
 
 const mark = computed(() => generatedMark(props.row));


### PR DESCRIPTION
The model shelf drew no thumbnails — not for a model's own icon, not for the
face of the person or set it is assigned to, and not for a training run's
samples in the import dialog. `ModelMark` already had the whole fallback chain;
none of it could ever draw.

## The cause

`apiClient.defaults.baseURL` is the backend **origin**. The `/api/v1` prefix is
added by the axios request interceptor — which only axios requests go through.
Four URL builders handed their result to an `<img src>`, which never reaches
that interceptor, so every one of them addressed a path that does not exist on
the API. FastAPI's SPA fallback answers it with `index.html`:

```
GET /characters/12/thumbnail          200 text/html      <- the SPA
GET /api/v1/characters/12/thumbnail   401 application/json  <- the API
```

The browser gets HTML where it expected an image, fires `error`, and the mark
falls back to generated initials. It fails as **200 OK**, which is why nothing
anywhere reported it.

Fixed by building all four from the exported `API_BASE_URL`, which is
`origin + /api/v1` — the same thing `pictureThumbnailUrl` has always done:

- `characterThumbnailUrl` — the assigned person's face
- `pictureSetThumbnailUrl` — the assigned set's thumbnail
- `modelIconUrl` — the model's own icon
- `runSampleUrl` — a training run's sample images

## Also in here

**The fallback chain now actually falls through.** `ModelMark` returned the
icon URL before consulting its failure flag, so once the prefix was fixed a
model whose icon *file* is missing would have sat on a permanently broken image
instead of borrowing the assigned face. It now records which URLs failed rather
than one flag, and the `<img>` is keyed on its URL so an `error` can be
attributed to the load that produced it.

**The failure record resets on a string key.** The shelf builds `ringFor(row)`
inline in its `v-for`, so every render hands each mark a new-but-identical ring
object. A watch source comparing object identity fired on every parent
re-render — every keystroke in the filter box — putting the mark straight back
on the URL that had just 404ed.

**Tests.** `src/api/imageUrls.test.js` covers all five browser-loaded URL
builders, unmocked and centrally. That is deliberate: the mocks standing in for
these builders elsewhere hardcode the correctly-prefixed string, so they agree
with each other about a URL the real code did not produce — which is precisely
how the suite stayed green while the shelf drew nothing. Every mechanism above
is mutation-checked: reverting any one of the four builders, neutering the
watch, removing the `:key`, or reading the failed URL off the computed instead
of the element each turns exactly the intended test red.

## Two review objections I did not act on, and why

**The ESLint guard on `apiClient.defaults` is not run by CI.** True — the
frontend job runs `npm test`, not `npm run lint`. I kept the rule anyway: it
catches a *new* builder written the wrong way, which a test over today's five
cannot, and `eslint.config.js` already carries a `no-restricted-imports` block
with exactly the same enforcement status. Wiring frontend lint into CI is a
worthwhile one-line change but it is a workflow change, which this repo gates
behind a security review, and it is not this bug.

**Other components still mock these builders with hardcoded prefixed strings.**
Left alone. Mocking the transport is the right thing for a component test; the
fix is a central assertion against the real module, which is what was missing.
