### PR TITLE
Give each feature its own glyph in the model shelf

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1998,6 +1998,20 @@ promises, which is the failure a test now pins.
   storage answer wrong: the file really does occupy both disks. The consequence
   is that group counts sum higher than the shelf holds, so the toolbar states
   both numbers when they differ (`1,782 models · 1,806 copies`).
+- **Under `Feature` each header wears that feature's own glyph**, not the axis's.
+  `CAPABILITY_ICONS` in `utils/modelShelf.js` is not a second icon family, the
+  same rule `FOLDER_TIERS` follows: where the product already marks a feature,
+  that mark is the one used and it is **not** re-drawn on anything else here —
+  `face` takes `ImageOverlay`'s `mdi-face-recognition`, `detector` takes the
+  `mdi-shape-outline` that "Object boxes" and "Detect objects" already wear (so
+  the catch-all may not have it), and `tagger` / `scorer` / `captioner` take the
+  operation log's tag, star and caption box. The two features nothing else marks
+  take glyphs nothing else uses: `checkpoint` a packaged model, deliberately not
+  the `mdi-cube-outline` that means *base model* on the sort and group-by
+  controls, and `other` the overflow dots. The **unset** group and a capability
+  this build has never seen both fall back to the axis's own glyph, which is the
+  rule every axis follows for its unset group; the fallback is what the whole
+  axis used to draw, one star over eight different features.
 - **The sort never reorders groups, only rows inside them.** Groups are
   alphabetical by label with the unset group last. Switching to "Largest first"
   and having every header move out from under the reader would be a different

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -1142,6 +1142,38 @@ describe("the group header's reserved column", () => {
     expect(mark.exists()).toBe(true);
     expect(mark.element.tagName.toLowerCase()).toBe("v-icon-stub");
   });
+
+  it("draws each FEATURE's own glyph there, not one axis glyph on every header", async () => {
+    // The bug: the header fell back to the axis's glyph for want of its own, so
+    // every feature wore one star. Asserted on the rendered mark rather than on
+    // the store's field, because the fallback lives in the template and the
+    // store test passes either way.
+    listAdapters.mockResolvedValue([
+      adapter({ id: 1, capabilities: ["tagger"] }),
+      adapter({ id: 2, capabilities: ["face"] }),
+    ]);
+    listCheckpoints.mockResolvedValue([]);
+    // The auto-stub swallows its slot, which is why the test above can only
+    // reach the tag name. This one has to read the glyph, so `v-icon` renders.
+    const wrapper = mount(ModelShelf, {
+      global: {
+        ...globalOpts.global,
+        stubs: {
+          ...globalOpts.global.stubs,
+          "v-icon": { template: "<i><slot /></i>" },
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await wrapper.vm.$nextTick();
+    useModelShelfStore().setView({ groupBy: "feature" });
+    await wrapper.vm.$nextTick();
+
+    const marks = wrapper
+      .findAll(".shelf-group-mark")
+      .map((mark) => mark.text());
+    expect(marks.sort()).toEqual(["mdi-face-recognition", "mdi-tag-outline"]);
+  });
 });
 
 describe("selection and drive bands together", () => {

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -512,10 +512,15 @@
                 }"
                 >mdi-chevron-right</v-icon
               >
-              <!-- Under `Folder` the glyph is the TIER's — one mdi folder
-                   family, never a hand-drawn box — and an unreachable folder
-                   wears the disconnected mark instead, which is the shape half
-                   of the offline treatment. -->
+              <!-- The GROUP's own glyph where it has one, and the axis's only
+                   where it does not. Under `Folder` that is the TIER's — one
+                   mdi folder family, never a hand-drawn box — and an
+                   unreachable folder wears the disconnected mark instead, which
+                   is the shape half of the offline treatment. Under `Feature`
+                   it is the feature's own mark, or eight headers read as eight
+                   copies of one star. The fallback is what the unset group and
+                   an unrecognised value get, both of which mean "no feature
+                   here to name" and so are exactly the axis. -->
               <v-icon size="16" class="shelf-group-mark">{{
                 group.icon || GROUP_BY_LABELS[store.view.groupBy].icon
               }}</v-icon>

--- a/frontend/src/stores/useModelShelfStore.js
+++ b/frontend/src/stores/useModelShelfStore.js
@@ -15,6 +15,7 @@ import { errorDetail } from "../utils/apiError";
 import {
   baseModelKey,
   collapseStacks,
+  capabilityIcon,
   capabilityLabel,
   compareGroups,
   locationState,
@@ -407,6 +408,10 @@ function groupsOf(row, axis) {
       key: String(capability),
       label: capabilityLabel(capability),
       labelKind: "name",
+      // The feature's own glyph, so eight headers read as eight things. Empty
+      // for a capability this build does not know, which leaves the header on
+      // the axis's glyph rather than on a wrong one.
+      icon: capabilityIcon(capability),
     }));
   }
   if (axis === "base_model") {
@@ -717,6 +722,10 @@ export const useModelShelfStore = defineStore("modelShelf", () => {
             // only place that survives the flattening: `location` belongs to a
             // copy, and a bucket outlives the copy that opened it.
             folderId: group.location ? Number(group.location.folder_id) : null,
+            // The header's glyph, where the axis has one per group rather than
+            // one for the whole axis. Empty elsewhere, and `withFolderSignals`
+            // fills it in for `folder` after the fact.
+            icon: group.icon || "",
             rows: [],
           };
           byKey.set(group.key, bucket);

--- a/frontend/src/stores/useModelShelfStore.test.js
+++ b/frontend/src/stores/useModelShelfStore.test.js
@@ -1232,6 +1232,19 @@ describe("capabilities", () => {
     expect(byKey.detector.label).toBe("Detection");
   });
 
+  it("marks each feature header with that feature's own glyph", async () => {
+    // The header falls back to the AXIS's glyph when a group carries none, so
+    // every feature used to wear one star. Two headers, two marks.
+    listEngines.mockResolvedValue([engine()]);
+    const store = useModelShelfStore();
+    await store.fetchRows();
+    store.setView({ groupBy: "feature" });
+
+    const byKey = Object.fromEntries(store.groups.map((g) => [g.key, g]));
+    expect(byKey.captioner.icon).toBe("mdi-text-box-outline");
+    expect(byKey.detector.icon).toBe("mdi-shape-outline");
+  });
+
   it("gives each draw its own rowKey, so focus cannot land on two at once", async () => {
     // The collision `folder` already had: one key across several draws put
     // `tabindex="0"` on all of them and made `indexOf` return the first.

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -173,6 +173,49 @@ export function capabilityLabel(capability) {
   return CAPABILITY_LABELS[key] || key;
 }
 
+/**
+ * The glyph that stands for each capability, in the app's OWN vocabulary.
+ *
+ * Not a new icon family. Where the product already marks a feature, that mark
+ * is the one used here and it is not re-drawn somewhere else: the face from
+ * `ImageOverlay` and the toolbar, the SHAPE from the same two — it is what
+ * "Object boxes" and "Detect objects" wear, so `detector` takes it and the
+ * catch-all does not — the tag, the star and the caption box from the operation
+ * log's icon rules. The two features nothing else in the app marks take glyphs
+ * nothing else in the app uses: a whole packaged model for `checkpoint` (NOT
+ * the cube, which is the base-model axis's), and the overflow dots for `other`.
+ *
+ * Grouped by feature, the shelf otherwise drew the AXIS's glyph on every
+ * header, so eight different headers all read as one star and the mark carried
+ * no information at all.
+ */
+export const CAPABILITY_ICONS = {
+  captioner: "mdi-text-box-outline",
+  tagger: "mdi-tag-outline",
+  detector: "mdi-shape-outline",
+  face: "mdi-face-recognition",
+  search: "mdi-magnify",
+  scorer: "mdi-star-outline",
+  checkpoint: "mdi-package-variant-closed",
+  other: "mdi-dots-horizontal-circle-outline",
+};
+
+/**
+ * The glyph for one capability.
+ *
+ * Returns "" for a capability this build has never seen, so the caller falls
+ * back to the grouping axis's own glyph rather than drawing a wrong one. Unlike
+ * {@link capabilityLabel}, which falls through to the STORED WORD, there is no
+ * such fallback for a glyph: an unknown capability has a name to show and no
+ * picture to show, and inventing one would be the confident wrong answer.
+ *
+ * @param {string} capability - a stored `model_capability.capability`.
+ * @returns {string} an mdi class name, or `""`.
+ */
+export function capabilityIcon(capability) {
+  return CAPABILITY_ICONS[String(capability || "")] || "";
+}
+
 const SIZE_UNITS = ["B", "KB", "MB", "GB", "TB"];
 
 /**

--- a/frontend/src/utils/modelShelf.test.js
+++ b/frontend/src/utils/modelShelf.test.js
@@ -29,7 +29,27 @@ import {
   trainingStep,
   withFolderSignals,
   FOLDER_TIERS,
+  CAPABILITY_LABELS,
+  capabilityIcon,
 } from "./modelShelf";
+
+describe("capabilityIcon", () => {
+  it("gives every named capability its own glyph", () => {
+    // The bug: the feature axis drew its own glyph on every header, so eight
+    // headers read as one star. A duplicate here would put two features back
+    // under one mark, and a missing one drops that header to the star again.
+    const icons = Object.keys(CAPABILITY_LABELS).map(capabilityIcon);
+    expect(icons.filter(Boolean)).toHaveLength(icons.length);
+    expect(new Set(icons).size).toBe(icons.length);
+  });
+
+  it("returns nothing for a capability this build has never seen", () => {
+    // The caller falls back to the axis's glyph. Inventing one would be the
+    // confident wrong answer.
+    expect(capabilityIcon("segmenter")).toBe("");
+    expect(capabilityIcon(null)).toBe("");
+  });
+});
 
 describe("cleanAssetName", () => {
   it("matches the Python it mirrors", () => {


### PR DESCRIPTION
Grouped by **Feature**, every header in the model shelf drew the same glyph. The
group header falls back to the grouping *axis's* icon when a group carries none
(`ModelShelf.vue`), and only `folder` groups ever set one — so eight different
features all read as one `mdi-star-four-points-outline`, and the mark carried no
information at all.

## What changed

- `CAPABILITY_ICONS` + `capabilityIcon()` in `utils/modelShelf.js`, next to the
  `CAPABILITY_LABELS` they mirror.
- `groupsOf` sets `icon` on each feature group, and the store's group bucket
  carries the field through (it picks fields explicitly, so a new one has to be
  named there). `withFolderSignals` spreads then sets `icon`, so folder grouping
  is unaffected.
- One architecture bullet, one stale in-code comment corrected.

**Not a second icon family.** Where the product already marks a feature, that
mark is the one used and it is not re-drawn on anything else: `face` takes
`ImageOverlay`'s `mdi-face-recognition`, `detector` takes the
`mdi-shape-outline` that "Object boxes" and "Detect objects" already wear, and
`tagger` / `scorer` / `captioner` take the operation log's tag, star and caption
box. The two features nothing else in the app marks take glyphs nothing else in
the app uses: a packaged model for `checkpoint` — deliberately **not** the
`mdi-cube-outline` that means *base model* on the sort and group-by controls —
and the overflow dots for `other`. All eight names verified against the shipped
`@mdi/font`.

## Tests

- `ModelShelf.test.js` asserts the rendered `.shelf-group-mark` under
  `groupBy: "feature"`. Anchored: deleting `group.icon ||` from the template
  turns it red (verified by mutation), which the store-level test alone does not.
- `modelShelf.test.js` proves every labelled capability has a glyph and that no
  two share one, and that an unknown capability gets none.

## Two review objections answered rather than obeyed

- *"The 'No feature recorded' group still draws the axis star."* Deliberate.
  Every axis draws its own glyph on its unset group — `base_model`'s "Not set"
  takes the cube, `folder`'s "No registered copy" the folder. Making `feature`
  the one exception adds a second rule to save one glyph.
- *"An unknown capability falls back to the same star as the unset group."*
  Also deliberate. `capabilityLabel` falls through to the stored word because
  there is a word to show; there is no glyph to fall through to, and inventing
  one would be the confident wrong answer. Both cases mean "no feature here to
  name", which is exactly what the axis glyph says.
