### PR TITLE
Assert no warning at all on a machine with no InsightFace packs

### DIFF
--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -461,7 +461,7 @@ def test_a_machine_that_has_never_run_face_detection_declares_nothing(
     is a normal machine and must not raise on the start-up path — nor warn."""
     with caplog.at_level("WARNING"):
         assert declare_insightface_packs(server_hub, str(tmp_path / "nope")) is None
-    assert "should have emptied" not in caplog.text, caplog.text
+    assert _warnings(caplog) == [], caplog.text
 
 
 def test_a_relocated_pack_root_that_is_gone_is_not_called_normal(


### PR DESCRIPTION
Closes #941.

`test_a_machine_that_has_never_run_face_detection_declares_nothing` asserted `"should have emptied" not in caplog.text`. Copilot flagged that as too narrow — a different warning would slip past it. It is worse than narrow: that phrase comes from `declare_builtin_models`, and this test calls `declare_insightface_packs`, which never reaches it. The assertion could not fail.

It now uses the `_warnings(caplog)` helper already in the file, which filters on level instead of text (the gate runs `--log-level=INFO`).

Checked by mutation: flipping `logger.info` to `logger.warning` at `builtin_caches.py:250` fails the new assertion; the old one passed.

Not done: the similar assertions in `test_server_external_listener.py:196,222` and `test_work_planner.py:220`. Those name a specific alternative message to tell two code paths apart, which is a different thing from standing in for silence.

51 tests pass, ruff clean.