### PR TITLE
Give the model shelf the toolbar's app-wide tail

### DIFF
--- a/docs/design/toolbar-responsive-decisions.md
+++ b/docs/design/toolbar-responsive-decisions.md
@@ -19,6 +19,17 @@ container queries today**):
 - Right: size slider + label → Auto-stack button (conditional, accent) →
   separator → **UndoControl** → TbGlobalActions
 
+**Model shelf toolbar** (`ModelShelf.vue`, `.shelf-toolbar`, container
+`shelfbar toolbar`) — added 2026-08-15, after this record was written:
+
+- Left: title → count → Add (accent) → stack sweep
+- Right: Group → Sort split-button → Show → separator → **UndoControl** →
+  TbGlobalActions
+
+It was shipped without the tail at all, so both app-wide controls simply
+vanished on `/models`; it now follows Decision 1 as written rather than
+inventing a third arrangement.
+
 So undo/redo sits mid-left in the grid and right-adjacent-to-TbGlobalActions in
 Duplicates. A user who learns one position loses it in the other view. That is
 the inconsistency to resolve.

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1505,6 +1505,17 @@ express that. Like Duplicates it is excluded from `selectionOwnsHighlight` in
 `SideBar.vue`, or the underlying picture selection would light a second active
 destination in the rail.
 
+**And like Duplicates its bar carries the shell chrome.** Replacing the grid
+also replaces the grid's toolbar, so `.shelf-toolbar` ends in the canonical tail
+whole — `[separator] [UndoControl] [TbGlobalActions]`, the same components the
+grid and the queue mount, with `TbGlobalActions` emitting `open-settings` up to
+`App.vue`. The shelf writes nothing to the operation log itself, but
+`useOperationStore` is a read model over the backend's app-wide log, so undo
+here is live for whatever library work preceded the visit — which is the point
+of a recovery control that survives a change of destination. `.shelf-toolbar`
+declares `container-name: shelfbar toolbar` for the same reason both other
+hosts do: the shared chrome's scoped `@container toolbar` rules must reach it.
+
 These rules come from measurement against real adapter folders and are easy to
 undo by accident:
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -606,7 +606,10 @@ defineExpose({
                    pictures in the library, so like Duplicates it replaces the
                    grid instead of floating over it, and the grid stays
                    unmounted while it is open. -->
-              <ModelShelf v-else-if="isModelsView" />
+              <ModelShelf
+                v-else-if="isModelsView"
+                @open-settings="openSettingsDialog"
+              />
               <ImageGrid
                 v-else
                 ref="gridContainer"

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -92,6 +92,7 @@ import ModelShelf from "./ModelShelf.vue";
 import { useModelMovesStore } from "../../stores/useModelMovesStore";
 import { useModelShelfStore } from "../../stores/useModelShelfStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
+import { useSidebarStore } from "../../stores/useSidebarStore";
 
 const globalOpts = {
   global: {
@@ -2345,5 +2346,58 @@ describe("a long move, in the panel that is running it", () => {
     expect(card().attributes("percent")).toBe("100");
     expect(card().attributes("message")).toContain("could not be moved");
     expect(card().attributes("abortlabel")).toBe("Dismiss");
+  });
+});
+
+// #938-follow-up: the shelf is a destination like Duplicates, so it carries the
+// app-wide tail — undo, Settings and the stats toggle — rather than dropping all
+// three the moment the grid unmounts.
+describe("the app-wide toolbar tail", () => {
+  it("asks App.vue for Settings and toggles the stats sidebar itself", async () => {
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const sidebar = useSidebarStore();
+    const settings = wrapper.find(".shelf-toolbar button[title='Settings']");
+
+    await settings.trigger("click");
+    expect(wrapper.emitted("open-settings")).toHaveLength(1);
+
+    // Directional, not a flip: the rail opens on the first press and closes on
+    // the second, from the shut state a fresh session starts in.
+    sidebar.statsOpen = false;
+    await wrapper.find(".shelf-toolbar .tb-stats-btn").trigger("click");
+    expect(sidebar.statsOpen).toBe(true);
+    await wrapper.find(".shelf-toolbar .tb-stats-btn").trigger("click");
+    expect(sidebar.statsOpen).toBe(false);
+  });
+
+  it("orders the tail separator → UndoControl → TbGlobalActions, last in the bar", async () => {
+    // The documented canonical tail
+    // (docs/design/toolbar-responsive-decisions.md). Asserted as PLACEMENT and
+    // not merely as presence: the whole point of the rule is that the pair sits
+    // after the view controls, ruled off from them, at the end of the bar.
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const cluster = wrapper.find(".shelf-bar-cluster").element;
+    const undo = wrapper.findComponent({ name: "UndoControl" }).element;
+    // TbGlobalActions is multi-root; its Settings button is a stable anchor.
+    const settings = wrapper.find("button[title='Settings']").element;
+    // The Show menu — the LAST of this view's own controls, and the one the
+    // tail has to come after. (`.bar-btn--boxed` alone would find the stack
+    // sweep, which sits outside the cluster and proves nothing.)
+    const showBtn = wrapper
+      .findAll(".shelf-bar-cluster .bar-btn--boxed")
+      .at(-1).element;
+    const follows = (a, b) =>
+      Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+
+    expect(
+      undo.previousElementSibling.classList.contains("bar-separator"),
+    ).toBe(true);
+    expect(follows(showBtn, undo)).toBe(true);
+    expect(follows(undo, settings)).toBe(true);
+    // Nothing of this view's own follows the app-wide pair. TbGlobalActions is
+    // multi-root, so its stats button IS the bar's last element.
+    expect(cluster.lastElementChild.classList.contains("tb-stats-btn")).toBe(
+      true,
+    );
   });
 });

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -14,11 +14,12 @@
     <p id="shelf-help" class="visually-hidden">
       Every adapter and checkpoint PixlStash has found on this machine. Group
       and Sort choose the order and whether the list is cut into groups; Show
-      chooses which kinds are listed and which base models. A ring around a
-      model's mark says who it is assigned to. A name in italics has not been
-      given one. A row that stands for a training run says how many files it
-      holds; Right and Left open and close it. Right-click a row for everything
-      that can be done to it. Escape clears the selection.
+      chooses which kinds are listed and which base models; the bar ends in the
+      app-wide pair, Undo and Settings, and the stats sidebar toggle. A ring
+      around a model's mark says who it is assigned to. A name in italics has
+      not been given one. A row that stands for a training run says how many
+      files it holds; Right and Left open and close it. Right-click a row for
+      everything that can be done to it. Escape clears the selection.
     </p>
 
     <!-- One announcement for a resort, because the rows reorder silently: the
@@ -247,6 +248,20 @@
           </template>
           <ShelfShowPanel />
         </v-menu>
+
+        <!-- The canonical tail, whole and in the documented order:
+             [separator] [UndoControl] [TbGlobalActions]
+             (docs/design/toolbar-responsive-decisions.md). The shelf replaces
+             the grid, and with it the grid's toolbar, so it owes the same
+             app-wide chrome the duplicates queue does — including undo, which
+             is about RECOVERY: the shelf writes nothing to the operation log
+             itself, but a library action undone from here is one the reader
+             does not have to navigate back to reach. The separator is required
+             at every width: proximity alone cannot separate identical icon
+             buttons into "this view's controls" and "the app's". -->
+        <span class="bar-separator" aria-hidden="true"></span>
+        <UndoControl />
+        <TbGlobalActions @open-settings="emit('open-settings')" />
       </div>
     </div>
 
@@ -885,6 +900,8 @@ import ShelfMoveDialog from "../panels/ShelfMoveDialog.vue";
 import ModelFoldersDialog from "../panels/ModelFoldersDialog.vue";
 import ModelImportDialog from "../panels/ModelImportDialog.vue";
 import ShelfStackProposalsDialog from "../panels/ShelfStackProposalsDialog.vue";
+import TbGlobalActions from "../panels/TbGlobalActions.vue";
+import UndoControl from "../panels/UndoControl.vue";
 import FolderBrowser from "../editors/FolderBrowser.vue";
 import ModelMark from "../widgets/ModelMark.vue";
 import ProgressOverlay from "../widgets/ProgressOverlay.vue";
@@ -916,6 +933,11 @@ import {
   trainingStep,
   sortDirectionLabel,
 } from "../../utils/modelShelf";
+
+// Settings lives in App.vue's sidebar dialog, so the toolbar's Settings button
+// asks for it the way the duplicates queue does. The stats toggle needs no
+// event: TbGlobalActions flips the sidebar store itself.
+const emit = defineEmits(["open-settings"]);
 
 const store = useModelShelfStore();
 const entityLists = useEntityListsStore();
@@ -2327,6 +2349,12 @@ watch(
   display: flex;
   align-items: center;
   gap: var(--space-4);
+  /* `shelfbar` for this bar's own ladder, and the shared `toolbar` name the
+     app-wide chrome (UndoControl, TbGlobalActions) writes its scoped
+     @container rules against — so it degrades here exactly as it does in the
+     grid bar (`selbar toolbar`) and the queue's (`dqbar toolbar`). */
+  container-type: inline-size;
+  container-name: shelfbar toolbar;
   height: var(--bar-height);
   padding: 0 var(--space-5);
   border-bottom: 1px solid rgb(var(--v-theme-divider));

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -14,10 +14,10 @@
     <p id="shelf-help" class="visually-hidden">
       Every adapter and checkpoint PixlStash has found on this machine. Group
       and Sort choose the order and whether the list is cut into groups; Show
-      chooses which kinds are listed and which base models; the bar ends in the
-      app-wide pair, Undo and Settings, and the stats sidebar toggle. A ring
-      around a model's mark says who it is assigned to. A name in italics has
-      not been given one. A row that stands for a training run says how many
+      chooses which kinds are listed and which base models. The bar ends in the
+      app-wide controls: Undo and Redo, Settings, and the stats sidebar toggle.
+      A ring around a model's mark says who it is assigned to. A name in italics
+      has not been given one. A row that stands for a training run says how many
       files it holds; Right and Left open and close it. Right-click a row for
       everything that can be done to it. Escape clears the selection.
     </p>


### PR DESCRIPTION
The model shelf replaces the grid, and with it the grid's toolbar — so on
`/models` both app-wide controls simply disappeared: no Settings, no stats
sidebar toggle, and no way to reach either without navigating back.

`.shelf-toolbar` now ends in the canonical tail the decision record already
specifies for every bar — `[separator] [UndoControl] [TbGlobalActions]` — the
same components the grid bar and the duplicates queue mount, so nothing here is
a new control, only the shipped one in the shipped position. `App.vue` wires
`@open-settings` to `openSettingsDialog` exactly as it does for the queue; the
stats toggle needs no event, `TbGlobalActions` flips the sidebar store itself.

Also in the diff:

- `.shelf-toolbar` gains `container-name: shelfbar toolbar`. Both other hosts
  declare the shared `toolbar` name so the shared chrome's scoped
  `@container toolbar` rules reach it; without it the shelf would silently opt
  out of every future one.
- `#shelf-help`, the region description screen readers get, names the new
  controls.
- Two vitest cases: the emit reaches the host and the toggle opens *and* closes
  the rail, and the tail's placement — after the view controls, ruled off, last
  in the bar. Both were mutation-checked: moving the tail to the front of the
  bar reddens the second one.
- `docs/frontend_architecture.md` §9.1a and the toolbar decision record, which
  listed exactly two toolbars and now lists three.

**UndoControl is in scope on purpose, though the issue named only the two
toggles.** An adversarial review pass raised it and it is right: undo is the
recovery control, `useOperationStore` is a read model over the backend's
app-wide log, so a library action stays undoable after a visit to the shelf —
dropping it while keeping Settings and Stats would have shipped a tail that
looks canonical and is not.

Two objections from that pass I did **not** act on, both pre-existing and
neither created here:

1. Opening the rail takes 288px off a bar that has no responsive ladder of its
   own. The shelf bar shipped without one; giving it one is a sizing pass, and
   this change adds two 32px buttons rather than the ladder.
2. The stats rail's Tags/Pictures tabs describe the library grid, which is
   unmounted on `/models`, and its Tasks tab does not show model moves. That is
   true of the rail itself in this destination and is a design question for the
   panel, not for the button that reveals it.
