### PR TITLE
Drop the derived tag from the model shelf

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1524,8 +1524,10 @@ undo by accident:
   so telling them apart is the column's main job (#897):
   - `named` — somebody chose it. Plain, at `--weight-semibold`.
   - `derived` — we made a readable string the file does not contain. The **UI**
-    face at `--weight-regular` (mono would claim the string were the file's),
-    plus an outline tag reading `derived`.
+    face at `--weight-regular` (mono would claim the string were the file's)
+    over a soft accent rule. **No tag**: it is the commonest state on the shelf,
+    so a `derived` chip stamped most of the column with a word the reader could
+    not act on (owner call, 2026-08-15).
   - `from-file` — nothing survived the strip, so what is shown *is* the
     filename. `--font-mono` (§3 gives mono to file paths) plus a small **accent**
     tag reading `from filename`.
@@ -1535,10 +1537,10 @@ undo by accident:
     looks like a name and reads as inert, so the row that most needed naming was
     the one that least invited it.
   Rank is type, shape and words — **never opacity** (`visual-language.md` §5.1):
-  a third of the rows faded would be a column of ghosts, and the two "nobody has
-  named this" tags carry their meaning in the label so the pair survives
-  greyscale. The empty `text` is already handled by `compareOn`, which sorts a
-  row that cannot answer the key last in both directions.
+  a third of the rows faded would be a column of ghosts, and the one remaining
+  tag carries its meaning in the label so it survives greyscale. The empty
+  `text` is already handled by `compareOn`, which sorts a row that cannot answer
+  the key last in both directions.
 - **The name is a field, and the affordance is not hover-only.** The dashed rule
   and the pencil appear on `.shelf-row:hover` **and** `:focus-within`, or a
   keyboard reader would have no sign the name is editable. Editing happens

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -201,14 +201,19 @@ describe("a row with nothing in its header", () => {
     const wrapper = await mountShelf([
       adapter({ id: 1, display_name: null }),
       adapter({ id: 2, display_name: "Clementine" }),
+      // Nothing survives the strip, so this one IS the filename — the positive
+      // control, or the two negatives below would also pass with the tag ripped
+      // out of the component altogether.
+      adapter({ id: 3, display_name: null, filename: "000002750.st" }),
     ]);
     const names = wrapper.findAll(".shelf-row-name");
     expect(names[0].classes()).toContain("shelf-row-name--derived");
     expect(names[1].classes()).toContain("shelf-row-name--named");
-    // ...and the mark is a WORD, because a font swap is silent to a screen
-    // reader and invisible in greyscale.
+    // ...and it carries no tag: "DERIVED" on most of the column said nothing a
+    // reader acts on.
     const rows = wrapper.findAll(".shelf-row");
-    expect(rows[0].find(".shelf-name-tag").text()).toBe("derived");
+    expect(rows[2].find(".shelf-name-tag").text()).toBe("from filename");
+    expect(rows[0].find(".shelf-name-tag").exists()).toBe(false);
     expect(rows[1].find(".shelf-name-tag").exists()).toBe(false);
   });
 });
@@ -242,13 +247,11 @@ describe("the four naming states", () => {
 
   it("tells derived from the file's own name without opening anything", async () => {
     const rows = (await mountStates()).findAll(".shelf-row");
-    // The two "nobody named this" states are different news, and the words are
-    // what carry it: the accent on the from-file tag is a hint on top.
-    expect(rows[2].find(".shelf-name-tag").text()).toBe("derived");
+    // Only the file's own string gets a word: a derived name already reads as
+    // ours from its type and rule, so tagging it was a chip on most of the
+    // column that a reader could not act on.
+    expect(rows[2].find(".shelf-name-tag").exists()).toBe(false);
     expect(rows[3].find(".shelf-name-tag").text()).toBe("from filename");
-    expect(rows[3].find(".shelf-name-tag").classes()).toContain(
-      "shelf-name-tag--from-file",
-    );
   });
 
   it("shows an unnamed model an empty field, not inert text", async () => {

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -2926,7 +2926,7 @@ watch(
 /* A readable name we generated. The UI face, because this string is OURS and
    is not in the file — mono would claim it were. Regular weight, so it does
    not carry the authority of a title somebody chose, and the accent rule under
-   it says the rest. No tag beside it — see NAME_TAG. */
+   it says the rest. */
 .shelf-row-name--derived {
   font-weight: var(--weight-regular);
   border-bottom-color: rgba(var(--v-theme-accent), 0.7);

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -662,9 +662,9 @@
                        guessed" from "there is nothing here" without opening
                        anything. Rendering all four as one string is what made
                        an unnamed row look inert, and an inert row never gets
-                       named (#897). The tag beside the name is the carrier;
-                       the type and the accent are hints on top of it, so the
-                       distinction survives greyscale. -->
+                       named (#897). Type and the accent rule carry the
+                       distinction; only the file's own string gets a tag on
+                       top, so the shelf is not a column of chips. -->
                   <input
                     v-if="editingRowKey === row.rowKey"
                     v-model="editingName"
@@ -684,11 +684,10 @@
                       >{{ row.name.text || "Name this model" }}</span
                     >
                     <span
-                      v-if="NAME_TAG[row.name.state]"
+                      v-if="row.name.state === 'from-file'"
                       class="shelf-name-tag"
-                      :class="`shelf-name-tag--${row.name.state}`"
-                      :title="NAME_TAG[row.name.state].title"
-                      >{{ NAME_TAG[row.name.state].label }}</span
+                      :title="FROM_FILE_TAG_TITLE"
+                      >from filename</span
                     >
                   </template>
                   <!-- Beside the name rather than in a column of its own: the
@@ -1780,24 +1779,16 @@ function onRowKeydown(row, event) {
 }
 
 /**
- * What the two "nobody has named this" states say out loud.
+ * One state gets a word beside the name, and it is `from-file`.
  *
- * Words, not colour: the accent on the from-file chip is a hint and the label
- * is what carries the meaning, so the pair still reads in greyscale. They are
- * different news — one string is the file's own and one is ours — and the whole
- * point of #897 is that a reader can tell which without opening the row.
+ * `derived` used to carry one too, and it was a chip on most of the column
+ * saying nothing a reader acts on: it is the commonest state on the shelf, and
+ * a name we made already reads as ours from its face and its accent rule. The
+ * file's own string is different news — that one is worth a word, and the word
+ * is what carries it, so it survives greyscale (§4).
  */
-const NAME_TAG = {
-  derived: {
-    label: "derived",
-    title:
-      "PixlStash made this name from the file. Nobody has named this model.",
-  },
-  "from-file": {
-    label: "from filename",
-    title: "This is the file's own name. Nobody has named this model.",
-  },
-};
+const FROM_FILE_TAG_TITLE =
+  "This is the file's own name. Nobody has named this model.";
 
 // Inline rename. One row at a time, held by row key: the field is what makes
 // the dashed rule and the pencil honest — an affordance that opened a dialog
@@ -2934,8 +2925,8 @@ watch(
 
 /* A readable name we generated. The UI face, because this string is OURS and
    is not in the file — mono would claim it were. Regular weight, so it does
-   not carry the authority of a title somebody chose; the tag beside it and the
-   accent rule under it say the rest. */
+   not carry the authority of a title somebody chose, and the accent rule under
+   it says the rest. No tag beside it — see NAME_TAG. */
 .shelf-row-name--derived {
   font-weight: var(--weight-regular);
   border-bottom-color: rgba(var(--v-theme-accent), 0.7);
@@ -2951,26 +2942,20 @@ watch(
   font-weight: var(--weight-regular);
 }
 
-/* The two "nobody has named this" tags. Both are shapes with words in them, so
-   which is which survives greyscale (§4): the accent is a hint on the
-   from-file one, never the thing carrying the meaning. */
+/* The "this is the file's own string" tag. A shape with a word in it, so it
+   survives greyscale (§4): the accent is a hint, never the thing carrying the
+   meaning. */
 .shelf-name-tag {
   flex: none;
   padding: 0 var(--space-2);
-  border: 1px solid rgba(var(--v-theme-on-background), 0.35);
+  border: 1px solid rgba(var(--v-theme-accent), 0.6);
   border-radius: var(--radius-sm);
+  background: rgba(var(--v-theme-accent), 0.14);
   font-size: var(--text-2xs);
   font-weight: var(--weight-semibold);
   letter-spacing: var(--tracking-label);
   text-transform: uppercase;
   white-space: nowrap;
-  /* 0.7 and not 0.6: at 11px the lower alpha misses the contrast floor (#836). */
-  color: rgba(var(--v-theme-on-background), 0.7);
-}
-
-.shelf-name-tag--from-file {
-  border-color: rgba(var(--v-theme-accent), 0.6);
-  background: rgba(var(--v-theme-accent), 0.14);
   /* The surface's own ink on a 14% wash, NOT `on-accent`: that pairing is for a
      solid fill and measures near-invisible over a tint (§4, §11). */
   color: rgb(var(--v-theme-on-background));


### PR DESCRIPTION
The model shelf stamped a small uppercase `DERIVED` chip beside every model
whose name PixlStash guessed from the filename. That is the commonest state on
the shelf — a third of real adapters carry no title at all — so the chip landed
on most of the column while telling the reader nothing they could act on. It is
gone.

The `from filename` tag stays. That one is different news: the string shown
*is* the file's own, and it is rare enough that the word earns its place.

What the derived row keeps, unchanged: the UI face at regular weight (mono
would claim the string were the file's) and the soft accent rule under the
name. Both were already there — the tag was a third signal on top.

Also here, because removing the chip left them behind:

- `NAME_TAG` was a two-entry lookup driving a dynamic modifier class. With one
  entry left it was a table for a single value, so the tag renders from a plain
  `v-if` and `.shelf-name-tag--from-file` is folded into `.shelf-name-tag`,
  whose base border and colour the modifier had always overridden anyway.
- `docs/frontend_architecture.md` §9.1 described the tag; it now describes its
  absence and why.

## Tests

`ModelShelf.test.js` — 105 pass. The two tag assertions that used to read
`"derived"` now assert the tag is absent, and each sits next to a positive
control asserting the `from filename` tag still renders, so neither would
survive the tag span being deleted outright.

## One objection I did not act on

An adversarial pass argued this is a screen-reader regression: the chip and its
tooltip were the only non-visual carrier of "we guessed this name", and weight
plus an accent rule are silent to assistive tech. That is factually right, but
restoring it as `sr-only` text would announce "derived" on a third of the rows —
the same noise the chip was removed for, moved to a channel where it cannot be
ignored at a glance. The state a reader acts on is `needs-a-name`, which renders
literal text, and `from-file`, which keeps its word. Happy to add a hidden
carrier if a reviewer disagrees.