### PR TITLE
Draw a set's icon on the shelf mark instead of its thumbnail

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1590,17 +1590,30 @@ shared and cached, never a lookup per attachment.
   contrast problem per image, and detached, its inner edge sits on the row
   background — a known colour in both themes. That is also why `ModelMark` is
   two boxes: one element cannot both clip an image and draw outside its own edge.
-- **The face inside the ring falls back twice.** The model's own icon wins,
-  because somebody chose that picture for this file; failing that the mark
-  borrows the thumbnail of whoever it is assigned to, since a LoRA of Sarah with
-  no icon is better identified by Sarah's reference face than by two letters —
-  and the ring around it is already her colour, so the halves say one thing;
-  failing that the generated mark. Thumbnails are `<img src>` from
-  `characterThumbnailUrl` / `pictureSetThumbnailUrl` rather than blobs, so one
-  response is cached however many rows borrow that face. **Each step is skipped
-  once its own URL has failed**, so the chain runs all the way down: a model
-  pointing at an icon whose file is gone falls to the assigned face and then to
-  the initials, rather than sitting on a broken image. `ModelMark` therefore
+- **The face inside the ring falls back three times.** In order: the model's own
+  icon, because somebody chose that picture for this file; then the `set_icon`
+  of the set it is assigned to, if that set carries one; then the thumbnail of
+  whoever it is assigned to, since a LoRA of Sarah with no icon is better
+  identified by Sarah's reference face than by two letters — and the ring around
+  it is already her colour, so the halves say one thing; then the generated mark.
+  A set's icon comes SECOND rather than last because `set_icon` is what its
+  thumbnail was replaced by: the sidebar rows and the set editor already draw
+  the set as that glyph, so lending the picture here would be the one surface
+  still showing a face the rest of the app has stopped showing. `assignmentRing`
+  carries the mdi name as `ring.icon` — empty for the `cards` sentinel, which
+  means "keep the thumbnail" — and the set's own colour as `ring.iconHue`,
+  deliberately not the ring's `hue`: `hue` invents a hashed palette entry so the
+  ring is never invisible, while a set with no `set_color` is drawn in theme ink
+  by the sidebar, and one set wearing two colours on one screen is the thing the
+  ring's "the hue is the entity's own" rule exists to prevent. Thumbnails are
+  `<img src>` from `characterThumbnailUrl` / `pictureSetThumbnailUrl` rather
+  than blobs, so one response is cached however many rows borrow that face.
+  **Each step that is a URL is skipped once that URL has failed**, so the chain
+  runs all the way down: a model pointing at an icon whose file is gone falls to
+  the assigned face and then to the initials, rather than sitting on a broken
+  image. The icon step is the one that cannot fail and the one that is therefore
+  terminal — a glyph is a name in a font, there is no `error` to catch, and a
+  set carrying an icon never reaches the thumbnail below it. `ModelMark` therefore
   records the URLs that 404ed, not one "it failed" flag — and clears that record
   on a *string* of the row's icon and ring identity, because the shelf builds a
   fresh ring object on every render and an identity comparison would reset the

--- a/frontend/src/components/widgets/ModelMark.test.js
+++ b/frontend/src/components/widgets/ModelMark.test.js
@@ -193,6 +193,91 @@ describe("ModelMark", () => {
     expect(parent.find("img").attributes("src")).toBe(ADA_FACE);
   });
 
+  // A picture set carrying an icon has said that IS its face; the thumbnail is
+  // the thing the icon replaces. Borrowing the picture here would put back on
+  // the shelf exactly what the sidebar stopped showing.
+  const SET_THUMB = `${API_BASE_URL}/picture_sets/5/thumbnail`;
+  const SET_RING = {
+    type: "set",
+    id: 5,
+    style: "solid",
+    label: "Studio (set)",
+    hue: "#fdd835",
+    icon: "mdi-star",
+    iconHue: "#fdd835",
+  };
+  // `v-icon` only resolves under the Vuetify plugin, which these mounts do not
+  // install. The stub is NAMED and carries its own class, so an assertion on it
+  // states "a Vuetify icon was rendered" — a plain span holding the string
+  // `mdi-star` would satisfy a text-only assertion just as happily, and that is
+  // the shape of the bug. It declares `color` so the binding is observable.
+  const ICON_STUB = {
+    global: {
+      stubs: {
+        VIcon: {
+          props: ["color"],
+          template: `<i class="stub-vicon" :data-color="color"><slot/></i>`,
+        },
+      },
+    },
+  };
+
+  it("draws the assigned set's icon instead of its thumbnail", () => {
+    const wrapper = mount(ModelMark, {
+      props: { row: row(), ring: SET_RING },
+      ...ICON_STUB,
+    });
+    expect(wrapper.find("img").exists()).toBe(false);
+    const glyph = wrapper.find("i.stub-vicon.mmark-icon");
+    expect(glyph.text()).toBe("mdi-star");
+    // In the SET'S OWN colour, which is what the sidebar paints it. The ring's
+    // `hue` falls back to a hashed palette entry when a set has no colour, and
+    // borrowing that here would put one set on screen in two colours at once.
+    expect(glyph.attributes("data-color")).toBe("#fdd835");
+  });
+
+  it("leaves a colourless set's icon in theme ink, as the sidebar does", () => {
+    const wrapper = mount(ModelMark, {
+      props: {
+        row: row(),
+        ring: { ...SET_RING, iconHue: "", hue: "#8e24aa" },
+      },
+      ...ICON_STUB,
+    });
+    expect(
+      wrapper.find("i.stub-vicon").attributes("data-color"),
+    ).toBeUndefined();
+  });
+
+  it("still lets the model's own icon win over the set's", () => {
+    // Step 1 of the chain is unchanged: somebody chose that picture for THIS
+    // file, which is a more specific statement than the set's icon.
+    const wrapper = mount(ModelMark, {
+      props: { row: row({ icon_sha256: "c".repeat(64) }), ring: SET_RING },
+      ...ICON_STUB,
+    });
+    expect(wrapper.find("img").attributes("src")).toBe(icon("c".repeat(64)));
+    expect(wrapper.find(".mmark-icon").exists()).toBe(false);
+  });
+
+  it("follows the set from thumbnail to icon and back", async () => {
+    // The set's appearance is edited elsewhere; the shelf reads it off the
+    // shared entity list, so the mark has to repaint when the list refreshes
+    // rather than only on mount.
+    const wrapper = mount(ModelMark, {
+      props: { row: row(), ring: { ...SET_RING, icon: "" } },
+      ...ICON_STUB,
+    });
+    expect(wrapper.find("img").attributes("src")).toBe(SET_THUMB);
+
+    await wrapper.setProps({ ring: SET_RING });
+    expect(wrapper.find("img").exists()).toBe(false);
+    expect(wrapper.find("i.stub-vicon.mmark-icon").text()).toBe("mdi-star");
+
+    await wrapper.setProps({ ring: { ...SET_RING, icon: "" } });
+    expect(wrapper.find("img").exists()).toBe(true);
+  });
+
   it("draws no ring at all where nothing hands it one", () => {
     // Distinct from the `none` style, which is the dashed grey "assigned to
     // nothing" and belongs on a shelf row. A mark in a picker or a dialog is

--- a/frontend/src/components/widgets/ModelMark.vue
+++ b/frontend/src/components/widgets/ModelMark.vue
@@ -28,6 +28,12 @@
         loading="lazy"
         @error="dropFace"
       />
+      <v-icon
+        v-else-if="ring?.icon"
+        class="mmark-icon"
+        :color="ring.iconHue || undefined"
+        >{{ ring.icon }}</v-icon
+      >
       <span
         v-else
         class="mmark-initials"
@@ -121,7 +127,8 @@ function dropFace(event) {
 // itself compares unequal each time, and the reset would fire on every keystroke
 // in the filter box — putting the mark back on the URL that just 404ed.
 watch(
-  () => `${iconUrl.value}|${props.ring?.type}|${props.ring?.id}`,
+  () =>
+    `${iconUrl.value}|${props.ring?.type}|${props.ring?.id}|${props.ring?.icon}`,
   () => {
     failed.value = [];
   },
@@ -131,15 +138,21 @@ watch(
  * The face inside the ring, in priority order.
  *
  * 1. The model's OWN icon, always: somebody chose that picture for this file.
- * 2. The face of whoever it is assigned to. A LoRA of Sarah with no icon of
+ * 2. The icon of whoever it is assigned to, if it carries one — a picture set's
+ *    `set_icon` is what its thumbnail was replaced BY, and the sidebar already
+ *    draws the set that way, in the same colour or the same theme ink.
+ *    Deliberately not fallible: an icon is a name in a font rather than a
+ *    fetch, so there is no `error` to catch and the step below is unreachable
+ *    once a set carries one.
+ * 3. The face of whoever it is assigned to. A LoRA of Sarah with no icon of
  *    its own is far better identified by Sarah's reference face than by the
  *    letters `SA` — and the ring around it is already that person's colour, so
  *    the two halves say one thing.
- * 3. The generated mark. A character with no reference face and a set with no
+ * 4. The generated mark. A character with no reference face and a set with no
  *    pictures both 404 their thumbnail, and an empty square would read as a
  *    broken mark rather than as an entity without a picture.
  *
- * Each step is skipped once its own URL has failed, so the chain runs all the
+ * Each step that IS a URL is skipped once that URL has failed, so the chain runs all the
  * way down: a model pointing at an icon whose file is gone falls to the
  * assigned face, and then to the mark, rather than sitting on a broken image.
  *
@@ -149,7 +162,13 @@ watch(
  */
 const faceUrl = computed(() => {
   const build = ENTITY_THUMBNAIL[props.ring?.type];
-  const entityUrl = build && props.ring?.id != null ? build(props.ring.id) : "";
+  // An entity that has chosen an icon has no thumbnail to lend: choosing one is
+  // how the owner turns the picture off, so borrowing it here would put back the
+  // face the sidebar no longer shows. `ring.icon` takes step 2 instead.
+  const entityUrl =
+    build && props.ring?.id != null && !props.ring.icon
+      ? build(props.ring.id)
+      : "";
   return (
     [iconUrl.value, entityUrl].find(
       (url) => url && !failed.value.includes(url),
@@ -188,6 +207,14 @@ const ringClass = computed(() =>
   height: 100%;
   object-fit: cover;
   display: block;
+}
+
+/* The entity's chosen icon, at the slot's own size so it fills the square the
+   thumbnail would have filled. `margin: auto` because the face is a flex box
+   sized by its child here rather than by an image stretched to 100%. */
+.mmark-icon {
+  margin: auto;
+  font-size: var(--entity-thumb);
 }
 
 /* The initials carry their own colour derived from the frozen 48, so the

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -10,7 +10,7 @@
 //   * A missing value is still rendered. "Base model not set" occupies the same
 //     slot in the same type as a real value; a blank cell is the failure mode.
 
-import { SET_COLORS } from "./setAppearance";
+import { ICON_CARDS, SET_COLORS } from "./setAppearance";
 
 /** Trailing tokens that record where in a training run a file was saved.
  *
@@ -1134,7 +1134,15 @@ const ATTACHMENT_KIND = {
     noun: "person",
     colorKey: "character_color",
   },
-  set: { list: "sets", noun: "set", colorKey: "set_color" },
+  // `iconKey` is what a set may carry INSTEAD of a thumbnail; a character has
+  // no such column, and the absence here is what keeps the lookup per-type
+  // rather than a hardcoded field read in the loop below.
+  set: {
+    list: "sets",
+    noun: "set",
+    colorKey: "set_color",
+    iconKey: "set_icon",
+  },
 };
 
 /**
@@ -1167,7 +1175,10 @@ const ATTACHMENT_KIND = {
  * @param {Array<Object>} [lists.characters] - `useEntityListsStore().characters`.
  * @param {Array<Object>} [lists.sets] - `useEntityListsStore().pictureSets`.
  * @returns {{style: string, hue: string, type: string, id: ?number,
- *   label: string, count: number}} `style`
+ *   icon: string, iconHue: string, label: string, count: number}} `icon` is
+ *   the mdi name a picture set carries instead of its thumbnail, empty
+ *   otherwise, and `iconHue` is that set's own colour — empty when it has none,
+ *   which is theme ink and NOT the ring's hashed fallback. `style`
  *   is `"none"` and `hue` empty when nothing is attached, which is the dashed
  *   grey ring — never an absent ring, because a mark with no edge at all would
  *   read as a rendering gap rather than as a state.
@@ -1190,6 +1201,23 @@ export function assignmentRing(
       type,
       id: att.entity_id,
       label: `${name} (${kind.noun})`,
+      // A set carrying an icon has said what its face is; the thumbnail is what
+      // an icon REPLACES, in the sidebar and here alike, so borrowing the
+      // picture would draw a face no other surface shows. `cards` is the
+      // sentinel for "keep the thumbnail", not an icon name.
+      icon:
+        kind.iconKey &&
+        entity?.[kind.iconKey] &&
+        entity[kind.iconKey] !== ICON_CARDS
+          ? entity[kind.iconKey]
+          : "",
+      // The icon's own colour, and deliberately NOT `hue` below: `hue` always
+      // resolves to something so the ring is never invisible, while an icon
+      // with no `set_color` is drawn in theme ink by the sidebar. Inventing a
+      // hashed hue here would paint one set two different colours on one
+      // screen, which is exactly what the ring's "the hue is the entity's own"
+      // rule exists to prevent.
+      iconHue: entity?.[kind.colorKey] || "",
       hue:
         entity?.[kind.colorKey] ||
         SET_COLORS[hash32(`${type}:${att.entity_id}`) % SET_COLORS.length]
@@ -1202,6 +1230,8 @@ export function assignmentRing(
       hue: "",
       type: "",
       id: null,
+      icon: "",
+      iconHue: "",
       label: "Unassigned",
       count: 0,
     };
@@ -1215,6 +1245,8 @@ export function assignmentRing(
     // which attachment owns the ring and which owns the face cannot drift.
     type: first.type,
     id: first.id,
+    icon: first.icon,
+    iconHue: first.iconHue,
     label: named.map((one) => one.label).join(", "),
     count: named.length,
   };

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -1190,17 +1190,16 @@ describe("assignmentRing", () => {
     // `cards` is the sentinel for "keep the thumbnail", so treating it as an
     // icon name would draw an mdi glyph that does not exist.
     //
-    // The fixtures below spell the sentinel out rather than using
-    // `ICON_CARDS`, because the value they stand for is what the BACKEND
-    // stored: `picture_sets.py` hardcodes `!= "cards"` too, and rows written
-    // before any rename would still hold the old string. A fixture built from
-    // the constant would rename itself alongside the source and prove nothing
-    // about them agreeing. The drift that leaves — the constant moving away
-    // from the stored value — is what this line catches, in one place instead
-    // of at every fixture.
+    // The literal is pinned HERE, once, and the fixtures use the constant.
+    // What they stand for is a value the BACKEND stored — `picture_sets.py`
+    // hardcodes `!= "cards"` too, and rows written before any rename would
+    // still hold the old string — so a suite built only from `ICON_CARDS`
+    // would rename itself alongside the source and stay green while the two
+    // sides had stopped agreeing. One pin closes that without making every
+    // fixture repeat the string.
     expect(ICON_CARDS).toBe("cards");
     for (const set of [
-      { id: 5, name: "Studio", set_icon: "cards" },
+      { id: 5, name: "Studio", set_icon: ICON_CARDS },
       { id: 5, name: "Studio" },
     ]) {
       expect(assignmentRing([attach("set", 5)], { sets: [set] }).icon).toBe("");
@@ -1240,7 +1239,7 @@ describe("assignmentRing", () => {
     // cache keyed on anything longer-lived would leave the mark on the face the
     // set no longer shows.
     const icon = (sets) => assignmentRing([attach("set", 5)], { sets }).icon;
-    const before = [{ id: 5, name: "Studio", set_icon: "cards" }];
+    const before = [{ id: 5, name: "Studio", set_icon: ICON_CARDS }];
     const after = [{ id: 5, name: "Studio", set_icon: "mdi-star" }];
     expect(icon(before)).toBe("");
     expect(icon(after)).toBe("mdi-star");

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from "vitest";
 import { contrastRatio } from "./contrastAudit.js";
-import { SET_COLORS } from "./setAppearance";
+import { ICON_CARDS, SET_COLORS } from "./setAppearance";
 import {
   assignmentRing,
   RING_STYLES,
@@ -1189,6 +1189,16 @@ describe("assignmentRing", () => {
   it("carries no icon for a set still on the thumbnail", () => {
     // `cards` is the sentinel for "keep the thumbnail", so treating it as an
     // icon name would draw an mdi glyph that does not exist.
+    //
+    // The fixtures below spell the sentinel out rather than using
+    // `ICON_CARDS`, because the value they stand for is what the BACKEND
+    // stored: `picture_sets.py` hardcodes `!= "cards"` too, and rows written
+    // before any rename would still hold the old string. A fixture built from
+    // the constant would rename itself alongside the source and prove nothing
+    // about them agreeing. The drift that leaves — the constant moving away
+    // from the stored value — is what this line catches, in one place instead
+    // of at every fixture.
+    expect(ICON_CARDS).toBe("cards");
     for (const set of [
       { id: 5, name: "Studio", set_icon: "cards" },
       { id: 5, name: "Studio" },

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -1176,6 +1176,28 @@ describe("assignmentRing", () => {
     expect(ring.label).toBe("#1 (person), #2 (set), #3 (person)");
   });
 
+  it("carries the icon a set chose instead of its thumbnail", () => {
+    const ring = assignmentRing([attach("set", 5)], {
+      sets: [
+        { id: 5, name: "Studio", set_icon: "mdi-star", set_color: "#fdd835" },
+      ],
+    });
+    expect(ring.icon).toBe("mdi-star");
+    expect(ring.hue).toBe("#fdd835");
+  });
+
+  it("carries no icon for a set still on the thumbnail", () => {
+    // `cards` is the sentinel for "keep the thumbnail", so treating it as an
+    // icon name would draw an mdi glyph that does not exist.
+    for (const set of [
+      { id: 5, name: "Studio", set_icon: "cards" },
+      { id: 5, name: "Studio" },
+    ]) {
+      expect(assignmentRing([attach("set", 5)], { sets: [set] }).icon).toBe("");
+    }
+    expect(assignmentRing([attach("character", 5)], {}).icon).toBe("");
+  });
+
   it("draws the dashed grey ring for a model assigned to nothing", () => {
     // Never an ABSENT ring: an unringed mark under a design where every other
     // mark has one reads as a rendering gap rather than as a state.
@@ -1199,5 +1221,35 @@ describe("assignmentRing", () => {
     expect(label(before)).toBe("Ada (person)");
     expect(label(before)).toBe("Ada (person)");
     expect(label(after)).toBe("Ada Lovelace (person)");
+  });
+
+  it("picks up a set's new icon when the entity list is replaced", () => {
+    // The other half of "it has to update when the icon changes": the shelf
+    // reads the sets off `useEntityListsStore`, which REPLACES the array on
+    // every refresh, and the id map above is cached per array reference. A
+    // cache keyed on anything longer-lived would leave the mark on the face the
+    // set no longer shows.
+    const icon = (sets) => assignmentRing([attach("set", 5)], { sets }).icon;
+    const before = [{ id: 5, name: "Studio", set_icon: "cards" }];
+    const after = [{ id: 5, name: "Studio", set_icon: "mdi-star" }];
+    expect(icon(before)).toBe("");
+    expect(icon(after)).toBe("mdi-star");
+    expect(icon(before)).toBe("");
+  });
+
+  it("takes the icon's colour from the set, never from the ring's fallback", () => {
+    // `hue` invents a hashed palette entry so the ring is never invisible;
+    // `iconHue` must not, or a set with no colour is drawn in theme ink by the
+    // sidebar and in an arbitrary hue by the shelf, on one screen.
+    const ring = assignmentRing([attach("set", 5)], {
+      sets: [{ id: 5, name: "Studio", set_icon: "mdi-star" }],
+    });
+    expect(ring.iconHue).toBe("");
+    expect(ring.hue).not.toBe("");
+    expect(
+      assignmentRing([attach("set", 5)], {
+        sets: [{ id: 5, set_icon: "mdi-star", set_color: "#00897b" }],
+      }).iconHue,
+    ).toBe("#00897b");
   });
 });


### PR DESCRIPTION
A picture set can be given an icon and a colour instead of a thumbnail. Every
surface honoured that except the model shelf, which kept borrowing the set's
thumbnail for the identity mark of any model assigned to it.

## What changed

- `assignmentRing` (`utils/modelShelf.js`) now carries two more fields off the
  attached entity: `icon`, the mdi name a set carries instead of a thumbnail
  (empty for the `cards` sentinel, which means "keep the thumbnail"), and
  `iconHue`, that set's own `set_color`. Both go through the existing
  `ATTACHMENT_KIND` table rather than a hardcoded field read, so a character —
  which has no such column — is unaffected and there is a seam if one ever gets
  one.
- `ModelMark.vue` draws that glyph where it would have drawn the set's
  thumbnail. The chain is now: the model's own icon → the assigned set's icon →
  the assigned entity's thumbnail → the generated initials mark.
- `iconHue`, deliberately not the ring's `hue`. `hue` invents a hashed palette
  entry so a ring is never invisible; a set with no `set_color` is drawn in
  theme ink by the sidebar, and borrowing the hashed hue here would put one set
  on screen in two different colours at once.
- Updating the icon repaints the shelf because the shelf reads the sets off
  `useEntityListsStore`, which both edit paths (the sidebar's appearance menu
  and the set editor) already refresh, and whose id cache is keyed on the array
  reference the store replaces on every refresh. Covered by a test at that seam.
- `docs/frontend_architecture.md`'s description of the fallback chain updated to
  match, including the fact that the icon step is terminal — a glyph is a name
  in a font, so unlike every other step it has no `error` to fall through.

No backend change: `set_icon` and `set_color` already ride on `GET /picture_sets`,
which is where the shelf gets its sets.

## Adversarial review, and the three objections I did not act on

A pre-push review pass raised eleven points; the secrets and privacy lists came
back empty. I took seven of them — the hardcoded field read, the hue, the
watcher key that omitted `ring.icon`, the doc's step count and stale sentences,
and two test gaps (the old assertions passed with `<v-icon>` replaced by a plain
`<span>` rendering the literal string `mdi-star`; both mutations are now red and
were re-verified). Three I think are wrong, and one is worth a reviewer's eye:

1. **"Most sets never chose an icon — one is auto-assigned at creation, so this
   silently reverts #938 for every set made since migration 0043."** The fact is
   right and the conclusion is not. The sidebar already suppresses the thumbnail
   for exactly those auto-assigned icons (`SideBar.vue`, `v-if="pset.set_icon &&
   pset.set_icon !== ICON_CARDS"`), so "a set with an icon shows the icon" is the
   app's existing convention, not something this PR invents; the shelf was the
   one surface disagreeing with it. #938 was about the mark drawing *anything*
   rather than a blank square, and it still does. **This is the judgement call in
   the PR**: if the intent is that an auto-assigned icon should not count as a
   choice, the fix belongs at creation (stop auto-assigning, or default to
   `cards`) so that every surface changes together — not in the shelf alone.
2. **Contrast: a raw palette hue as the glyph's only carrier.** True of the pale
   entries, and equally true of the sidebar today, which draws the same glyph in
   the same `set_color`. This PR adds no new value, token or treatment — after
   the `iconHue` fix it renders the identical colour to the identical glyph. A
   contrast pass over the set palette is worth doing; doing it here would make
   the shelf disagree with the sidebar in a second way.
3. **An unknown or stale `set_icon` renders an empty square with no fallback.**
   Real, and again shared with every other surface: the value space is closed on
   both sides (`SET_ICON_CATEGORIES` in the frontend, `_SET_ICONS` in
   `picture_sets.py`), and a whitelist here would make the shelf draw a thumbnail
   for a set the sidebar draws as a glyph. Documented rather than guarded.

## Tests

`modelShelf.test.js` covers the icon field, the `cards` sentinel, the character
case, `iconHue` vs the ring's fallback hue, and repainting when the entity list
is replaced. `ModelMark.test.js` covers the glyph replacing the thumbnail, the
model's own icon still winning, a colourless set staying in theme ink, and the
thumbnail↔icon round trip. 1283 frontend tests green in `widgets`, `utils` and
the shelf suite.
