### PR TITLE
Use placeholder paths in the examples, not a real machine's

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -1803,7 +1803,7 @@ models is thirty-six headers. Under `Folder` the second level is spent on the
     of a list of empty folders, because "add the folder where you keep them" is
     the better answer on a fresh install than an inventory of nothing.
 - **The band is named by the volume, not by the mount point.** A Linux mount
-  point runs to `/media/glindkvist/102AB4B6757AF9A3` and crowds the header out,
+  point runs to `/media/<user>/A1B2C3D4E5F60789` and crowds the header out,
   so the band shows `label` behind a disk glyph and keeps `mount_point` as its
   `title`. The server reads the label from `/dev/disk/by-label` on Linux,
   `GetVolumeInformationW` on Windows and the `/Volumes` mount name on macOS, and

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -854,7 +854,7 @@ describe("drive bands", () => {
     const bands = wrapper.findAll(".shelf-band");
     expect(bands).toHaveLength(1);
     // The volume's name, not its mount point: a Linux mount point runs to
-    // `/media/glindkvist/102AB4B6757AF9A3` and crowds the header out.
+    // `/media/<user>/A1B2C3D4E5F60789` and crowds the header out.
     expect(textOf(bands[0])).toContain("FastModels");
     // And the mount point beside it, in the mono face: the volume label answers
     // "which disk" and the path answers "which one is that", which on a machine

--- a/frontend/src/utils/modelShelf.js
+++ b/frontend/src/utils/modelShelf.js
@@ -569,8 +569,8 @@ export function bandGroups(groups, deviceByFolderId) {
       band = {
         key,
         // The volume's name if it has one, else where it is mounted. A Linux
-        // mount point runs to `/media/glindkvist/102AB4B6757AF9A3` and crowds
-        // the header out; the precise string stays available as the tooltip.
+        // mount point runs to `/media/<user>/A1B2C3D4E5F60789` and crowds the
+        // header out; the precise string stays available as the tooltip.
         label: device?.label || device?.mount_point || group.label,
         mountPoint: device?.mount_point || group.label,
         measured: Boolean(device?.device_id),

--- a/tests/test_docker_windows_host_paths.py
+++ b/tests/test_docker_windows_host_paths.py
@@ -18,7 +18,7 @@ def test_docker_accepts_windows_absolute_host_paths(monkeypatch):
     """Windows absolute host paths should be accepted in Linux Docker mode."""
 
     monkeypatch.setenv("PIXLSTASH_IN_DOCKER", "1")
-    windows_host_path = "C:\\Users\\lindk\\Pictures\\Test"
+    windows_host_path = "C:\\Users\\<user>\\Pictures\\Test"
 
     with tempfile.TemporaryDirectory() as temp_dir:
         server_config_path = f"{temp_dir}/server-config.json"
@@ -52,7 +52,7 @@ def test_docker_rejects_relative_host_paths(monkeypatch):
     """Relative host paths must still be rejected in Docker mode."""
 
     monkeypatch.setenv("PIXLSTASH_IN_DOCKER", "1")
-    relative_host_path = "Users\\lindk\\Pictures\\Test"
+    relative_host_path = "Users\\<user>\\Pictures\\Test"
 
     with tempfile.TemporaryDirectory() as temp_dir:
         server_config_path = f"{temp_dir}/server-config.json"

--- a/tests/test_model_shelf_api.py
+++ b/tests/test_model_shelf_api.py
@@ -3267,7 +3267,7 @@ _LINUX_ONLY = pytest.mark.skipif(
 def test_a_band_is_named_by_its_volume_label_when_it_has_one(
     shelf_env, tmp_path, monkeypatch
 ):
-    """A Linux mount point runs to `/media/glindkvist/102AB4B6757AF9A3`, which
+    """A Linux mount point runs to `/media/<user>/A1B2C3D4E5F60789`, which
     crowds a band header out. The volume's own name is what the owner recognises;
     the mount point stays on the response for the tooltip."""
     from pixlstash.utils import system_utils


### PR DESCRIPTION
Six illustrative paths named a real account and a real disk rather than an example. They are examples, so they now read as examples.

| Where | Was | Now |
|---|---|---|
| `frontend/src/utils/modelShelf.js`, `ModelShelf.test.js`, `tests/test_model_shelf_api.py`, `docs/frontend_architecture.md` | a real Linux mount point, 4 comments | `/media/<user>/A1B2C3D4E5F60789` |
| `tests/test_docker_windows_host_paths.py`, 2 test literals | a real Windows profile | `C:\Users\<user>\Pictures\Test` |

The volume id keeps its full 16-hex width because the *length* is the thing those comments are illustrating — "a Linux mount point runs to … and crowds the header out" stops making its point with a short stand-in. `A1B2C3D4E5F6…` is the canonical fake-hex walk, so it reads as invented on sight while still being the right shape. One placeholder register throughout, `<user>` on both platforms, matching the `/Volumes/<name>` convention already in the tree.

The two Windows strings are inert: both tests assert round-trip equality and a 400 detail, so the literal's value is never matched against anything.

## What this does and does not do

**It does not remove the string from the published repository, and this PR does not claim to.** `git log -S` puts the Linux path in one commit — `61b38ba8`, 2026-08-10 — which is an ancestor of `develop` and nine other remote branches and has been public for five days. After this merges, `git show 61b38ba8`, `git log -p`, the diff pages, GitHub's `.patch`/archive endpoints, every fork and every existing clone still serve the original.

What it buys is that a fresh checkout of `HEAD` is clean and the string stops being copied into new files, which is how it reached four of them. Genuinely removing it would mean rewriting history across ten branches, force-pushing, asking GitHub Support to purge unreachable objects and cached views, and notifying forks — a separate, destructive decision, and not one this PR takes.

## Testing

`tests/test_docker_windows_host_paths.py` 10 passed · `tests/test_model_shelf_api.py` 166 passed · frontend unit suite 171 files / 3148 tests passed · `ruff format --check` and `ruff check` clean · eslint and prettier clean on both JS files. No CI guardrail parses `docs/frontend_architecture.md`.
