### PR TITLE
Stop the test suite writing the machine-global model locations

### DIFF
--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1521,6 +1521,67 @@ Resolution order, first hit wins:
    the default;
 3. `user_data_dir("pixlstash")/downloaded_models`.
 
+**A record naming a folder that is not there is still obeyed, and said so once
+per start.** Obeyed, because the folder is normally on a drive and a drive may
+be away for an afternoon; the alternative was tried and withdrawn under review,
+since falling back to the default makes a vanished folder unrelocatable
+(`relocatable_identity` recognises it by path) and leaves two copies once it
+returns. Said, because the next download re-creates the recorded path and pulls
+~750 MB into it, and nothing anywhere used to mention that — which is what made
+one stale record an investigation rather than a `grep`.
+
+The line is `_warn_if_the_recorded_folder_looks_wrong`, called from
+`declare_builtin_models` at start-up. **Not from the accessor**, which was the
+second withdrawn attempt: `builtin_model_dir()` is read on every call and sits
+behind `relocatable_identity` on the per-row path of `GET /model-folders`, which
+the frontend polls every three seconds, so a line there is a flood and its
+`stat` is a syscall against a drive that may be gone.
+
+**Two symptoms, because either alone goes quiet.** "The recorded folder cannot
+be read" is what a start sees while the drive is away — but where the record
+merely went stale, the download that follows creates the path, so that symptom
+lasts one start. The second says the same thing from the other side and does not
+heal itself: **engines still in the default folder, which a relocation should
+have emptied**. Before the re-download that is a fetch about to be repeated;
+after it, two copies with the recorded folder still filling. It is checked
+whatever the recorded folder holds, for exactly that reason — stopping at "the
+recorded folder has something in it" would report the accident only inside the
+window its own download closes. Silent when the default is empty, which is a
+relocation that worked: the files went with it.
+
+It fires only for the folder **a relocation recorded**, matched against the
+record itself. Not "anything that is not the default": the owner who symlinked
+the default folder at their big drive and then relocated onto it has a default
+that *resolves to* the recorded location, so a path test goes quiet for the
+person who did the most to move their models. And not at all while
+`PIXLSTASH_BUILTIN_MODEL_DIR` is set, since that names the folder over the
+record's head — a volume that has not mounted yet is a first start, nothing was
+ever fetched, and "delete the pointer" would be advice that does nothing. The
+record is read by a quiet reader beside `_configured_model_dir()`, which reports
+its own failures and has already been called by the time the declaration runs.
+
+It reports what `stat` says rather than asserting the folder is missing, so a
+permission error reads as one. An unmounted mount point that still exists as an
+empty directory is indistinguishable from an empty folder and is not claimed.
+
+`declare_insightface_packs` says the **first** of those about a recorded pack
+root that cannot be listed, in place of the "normal on a machine that has not
+run face detection" it logs otherwise — which is exactly wrong for a machine
+that has a recorded root, since having one means it ran face detection. A root
+recorded back onto `~/.insightface` itself falls through to that ordinary line,
+because the remedy would name the directory it starts from.
+
+It deliberately does **not** say the second, and the asymmetry is the point:
+`downloaded_models` is PixlStash's alone, so engines still sitting in it can
+only mean a relocation that did not take. `~/.insightface` is the *library's*
+root, shared with every other InsightFace tool on the host — ComfyUI's face
+nodes among them — so packs under it are just as likely to be another tool's,
+and the two states are byte-identical on disk. A line claiming a failed
+relocation there would fire forever on an ordinary machine, and its remedy would
+tell the owner to abandon the packs they moved in favour of somebody else's
+directory. Where a claim cannot be told apart from an innocent state, the claim
+is not made.
+
 **The recorded location is a file, not a hub row**, because the folder is
 machine-global — one download serves every library and every server instance on
 the host — while a hub belongs to one deployment. In the hub, a second deployment
@@ -1550,6 +1611,52 @@ being an option the moment the downloaders started reading it: a fresh temp
 directory means every engine is downloaded again on every shard, against the model
 cache CI restores. `tests/test_builtin_models.py` covers the declaration directly
 against a `tmp_path`.
+
+**Writing the recorded locations is off in the test suite too**, and by
+construction rather than by convention: the session-scoped autouse
+`sandbox_the_recorded_model_locations` in `tests/conftest.py` redirects
+`builtin_models._pointer_path` and `insightface_model_utils._pointer_path` into a
+session temp directory, leaving a test's own redirection of `_pixlstash_data_dir`
+untouched. Both records are machine-global and outlive the process that writes
+them, so a test that writes one has changed where the real PixlStash on that
+machine downloads its engines — which is not hypothetical: a record naming a
+finished run's `tmp_path` had every later start re-create the deleted directory
+and fetch ~750 MB of engines into it, silently, while the real ones sat in the
+default folder. Per-test redirection of the seam was the previous protection and
+it is the remembered kind: it lapses when a relocation's worker thread finishes
+after the redirection is undone, and it never existed for a module that did not
+think to add it. `test_no_test_can_name_the_machines_own_recorded_locations`
+fails if the fixture goes away.
+
+Two details of that fixture are load-bearing. The redirected name carries the
+**writing test's id**, so one test's record cannot change where a later test in
+the same shard downloads — one shared file would be a flake the sharder
+reshuffles between runs. And nothing is **restored** at the end: a relocation
+records its location from a daemon worker thread the suite leaves unjoined, so
+putting the original `_pointer_path` back would reopen the machine's file for
+exactly that write. The empty-sandbox assertion is a tripwire rather than a
+census — it sees a write made while no test had redirected the seam, and a late
+thread write that lands during a test which *has* redirected it goes to that
+test's `tmp_path` instead: safe, but unreported.
+
+The write that poisoned a real machine has **not** been reproduced, and nothing
+here should be read as naming it. What was found alongside the fixture is a
+shape that lets any of this escape a test: `test_relocate_is_owner_only_and_local_only`
+ended on a real `202` relocation it never awaited, so that job's ending ran
+inside whichever test came next. **A `202` from this route is awaited, always**,
+and `no_model_move_outlives_its_test` in `tests/conftest.py` fails any test that
+leaves a move running, suite-wide — which is why a module fixture may clear
+`model_moves._job` when it sets up but never when it tears down: an autouse
+fixture tears down last, so clearing it there hides the leak from the guard.
+
+**Note what that identity rests on.** The route decides whether it is relocating
+the download folder with `is_builtin_model_dir(folder["path"])`, which compares
+against `builtin_model_dir()` — the recorded location itself. Identity is
+therefore held in a mutable file rather than in the row, so a folder whose path
+comes to equal the recorded value inherits it, including the right to rewrite
+the record when relocated. That is worth closing; it is also the loose end of
+the investigation this fixture came from, which never established which process
+wrote the record it found.
 
 #### Relocating the InsightFace packs (#906)
 

--- a/pixlstash/services/builtin_caches.py
+++ b/pixlstash/services/builtin_caches.py
@@ -45,8 +45,10 @@ from pixlstash.services.builtin_models import (
 )
 from pixlstash.services.model_features import features_for_repo
 from pixlstash.utils.insightface_model_utils import (
+    DEFAULT_INSIGHTFACE_ROOT,
     KNOWN_MODEL_PACKS,
     insightface_root,
+    recorded_insightface_root,
 )
 
 logger = get_logger(__name__)
@@ -208,6 +210,41 @@ def declare_insightface_packs(hub, folder_path: str) -> Optional[int]:
             and os.path.isdir(os.path.join(folder_path, name))
         }
     except OSError as exc:
+        recorded, pointer = recorded_insightface_root()
+        recorded_is_this_folder = recorded is not None and os.path.realpath(
+            folder_path
+        ) == os.path.realpath(insightface_models_dir_under(recorded))
+        if recorded_is_this_folder and os.path.normpath(
+            folder_path
+        ) == os.path.normpath(insightface_models_dir_under(DEFAULT_INSIGHTFACE_ROOT)):
+            # Recorded back onto the root InsightFace uses anyway. The warning
+            # would tell the owner to delete the record to go back to the
+            # directory they are already on, so it falls through to the ordinary
+            # line below instead of saying nothing at all.
+            recorded_is_this_folder = False
+        if recorded_is_this_folder:
+            # A relocation put the packs here and they are not here, which is
+            # the download folder's failure in the folder beside it: they are
+            # re-fetched into a path PixlStash re-creates, and until this line
+            # nothing said so. Not "normal" — the machine has run face
+            # detection, which is why it has a recorded root at all. Recognised
+            # by the record rather than by "not the default", because the owner
+            # who symlinked `~/.insightface` at their big drive and then
+            # recorded it has a default that resolves to the same place.
+            logger.warning(
+                "A relocation recorded %s as the InsightFace root and %s cannot "
+                "be read (%s), so every pack will be downloaded again into a "
+                "re-created path. Restore, mount or re-permission it. If it is "
+                "gone for good, deleting %s sends face detection back to %s — "
+                "but nothing is moved back, and PixlStash stops recognising the "
+                "old root as one it can relocate.",
+                recorded,
+                folder_path,
+                exc,
+                pointer,
+                DEFAULT_INSIGHTFACE_ROOT,
+            )
+            return None
         # InsightFace creates this the first time it downloads a pack, so an
         # absent directory is a machine that has not used face detection yet.
         logger.info(

--- a/pixlstash/services/builtin_models.py
+++ b/pixlstash/services/builtin_models.py
@@ -281,6 +281,23 @@ def _pointer_path() -> str:
     return os.path.join(_pixlstash_data_dir(), BUILTIN_MODEL_DIR_POINTER)
 
 
+def _recorded_model_dir_quietly() -> Optional[str]:
+    """The recorded location, or None, reporting nothing about either answer.
+
+    :func:`_configured_model_dir` is the one that speaks up, and it is called on
+    every resolution — so a second caller wanting only to *know* whether a
+    location was recorded would double every line it logs. This reads the same
+    file and says nothing, which is what a caller checking the record against a
+    path needs.
+    """
+    try:
+        with open(_pointer_path(), encoding="utf-8") as handle:
+            return handle.read().strip() or None
+    except OSError:
+        # Already reported by the reader that resolves the folder for real.
+        return None
+
+
 def _configured_model_dir() -> Optional[str]:
     """The location a relocation recorded, or None if it never happened.
 
@@ -446,6 +463,117 @@ def unclaimed_files(folder_path: str) -> list[dict]:
     return sorted(found, key=lambda item: item["relpath"])
 
 
+def _warn_if_the_recorded_folder_looks_wrong(folder_path: str, present: int) -> None:
+    """Say so at start-up when a relocation's record has gone stale.
+
+    A stale record costs a full re-download and says nothing while it does it:
+    the downloaders ``makedirs`` their destination, so a record left naming a
+    directory that has been deleted — or a drive that is not plugged in — has
+    every start re-create the path and fetch every engine into it again, while
+    the real ones sit untouched in the folder they were moved out of. That is
+    the accident this exists to make legible; it took an investigation precisely
+    because nothing anywhere said a word.
+
+    **Two symptoms, because either one alone goes quiet.** The recorded folder
+    being unreadable is what a start sees while the drive is away — but the
+    download that follows creates the path, so on a machine where the record
+    merely went stale that symptom lasts exactly one start. The second is
+    **engines in the default folder that a relocation should have emptied**,
+    which says the same thing from the other side and does not heal itself:
+    before the re-download it is a fetch about to be repeated, and afterwards it
+    is two copies with the folder still filling. Checked whatever the recorded
+    folder holds, for that reason — a check that stopped at "the recorded folder
+    has something in it" would report the accident only in the window its own
+    download closes.
+
+    **Here rather than in the accessor**, which is read on every call and on the
+    per-row path behind ``GET /model-folders`` — the frontend polls it — so a
+    line there is a flood and its ``stat`` is a syscall against a drive that may
+    be gone. This runs once per start, beside the declaration that is already
+    reading the folder.
+
+    Deliberately narrow. It fires only for a folder a **relocation recorded**,
+    matched against the record itself rather than by "not the default": an owner
+    who symlinked the default folder at their big drive and then relocated onto
+    it has a default that resolves to the recorded path, and a path test would
+    go quiet for exactly the person who did the most to move their models. It
+    does not fire at all while :data:`BUILTIN_MODEL_DIR_ENV` is set, because
+    that names the folder over the record's head — a volume that has not mounted
+    yet is a first start, nothing was ever fetched, and "delete the pointer"
+    would be advice that does nothing. And it says what ``stat`` said rather
+    than asserting the folder is missing, so a permission error reads as one.
+
+    Args:
+        folder_path: The folder the declaration is about to describe.
+        present: How many declared engines were found in it.
+    """
+    if os.environ.get(BUILTIN_MODEL_DIR_ENV, "").strip():
+        return
+    recorded = _recorded_model_dir_quietly()
+    if recorded is None or os.path.realpath(folder_path) != os.path.realpath(recorded):
+        return
+    pointer = _pointer_path()
+    default = os.path.join(_pixlstash_data_dir(), BUILTIN_DIRNAME)
+    if os.path.normpath(default) == os.path.normpath(folder_path):
+        # Recorded back onto the default, which nothing below has anything to
+        # say about. `normpath` and not `realpath`: a default that is a SYMLINK
+        # to the recorded folder is still a real relocation onto a real drive,
+        # and it can still go away — silencing that would lose the case for the
+        # owner who moved their models the hard way.
+        return
+    try:
+        os.stat(folder_path)
+    except OSError as exc:
+        logger.warning(
+            "A relocation recorded %s as the folder PixlStash downloads its "
+            "engines into, and it cannot be read (%s), so every engine will be "
+            "fetched again into a re-created path. Restore, mount or "
+            "re-permission it. If it is gone for good, deleting %s sends the "
+            "downloads back to %s — but nothing is moved back, and PixlStash "
+            "stops recognising the old folder as one it can relocate.",
+            folder_path,
+            exc,
+            pointer,
+            default,
+        )
+        return
+    if os.path.realpath(default) == os.path.realpath(folder_path):
+        # One directory reached by two names — a default symlinked at the
+        # recorded folder. `os.path.exists` follows the link, so every engine
+        # that IS in the recorded folder would also be counted as left behind,
+        # for ever. The `stat` branch above still applies to this shape (the
+        # drive can still go away); this one has nothing to compare.
+        return
+    left_behind = [
+        engine.relpath
+        for engine in BUILTIN_ENGINES
+        if os.path.exists(os.path.join(default, engine.relpath))
+    ]
+    if left_behind:
+        # Whether or not the recorded folder holds engines of its own. A
+        # relocation *moves* the files, so engines in both places mean the
+        # record and the disk disagree — before the re-download that is a fetch
+        # about to be repeated, and after it, two copies and a folder still
+        # filling. Stopping at `present` would report the accident only in the
+        # window before its own download closed it, which is the one state the
+        # owner is least likely to be reading the log in.
+        logger.warning(
+            "A relocation recorded %s as the folder PixlStash downloads its "
+            "engines into: it holds %d of them and %d are also in %s, which a "
+            "relocation should have emptied. Downloads go to the recorded "
+            "folder, so anything missing there is fetched again rather than "
+            "found. If that is not where you meant them to go, deleting %s "
+            "sends the downloads back to the ones you already have — nothing "
+            "is moved, and the recorded folder stops being one PixlStash can "
+            "relocate.",
+            folder_path,
+            present,
+            len(left_behind),
+            default,
+            pointer,
+        )
+
+
 def declare_builtin_models(hub, folder_path: str) -> Optional[int]:
     """Register the built-in folder and write a row per engine present.
 
@@ -496,6 +624,9 @@ def declare_builtin_models(hub, folder_path: str) -> Optional[int]:
                 present=present,
             )
         )
+    _warn_if_the_recorded_folder_looks_wrong(
+        folder_path, sum(1 for entry in entries if entry.present)
+    )
     for leftover in unclaimed_files(folder_path):
         # `present` unconditionally: the walk just saw the file. One that goes
         # away is swept to `missing` by `declare_folder` like any other row,

--- a/pixlstash/utils/insightface_model_utils.py
+++ b/pixlstash/utils/insightface_model_utils.py
@@ -132,6 +132,31 @@ def _configured_root() -> Optional[str]:
     return configured
 
 
+def recorded_insightface_root() -> tuple[Optional[str], str]:
+    """The root a relocation recorded and the file it is recorded in.
+
+    Both, because the one caller outside this module needs both and neither is
+    worth reaching into the privates for: the shelf's declaration asks whether
+    the directory it failed to read is the *recorded* one — which is what tells
+    a relocated root that has gone apart from a machine that has simply never
+    run face detection — and then names the file to delete.
+
+    Quiet on purpose, unlike :func:`_configured_root`, which reports its own
+    failures and is called on every resolution: a second caller that only wants
+    to know whether a root was recorded would double every line it logs.
+
+    Returns:
+        ``(recorded root or None, pointer path)``.
+    """
+    pointer = _pointer_path()
+    try:
+        with open(pointer, encoding="utf-8") as handle:
+            return (handle.read().strip() or None), pointer
+    except OSError:
+        # Already reported by the reader that resolves the root for real.
+        return None, pointer
+
+
 def insightface_root() -> str:
     """Where InsightFace keeps its packs.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@ Pytest configuration and fixtures for test suite.
 """
 
 import gc
+import hashlib
 import json
 import math
 import os
+import re
 import socket
 import statistics
 import sys
@@ -23,6 +25,9 @@ from pixlstash.server import Server
 from pixlstash.tasks.face_extraction_task import FaceExtractionTask
 from pixlstash.tasks.image_embedding_task import ImageEmbeddingTask
 from pixlstash.tasks.tag_task import TagTask
+
+# pytest appends the phase it is in to PYTEST_CURRENT_TEST.
+_PYTEST_PHASE = re.compile(r" \((setup|call|teardown)\)$")
 
 _API_V1_PREFIX = "/api/v1"
 _NON_API_ROOT_PATHS = {
@@ -416,6 +421,147 @@ def pytest_configure(config):
     Server.DEFAULT_FAST_CAPTIONS = config.getoption("--fast-captions")
     Server.DEFAULT_MAX_VRAM_GB = config.getoption("--max-vram-gb")
     Server.DEFAULT_INSIGHTFACE_MODEL_PACK = config.getoption("--insightface-model-pack")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def sandbox_the_recorded_model_locations(tmp_path_factory):
+    """Put both recorded-location files somewhere the suite may safely write.
+
+    A relocation records where PixlStash downloads its engines
+    (``downloaded_models.location``) and where the InsightFace packs live
+    (``insightface.location``). Both are **machine-global** — one download
+    serves every library and every server instance on the host — so both live in
+    the platform user data directory, next to nothing else the suite touches,
+    and both outlive the process that wrote them.
+
+    Which is how the developer's real machine ended up with a record naming a
+    ``tmp_path`` from a finished test run. pytest deleted the directory; the
+    accessor kept naming it; every start after that re-created the path and
+    downloaded ~750 MB of engines into it, while the real ones sat untouched in
+    the default folder. Nothing failed and nothing said so.
+
+    ``pytest_configure`` above already stops the suite *declaring* these roots,
+    for the same reason in the other direction: they describe the developer's
+    home, not the test's. This is the write half of that decision, and it is
+    made mechanically rather than remembered — three test modules redirect
+    ``_pixlstash_data_dir`` per test to stay out of the way, which works right up
+    until a relocation's worker thread finishes after the redirection is undone,
+    or a fourth module forgets. Redirecting ``_pointer_path`` for the whole
+    session leaves nothing to remember: no test can name the machine's file, so
+    no test can write it.
+
+    Only the machine's own directory is replaced. A test that redirects
+    ``_pixlstash_data_dir`` itself still gets its pointer beside the directory it
+    chose, which is what those modules assert on.
+
+    **The sandbox is per test, not one shared file**, even though it is one
+    directory. A record is read back on every call, so a single shared file
+    would let one test's write change where every *later* test in the shard
+    downloads — a flake the sharder reshuffles between runs. The redirected name
+    carries the writing test's id instead, and the check below fails the run
+    with whatever the sandbox holds.
+
+    **That check is a tripwire, not a census.** It sees a write made while no
+    test had redirected the seam. A write from a worker thread that lands
+    *during* a later test which has redirected it goes to that test's own
+    ``tmp_path`` instead — safe, which is the point, but invisible here and
+    attributed to the wrong test if it does show up, since
+    ``PYTEST_CURRENT_TEST`` is process-global. So an empty sandbox is not proof
+    that nothing wrote; the protection is the redirection, and this only reports
+    the cases it can see.
+
+    Nothing is restored at the end. The rebinding has to outlive the session:
+    a relocation records its new location from a daemon worker thread
+    (``model_moves._start_job``), and the suite leaves such a thread unjoined —
+    restoring the original here would reopen the machine's file for exactly the
+    write this fixture exists to stop.
+    """
+    from pixlstash.services import builtin_models
+    from pixlstash.utils import insightface_model_utils
+
+    sandbox = str(tmp_path_factory.mktemp("recorded-model-locations"))
+    machine_data_dir = os.path.realpath(builtin_models._pixlstash_data_dir())
+
+    def _redirected(module, constant):
+        def _pointer_path() -> str:
+            # Both the seam and the filename are read per call: a test may have
+            # redirected the first, and the second is a module constant.
+            filename = getattr(module, constant)
+            directory = builtin_models._pixlstash_data_dir()
+            # `realpath`, not `==`: a trailing slash, a `..` or a symlink are
+            # all the machine's own directory spelled differently, and a
+            # redirection that reached it by one of those names would write the
+            # real file. `is_builtin_model_dir` compares the same way.
+            if os.path.realpath(directory) != machine_data_dir:
+                return os.path.join(directory, filename)
+            # One file per test. A shared one would let a record written by one
+            # test change where a later test in the shard downloads, which is a
+            # flake the sharder reshuffles. Hashed rather than spelled out: a
+            # node id can carry spaces and run past NAME_MAX once the pointer's
+            # own name is appended, and two ids must never collide here.
+            # Only pytest's own phase suffix is stripped, so a record written
+            # by a fixture is not invisible to the test body it was written for
+            # and two parametrised ids whose params contain " (" stay apart.
+            current = _PYTEST_PHASE.sub(
+                "", os.environ.get("PYTEST_CURRENT_TEST", "session")
+            )
+            unique = hashlib.blake2b(current.encode(), digest_size=8).hexdigest()
+            readable = "".join(c if c.isalnum() or c in "._-" else "_" for c in current)
+            return os.path.join(sandbox, f"{unique}.{readable[-60:]}.{filename}")
+
+        return _pointer_path
+
+    builtin_models._pointer_path = _redirected(
+        builtin_models, "BUILTIN_MODEL_DIR_POINTER"
+    )
+    insightface_model_utils._pointer_path = _redirected(
+        insightface_model_utils, "INSIGHTFACE_ROOT_POINTER"
+    )
+    yield sandbox
+    leaked = sorted(os.listdir(sandbox))
+    assert not leaked, (
+        "these tests recorded a machine-global model location, which outside "
+        f"the suite lands in {machine_data_dir} and outlives the run: {leaked}. "
+        "Every relocation a test starts has to finish inside it (await the 202) "
+        "and the test has to redirect builtin_models._pixlstash_data_dir to a "
+        "tmp_path first — tests/test_builtin_models.py::data_dir is the shape."
+    )
+
+
+@pytest.fixture(autouse=True)
+def no_model_move_outlives_its_test():
+    """Fail a test that leaves a model move running rather than the next one.
+
+    A relocation or an import runs on a daemon thread (``_start_job``) whose
+    *ending* is where the work lands: folder rows are repointed, and for the
+    folder PixlStash downloads into, a machine-global location is recorded. A
+    test that starts one and does not wait hands all of that to whichever test
+    runs next — at a moment no fixture is holding the seams still, which is the
+    shape that lets a recorded location escape the redirection above.
+
+    Suite-wide rather than in the one module that noticed: ``_job`` is a global,
+    and three test modules drive the same route. Await the ``202``.
+
+    Not reset at set-up on purpose. Nulling a running job here would orphan the
+    thread and hide the leak instead of reporting it; a slow one may accuse a
+    later test as well, but the test that actually leaked it fails first and is
+    the one named at the top of the report.
+    """
+    yield
+    from pixlstash.routes import model_moves
+
+    # Under the readers' lock, which is the contract the module states and
+    # `test_the_move_worker_writes_the_job_under_the_readers_lock` pins: the
+    # worker writes `status` while holding it.
+    with model_moves._job_lock:
+        job = model_moves._job
+        status = None if job is None else job["status"]
+    assert status != "running", (
+        "this test left a model move running. Await it (`_await_move`) before "
+        "the test ends, or its ending lands inside the next test. Tests after "
+        "this one may fail for the same reason until that move finishes; this "
+        "is the one that started it."
+    )
 
 
 def _measured_test_seconds(reporter) -> float:

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -15,6 +15,7 @@ from pixlstash.hub.db import HubDatabase
 from pixlstash.services.builtin_models import (
     BUILTIN_DIRNAME,
     BUILTIN_ENGINES,
+    BUILTIN_MODEL_DIR_POINTER,
     BUILTIN_OWNER,
     TOOLING_DIRS,
     builtin_model_dir,
@@ -453,11 +454,38 @@ def test_the_zip_insightface_downloaded_a_pack_from_is_not_a_pack(server_hub, tm
 
 
 def test_a_machine_that_has_never_run_face_detection_declares_nothing(
-    server_hub, tmp_path
+    server_hub, tmp_path, caplog
 ):
     """InsightFace creates the directory on its first download, so an absent one
-    is a normal machine and must not raise on the start-up path."""
-    assert declare_insightface_packs(server_hub, str(tmp_path / "nope")) is None
+    is a normal machine and must not raise on the start-up path — nor warn."""
+    with caplog.at_level("WARNING"):
+        assert declare_insightface_packs(server_hub, str(tmp_path / "nope")) is None
+    assert "should have emptied" not in caplog.text, caplog.text
+
+
+def test_a_relocated_pack_root_that_is_gone_is_not_called_normal(
+    server_hub, tmp_path, data_dir, caplog
+):
+    """The same silence as the download folder, in the folder beside it.
+
+    "Normal on a machine that has not run face detection" is exactly wrong for a
+    root a relocation recorded: that machine *has* run face detection, which is
+    why it has a record, and what the absence means is that the packs will be
+    fetched again into a directory PixlStash re-creates.
+    """
+    from pixlstash.services.builtin_caches import insightface_models_dir_under
+    from pixlstash.utils import insightface_model_utils as model_utils
+
+    gone = str(tmp_path / "unplugged" / ".insightface")
+    model_utils.set_insightface_root(gone)
+
+    with caplog.at_level("WARNING"):
+        assert (
+            declare_insightface_packs(server_hub, insightface_models_dir_under(gone))
+            is None
+        )
+    assert gone in caplog.text, caplog.text
+    assert "downloaded again" in caplog.text, caplog.text
 
 
 def test_the_huggingface_cache_is_declared_per_repo_not_per_file(
@@ -1049,6 +1077,187 @@ def test_an_unreadable_record_names_the_default_rather_than_nothing(
     with caplog.at_level("ERROR"):
         assert builtin_model_dir() == os.path.join(str(data_dir), BUILTIN_DIRNAME)
     assert "permission denied" in caplog.text
+
+
+def test_a_start_up_declaration_says_when_the_recorded_folder_cannot_be_read(
+    server_hub, data_dir, tmp_path, caplog
+):
+    """Half of the line whose absence made a stale record an investigation.
+
+    The unplugged-drive moment, and the two silences that keep it worth
+    reading: the folder being there is not news, and neither is a machine that
+    never relocated anything, whose default folder does not exist yet because it
+    has downloaded nothing.
+    """
+    gone = str(tmp_path / "unplugged" / "models")
+    set_builtin_model_dir(gone)
+
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, gone)
+    assert gone in caplog.text, caplog.text
+    assert "cannot be read" in caplog.text, caplog.text
+
+    caplog.clear()
+    os.makedirs(gone)
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, gone)
+    assert caplog.text == "", caplog.text
+
+    caplog.clear()
+    os.remove(data_dir / BUILTIN_MODEL_DIR_POINTER)
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, str(tmp_path / "never-downloaded"))
+    assert caplog.text == "", caplog.text
+
+
+def test_a_start_up_declaration_says_when_the_engines_stayed_where_they_were(
+    server_hub, data_dir, tmp_path, caplog
+):
+    """The other half, and the one that lasts.
+
+    "The recorded folder cannot be read" is true for a single start: the
+    download that follows creates the path, and every start after that sees a
+    perfectly readable directory with nothing in it. The steady state of the
+    accident — which is the state the machine that reported it was found in — is
+    a recorded folder holding none of the engines while the default still holds
+    them. Silent when the default is empty too, because that is a machine that
+    has downloaded nothing rather than one that lost track of what it has.
+    """
+    default = data_dir / BUILTIN_DIRNAME
+    default.mkdir()
+    elsewhere = tmp_path / "big-drive" / "models"
+    elsewhere.mkdir(parents=True)
+    set_builtin_model_dir(str(elsewhere))
+
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, str(elsewhere))
+    assert caplog.text == "", "nothing has been downloaded anywhere yet"
+
+    (default / "pixlstash-anomaly-tagger.safetensors").write_bytes(b"x" * 8)
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, str(elsewhere))
+    assert str(elsewhere) in caplog.text, caplog.text
+    assert str(default) in caplog.text, caplog.text
+    assert "should have emptied" in caplog.text, caplog.text
+
+    # And it keeps saying so after the re-download has filled the recorded
+    # folder, which is the state that lasts: two copies, and every start still
+    # fetching into the wrong one. Stopping here would report the accident only
+    # inside the window its own download closes.
+    (elsewhere / "pixlstash-anomaly-tagger.safetensors").write_bytes(b"x" * 8)
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, str(elsewhere))
+    assert "should have emptied" in caplog.text, caplog.text
+
+    # It stops when the default really is empty, which is a relocation that
+    # worked: the files went with it.
+    os.remove(default / "pixlstash-anomaly-tagger.safetensors")
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, str(elsewhere))
+    assert caplog.text == "", caplog.text
+
+
+def test_a_volume_the_environment_names_is_not_reported_as_a_lost_relocation(
+    server_hub, data_dir, tmp_path, monkeypatch, caplog
+):
+    """The override exists for a deployment that points the folder at a volume
+    *without moving anything into it*, so a volume that has not mounted yet is a
+    first start and nothing was ever fetched. Warning there would be a false
+    alarm on the override's primary use, and it would name a remedy — delete the
+    pointer file — that does nothing while the environment wins.
+    """
+    from pixlstash.services.builtin_models import BUILTIN_MODEL_DIR_ENV
+
+    volume = str(tmp_path / "model-volume" / "models")
+    # A record as well, because the override wins over one and the warning has
+    # to stay quiet anyway: recording alone would make this pass for having
+    # nothing to report.
+    set_builtin_model_dir(volume)
+    monkeypatch.setenv(BUILTIN_MODEL_DIR_ENV, volume)
+
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, builtin_model_dir())
+    assert caplog.text == "", caplog.text
+
+
+def test_a_recorded_folder_reached_through_a_symlinked_default_still_reports(
+    server_hub, data_dir, tmp_path, caplog
+):
+    """Recognised by the record, not by "this is not the default path".
+
+    The owner who symlinked the default folder at their big drive and then
+    relocated onto it has a default that *resolves to* the recorded location, so
+    a "not the default" test goes quiet exactly for the person who did the most
+    to move their models.
+    """
+    recorded = tmp_path / "big-drive" / "models"
+    recorded.mkdir(parents=True)
+    os.symlink(str(recorded), os.path.join(str(data_dir), BUILTIN_DIRNAME))
+    set_builtin_model_dir(str(recorded))
+    os.rmdir(recorded)
+
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, builtin_model_dir())
+    assert str(recorded) in caplog.text, caplog.text
+    assert "fetched again" in caplog.text, caplog.text
+
+    # And the other half of the same shape: with the drive back, the engines in
+    # it are reached through the link as well, so a "still in the default
+    # folder" count would report every one of them as left behind, for ever.
+    # One directory has nothing to have left behind in the other.
+    recorded.mkdir()
+    (recorded / "pixlstash-anomaly-tagger.safetensors").write_bytes(b"x" * 8)
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, builtin_model_dir())
+    assert caplog.text == "", caplog.text
+
+
+def test_a_record_naming_the_default_folder_says_nothing(
+    server_hub, data_dir, tmp_path, caplog
+):
+    """Relocated away and then back again. Both remedies would name the folder
+    they start from, and there is no second place for anything to be left in."""
+    default = os.path.join(str(data_dir), BUILTIN_DIRNAME)
+    set_builtin_model_dir(default)
+
+    with caplog.at_level("WARNING"):
+        declare_builtin_models(server_hub, builtin_model_dir())
+    assert caplog.text == "", caplog.text
+
+
+def test_no_test_can_name_the_machines_own_recorded_locations():
+    """The suite must not be able to write either machine-global pointer.
+
+    Both records outlive the process that writes them and are read by the real
+    product on the same machine, so a test that writes one has changed where
+    PixlStash downloads its engines for good. That is not hypothetical: a record
+    left naming a finished run's ``tmp_path`` had every later start re-create
+    the deleted directory and download ~750 MB into it.
+
+    Asserted on the *path* rather than by writing, because the path is what
+    ``set_builtin_model_dir`` and ``set_insightface_root`` open — sandbox the
+    name and the write follows it. No fixture: the session-scoped redirection in
+    ``conftest`` is exactly what is under test, and a per-test ``data_dir``
+    would hide it. Drop that fixture and this goes red.
+    """
+    from platformdirs import user_data_dir
+
+    from pixlstash.services import builtin_models
+    from pixlstash.utils import insightface_model_utils
+
+    machine = user_data_dir("pixlstash")
+    for pointer in (
+        builtin_models._pointer_path(),
+        insightface_model_utils._pointer_path(),
+    ):
+        assert not pointer.startswith(machine), (
+            f"{pointer} is the machine's own record; a test that writes it "
+            "changes where the real PixlStash downloads its engines"
+        )
 
 
 def test_the_environment_override_still_wins(data_dir, monkeypatch):

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -7,6 +7,7 @@ honest, so the first case here imports the real ones and asserts they agree.
 
 from __future__ import annotations
 
+import logging
 import os
 
 import pytest
@@ -1079,6 +1080,24 @@ def test_an_unreadable_record_names_the_default_rather_than_nothing(
     assert "permission denied" in caplog.text
 
 
+def _warnings(caplog) -> list[str]:
+    """Every WARNING-or-worse message captured, and nothing else.
+
+    ``caplog.text`` is whatever the capture handler saw, which includes INFO
+    when the runner asks for it — the gate passes ``--log-level=INFO``. So
+    ``caplog.text == ""`` is not "this said nothing worrying", it is "this said
+    nothing at all, at whatever level today's command line happens to capture",
+    and an ordinary INFO such as ``set_builtin_model_dir``'s own "now downloads
+    its engines to …" turns a correct silence into a failure. The assertions
+    below mean the narrow thing: no warning.
+    """
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ]
+
+
 def test_a_start_up_declaration_says_when_the_recorded_folder_cannot_be_read(
     server_hub, data_dir, tmp_path, caplog
 ):
@@ -1101,13 +1120,13 @@ def test_a_start_up_declaration_says_when_the_recorded_folder_cannot_be_read(
     os.makedirs(gone)
     with caplog.at_level("WARNING"):
         declare_builtin_models(server_hub, gone)
-    assert caplog.text == "", caplog.text
+    assert _warnings(caplog) == [], caplog.text
 
     caplog.clear()
     os.remove(data_dir / BUILTIN_MODEL_DIR_POINTER)
     with caplog.at_level("WARNING"):
         declare_builtin_models(server_hub, str(tmp_path / "never-downloaded"))
-    assert caplog.text == "", caplog.text
+    assert _warnings(caplog) == [], caplog.text
 
 
 def test_a_start_up_declaration_says_when_the_engines_stayed_where_they_were(
@@ -1131,7 +1150,7 @@ def test_a_start_up_declaration_says_when_the_engines_stayed_where_they_were(
 
     with caplog.at_level("WARNING"):
         declare_builtin_models(server_hub, str(elsewhere))
-    assert caplog.text == "", "nothing has been downloaded anywhere yet"
+    assert _warnings(caplog) == [], "nothing has been downloaded anywhere yet"
 
     (default / "pixlstash-anomaly-tagger.safetensors").write_bytes(b"x" * 8)
     caplog.clear()
@@ -1157,7 +1176,7 @@ def test_a_start_up_declaration_says_when_the_engines_stayed_where_they_were(
     caplog.clear()
     with caplog.at_level("WARNING"):
         declare_builtin_models(server_hub, str(elsewhere))
-    assert caplog.text == "", caplog.text
+    assert _warnings(caplog) == [], caplog.text
 
 
 def test_a_volume_the_environment_names_is_not_reported_as_a_lost_relocation(
@@ -1180,7 +1199,7 @@ def test_a_volume_the_environment_names_is_not_reported_as_a_lost_relocation(
 
     with caplog.at_level("WARNING"):
         declare_builtin_models(server_hub, builtin_model_dir())
-    assert caplog.text == "", caplog.text
+    assert _warnings(caplog) == [], caplog.text
 
 
 def test_a_recorded_folder_reached_through_a_symlinked_default_still_reports(
@@ -1213,7 +1232,7 @@ def test_a_recorded_folder_reached_through_a_symlinked_default_still_reports(
     caplog.clear()
     with caplog.at_level("WARNING"):
         declare_builtin_models(server_hub, builtin_model_dir())
-    assert caplog.text == "", caplog.text
+    assert _warnings(caplog) == [], caplog.text
 
 
 def test_a_record_naming_the_default_folder_says_nothing(
@@ -1226,7 +1245,7 @@ def test_a_record_naming_the_default_folder_says_nothing(
 
     with caplog.at_level("WARNING"):
         declare_builtin_models(server_hub, builtin_model_dir())
-    assert caplog.text == "", caplog.text
+    assert _warnings(caplog) == [], caplog.text
 
 
 def test_no_test_can_name_the_machines_own_recorded_locations():

--- a/tests/test_insightface_relocation.py
+++ b/tests/test_insightface_relocation.py
@@ -139,7 +139,11 @@ def face_env(tmp_path, data_dir, monkeypatch):
     finally:
         server.__exit__(None, None, None)
         tmp.cleanup()
-        model_moves._job = None
+        # `_job` is deliberately NOT cleared here. Set-up already nulls it, and
+        # an autouse fixture tears down after this one, so clearing it here
+        # would hide a move this module left running from
+        # `no_model_move_outlives_its_test` — in the one module whose route
+        # records the InsightFace root.
 
 
 class _FaceEnv:

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -2551,6 +2551,16 @@ def test_relocate_is_owner_only_and_local_only(shelf_env, relocatable_store):
     # Positive control: the local owner is not blocked.
     local = shelf_env.owner.post(path, headers=_xff("192.168.1.9"), **body)
     assert "restricted to local" not in local.text, local.text
+    # Accepted, and then waited for. The status code is asserted because
+    # `_await_move` cannot tell "the job finished" from "there was never a job":
+    # the fixture nulls `_job`, and a snapshot of nothing reads `idle`, so a
+    # positive control that regressed to a 409 would be awaited in name only.
+    # And it is waited for because it really relocates — the job runs on a
+    # daemon thread whose ending repoints folder rows, and for the download
+    # folder, which shares this route, records a machine-global location. Left
+    # running it finishes inside whichever test comes next.
+    assert local.status_code == 202, local.text
+    _await_move(shelf_env)
 
 
 def test_relocating_keeps_the_stores_subdirectories(shelf_env, relocatable_store):


### PR DESCRIPTION
## What happened

PixlStash records where it downloads its own engines in a machine-global file next
to the default folder — `downloaded_models.location` in the platform user data dir
— and reads it on every resolution. The InsightFace root has the same arrangement
in `insightface.location`.

A test run wrote a **pytest temp directory** into that record. pytest deleted the
directory afterwards; the record survived, because it is designed to. From then on
every start resolved the download folder to a path that was not there, the first
downloader `makedirs`'d it, and ~750 MB of engines were fetched into a directory
that only existed because the downloader had just created it — while the real ones
sat untouched in the default folder. Nothing failed and nothing said a word, which
is why this took an investigation rather than a `grep`.

**The process that wrote it has not been reproduced.** The relocate route records a
location only for the download folder, and the record found named a *managed store*
relocation's destination, which does not take that path. Those two facts have not
been reconciled. What can be said is where to look, and it is now in the
architecture doc: the route decides whether it is relocating the download folder
with `is_builtin_model_dir(folder["path"])`, which compares against
`builtin_model_dir()` — the record itself — so identity lives in a mutable file
rather than in the row, and any folder whose path comes to equal the recorded value
inherits it, including the right to rewrite the record when relocated.

## What this changes

**The suite can no longer write either record.** A session-scoped autouse fixture
in `tests/conftest.py` redirects both `_pointer_path` functions into a session temp
directory, leaving a test's own redirection of `_pixlstash_data_dir` alone, and
fails the run naming any test that recorded a location. It is never restored: a
relocation records from a daemon worker thread, and putting the original back at
session end would reopen the machine's file for exactly that write. `conftest`
already refuses to *declare* these roots for the mirror-image reason; this is the
write half, made mechanically instead of remembered.

**No test may leave a model move running.** A move's ending is where folder rows are
repointed and a location is recorded, and it runs on a daemon thread. The shelf's
`test_relocate_is_owner_only_and_local_only` ended on a real `202` it never awaited,
so that ending landed inside whichever test came next — outside any fixture's
redirection window. It awaits now, and `no_model_move_outlives_its_test` fails any
test suite-wide that leaves one running.

**A stale record is no longer silent.** Both start-up declarations report a recorded
folder they cannot read; the download folder's also reports engines still sitting in
the default folder a relocation should have emptied, which is the half that does not
heal itself — "cannot be read" stops being true the moment the re-download recreates
the path.

## What was deliberately not done

- **The accessors still obey a stale record.** Two attempts to change that were
  withdrawn under review. Falling back to the default makes a vanished folder
  unrelocatable (identity is by path) and leaves two copies once the drive returns;
  and an `isdir` guard does not even cover the case it advertises, since an unmounted
  mount point normally still exists as an empty directory.
- **The diagnostic is not in the accessor.** `builtin_model_dir()` is read on every
  call and sits behind `relocatable_identity` on the per-row path of
  `GET /model-folders`, which the frontend polls every three seconds. A line there is
  a flood, and its `stat` is a syscall against a drive that may be gone.
- **The InsightFace root gets no "packs left behind" line.** `~/.insightface` is the
  *library's* root, shared with every InsightFace tool on the host. "We re-downloaded
  and the originals are still there" and "another tool owns that directory" are
  byte-identical on disk, so the claim would fire forever on an ordinary machine and
  its remedy would tell the owner to abandon the packs they moved. The download
  folder is PixlStash's alone, which is why it can make the claim.
- **Identity-by-mutable-file is recorded, not fixed.** It is the loose end above and
  wants its own change.

## Verification

Every new mechanism was mutation-checked in both directions — neutralise it and a
named test goes red; force it to always fire and a different one does. That covers
the session redirection, the move guard, the awaited `202`, both stale-record
warnings, the environment-override exemption, and the two symlink/default skips.
