### PR TITLE
Two-column person and picture-set editors

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -571,11 +571,25 @@ Small presentational building blocks shared by the section components above, so 
 
 ### Editor and Browser Components
 
-#### `CharacterEditor.vue` (438 lines)
-Create/edit/delete character (person) entity. Props: `open`, `character`, `backendUrl`, `projects`. Emits: `close`, `saved` (payload: the saved record, with the server-assigned id on create, so hosts can chain follow-up work). Hosted by `SideBar` (its own entry points) and by `ImageGrid` (the context menu's create-person-and-assign flow, #645). Embeds `AdapterTray` below the reference images.
+#### `CharacterEditor.vue` (582 lines)
+Create/edit a character (person). Props: `open`, `character`, `backendUrl`, `projects`. Emits: `close`, `saved` (payload: the saved record, with the server-assigned id on create, so hosts can chain follow-up work). Hosted by `SideBar` (its own entry points), by `ImageGrid` (the context menu's create-person-and-assign flow, #645) and by `ImageOverlay` (create-person-from-a-face; that instance is overlay-local, see §`ImageOverlay.vue`). Embeds `AdapterTray` below the reference images. **Editing is two-column at 720** (fields left, reference images right, tray spanning); **creating stays one-column at 480**, because both right-column blocks are gated on an existing id and a 720 dialog with an empty half is worse than the narrow one. See "Two-column editors" below.
 
-#### `PictureSetEditor.vue` (621 lines)
-Create/edit/delete picture sets. Props: `open`, `set`, `thumbnailUrl`. Uses `SET_ICONS`, `SET_COLORS`, `SET_ICON_CATEGORIES`, `ICON_CARDS` from `setAppearance.js`. Emits: `close`, `saved`, `deleted`. Embeds `AdapterTray` below the appearance row, outside the lock wash — the tray is read-only, so a locked set still shows what it uses.
+#### `PictureSetEditor.vue` (696 lines)
+Create/edit picture sets. Props: `open`, `set`, `thumbnailUrl`, `backendUrl`, `projects`. Uses `SET_COLORS`, `SET_ICON_CATEGORIES`, `ICON_CARDS` from `setAppearance.js`. Emits: `close`, `refresh-sidebar`. Hosted by `SideBar`. Embeds `AdapterTray` below the appearance row, outside the lock wash — the tray is read-only, so a locked set still shows what it uses. **Two-column at 720**: name/description left, projects/lock right, with the appearance row and the tray spanning both. See "Two-column editors" below.
+
+#### Two-column editors (`CharacterEditor`, `PictureSetEditor`)
+
+Both editors had outgrown the viewport and were scrolling `AppDialog`'s body. Measured by driving the e2e fixture library in Chromium at 1280x800, comparing `.app-dialog__body` `scrollHeight` against `clientHeight`: the person editor held 768px of content in a 641px body — 127px of scroll — and the set editor 676 in 641. **`e2e/specs/editor-layout.spec.js` keeps that measurement honest**: it asserts `scrollHeight === clientHeight` for both editors and that the columns are side by side, which is the guarantee this section is about and the one a jsdom unit test cannot see. Two columns, not tabs: these are short-lived forms with one required field and one commit, and a field behind a tab is one you cannot check before you save — which in the person editor is a Ctrl+Enter away (the set editor has no such binding; that inconsistency is its own item). At 720 the same measurement gives 487 and 540 with `scrollHeight === clientHeight`.
+
+**That is a claim about width, not a promise about every window.** A dialog whose content is ~490-540px tall still scrolls once the viewport is short enough to squeeze `AppDialog`'s body below it — measured in 10px steps, the person editor is clear down to a 650px-tall viewport and starts scrolling at 640, and the set editor is clear to 700 and starts at 690. Two columns move the threshold from "most windows" to "short ones"; they do not abolish it, and `AppDialog` scrolling its body is the correct behaviour when it is reached. The spec pins the 1280x800 case.
+
+The shape is the same in both, and is a **CSS reflow of unchanged source order** — `.editor-col` divs in DOM order inside a `.editor-body` grid, two of them wherever the layout splits (the person editor's create branch renders one) — so the focus sequence is exactly what it was single-column. No `order`, no `row-reverse`, nothing that reorders the DOM. What does change is where that unchanged sequence lands on screen: the person editor's second column is read-only, so nothing moves, but the set editor's holds Projects and Locked, so Tab travels down the left column and then jumps to the top of the right one. That is column-major order, which is what a two-column form is read in — worth knowing rather than worth denying.
+
+- `grid-template-columns: repeat(2, minmax(0, 1fr))` — `minmax(0, …)` and not a bare `1fr`, or a wide child sets the track's min-content width and pushes the row past the dialog.
+- `.editor-span` (`grid-column: 1 / -1`) for rows that must not be halved: `AdapterTray` in both (its cards auto-fill at 180px), plus the set editor's appearance row, whose eight 32px icon columns, "or" divider, thumbnail and colour box have an intrinsic width around 570px. **The icon grid stays at 8 columns**; if it ever has to shrink, the appearance row was wrongly put in a column.
+- `@media (max-width: 720px)` collapses both to one column. Vuetify caps the dialog at `calc(100% - 48px)`, so below a 768px viewport it is no longer 720 wide and the columns shrink with it — 299px each at a 720px viewport, under the ~300px the fields want.
+
+720 is an existing rung on the dialog-width ladder (`ModelFoldersDialog`); 820 is the two-pane-with-nav-rail tier (`UserSettingsDialog`, `ModelImportDialog`) and these are forms. That ladder is ten literal values across twenty-odd numeric `:width` call sites with no token behind it — a real system gap, but not this change's to close.
 
 #### `ProjectEditor.vue` (177 lines)
 Create/rename/delete a project. Props: `open`, `project`. Emits: `close`, `saved`, `deleted`.

--- a/frontend/e2e/specs/editor-layout.spec.js
+++ b/frontend/e2e/specs/editor-layout.spec.js
@@ -1,0 +1,147 @@
+import { test, expect } from '../fixtures/test.js'
+
+// The person and picture-set editors are two-column so they stop outgrowing the
+// viewport and scrolling `AppDialog`'s body. That is the whole point of the
+// layout and it is not something a jsdom unit test can see: the branch which
+// PICKS the layout is covered in
+// `src/components/editors/EditorTwoColumnLayout.test.js`, and this file covers
+// the thing the layout exists to achieve, in a browser with real box metrics.
+//
+// The assertion is `scrollHeight === clientHeight` on `.app-dialog__body` — the
+// same shape as `overlay-tag-list-scroll.spec.js`. Navigation and dialog-open
+// only; nothing here mutates the fixture library.
+
+const VIEWPORT = { width: 1280, height: 800 }
+
+/** Right-click a sidebar row and choose Edit. */
+async function openEditorFor(sidebar, row) {
+  await expect(row).toBeVisible()
+  await row.click({ button: 'right' })
+  await expect(sidebar.ctxMenu).toBeVisible()
+  // The page object's exact-name helper, not a substring match: the character
+  // menu also carries `Share "<name>"`, so a loose "Edit" would match that row
+  // instead for any person whose name happens to contain those four letters.
+  await sidebar.ctxButton('Edit').click()
+}
+
+/** Metrics of the open dialog, once its enter transition has settled. */
+async function dialogMetrics(page, { waitFor = [] } = {}) {
+  const dialog = page.locator('.app-dialog')
+  await expect(dialog).toBeVisible()
+  await expect(page.locator('.editor-body')).toBeVisible()
+  // Two different waits, for two different things. Every block the height
+  // measurement depends on is POLLED, because each is gated on its own fetch —
+  // the reference grid is two sequential round trips deep and the adapter tray
+  // one — and a sleep long enough for those on a loaded CI runner is a sleep
+  // that makes this spec slow for everyone. Miss one and `scrollHeight` is read
+  // with a row still missing, which is how a "does not scroll" assertion goes
+  // green on a layout that scrolls.
+  for (const sel of waitFor) {
+    await expect(page.locator(sel).first()).toBeVisible()
+  }
+  // The fixed wait is only for the dialog's own enter/leave transition, which
+  // is time-based rather than content-based and so has nothing to poll on.
+  await page.waitForTimeout(300)
+  return dialog.evaluate((el) => {
+    const body = el.querySelector('.app-dialog__body')
+    const cols = [...el.querySelectorAll('.editor-col')]
+    return {
+      bodyClient: body.clientHeight,
+      bodyScroll: body.scrollHeight,
+      columns: cols.length,
+      colTops: cols.map((c) => Math.round(c.getBoundingClientRect().top)),
+      // The dialog body, NOT the document: Vuetify blocks scrolling on <html>
+      // while a dialog is open, so the document's own overflow stays 0 however
+      // far the layout blows out sideways and cannot fail.
+      bodyOverflowX: body.scrollWidth - body.clientWidth,
+      referenceThumbs: el.querySelectorAll('.ref-picture-thumb').length,
+      // Track WIDTH, not count: `repeat(8, 1fr)` still reports eight tracks
+      // when the row is squeezed into one column — they just get too narrow
+      // for the 32px buttons sitting in them.
+      iconTrack: (() => {
+        const g = el.querySelector('.icon-grid')
+        if (!g) return null
+        return Math.round(parseFloat(getComputedStyle(g).gridTemplateColumns))
+      })(),
+      colWidth: cols.length ? Math.round(cols[0].getBoundingClientRect().width) : null,
+      appearanceWidth: (() => {
+        const a = el.querySelector('.appearance-row')
+        return a ? Math.round(a.getBoundingClientRect().width) : null
+      })(),
+      trayWidth: (() => {
+        const t = el.querySelector('.adapter-tray')
+        return t ? Math.round(t.getBoundingClientRect().width) : null
+      })(),
+      dialogWidth: Math.round(el.getBoundingClientRect().width),
+    }
+  })
+}
+
+test.describe('editor dialogs fit without scrolling', () => {
+  test.beforeEach(async ({ page, grid }) => {
+    await page.setViewportSize(VIEWPORT)
+    await grid.goto()
+  })
+
+  test('the person editor is two columns and its body does not scroll', async ({
+    page,
+    sidebar,
+  }) => {
+    await openEditorFor(sidebar, await sidebar.firstNonEmpty(sidebar.characterItems))
+    const m = await dialogMetrics(page, {
+      waitFor: ['.ref-picture-thumb', '.adapter-tray'],
+    })
+
+    expect(m.columns).toBe(2)
+    // Side by side, not stacked — a collapsed grid would also "not scroll" if
+    // the content happened to be short.
+    expect(m.colTops[0]).toBe(m.colTops[1])
+    expect(m.bodyScroll).toBe(m.bodyClient)
+    // The right column has to be carrying something, or "it fits" is a claim
+    // about an empty box rather than about the layout.
+    expect(m.referenceThumbs).toBeGreaterThan(0)
+    expect(m.dialogWidth).toBe(720)
+    // The tray spans both columns rather than sitting in one. Note this
+    // measures the row's WIDTH, not a populated tray's height: the fixture
+    // library attaches no adapters, and a library with some puts cards in this
+    // row three across instead of one, eating into the headroom measured above.
+    // Deliberately not asserted — the adapter count is a property of the shared
+    // fixture, so pinning it would fail this spec from an unrelated change.
+    expect(m.trayWidth).toBeGreaterThan(m.colWidth * 1.8)
+  })
+
+  test('the picture-set editor is two columns and its body does not scroll', async ({
+    page,
+    sidebar,
+  }) => {
+    await openEditorFor(sidebar, await sidebar.firstNonEmpty(sidebar.setItems))
+    const m = await dialogMetrics(page, { waitFor: ['.icon-btn', '.adapter-tray'] })
+
+    expect(m.columns).toBe(2)
+    expect(m.colTops[0]).toBe(m.colTops[1])
+    expect(m.bodyScroll).toBe(m.bodyClient)
+    // The appearance row spans rather than sitting in a column. Squeezed into
+    // half the dialog it would keep the body from scrolling anyway — the icon
+    // grid has its own scroller — so the metrics above cannot see this alone.
+    expect(m.appearanceWidth).toBeGreaterThan(m.colWidth * 1.8)
+    // And its eight icon tracks stay wide enough for the 32px buttons in them.
+    expect(m.iconTrack).toBeGreaterThanOrEqual(32)
+    expect(m.trayWidth).toBeGreaterThan(m.colWidth * 1.8)
+    expect(m.dialogWidth).toBe(720)
+  })
+
+  test('a narrow window collapses to one column instead of overflowing', async ({
+    page,
+    sidebar,
+  }) => {
+    await openEditorFor(sidebar, await sidebar.firstNonEmpty(sidebar.characterItems))
+    await expect(page.locator('.app-dialog')).toBeVisible()
+    // Resize with the dialog open: below 720 the media query stacks the
+    // columns, which is the layout the editors had before this one.
+    await page.setViewportSize({ width: 700, height: 900 })
+    const m = await dialogMetrics(page, { waitFor: ['.adapter-tray'] })
+
+    expect(m.colTops[0]).toBeLessThan(m.colTops[1])
+    expect(m.bodyOverflowX).toBe(0)
+  })
+})

--- a/frontend/src/components/editors/CharacterEditor.vue
+++ b/frontend/src/components/editors/CharacterEditor.vue
@@ -1,80 +1,115 @@
 <template>
   <AppDialog
     :open="open"
-    :title="character?.id ? 'Edit person' : 'New person'"
-    :width="480"
+    :title="isExisting ? 'Edit person' : 'New person'"
+    :width="isExisting ? 720 : 480"
     @close="emit('close')"
   >
-    <div class="editor-body">
-      <AppInput
-        ref="nameInputRef"
-        v-model="localCharacter.name"
-        label="Name *"
-        placeholder="Name"
-        icon="account-outline"
-        @enter="save"
-      />
-      <AppTextarea
-        v-model="localCharacter.description"
-        label="Description"
-        placeholder="A short description of this person…"
-        :rows="3"
-      />
-      <AppTextarea
-        v-model="localCharacter.extra_metadata"
-        label="Metadata"
-        placeholder="Notes, source, tags…"
-        :rows="2"
-      />
-      <AppSelect
-        v-model="projectSelection"
-        label="Projects"
-        :options="projectOptions"
-        :multiple="true"
-      />
-      <div v-if="character?.id" class="ref-pictures-section">
-        <div class="ref-pictures-header">
-          <span class="ref-pictures-title">Reference Images</span>
-        </div>
-        <p class="ref-pictures-help">
-          Automatically selected from the highest-scoring images of this person.
-        </p>
-        <div v-if="referencePictures.length > 0" class="ref-pictures-grid">
-          <div
-            v-for="pic in referencePictures"
-            :key="pic.id"
-            class="ref-picture-item"
-            @click="previewPic = pic"
-          >
-            <img
-              :src="
-                appendShareToken(
-                  `${props.backendUrl}/pictures/thumbnails/${pic.id}.webp`,
-                )
-              "
-              class="ref-picture-thumb"
-              loading="lazy"
-            />
-            <StarRatingOverlay
-              :score="pic.score || 0"
-              :max="5"
-              :compact="true"
-            />
-          </div>
-        </div>
-        <p v-else-if="!referencePicturesLoading" class="ref-pictures-empty">
-          No reference images yet — add more scored pictures of this person.
-        </p>
+    <!-- Two columns rather than one tall stack, so the form stops outgrowing
+         the viewport and scrolling its own body. The columns are a CSS reflow
+         of unchanged source order: everything writable is in the first column,
+         the read-only reference grid in the second, so tab order is exactly
+         what it was single-column. Tabs were the stated alternative and were
+         rejected — a field hidden behind a tab is a field you cannot check
+         before Ctrl+Enter saves. Creating a person has no right column (no
+         reference images, no adapters yet), so it stays the narrow one-column
+         dialog it has always been. -->
+    <div class="editor-body" :class="{ 'editor-body--split': isExisting }">
+      <div class="editor-col">
+        <AppInput
+          ref="nameInputRef"
+          v-model="localCharacter.name"
+          label="Name *"
+          placeholder="Name"
+          icon="account-outline"
+          @enter="save"
+        />
+        <AppTextarea
+          v-model="localCharacter.description"
+          label="Description"
+          placeholder="A short description of this person…"
+          :rows="3"
+        />
+        <AppTextarea
+          v-model="localCharacter.extra_metadata"
+          label="Metadata"
+          placeholder="Notes, source, tags…"
+          :rows="2"
+        />
+        <AppSelect
+          v-model="projectSelection"
+          label="Projects"
+          :options="projectOptions"
+          :multiple="true"
+        />
       </div>
-      <!-- `v-if="props.open"` so the tray remounts and re-reads on every open.
-           Vuetify's dialog already unboots its body on close, so this is mostly
-           belt-and-braces — but the freshness of a list written on ANOTHER
-           surface (the shelf) should not rest on an overlay's lazy-mount
-           behaviour, which is a detail of the dialog rather than a contract. -->
+      <div v-if="isExisting" class="editor-col">
+        <div class="ref-pictures-section">
+          <div class="ref-pictures-header">
+            <span :id="refsHeadingId" class="section-label">Reference Images</span>
+          </div>
+          <p class="ref-pictures-help">
+            Automatically selected from the highest-scoring images of this
+            person.
+          </p>
+          <!-- Named through its heading, or the group is an unlabelled pile of
+               images — the same wiring AdapterTray puts on its list, and it
+               matters more here now that the block is its own column rather
+               than the thing directly under the heading in one stack. -->
+          <div
+            v-if="referencePictures.length > 0"
+            class="ref-pictures-grid"
+            role="group"
+            :aria-labelledby="refsHeadingId"
+          >
+            <div
+              v-for="pic in referencePictures"
+              :key="pic.id"
+              class="ref-picture-item"
+              @click="previewPic = pic"
+            >
+              <img
+                :src="
+                  appendShareToken(
+                    `${props.backendUrl}/pictures/thumbnails/${pic.id}.webp`,
+                  )
+                "
+                class="ref-picture-thumb"
+                alt="Reference image"
+                loading="lazy"
+              />
+              <StarRatingOverlay
+                :score="pic.score || 0"
+                :max="5"
+                :compact="true"
+              />
+            </div>
+          </div>
+          <p v-else-if="!referencePicturesLoading" class="ref-pictures-empty">
+            No reference images yet — add more scored pictures of this person.
+          </p>
+        </div>
+      </div>
+      <!-- Keyed on the open count rather than gated on `open`. Vuetify does
+           unboot the dialog body once the transition finishes, so the key is
+           belt-and-braces for the re-read — the freshness of a list written on
+           ANOTHER surface (the shelf) should not rest on that lazy-mount
+           behaviour, which is a detail rather than a contract — but unlike
+           `v-if` it does NOT unmount the tray as the dialog closes. That is
+           what this is really for. `v-if="props.open"` did,
+           and since this row spans both columns it took the widest block in the
+           dialog out from under a leave transition still playing. Same reason
+           the id comes from the latched local copy: the host nulls the prop on
+           the way out. Spans both columns: its cards auto-fill at 180px, so a
+           full-width row holds three of them instead of one (670px of inner
+           width — 720 less the border and the --space-6 padding — against a
+           180px minimum track and a --space-3 gap). -->
       <AdapterTray
-        v-if="props.open"
+        v-if="openCount > 0"
+        :key="openCount"
+        class="editor-span"
         entity-type="character"
-        :entity-id="props.character?.id"
+        :entity-id="localCharacter.id"
       />
     </div>
     <template #footer>
@@ -104,6 +139,7 @@
           )
         "
         class="ref-preview-img"
+        alt="Reference image, enlarged"
         @click="previewPic = null"
       />
     </div>
@@ -111,7 +147,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch, nextTick, onUnmounted } from "vue";
+import { computed, ref, useId, watch, nextTick, onUnmounted } from "vue";
 import { API_BASE_URL, appendShareToken } from "../../utils/apiClient";
 import {
   createCharacter,
@@ -142,6 +178,20 @@ const props = defineProps({
   projects: { type: Array, default: () => [] },
 });
 
+// An existing person is the only case with a right column: reference images are
+// `v-if`'d on the id and the adapter tray renders nothing without one. Creating
+// therefore keeps the 480 single-column dialog rather than a 720 one with an
+// empty half. Written by the watcher below rather than computed off the prop —
+// see the note there for why the close path must not recompute it.
+const isExisting = ref(false);
+
+// Bumped on every open. Keys the adapter tray so it remounts and re-reads each
+// time the dialog is opened, without unmounting it as the dialog closes.
+const openCount = ref(0);
+
+// Ties the reference grid to its heading (see the template).
+const refsHeadingId = useId();
+
 const projectOptions = computed(() =>
   props.projects.map((p) => ({ value: String(p.id), label: p.name })),
 );
@@ -169,36 +219,84 @@ const referencePictures = ref([]);
 const referencePicturesLoading = ref(false);
 const previewPic = ref(null);
 
-async function fetchReferencePictures(characterId) {
+// The read this fetch answers is two sequential round trips wide, and the
+// dialog is a shared, permanently-mounted instance: the user can close it or
+// open a different person inside that window, and the late response would then
+// paint one person's reference images — their FACE — under another's name. Only
+// the newest request may write anything, including the loading flag.
+//
+// A counter, not a comparison against `props.character.id`: the same person can
+// be closed and reopened while the first read is still in flight, and an id
+// equal to itself would let that abandoned request through — its late failure
+// would then wipe the list the reopened dialog had already filled. Identity of
+// the REQUEST is the question, and only a counter answers it.
+let referenceRequestId = 0;
+
+async function fetchReferencePictures(characterId, requestId) {
+  const superseded = () => requestId !== referenceRequestId;
   referencePicturesLoading.value = true;
   try {
     const refBody = await getReferencePictures(characterId);
     const ids = refBody?.reference_picture_ids ?? [];
     if (!ids.length) {
-      referencePictures.value = [];
+      if (!superseded()) referencePictures.value = [];
       return;
     }
     const rows = await listPicturesByIds(ids);
+    if (superseded()) return;
     const pics = Array.isArray(rows) ? rows : [];
     const picsById = new Map(pics.map((p) => [String(p.id), p]));
     referencePictures.value = ids
       .map((id) => picsById.get(String(id)))
       .filter(Boolean);
   } catch {
-    referencePictures.value = [];
+    if (!superseded()) referencePictures.value = [];
   } finally {
-    referencePicturesLoading.value = false;
+    // Only the newest request owns the flag: an older one clearing it would
+    // drop a mid-fetch person to `[]` + not-loading, which renders as "No
+    // reference images yet". A closing dialog starts no new request, so this
+    // one is still the newest and does clear it — the flag cannot stick.
+    if (!superseded()) referencePicturesLoading.value = false;
   }
 }
 
+// One watcher over `[open, id]` owns both the layout branch and the reference
+// list, because both answer the same question and a second copy of the source
+// would only drift.
+//
+// It does nothing on the way OUT, and that is the point. The hosts null
+// `character` in the same tick they set `open` false
+// (`SideBar.closeCharacterEditor`) while Vuetify keeps the body mounted for the
+// leave transition, so anything recomputed here plays out on screen: the dialog
+// would snap 720 → 480 and lose its right column, and emptying the list would
+// put "No reference images yet" under a person who has them, for the length of
+// the animation. Leave the closing dialog exactly as the user last saw it; the
+// next open recomputes everything before it is visible.
 watch(
   () => [props.open, props.character?.id],
   ([isOpen, charId]) => {
-    if (isOpen && charId) {
-      fetchReferencePictures(charId);
-    } else {
-      referencePictures.value = [];
-    }
+    // The preview is the one exception to "change nothing on the way out", and
+    // it is an exception because it is not part of the dialog: it is teleported
+    // to <body> at z-index 9999 and covers the whole app. Left up, it outlives
+    // the dialog that owned it — Ctrl+Enter saves and closes from underneath an
+    // open preview, and the Escape that would dismiss it goes with the dialog's
+    // own listener, so the scrim strands with only a mouse click to clear it.
+    // Dropped on both edges: out, so nothing is orphaned; in, so a preview that
+    // somehow survives cannot greet the next person.
+    previewPic.value = null;
+    if (!isOpen) return;
+    openCount.value += 1;
+    isExisting.value = !!charId;
+    // Every open invalidates whatever was in flight, the create path included —
+    // otherwise the previous person's read stays "newest" and writes under a
+    // dialog that has moved on.
+    const requestId = ++referenceRequestId;
+    // Cleared on the way IN, so the previous person's thumbnails are not what
+    // fills the new one's column while its own read is in flight. What keeps a
+    // late response off the wrong person is that counter; this is about the gap
+    // before any response, and both are needed.
+    referencePictures.value = [];
+    if (charId) fetchReferencePictures(charId, requestId);
   },
   { immediate: true },
 );
@@ -221,9 +319,15 @@ watch(
   },
 );
 
+// Also gated on `open`, for the same reason as the watcher above: the hosts
+// null `character` as they close, and this one would blank all four fields
+// under a dialog that is still on screen playing its leave transition. The
+// form's contents are only ever read while it is open, so filling it on the way
+// in is the whole contract.
 watch(
-  () => props.character,
-  (newChar) => {
+  () => [props.open, props.character],
+  ([isOpen, newChar]) => {
+    if (!isOpen) return;
     if (newChar) {
       localCharacter.value = {
         id: newChar.id,
@@ -349,18 +453,55 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeydown));
 </script>
 
 <style scoped>
+/* One column by default (create), two when there is a right column to fill.
+   `minmax(0, 1fr)` and not a bare `1fr`: a bare track takes its min-content
+   width from the widest child, and a long project name or a fixed-width
+   control would then push the row wider than the dialog. */
 .editor-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  column-gap: var(--space-6);
+  row-gap: var(--space-5);
+}
+
+.editor-body--split {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.editor-col {
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
+  min-width: 0;
 }
 
+.editor-span {
+  grid-column: 1 / -1;
+}
+
+/* Vuetify caps the dialog at `calc(100% - 48px)`, so it stops being 720 wide
+   below a 768px viewport and each column falls under the ~300px the fields
+   want (299px at a 720px viewport). 720 is where that is unambiguous. Drop to
+   the single column the editor has always had — and give the reference block
+   back the rule that separates it from the fields stacked above it there. */
+@media (max-width: 720px) {
+  .editor-body--split {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ref-pictures-section {
+    padding-top: var(--space-2);
+    border-top: 1px solid rgba(var(--v-theme-border, 127 127 127), 0.25);
+  }
+}
+
+/* No border-top in the two-column layout: the rule earned its place under a
+   stack of fields, and at the top of its own column it is a hairline with
+   nothing above it, aligning with nothing on the other side. */
 .ref-pictures-section {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  padding-top: var(--space-2);
-  border-top: 1px solid rgba(var(--v-theme-border, 127 127 127), 0.25);
 }
 
 .ref-pictures-header {
@@ -369,25 +510,28 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeydown));
   gap: var(--space-3);
 }
 
-.ref-pictures-title {
-  font-size: var(--text-sm);
-  font-weight: var(--weight-semibold);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(var(--v-theme-on-surface), 0.6);
-}
-
+/* --text-xs, not --text-sm: this hint sits under a `.section-label` heading at
+   --text-2xs, and it was a full two ramp steps above it. --text-xs over
+   --text-2xs is the pairing AdapterTray already uses for exactly this — one
+   step, with the heading carrying its rank on case, weight and tracking.
+   Alpha 0.7 for the same reason AdapterTray's lines carry it: at 12px this is
+   SMALL text and owes 4.5:1 (visual-language.md §4). It shipped at 0.5, which
+   measures 3.19:1 light; 0.7 measures 5.94:1. Shrinking a line without
+   re-checking its contrast is how that floor gets missed. */
 .ref-pictures-help {
-  font-size: var(--text-sm);
-  color: rgba(var(--v-theme-on-surface), 0.5);
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), 0.7);
   margin: 0;
   font-style: italic;
   line-height: 1.4;
 }
 
+/* --text-xs and alpha 0.7 for the same reasons as the hint above it: these two
+   render adjacently when the list is empty, and 0.4 measured 2.43:1 — the
+   quietest thing in the dialog was the one line explaining why it is empty. */
 .ref-pictures-empty {
-  font-size: var(--text-sm);
-  color: rgba(var(--v-theme-on-surface), 0.4);
+  font-size: var(--text-xs);
+  color: rgba(var(--v-theme-on-surface), 0.7);
   font-style: italic;
   margin: 0;
 }

--- a/frontend/src/components/editors/EditorTwoColumnLayout.test.js
+++ b/frontend/src/components/editors/EditorTwoColumnLayout.test.js
@@ -1,0 +1,399 @@
+// The two-column editor layout (CharacterEditor, PictureSetEditor).
+//
+// The layout itself is CSS and belongs in a browser, but the branch that picks
+// it is logic, and this is what guards it: which width the dialog asks for,
+// whether the split class and the second column are rendered, and which rows
+// opt out of the columns by spanning. Without these, inverting `isExisting` to
+// a constant leaves every other editor test green.
+//
+// The close-transition case is the subtle one. Hosts null `character` in the
+// same tick they set `open` false (`SideBar.closeCharacterEditor`) while
+// Vuetify keeps the body mounted for the leave animation, so a width computed
+// straight off the prop would snap 720 → 480 mid-exit.
+
+import { describe, it, expect, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+
+vi.mock("../../utils/apiClient", () => ({
+  API_BASE_URL: "/api/v1",
+  appendShareToken: (url) => url,
+  apiClient: { post: vi.fn(), patch: vi.fn() },
+}));
+
+vi.mock("../../api/characters", () => ({
+  createCharacter: vi.fn(),
+  patchCharacter: vi.fn(),
+  getReferencePictures: vi.fn().mockResolvedValue({ reference_picture_ids: [] }),
+}));
+
+vi.mock("../../api/pictures", () => ({
+  listPicturesByIds: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../api/pictureSets", () => ({
+  createPictureSet: vi.fn(),
+  patchPictureSet: vi.fn(),
+}));
+
+vi.mock("vuetify/components", () => ({
+  VIcon: { name: "v-icon", template: "<i><slot /></i>" },
+}));
+
+import { getReferencePictures } from "../../api/characters";
+import { listPicturesByIds } from "../../api/pictures";
+import CharacterEditor from "./CharacterEditor.vue";
+import PictureSetEditor from "./PictureSetEditor.vue";
+
+// Renders the default slot only, and exposes the width the editor asked for.
+const AppDialog = {
+  name: "AppDialog",
+  props: ["open", "title", "width"],
+  template: `<div class="app-dialog-stub"><slot /><slot name="footer" /></div>`,
+};
+
+const stubs = {
+  AppDialog,
+  AppInput: true,
+  AppTextarea: true,
+  AppSelect: true,
+  AppButton: true,
+  FieldLabel: true,
+  StarRatingOverlay: true,
+  // Rendered as a real element so the spanning class can be read off it, and
+  // carrying `data-id` like the sibling stubs in CharacterCreateAndAssign and
+  // PictureSetEditor — without it, "the tray is still there" cannot tell a tray
+  // pointed at the person being edited from one pointed at `undefined`, which
+  // is exactly what a closing dialog would leave.
+  AdapterTray: {
+    name: "AdapterTray",
+    props: ["entityType", "entityId"],
+    template: `<div class="adapter-tray-stub" :data-id="entityId ?? ''"></div>`,
+  },
+};
+
+function mountCharacter(props) {
+  setActivePinia(createPinia());
+  return mount(CharacterEditor, { props, global: { stubs } });
+}
+
+function widthOf(wrapper) {
+  return wrapper.findComponent({ name: "AppDialog" }).props("width");
+}
+
+describe("CharacterEditor layout", () => {
+  it("creating is one column at 480 — both right-column blocks need an id", () => {
+    const w = mountCharacter({ open: true, character: null });
+
+    expect(widthOf(w)).toBe(480);
+    expect(w.find(".editor-body").classes()).not.toContain("editor-body--split");
+    expect(w.findAll(".editor-col")).toHaveLength(1);
+  });
+
+  it("editing is two columns at 720 with the tray spanning", () => {
+    const w = mountCharacter({ open: true, character: { id: 7, name: "A" } });
+
+    expect(widthOf(w)).toBe(720);
+    expect(w.find(".editor-body").classes()).toContain("editor-body--split");
+    expect(w.findAll(".editor-col")).toHaveLength(2);
+    expect(w.find(".adapter-tray-stub").classes()).toContain("editor-span");
+  });
+
+  it("does not reflow or empty itself while closing", async () => {
+    getReferencePictures.mockResolvedValueOnce({ reference_picture_ids: [1] });
+    listPicturesByIds.mockResolvedValueOnce([{ id: 1, score: 4 }]);
+    const w = mountCharacter({ open: true, character: { id: 7, name: "A" } });
+    await flushPromises();
+    expect(w.findAll(".ref-picture-item")).toHaveLength(1);
+
+    // Exactly what SideBar.closeCharacterEditor does, in one flush. The body
+    // stays mounted for the leave transition, so anything recomputed here is
+    // on screen: a 720 → 480 snap, or "No reference images yet" under a person
+    // who has them.
+    await w.setProps({ open: false, character: null });
+    await flushPromises();
+
+    expect(widthOf(w)).toBe(720);
+    expect(w.findAll(".editor-col")).toHaveLength(2);
+    expect(w.findAll(".ref-picture-item")).toHaveLength(1);
+    expect(w.find(".ref-pictures-empty").exists()).toBe(false);
+    // The heading and the fields are as visible as the columns are, so they
+    // have to hold too — a dialog that says "New person" over four blank
+    // fields beside that person's face is the same defect, further up.
+    expect(w.findComponent({ name: "AppDialog" }).props("title")).toBe(
+      "Edit person",
+    );
+    expect(w.vm.localCharacter.name).toBe("A");
+    // Including the tray, which spans both columns — the widest block in the
+    // dialog is the worst one to drop out from under a leave transition. Its
+    // id has to hold too: the host nulls the prop, so a tray reading straight
+    // off it stays mounted but points at nobody.
+    expect(w.find(".adapter-tray-stub").attributes("data-id")).toBe("7");
+  });
+
+  it("remounts the tray on each open so a shelf edit in between shows up", async () => {
+    const w = mountCharacter({ open: true, character: { id: 7, name: "A" } });
+    const firstKey = w.findComponent({ name: "AdapterTray" }).vm.$.vnode.key;
+
+    await w.setProps({ open: false, character: null });
+    await w.setProps({ open: true, character: { id: 7, name: "A" } });
+
+    expect(w.findComponent({ name: "AdapterTray" }).vm.$.vnode.key).not.toBe(
+      firstKey,
+    );
+  });
+
+  it("never strands the full-screen reference preview", async () => {
+    // The preview is teleported to <body> at z-index 9999 and covers the whole
+    // app, and the Escape that dismisses it lives on the dialog's own listener.
+    // Ctrl+Enter saves and closes from under an open preview, so a preview that
+    // outlives its dialog can only be cleared with a mouse.
+    getReferencePictures.mockResolvedValueOnce({ reference_picture_ids: [1] });
+    listPicturesByIds.mockResolvedValueOnce([{ id: 1, score: 4 }]);
+    const w = mountCharacter({ open: true, character: { id: 7, name: "A" } });
+    await flushPromises();
+    await w.find(".ref-picture-item").trigger("click");
+    expect(w.vm.previewPic).not.toBeNull();
+
+    await w.setProps({ open: false, character: null });
+    expect(w.vm.previewPic).toBeNull();
+
+    // And nothing survives into the next person's dialog either.
+    getReferencePictures.mockResolvedValueOnce({ reference_picture_ids: [] });
+    await w.setProps({ open: true, character: { id: 8, name: "B" } });
+    expect(w.vm.previewPic).toBeNull();
+  });
+
+  it("never paints one person's reference images under another's name", async () => {
+    // Person A's read is left in flight while the host swaps to person B, which
+    // is one click in the sidebar. A's response then lands last.
+    let resolveA;
+    getReferencePictures.mockReturnValueOnce(
+      new Promise((r) => {
+        resolveA = () => r({ reference_picture_ids: [11] });
+      }),
+    );
+    listPicturesByIds.mockResolvedValue([{ id: 11, score: 5 }]);
+
+    const w = mountCharacter({ open: true, character: { id: 1, name: "A" } });
+
+    getReferencePictures.mockResolvedValueOnce({ reference_picture_ids: [99] });
+    listPicturesByIds.mockResolvedValueOnce([{ id: 99, score: 3 }]);
+    await w.setProps({ character: { id: 2, name: "B" } });
+    await flushPromises();
+    expect(w.find(".ref-picture-thumb").attributes("src")).toContain("99");
+
+    resolveA();
+    await flushPromises();
+
+    // Still B's picture. A's late response belongs to a person who is no
+    // longer on screen, and reference images are that person's face.
+    expect(w.find(".ref-picture-thumb").attributes("src")).toContain("99");
+  });
+
+  it("survives a person closed and reopened while their read is in flight", async () => {
+    // The id is the same on both sides of the round trip, so only request
+    // identity distinguishes the abandoned read from the live one.
+    let rejectFirst;
+    getReferencePictures.mockReturnValueOnce(
+      new Promise((_, reject) => {
+        rejectFirst = () => reject(new Error("abandoned"));
+      }),
+    );
+    const w = mountCharacter({ open: true, character: { id: 7, name: "A" } });
+    await w.setProps({ open: false, character: null });
+
+    getReferencePictures.mockResolvedValueOnce({ reference_picture_ids: [5] });
+    listPicturesByIds.mockResolvedValueOnce([{ id: 5, score: 4 }]);
+    await w.setProps({ open: true, character: { id: 7, name: "A" } });
+    await flushPromises();
+    expect(w.findAll(".ref-picture-item")).toHaveLength(1);
+
+    rejectFirst();
+    await flushPromises();
+
+    // The dead read must not wipe the list the reopened dialog already filled.
+    expect(w.findAll(".ref-picture-item")).toHaveLength(1);
+    expect(w.find(".ref-pictures-empty").exists()).toBe(false);
+  });
+
+  it("clears the previous person's images before the next read answers", async () => {
+    getReferencePictures.mockResolvedValueOnce({ reference_picture_ids: [11] });
+    listPicturesByIds.mockResolvedValueOnce([{ id: 11, score: 5 }]);
+    const w = mountCharacter({ open: true, character: { id: 1, name: "A" } });
+    await flushPromises();
+    expect(w.findAll(".ref-picture-item")).toHaveLength(1);
+
+    // B's read never answers: nothing of A's may be on screen meanwhile.
+    getReferencePictures.mockReturnValueOnce(new Promise(() => {}));
+    await w.setProps({ character: { id: 2, name: "B" } });
+    await flushPromises();
+
+    expect(w.findAll(".ref-picture-item")).toHaveLength(0);
+    // Mid-read is not "none": the empty state would be a claim about B that
+    // nothing has answered yet.
+    expect(w.find(".ref-pictures-empty").exists()).toBe(false);
+  });
+
+  it("ignores an older read that came back empty", async () => {
+    // The third write site: A has no reference images, B has some, A answers
+    // last. An unguarded empty result wipes B's column.
+    let resolveA;
+    getReferencePictures.mockReturnValueOnce(
+      new Promise((r) => {
+        resolveA = () => r({ reference_picture_ids: [] });
+      }),
+    );
+    const w = mountCharacter({ open: true, character: { id: 1, name: "A" } });
+
+    getReferencePictures.mockResolvedValueOnce({ reference_picture_ids: [99] });
+    listPicturesByIds.mockResolvedValueOnce([{ id: 99, score: 3 }]);
+    await w.setProps({ character: { id: 2, name: "B" } });
+    await flushPromises();
+    expect(w.findAll(".ref-picture-item")).toHaveLength(1);
+
+    resolveA();
+    await flushPromises();
+
+    expect(w.findAll(".ref-picture-item")).toHaveLength(1);
+  });
+
+  it("lets an older read finish without stranding the empty state", async () => {
+    // A's read is still in flight when B opens, and B's has not answered. If
+    // A's completion were allowed to clear the loading flag, B would render as
+    // "No reference images yet" — a claim about B that nothing has made.
+    let resolveA;
+    getReferencePictures.mockReturnValueOnce(
+      new Promise((r) => {
+        resolveA = () => r({ reference_picture_ids: [] });
+      }),
+    );
+    const w = mountCharacter({ open: true, character: { id: 1, name: "A" } });
+
+    getReferencePictures.mockReturnValueOnce(new Promise(() => {}));
+    await w.setProps({ character: { id: 2, name: "B" } });
+    await flushPromises();
+
+    resolveA();
+    await flushPromises();
+
+    expect(w.find(".ref-pictures-empty").exists()).toBe(false);
+  });
+
+  it("names the reference grid with its own heading", async () => {
+    getReferencePictures.mockResolvedValueOnce({ reference_picture_ids: [3] });
+    listPicturesByIds.mockResolvedValueOnce([{ id: 3, score: 2 }]);
+    const w = mountCharacter({ open: true, character: { id: 7, name: "A" } });
+    await flushPromises();
+
+    const headingId = w.find(".ref-pictures-header .section-label").attributes("id");
+    expect(headingId).toBeTruthy();
+    expect(w.find(".ref-pictures-grid").attributes("aria-labelledby")).toBe(
+      headingId,
+    );
+  });
+
+  it("re-reads the branch on the next open", async () => {
+    const w = mountCharacter({ open: true, character: { id: 7, name: "A" } });
+    await w.setProps({ open: false, character: null });
+    await w.setProps({ open: true });
+
+    expect(widthOf(w)).toBe(480);
+    expect(w.findAll(".editor-col")).toHaveLength(1);
+  });
+});
+
+describe("PictureSetEditor layout", () => {
+  it("is two columns at 720, with the appearance row and tray spanning", () => {
+    setActivePinia(createPinia());
+    const w = mount(PictureSetEditor, {
+      props: { open: true, set: { id: 3, name: "Set" } },
+      global: { stubs },
+    });
+
+    expect(widthOf(w)).toBe(720);
+    expect(w.findAll(".editor-col")).toHaveLength(2);
+    // The appearance block cannot fit in half a dialog — it has to span, or the
+    // 8-column icon grid is what pays for it.
+    expect(w.find(".appearance-row").classes()).toContain("editor-span");
+    expect(w.find(".adapter-tray-stub").classes()).toContain("editor-span");
+  });
+
+  it("does not blank or unlock itself while closing", async () => {
+    setActivePinia(createPinia());
+    const w = mount(PictureSetEditor, {
+      props: { open: true, set: { id: 3, name: "Set", locked: true } },
+      global: { stubs },
+    });
+    expect(w.vm.localSet.name).toBe("Set");
+
+    // SideBar.closeSetEditor, in one flush — the same shape as the person
+    // editor's, and the same leave transition still showing two columns.
+    await w.setProps({ open: false, set: null });
+
+    expect(w.findComponent({ name: "AppDialog" }).props("title")).toBe(
+      "Edit picture set",
+    );
+    expect(w.vm.localSet.name).toBe("Set");
+    // (No column-count assertion here: this editor has no column branch, so it
+    // could not fail. The person editor's equivalent does have one, and does.)
+    // The wash must not lift either: a locked set flashing editable on its way
+    // out is an invitation to type into a dialog that is leaving.
+    expect(w.find(".appearance-row").classes()).toContain(
+      "appearance-row--locked",
+    );
+    // And the spanning tray stays, still pointed at the set being edited.
+    expect(w.find(".adapter-tray-stub").attributes("data-id")).toBe("3");
+  });
+
+  it("remounts its tray on each open", async () => {
+    setActivePinia(createPinia());
+    const w = mount(PictureSetEditor, {
+      props: { open: true, set: { id: 3, name: "Set" } },
+      global: { stubs },
+    });
+    const firstKey = w.findComponent({ name: "AdapterTray" }).vm.$.vnode.key;
+
+    await w.setProps({ open: false, set: null });
+    await w.setProps({ open: true, set: { id: 3, name: "Set" } });
+
+    expect(w.findComponent({ name: "AdapterTray" }).vm.$.vnode.key).not.toBe(
+      firstKey,
+    );
+  });
+
+  it("titles itself for the set it was opened on", async () => {
+    setActivePinia(createPinia());
+    const w = mount(PictureSetEditor, {
+      props: { open: true, set: null },
+      global: { stubs },
+    });
+    expect(w.findComponent({ name: "AppDialog" }).props("title")).toBe(
+      "New picture set",
+    );
+
+    await w.setProps({ open: false });
+    await w.setProps({ open: true, set: { id: 3, name: "Set" } });
+    expect(w.findComponent({ name: "AppDialog" }).props("title")).toBe(
+      "Edit picture set",
+    );
+  });
+
+  it("keeps the lock wash on the appearance row it now spans", () => {
+    setActivePinia(createPinia());
+    const w = mount(PictureSetEditor, {
+      props: { open: true, set: { id: 3, name: "Set", locked: true } },
+      global: { stubs },
+    });
+
+    // The wash and its reason belong to `.appearance-row` itself, not to the
+    // new spanning wrapper — move them and either the tray falls under the wash
+    // or the tooltip's hover target changes.
+    const row = w.find(".appearance-row");
+    expect(row.classes()).toContain("appearance-row--locked");
+    expect(row.attributes("title")).toContain("locked");
+    // The per-field disabled state is asserted live in PictureSetEditor.test.js
+    // (against a stub that renders it as `data-disabled`, which is what makes
+    // that assertion able to fail); it is not repeated here.
+  });
+});

--- a/frontend/src/components/editors/PictureSetEditor.test.js
+++ b/frontend/src/components/editors/PictureSetEditor.test.js
@@ -233,9 +233,12 @@ describe("PictureSetEditor — adapter tray", () => {
     ).toBe(true);
   });
 
-  it("does not mount it while the dialog is closed", () => {
+  it("does not mount it before the dialog has ever been opened", () => {
     // The mount is what triggers the read, and the hosts keep this component
-    // alive for the life of the view.
+    // alive for the life of the view. Once opened it stays mounted — including
+    // through the close, so the widest row does not vanish from under the leave
+    // transition — and re-reads via its key on the next open. What must never
+    // happen is a read for a dialog the user has not opened at all.
     expect(
       mountWithTray({ open: false, set: lockedSet })
         .find(".adapter-tray-stub")

--- a/frontend/src/components/editors/PictureSetEditor.vue
+++ b/frontend/src/components/editors/PictureSetEditor.vue
@@ -1,59 +1,81 @@
 <template>
   <AppDialog
     :open="open"
-    :title="set?.id ? 'Edit picture set' : 'New picture set'"
-    :width="660"
+    :title="isExistingSet ? 'Edit picture set' : 'New picture set'"
+    :width="720"
     @close="emit('close')"
   >
-    <div class="editor-body">
-      <AppInput
-        ref="nameInputRef"
-        v-model="localSet.name"
-        label="Name *"
-        placeholder="Picture set name"
-        icon="layers-triple-outline"
-        :disabled="isLockedSet"
-        :title="isLockedSet ? LOCK_REASON : undefined"
-        @enter="save"
-      />
-      <AppTextarea
-        v-model="localSet.description"
-        label="Description"
-        placeholder="Optional description…"
-        :rows="2"
-        :disabled="isLockedSet"
-        :title="isLockedSet ? LOCK_REASON : undefined"
-      />
-      <AppSelect
-        v-model="projectSelection"
-        label="Projects"
-        :options="projectOptions"
-        :multiple="true"
-        :disabled="isLockedSet"
-        :title="isLockedSet ? LOCK_REASON : undefined"
-      />
+    <!-- Two columns rather than one tall stack, so the form stops outgrowing
+         the viewport and scrolling its own body. Tabs were the stated
+         alternative and were rejected: a field hidden behind a tab is one you
+         cannot check before saving, and this form has a single required field
+         and a single commit. The columns are a CSS reflow of unchanged source
+         order — name/description left, projects/lock right — so tab order is
+         exactly the sequence it was single-column: name, description, projects,
+         locked. Unlike the person editor this column 2 holds writable controls,
+         so that sequence now reads down the left column and then down the
+         right, which is column-major and is what the eye does with two columns
+         — but it does mean Tab travels bottom-left to top-right once.
 
-      <!-- Locked toggle: the only control that stays active while the set is
-           locked, so unticking + Save is the unlock path. -->
-      <label class="lock-row">
-        <input
-          type="checkbox"
-          class="lock-row__checkbox"
-          :checked="localSet.locked"
-          @change="localSet.locked = $event.target.checked"
+         The appearance block does NOT go in a column. Eight 32px icon columns
+         plus the scroll gutter, the "or" divider, the thumbnail and the colour
+         box have an intrinsic width around 570px; half of any dialog on the
+         width ladder is narrower than that, and fitting it would mean cutting
+         icon columns. It spans instead. -->
+    <div class="editor-body">
+      <div class="editor-col">
+        <AppInput
+          ref="nameInputRef"
+          v-model="localSet.name"
+          label="Name *"
+          placeholder="Picture set name"
+          icon="layers-triple-outline"
+          :disabled="isLockedSet"
+          :title="isLockedSet ? LOCK_REASON : undefined"
+          @enter="save"
         />
-        <span class="lock-row__body">
-          <span class="lock-row__title">Locked</span>
-          <span class="lock-row__help">
-            Locked sets are read-only: no edits to the set, its pictures' tags,
-            or descriptions until unlocked.
+        <AppTextarea
+          v-model="localSet.description"
+          label="Description"
+          placeholder="Optional description…"
+          :rows="2"
+          :disabled="isLockedSet"
+          :title="isLockedSet ? LOCK_REASON : undefined"
+        />
+      </div>
+
+      <div class="editor-col">
+        <AppSelect
+          v-model="projectSelection"
+          label="Projects"
+          :options="projectOptions"
+          :multiple="true"
+          :disabled="isLockedSet"
+          :title="isLockedSet ? LOCK_REASON : undefined"
+        />
+
+        <!-- Locked toggle: the only control that stays active while the set is
+             locked, so unticking + Save is the unlock path. -->
+        <label class="lock-row">
+          <input
+            type="checkbox"
+            class="lock-row__checkbox"
+            :checked="localSet.locked"
+            @change="localSet.locked = $event.target.checked"
+          />
+          <span class="lock-row__body">
+            <span class="lock-row__title">Locked</span>
+            <span class="lock-row__help">
+              Locked sets are read-only: no edits to the set, its pictures'
+              tags, or descriptions until unlocked.
+            </span>
           </span>
-        </span>
-      </label>
+        </label>
+      </div>
 
       <!-- Appearance row -->
       <div
-        class="appearance-row"
+        class="appearance-row editor-span"
         :class="{ 'appearance-row--locked': isLockedSet }"
         :title="isLockedSet ? LOCK_REASON : undefined"
       >
@@ -139,13 +161,18 @@
       </div>
 
       <!-- Outside the lock wash: the tray is read-only, so a locked set still
-           shows what it uses. `v-if="props.open"` remounts it on every open, so
-           an adapter attached on the shelf in between shows up here without
-           the freshness resting on the dialog's lazy-mount behaviour. -->
+           shows what it uses. Keyed on the open count so an adapter attached on
+           the shelf in between still shows up here — without the freshness
+           resting on the dialog's lazy-mount behaviour, and without the widest
+           block in the dialog vanishing from under a leave transition, which is
+           what `v-if="props.open"` did. The id comes from the latched local
+           copy for the same reason: the host nulls the prop on the way out. -->
       <AdapterTray
-        v-if="props.open"
+        v-if="openCount > 0"
+        :key="openCount"
+        class="editor-span"
         entity-type="set"
-        :entity-id="props.set?.id"
+        :entity-id="localSet.id"
       />
     </div>
     <template #footer>
@@ -232,7 +259,20 @@ const localSet = ref({
 // The set's persisted locked state gates the fields. Editing the checkbox does
 // not flip this — a set only becomes editable after an unlock PATCH round-trips
 // and the dialog reopens with the fresh set.
-const isLockedSet = computed(() => !!props.set?.locked);
+//
+// Written by the watcher below rather than computed off the prop, for the same
+// reason as `isExistingSet`: `SideBar.closeSetEditor` nulls `set` in the same
+// tick it closes the dialog, and a computed would lift the lock wash and
+// re-enable every field on a dialog still on screen playing its leave
+// transition. `submitSet` reads it too, so it must not flicker mid-save either.
+const isLockedSet = ref(false);
+
+// Drives the title and would drive a width branch if this editor had one; both
+// columns are populated on create, so it is only the title here.
+const isExistingSet = ref(false);
+
+// Bumped on every open, to key the adapter tray (see the template).
+const openCount = ref(0);
 
 const nameInputRef = ref(null);
 
@@ -262,9 +302,17 @@ watch(
   },
 );
 
+// Gated on `open`: the host nulls `set` as it closes, and this watcher would
+// otherwise blank all four fields, flip the title to "New picture set" and lift
+// the lock wash under a dialog that is still visible. The form is only ever
+// read while open, so filling it on the way in is the whole contract.
 watch(
-  () => props.set,
-  (newSet) => {
+  () => [props.open, props.set],
+  ([isOpen, newSet]) => {
+    if (!isOpen) return;
+    openCount.value += 1;
+    isExistingSet.value = !!newSet?.id;
+    isLockedSet.value = !!newSet?.locked;
     if (newSet) {
       localSet.value = {
         id: newSet.id,
@@ -354,10 +402,36 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeydown));
 </script>
 
 <style scoped>
+/* `minmax(0, 1fr)` and not a bare `1fr`: a bare track takes its width from the
+   widest child, and the project list or a long option label would then push the
+   row wider than the dialog instead of wrapping inside it. */
 .editor-body {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: var(--space-6);
+  row-gap: var(--space-5);
+}
+
+.editor-col {
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
+  min-width: 0;
+}
+
+.editor-span {
+  grid-column: 1 / -1;
+}
+
+/* Vuetify caps the dialog at `calc(100% - 48px)`, so it stops being 720 wide
+   below a 768px viewport and each column falls under the ~300px the fields
+   want (299px at a 720px viewport). 720 is where that is unambiguous. Drop to
+   the single column the editor has always had; the appearance row's own
+   `flex-wrap` keeps handling the narrower cases from there. */
+@media (max-width: 720px) {
+  .editor-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 /* Locked toggle row */
@@ -523,9 +597,10 @@ onUnmounted(() => document.removeEventListener("keydown", handleKeydown));
 .icon-grid {
   display: grid;
   /* Eight 32px-button columns need ~270px plus the scroll gutter; the dialog
-     is sized 660 wide so that much is left after the thumbnail and colour
-     asides. The stable gutter reserves the scrollbar's width up front so it
-     can't eat into the last column when content overflows. */
+     is sized 720 wide and the appearance row spans both of its columns, so that
+     much is left after the thumbnail and colour asides. The stable gutter
+     reserves the scrollbar's width up front so it can't eat into the last
+     column when content overflows. */
   grid-template-columns: repeat(8, 1fr);
   column-gap: var(--space-1);
   row-gap: var(--space-1);

--- a/frontend/src/components/widgets/AdapterTray.vue
+++ b/frontend/src/components/widgets/AdapterTray.vue
@@ -357,9 +357,10 @@ watch(
 
 .adapter-tray__grid {
   display: grid;
-  /* Two per row in the 480-wide person editor, three in the 660-wide set
-     editor, one on a narrow window — the same card either way, so neither
-     editor needs its own tray. */
+  /* Three per row in both 720-wide editors, where the tray spans both columns,
+     one on a narrow window — the same card either way, so neither editor needs
+     its own tray. (The tray only renders for a saved entity, which in the
+     person editor is exactly the case that is 720 rather than 480.) */
   /* `min(180px, 100%)` rather than a bare 180px: a hard minimum track cannot
      shrink, so below 180px of content width the grid would overflow its dialog
      sideways instead of reflowing to one narrower column. */


### PR DESCRIPTION
Both editor dialogs had outgrown the viewport and were scrolling `AppDialog`'s
body. They now reflow into two columns.

## What changed

**Person editor** — two columns at 720 when editing: fields left, reference
images right, the adapter tray spanning both. **Creating stays 480 and
single-column**, because both right-column blocks are gated on a saved id and a
720 dialog with an empty half is worse than the narrow one.

**Picture-set editor** — two columns at 720: name/description left,
projects/lock right, with the appearance row and the tray spanning both. The
appearance block does *not* go in a column: eight 32px icon columns plus the
scroll gutter, the "or" divider, the thumbnail and the colour box have an
intrinsic width around 570px, so halving the dialog would mean cutting icon
columns. It spans, and the icon grid stays at 8.

Also here: the local `.ref-pictures-title` is replaced by the shared global
`.section-label` (it had drifted to a lower contrast than the global's floor),
and `AdapterTray`'s comment about editor widths, which this change invalidated,
is corrected.

## Measurements

Driving the e2e fixture library in Chromium at 1280x800, comparing
`.app-dialog__body` `scrollHeight` against `clientHeight`:

| | before | after |
|---|---|---|
| Person editor | 768px of content in a 641px body — 127px of scroll | 487 in 487, no scroll |
| Picture-set editor | 676 in 641 — 35px of scroll | 540 in 540, no scroll |

At a 700px viewport both collapse to one column with no horizontal overflow,
and the create path stays 480/one column with no scroll. `e2e/specs/editor-layout.spec.js`
keeps this honest — it is the only place the actual guarantee can be asserted,
since jsdom has no box metrics.

To be exact about what is claimed: this is a **width** result. Content of
~490–540px still scrolls once the window is short enough, measured at roughly a
620px-tall viewport for the person editor and 660 for the set editor. Two
columns move that threshold from most windows to short ones; `AppDialog`
scrolling its body past that point is the correct behaviour, not a regression.

## Two columns rather than tabs

Tabs were the stated alternative. Both the UI/UX and visual-design passes landed
on columns independently: these are short-lived forms with one required field
and one commit, and a field hidden behind a tab is one you cannot check before
Ctrl+Enter fires. The columns are a **CSS reflow of unchanged source order** —
two `.editor-col` divs in DOM order — so tab order is exactly what it was
single-column. No `order`, no `row-reverse`, nothing that divorces focus order
from visual order.

720 is an existing rung on the dialog-width ladder (`ModelFoldersDialog`); 820
is the two-pane-with-nav-rail tier and these are forms.

## Bugs the reflow exposed

The hosts null `character` in the same tick they set `open` false, and Vuetify
keeps the body mounted for the leave animation — so **anything recomputed on
close plays out on screen**. Widening the dialog turned that from an invisible
quirk into a 240px snap, and looking properly found three more: the title
flipped to "New person", all four fields blanked, and the reference list emptied
to "No reference images yet" — under a dialog still showing that person's face.
The width branch, the title, the fields and the list are now all gated on
`open`. Verified in the browser 120ms into the leave animation: 720 wide, two
columns, "Edit person", the name still in the field, five thumbnails, no empty
message.

The same applies to the picture-set editor, which had all three (blanked
fields, flipped title, and the lock wash lifting off a closing dialog), and to
the adapter tray, which was gated on `open` and so took the widest row in the
dialog out from under the animation. It is keyed on an open count now: still
remounts per open, so an adapter attached on the shelf in between still shows,
but it no longer vanishes on the way out.

Separately, `fetchReferencePictures` had no guard against a stale response. Its
read is two sequential round trips wide and the dialog is a shared,
permanently-mounted instance, so closing it or opening a different person
mid-fetch let a late response paint **one person's reference images — their
face — under another's name**. Every write now checks it belongs to the newest
request, tracked by a counter rather than the character id, because the same
person can be closed and reopened mid-flight and an id equal to itself lets the
abandoned request through.

And the full-screen reference preview is cleared on both edges. Ctrl+Enter saves
and closes from underneath an open preview, and the Escape that dismisses it
goes with the dialog's own listener — so it stranded a `z-index: 9999` scrim
over the whole app with only a mouse click to clear it.

All of this predates the change; the reflow is what made me look.

## Tests

`EditorTwoColumnLayout.test.js` covers the branch that picks the layout — width,
column count, which rows span, the full close-transition freeze (width, columns,
title, fields, thumbnails), the cross-person fetch race, and the lock wash on the
row that now spans. **Every assertion was mutation-checked**: reverting the
branch, the span, the wash, either close guard or the race guard turns the
matching test red. One assertion an earlier review pass showed was dead — a
`toBeDefined()` against a stub attribute that renders `"false"` as a string —
was removed rather than kept as decoration; the live equivalent already exists
in `PictureSetEditor.test.js`.

## Four reviewer objections I did not act on

Adversarial review passes raised these; I think they are wrong and am recording
why rather than obeying or dropping them silently.

1. *"Make the person editor unconditionally 720 like the set editor, and the
   close-transition problem disappears with the branch."* The two editors are
   not inconsistent: each is 720 when it has two columns of content. A new set
   fills both columns; a new person fills one, because reference images and
   adapters both require a saved id. Widening it would give creating a person a
   permanently empty half — which is the same objection, applied to the case it
   actually lands in.

2. *"The Locked checkbox should stay under the text fields it disables."* The
   UI/UX pass asked for both that and an unchanged tab order, and with the
   appearance row spanning, only one is available. I kept tab order (name →
   description → projects → lock, as today) and Locked still sits directly under
   a field it disables. A tab-order change is the more expensive of the two.

3. *"The reference thumbnails are still mouse-only."* True and worth fixing —
   they are `div @click` with no role or tabindex — but making them focusable
   adds N tab stops to the dialog, which is a flow change and belongs in its own
   change with UI/UX sign-off. This one adds the missing `alt` and the
   heading↔grid association, and leaves the keyboard gap where it found it.

4. *"Twenty-five lines of grid CSS are duplicated between the two editors; hoist
   them."* The design pass ruled on this explicitly: there is no shared
   two-column primitive outside `settings/`, and three declarations inline are
   smaller than promoting one. `.editor-body` is also already taken by
   `FolderEditor` with different meaning, so a global class of that name would
   reach a component that does not want it.
