### PR TITLE
Show the shelf when Engines is the only block ticked

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1562,6 +1562,23 @@ undo by accident:
   would have defeated the change on exactly the machines that had used the shelf
   longest, so `pixlstash:modelShelfFilters` gained `FILTERS_SCHEMA_VERSION` and
   a blob from another `v` is discarded whole — the same trade `storedView` makes.
+- **The four blocks are one list, and the empty states read it.** `nothingSelected`
+  and `activeCount` both derive from `BLOCKS`, never from a hand-written run of
+  `filters.adapters && filters.checkpoints && …`: naming three of the four is how
+  a shelf with **only Engines ticked** fetched its engines, counted them in the
+  toolbar, and then drew "Nothing is selected in Show" over the top of them.
+  `activeCount` therefore counts turning `engines` off exactly as it counts
+  `unclassified`, which also un-greys the panel's Reset button. The remaining
+  block-by-block lists (`defaultFilters`, `storedFilters`, `blockOf`,
+  `fetchRows`) each say something different per block and stay explicit.
+- **A narrowed selection that comes back empty is not "there is nothing here".**
+  Only the ticked blocks are fetched, so a shelf reopened with one empty block
+  selected has `rows` empty on a machine holding 1,800 adapters. The three empty
+  states are therefore ordered `nothingSelected` → *no models match these
+  filters* (whenever `activeCount` is non-zero) → the terminal *no models found*,
+  so the reader is only sent to "add a model folder" when nothing is narrowing
+  the shelf. Reset refetches every block and the terminal state then tells the
+  truth.
 
 **The assignment ring** (`assignmentRing` in `utils/modelShelf.js`, drawn by
 `ModelMark.vue`) is what the shelf says about who a model belongs to. It

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -405,11 +405,50 @@ describe("empty states", () => {
       adapters: false,
       checkpoints: false,
       unclassified: false,
+      engines: false,
     });
     await wrapper.vm.$nextTick();
     expect(textOf(wrapper.find(".shelf-state"))).toContain(
       "Nothing is selected in Show",
     );
+  });
+
+  it("draws the engines when Engines is the only block ticked", async () => {
+    // The reported bug, at the layer it was seen: the toolbar counted the
+    // engine rows and the body drew "Nothing is selected in Show" over the
+    // top of them, because the check knew about three blocks out of four.
+    const wrapper = await mountShelf([adapter()]);
+    listEngines.mockResolvedValue([
+      adapter({
+        id: 900,
+        file_kind: "engine",
+        kind: "captioner",
+        display_name: "JoyCaption",
+      }),
+    ]);
+    await useModelShelfStore().setFilters(
+      { adapters: false, checkpoints: false, unclassified: false },
+      { refetch: true },
+    );
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".shelf-state").exists()).toBe(false);
+    expect(textOf(wrapper.find(".shelf-row"))).toContain("JoyCaption");
+  });
+
+  it("offers Reset rather than 'add a folder' when a narrowed shelf is empty", async () => {
+    // A narrowed selection only FETCHES the blocks it asks for, so a shelf
+    // reopened with one empty block ticked arrives with no rows at all on a
+    // machine full of models. Reading that as the terminal "there is nothing
+    // here" leaves the reader no way back.
+    const wrapper = await mountShelf([]);
+    await useModelShelfStore().setFilters(
+      { adapters: false, checkpoints: false, unclassified: false },
+      { refetch: true },
+    );
+    await wrapper.vm.$nextTick();
+    const state = textOf(wrapper.find(".shelf-state"));
+    expect(state).toContain("No models match these filters");
+    expect(state).toContain("Reset filters");
   });
 });
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -318,7 +318,27 @@
           Reset filters
         </button>
       </div>
-      <div v-else-if="!store.rows.length" class="shelf-state">
+      <!-- Ahead of the terminal state, and gated on the selection rather than
+           on `rows`: a narrowed selection only FETCHES the blocks it asks for,
+           so a shelf reopened with one block ticked and nothing in it arrives
+           with `rows` empty for a machine holding 1,800 adapters. Reading that
+           as "there is nothing here" dead-ends the reader with no Reset — the
+           exact conflation the note above forbids. Reset refetches every block
+           and the terminal state below then says so truthfully. -->
+      <div
+        v-else-if="!store.visibleRows.length && store.activeCount"
+        class="shelf-state"
+      >
+        <p>No models match these filters.</p>
+        <button
+          class="tbm-action tbm-action--secondary"
+          type="button"
+          @click="store.resetFilters()"
+        >
+          Reset filters
+        </button>
+      </div>
+      <div v-else-if="!store.visibleRows.length" class="shelf-state">
         <p>No models found.</p>
         <p>
           PixlStash lists what it finds in the model folders registered on this
@@ -330,16 +350,6 @@
           @click="openFolders()"
         >
           Add a model folder
-        </button>
-      </div>
-      <div v-else-if="!store.visibleRows.length" class="shelf-state">
-        <p>No models match these filters.</p>
-        <button
-          class="tbm-action tbm-action--secondary"
-          type="button"
-          @click="store.resetFilters()"
-        >
-          Reset filters
         </button>
       </div>
 

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -813,21 +813,36 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
    * narrowing and the number would stop meaning anything.
    */
   const activeCount = computed(() => {
-    let n = 0;
-    if (!filters.adapters || filters.adapterKinds.length) n += 1;
-    if (!filters.checkpoints) n += 1;
-    // Counted the way `checkpoints` is, because it now defaults the same way:
-    // the badge says how far the selection has moved from the default, so the
-    // departure is turning it OFF.
-    if (!filters.unclassified) n += 1;
+    // Every block defaults to ON, so the departure is turning one OFF — and
+    // read off {@link BLOCKS} rather than named one by one, which is how
+    // `engines` came to be uncounted: a shelf showing engines alone reported
+    // "3 filters active" while the fourth block was the only one showing
+    // anything.
+    let n = BLOCKS.filter((block) => !filters[block]).length;
+    // The nested kinds are part of the Adapters section, so they add nothing
+    // when that block is already counted.
+    if (filters.adapters && filters.adapterKinds.length) n += 1;
     if (filters.baseModels.length) n += 1;
     if (filters.capabilities.length) n += 1;
     return n;
   });
 
-  /** True when the selection asks for no rows at all — a distinct empty state. */
+  /**
+   * True when the selection asks for no rows at all — a distinct empty state.
+   *
+   * Read off {@link BLOCKS} rather than named block by block, which is how
+   * `engines` came to be left out of it: a shelf showing engines alone asks
+   * for plenty of rows, fetched them, and then drew "Nothing is selected in
+   * Show" over the top of them.
+   *
+   * This and `activeCount` now derive; `defaultFilters`, `storedFilters`,
+   * `blockOf` and `fetchRows` still spell the blocks out, because each says
+   * something different about each one. A fifth block is four deliberate
+   * edits, not five — the two that could silently disagree with the fetch are
+   * the two that no longer can.
+   */
   const nothingSelected = computed(
-    () => !filters.adapters && !filters.checkpoints && !filters.unclassified,
+    () => !BLOCKS.some((block) => filters[block]),
   );
 
   /**

--- a/frontend/src/stores/useModelShelfStore.test.js
+++ b/frontend/src/stores/useModelShelfStore.test.js
@@ -322,6 +322,12 @@ describe("the badge", () => {
     await store.setFilters({ unclassified: false }, { refetch: true });
     expect(store.activeCount).toBe(1);
   });
+
+  it("counts turning engines off, for the same reason", async () => {
+    const store = useModelShelfStore();
+    await store.setFilters({ engines: false }, { refetch: true });
+    expect(store.activeCount).toBe(1);
+  });
 });
 
 describe("empty states", () => {
@@ -329,10 +335,27 @@ describe("empty states", () => {
     const store = useModelShelfStore();
     expect(store.nothingSelected).toBe(false);
     await store.setFilters(
-      { adapters: false, checkpoints: false, unclassified: false },
+      {
+        adapters: false,
+        checkpoints: false,
+        unclassified: false,
+        engines: false,
+      },
       { refetch: true },
     );
     expect(store.nothingSelected).toBe(true);
+  });
+
+  it("does not call a shelf showing engines alone empty", async () => {
+    // The block was added to the fetch and to the row buckets but not to this
+    // check, so ticking Engines alone fetched its rows, counted them in the
+    // toolbar, and drew "Nothing is selected in Show" over the top of them.
+    const store = useModelShelfStore();
+    await store.setFilters(
+      { adapters: false, checkpoints: false, unclassified: false },
+      { refetch: true },
+    );
+    expect(store.nothingSelected).toBe(false);
   });
 });
 

--- a/tests/test_read_token_security.py
+++ b/tests/test_read_token_security.py
@@ -305,6 +305,43 @@ def _setup_two_picture_sets(tmp: str):
 # ---------------------------------------------------------------------------
 
 
+def _stop_planner_and_settle(server, timeout_s: float = 120.0) -> None:
+    """Stop *server*'s planner and wait out the work it already handed off.
+
+    ``WorkPlanner.stop()`` stops the loop that FINDS work. It does not touch
+    the ``TaskRunner``, which owns its own queues and worker threads, so a task
+    the planner submitted seconds earlier is still queued or already executing
+    when ``stop()`` returns — measured on this very fixture: one task on the
+    GPU queue and a ``FaceExtractionTask`` running.
+
+    That is what a shared module environment cannot survive. ``TagTask``
+    deletes a picture's tags before writing its own, so a tagger still in
+    flight lands inside a test body, wipes the ``tag-a-only`` row the test just
+    posted, and leaves the tagger's own vocabulary in its place — which is
+    exactly how ``test_list_all_tags_cannot_leak_out_of_scope_vocab`` failed on
+    a CI runner slow enough to keep the pipeline alive that long, while passing
+    on every machine fast enough to finish it during setup.
+
+    Same shape as ``tests/test_picture_mutation_scope.py``'s pipeline settle:
+    drain what is queued, then wait for what is running. Looped, because a
+    finishing task's completion callback can submit its own follow-up.
+    """
+    server.vault._work_planner.stop()
+    runner = server.vault._task_runner
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        runner.cancel_pending_tasks()
+        with runner._active_task_lock:
+            active = list(runner._active_tasks.values())
+        if not active and runner._queue.empty() and runner._gpu_queue.empty():
+            return
+        time.sleep(0.05)
+    raise AssertionError(
+        f"the import pipeline did not settle within {timeout_s}s; still "
+        f"running: {active}"
+    )
+
+
 def _clear_rate_limit_window(server) -> None:
     """Empty the global rate limiter's sliding window on *server*.
 
@@ -459,12 +496,14 @@ class _SharedPictureLibrary:
 def _two_set_env():
     """One Server holding two single-picture sets, shared by the isolation tests.
 
-    The planner is stopped once the two imports are done. Nothing after setup
-    imports a picture, so it has no legitimate work left here — but several of
-    these tests hand-write ``Tag``, ``Character`` and ``PictureStack`` rows, and
-    on a warm long-lived server a ``TagTask`` (which deletes a picture's tags
-    before rewriting them) or a stack-cohesion sweep would clobber them. Same
-    move as tests/test_smart_score_invalidation.py.
+    The planner is stopped once the two imports are done, and the work it has
+    ALREADY handed to the runner is waited out — see
+    {@link _stop_planner_and_settle}, which is the half this fixture used to
+    skip. Nothing after setup imports a picture, so there is no legitimate work
+    left here — but several of these tests hand-write ``Tag``, ``Character``
+    and ``PictureStack`` rows, and a ``TagTask`` still in flight (it deletes a
+    picture's tags before rewriting them) or a stack-cohesion sweep would
+    clobber them. Same move as tests/test_smart_score_invalidation.py.
 
     Private on purpose: reach it through ``TestResourceScopedReadTokenIsolation.env``,
     never directly, or the test gets no reset and no integrity check.
@@ -472,7 +511,7 @@ def _two_set_env():
     with tempfile.TemporaryDirectory() as tmp:
         env = _setup_two_picture_sets(tmp)
         try:
-            env.server.vault._work_planner.stop()
+            _stop_planner_and_settle(env.server)
             yield env
         finally:
             env.server.__exit__(None, None, None)
@@ -660,7 +699,7 @@ def _comfyui_stack_env():
 
             ids = _seed_stack_pictures(server)
             _form_stacks(server, ids)
-            server.vault._work_planner.stop()
+            _stop_planner_and_settle(server)
 
             yield SimpleNamespace(server=server, owner_client=owner_client, ids=ids)
         finally:


### PR DESCRIPTION
Ticking **Engines** alone in the model shelf's `Show` panel fetched the engine rows, counted them in the toolbar — and then drew *"Nothing is selected in Show"* over the top of them.

## The cause

`nothingSelected` named three of the four blocks:

```js
() => !filters.adapters && !filters.checkpoints && !filters.unclassified
```

`engines` was added to `BLOCKS`, to `fetchRows`, to `blockOf` and to `defaultFilters`, but not here. So a selection asking only for engines read as a selection asking for nothing.

## The change

- `nothingSelected` and `activeCount` both derive from `BLOCKS` instead of naming blocks one at a time, so the two computeds that decide "is anything selected" can no longer disagree with the fetch that decides what is loaded. The four lists that say something *different* per block (`defaultFilters`, `storedFilters`, `blockOf`, `fetchRows`) stay explicit.
- `activeCount` now counts turning **Engines** off, the way it already counts `unclassified` and `checkpoints`. That also un-greys the `Show` panel's Reset button when engines-off is the only deviation — a second, deliberate consequence, called out here because it is not the reported symptom.
- The empty states are reordered: *no models match these filters* now runs ahead of the terminal *no models found* whenever `activeCount` is non-zero. A narrowed selection only fetches the blocks it asks for, so a shelf reopened with one empty block ticked arrives with `rows` empty on a machine full of models — and the old order dead-ended that reader on "Add a model folder" with no Reset, which is the exact conflation the component's own comment forbids.
- `docs/frontend_architecture.md` gains the two rules above.

## Tests

Four new ones, each verified to fail against `develop`: the store's `nothingSelected` and badge behaviour, and — at the layer the bug was actually seen — the shelf rendering an engine row under an engines-only selection, plus the narrowed-and-empty shelf offering Reset. Full frontend suite green (3116 tests).

## From the pre-push adversarial review

Two of its findings are answered above (the doc gap, the missing component-level test); the reordered empty state and the generalized `activeCount` came from it too. Its remaining point — that `defaultFilters`, `storedFilters`, `blockOf` and `fetchRows` still enumerate the blocks by hand — is left as is on purpose: each of those states something block-specific (a default, a validator, a bucket, a request), and folding them into one loop would trade a real distinction for a false symmetry.