### PR TITLE
Clear the shelf selection on Escape from outside the shelf too

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -2153,6 +2153,34 @@ double click on the name, or F2 on the row for the keyboard.
 Arrows move the stop **without** selecting, so a reader can walk the list
 without arming a verb against every row they pass; Space and Enter pick;
 Shift+arrow extends from the anchor, the keyboard's Shift+click; Escape clears.
+**Escape is bound on the `window`, not on the shelf's root**, because a keydown
+only reaches an element that contains the focus: bound to the root it worked
+from a row and from the toolbar and did nothing once the sidebar or the app bar
+had been clicked, while the selection was still on screen. A window listener
+then has to know what else owns the key, and hand it back rather than clear
+underneath. Five checks, in this order, each for its own reason:
+
+- **The shelf's own dialogs, by REF** (`moveOpen`, `importOpen`, `stacksOpen`,
+  `foldersOpen`, `addFileOpen`, `editVerb`) — they are `AppDialog`s inside this
+  subtree, and a press with nothing focused targets `<body>`, which no ancestor
+  test can see. Same body-target hole the create-person dialog documents above.
+- **Any active Vuetify overlay that is not a tooltip**, plus `.image-overlay` —
+  read off the OVERLAY, not the event target, because `VMenu` only pulls focus
+  into its content on a later `focusin`: a menu opened with the mouse leaves
+  focus on its activator, so a target test would let the shelf's own Sort, Show
+  and verb menus close *and* drop the selection in one press. Tooltips are
+  exempt, or a hovered button anywhere in the app would swallow the key.
+- **`reviewSessionsStore.overlayOpen`** — that overlay renders outside `App.vue`'s
+  view switch, so the shelf is still mounted under it.
+- **The revealed auto-hide sidebar** — `useGlobalKeydown` dismisses it on Escape
+  and deliberately does not stop the event, so without this one press would hide
+  the sidebar and wipe the selection behind it.
+- **A `[role="dialog"]`/`.ate` target, and any typing target** (`isTypingTarget`,
+  so the search field's own Escape stays its own).
+
+Bubble phase, not capture: every owner above is meant to resolve the key first.
+The view is `v-else-if`'d away with the route, so the listener is only live while
+there is a shelf to clear.
 **The panel's text is not selectable** (`user-select: none` on `.shelf`, #932).
 Picking rows is the gesture here and the browser's own text selection rode along
 with it: Shift+click extends a text range from the last click and a fast double

--- a/frontend/src/components/views/ModelShelf.test.js
+++ b/frontend/src/components/views/ModelShelf.test.js
@@ -92,6 +92,8 @@ import ModelShelf from "./ModelShelf.vue";
 import { useModelMovesStore } from "../../stores/useModelMovesStore";
 import { useModelShelfStore } from "../../stores/useModelShelfStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
+import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
+import { useSidebarStore } from "../../stores/useSidebarStore";
 
 const globalOpts = {
   global: {
@@ -738,6 +740,9 @@ describe("selecting rows", () => {
       adapter({ id: 2 }),
       adapter({ id: 3 }),
     ]);
+    // Attached, because Escape is handled on the window: a keydown on a
+    // detached row bubbles into nothing and would pass for the wrong reason.
+    document.body.appendChild(wrapper.element);
     const store = useModelShelfStore();
     await rowAt(wrapper, 0).trigger("keydown", { key: " " });
     await rowAt(wrapper, 0).trigger("keydown", {
@@ -748,6 +753,7 @@ describe("selecting rows", () => {
 
     await rowAt(wrapper, 0).trigger("keydown", { key: "Escape" });
     expect(store.selectedRows).toHaveLength(0);
+    wrapper.unmount();
   });
 
   it("shows no selection bar until something is selected", async () => {
@@ -2067,11 +2073,20 @@ describe("the manual stack verb", () => {
 });
 
 describe("Escape", () => {
+  // The key is handled on the WINDOW, so every assertion here needs a real
+  // event path out of the shelf — a detached wrapper's keydown bubbles into
+  // nothing and would pass or fail for the wrong reason.
+  async function mountAttachedShelf() {
+    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    document.body.appendChild(wrapper.element);
+    return wrapper;
+  }
+
   it("clears the selection from anywhere in the shelf, not only from a row", async () => {
     // It used to be handled on the row, so it only worked while a row held the
     // roving tab stop — not after a click moved focus, and not from the
     // toolbar. "Escape clears the selection" has to mean everywhere.
-    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const wrapper = await mountAttachedShelf();
     const store = useModelShelfStore();
     store.toggleSelected(1);
     await wrapper.vm.$nextTick();
@@ -2079,12 +2094,64 @@ describe("Escape", () => {
 
     await wrapper.find(".shelf-toolbar").trigger("keydown", { key: "Escape" });
     expect(store.selectedRows).toHaveLength(0);
+    wrapper.unmount();
+  });
+
+  it("clears the selection when focus has left the shelf entirely", async () => {
+    // The listener used to sit on the shelf's own root, so the key only
+    // reached it while focus was inside that subtree. Click the sidebar, the
+    // app bar, or anything else after picking rows and Escape did nothing —
+    // which is how "Escape clears the selection" reads as broken.
+    const wrapper = await mountAttachedShelf();
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(store.selectedRows).toHaveLength(0);
+    wrapper.unmount();
+  });
+
+  it("stops listening once the shelf is gone", async () => {
+    // The view is v-else-if'd away when another one opens, and a window
+    // listener outlives its element unless it is taken down.
+    const wrapper = await mountAttachedShelf();
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+    wrapper.unmount();
+
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(store.selectedRows).toHaveLength(1);
+  });
+
+  it("leaves the key to whoever is being typed in", async () => {
+    // The bare input stands in for the app's search field, whose own Escape
+    // clears the search. Clearing the shelf's selection underneath at the same
+    // time is the same unasked-for second effect a dialog gets protected from.
+    const wrapper = await mountAttachedShelf();
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(store.selectedRows).toHaveLength(1);
+    input.remove();
+    wrapper.unmount();
   });
 
   it("leaves the selection alone when a dialog owns the key", async () => {
     // Escape inside a dialog means "close me". Clearing the selection
     // underneath at the same time is a second, unasked-for effect.
-    const wrapper = await mountShelf([adapter({ id: 1 })]);
+    const wrapper = await mountAttachedShelf();
     const store = useModelShelfStore();
     store.toggleSelected(1);
     await wrapper.find(".shelf-toolbar").trigger("click");
@@ -2093,6 +2160,80 @@ describe("Escape", () => {
 
     await wrapper.find(".shelf-toolbar").trigger("keydown", { key: "Escape" });
     expect(store.selectedRows).toHaveLength(1);
+
+    // Every dialog the shelf owns, not only the edit one: a press with nothing
+    // focused targets `<body>`, so the ref is the only thing that can see them.
+    wrapper.vm.editVerb = "";
+    wrapper.vm.foldersOpen = true;
+    await wrapper.vm.$nextTick();
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(store.selectedRows).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it("leaves the key to an open menu, whose activator still holds the focus", async () => {
+    // Vuetify only pulls focus into a menu's content on a later `focusin`, so a
+    // menu opened with the MOUSE leaves focus on its activator inside the
+    // shelf. Read off the target alone, the shelf's own Sort, Show and verb
+    // menus would close and drop the selection in one press.
+    const wrapper = await mountAttachedShelf();
+    const store = useModelShelfStore();
+    store.toggleSelected(1);
+    await wrapper.vm.$nextTick();
+
+    const overlay = document.createElement("div");
+    overlay.className = "v-overlay v-overlay--active";
+    document.body.appendChild(overlay);
+    await wrapper.find(".shelf-toolbar").trigger("keydown", { key: "Escape" });
+    expect(store.selectedRows).toHaveLength(1);
+
+    // A tooltip is not an owner: hovering one elsewhere must not swallow the key.
+    overlay.className = "v-overlay v-overlay--active v-tooltip";
+    await wrapper.find(".shelf-toolbar").trigger("keydown", { key: "Escape" });
+    expect(store.selectedRows).toHaveLength(0);
+    overlay.remove();
+    wrapper.unmount();
+  });
+
+  it("leaves the key to a full-screen surface over the shelf", async () => {
+    // The review overlay renders outside `App.vue`'s view switch, so the shelf
+    // is still mounted underneath it — and a selection nobody can see must not
+    // be cleared by the press that dismisses what is covering it.
+    const wrapper = await mountAttachedShelf();
+    const store = useModelShelfStore();
+    const reviews = useReviewSessionsStore();
+    store.toggleSelected(1);
+    reviews.overlayOpen = true;
+    await wrapper.vm.$nextTick();
+
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(store.selectedRows).toHaveLength(1);
+    reviews.overlayOpen = false;
+    wrapper.unmount();
+  });
+
+  it("leaves the key to the auto-hide sidebar it is dismissing", async () => {
+    // `useGlobalKeydown` hides the revealed sidebar on Escape and deliberately
+    // does not stop the event, so one press would otherwise hide the sidebar
+    // and wipe the selection behind it.
+    const wrapper = await mountAttachedShelf();
+    const store = useModelShelfStore();
+    const sidebar = useSidebarStore();
+    store.toggleSelected(1);
+    // Both flags are computed: unpinning makes it an overlay and reveals it.
+    sidebar.setSidebarPinned(false);
+    sidebar.revealSidebar();
+    await wrapper.vm.$nextTick();
+
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(store.selectedRows).toHaveLength(1);
+    wrapper.unmount();
   });
 });
 

--- a/frontend/src/components/views/ModelShelf.vue
+++ b/frontend/src/components/views/ModelShelf.vue
@@ -9,7 +9,6 @@
     tabindex="-1"
     aria-label="Model shelf"
     aria-describedby="shelf-help"
-    @keydown.escape="onShelfEscape"
   >
     <p id="shelf-help" class="visually-hidden">
       Every adapter and checkpoint PixlStash has found on this machine. Group
@@ -876,7 +875,15 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onMounted, ref, shallowRef, watch } from "vue";
+import {
+  computed,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  ref,
+  shallowRef,
+  watch,
+} from "vue";
 import ShelfShowPanel from "../panels/ShelfShowPanel.vue";
 import ShelfSortPanel from "../panels/ShelfSortPanel.vue";
 import ShelfSelectionBar from "../panels/ShelfSelectionBar.vue";
@@ -897,7 +904,10 @@ import { useModelShelfStore } from "../../stores/useModelShelfStore";
 import { useModelFoldersStore } from "../../stores/useModelFoldersStore";
 import { useModelMovesStore } from "../../stores/useModelMovesStore";
 import { useNoticeStore } from "../../stores/useNoticeStore";
+import { useReviewSessionsStore } from "../../stores/useReviewSessionsStore";
+import { useSidebarStore } from "../../stores/useSidebarStore";
 import { errorDetail } from "../../utils/apiError";
+import { isTypingTarget } from "../../utils/dom.js";
 import { isModelFileDrag, setInternalDragPayload } from "../../utils/media";
 import {
   assignmentRing,
@@ -921,6 +931,10 @@ const store = useModelShelfStore();
 const entityLists = useEntityListsStore();
 const foldersStore = useModelFoldersStore();
 const moves = useModelMovesStore();
+// Both read by the window-level Escape, which has to know what else on screen
+// owns the key before it clears anything. See `onShelfEscape`.
+const reviewSessionsStore = useReviewSessionsStore();
+const sidebarStore = useSidebarStore();
 const rootEl = ref(null);
 const showMenuOpen = ref(false);
 const sortMenuOpen = ref(false);
@@ -1309,32 +1323,70 @@ function onBandDrop(band, event) {
 }
 
 /**
- * Escape clears the selection, from anywhere in the shelf.
+ * Escape clears the selection, from anywhere — including outside the shelf.
  *
- * On the ROOT rather than on the row: a selection made by clicking leaves focus
- * on the row, but a selection survives Tab to the toolbar, a dialog opening and
- * closing, or a click on empty space — and "Escape clears the selection" has to
- * mean that everywhere, not only while a row holds the roving tab stop.
+ * On the WINDOW rather than on the shelf root, because a keydown only reaches
+ * an element that contains the focus: bound to the root it worked from a row
+ * and from the toolbar, and did nothing at all once the sidebar, the app bar or
+ * anything else outside this view had been clicked. The selection is still on
+ * screen at that point, so "Escape clears the selection" reads as broken. The
+ * shelf is `v-else-if`'d away with the view, so the listener is only live while
+ * there is a shelf to clear.
  *
- * A dialog is checked for first. Vuetify's own overlays stop the key before it
- * reaches here, but the shelf's `AppDialog`s and the entity picker are inside
- * this subtree, and Escape inside one of those means "close me" — clearing the
- * selection underneath at the same time would be a second, unasked-for effect.
+ * Everything that can own the key ahead of the shelf gets it handed back
+ * rather than taken from it, all one rule — Escape means "undo the thing in
+ * front of you", and clearing the selection underneath would be a second,
+ * unasked-for effect. What that means in practice, and why each one is checked
+ * the way it is:
+ *   * one of the shelf's OWN dialogs is open. By ref, not by target: those are
+ *     `AppDialog`s inside this subtree and a press with nothing focused targets
+ *     `<body>`, which no ancestor test can see. `docs/frontend_architecture.md`
+ *     §"the create-person dialog" records that same body-target hole.
+ *   * any Vuetify overlay that is not a tooltip is up — a menu, a dialog, a
+ *     select. On the OVERLAY rather than on the target, because `VMenu` only
+ *     pulls focus into its content on a later `focusin`: a menu opened with the
+ *     mouse leaves focus on its activator, so the shelf's own Sort, Show and
+ *     verb menus would close AND drop the selection. Tooltips are exempt or a
+ *     hovered button elsewhere would swallow the key.
+ *   * a full-screen surface is over the shelf. The review overlay renders
+ *     OUTSIDE `App.vue`'s view switch, so the shelf is still mounted under it
+ *     and would clear a selection nobody can see.
+ *   * the auto-hide sidebar is showing. Escape dismisses it (WCAG 1.4.13) and
+ *     `useGlobalKeydown` deliberately does not stop the event, so without this
+ *     one press would hide the sidebar and wipe the selection behind it.
+ *   * something is being typed in — the search field's own Escape clears the
+ *     search.
+ *
+ * Bubble phase, not capture: every owner above is meant to resolve the key
+ * FIRST, and a capture-phase listener would take it from them.
  */
 function onShelfEscape(event) {
+  if (event.key !== "Escape") return;
   if (
     moveOpen.value ||
     importOpen.value ||
     stacksOpen.value ||
+    foldersOpen.value ||
+    addFileOpen.value ||
     editVerb.value
   ) {
     return;
   }
+  if (
+    reviewSessionsStore.overlayOpen ||
+    document.querySelector(".v-overlay--active:not(.v-tooltip), .image-overlay")
+  ) {
+    return;
+  }
+  if (sidebarStore.sidebarOverlay && sidebarStore.sidebarVisible) return;
   if (event.target?.closest?.(".ate, [role='dialog']")) return;
+  if (isTypingTarget(event.target)) return;
   if (!store.selectedRows.length) return;
-  event.preventDefault();
   store.clearSelection();
 }
+
+onMounted(() => window.addEventListener("keydown", onShelfEscape));
+onUnmounted(() => window.removeEventListener("keydown", onShelfEscape));
 
 // ── The icon verb ───────────────────────────────────────────────────────────
 
@@ -1772,9 +1824,9 @@ function onRowKeydown(row, event) {
     );
     return;
   }
-  // Escape is NOT handled here. It is owned by the shelf root, so it works
-  // wherever focus happens to be — on a row, on the toolbar, or nowhere at all
-  // after a click — rather than only while a row holds the roving tab stop,
+  // Escape is NOT handled here. It is owned by a window listener, so it works
+  // wherever focus happens to be — on a row, on the toolbar, on the sidebar, or
+  // nowhere at all — rather than only while a row holds the roving tab stop,
   // which is what it used to mean and is not what a reader expects from
   // "Escape clears the selection".
 }


### PR DESCRIPTION
"Escape clears the selection" was already the shelf's stated contract — its own
help paragraph says so — but the handler was a `@keydown.escape` binding on the
shelf's root element, and a keydown only reaches an element that *contains* the
focus. Select some rows, then click the sidebar, the app bar, or anything else
outside the view, and Escape did nothing while the selection pill was still on
screen. That is the whole bug.

## What changed

- `ModelShelf.vue` — the handler moves to a `window` keydown listener registered
  on mount and removed on unmount. The view is `v-else-if`'d away with the route,
  so the listener is only live while there is a shelf to clear.
- A window listener has to know what else owns the key, so it hands it back
  rather than clearing underneath. In order: the shelf's own dialogs (by ref —
  they are `AppDialog`s in this subtree and a press with nothing focused targets
  `<body>`, which no ancestor test can see); any active Vuetify overlay that is
  not a tooltip, plus the lightbox; the review overlay (it renders outside
  `App.vue`'s view switch, so the shelf stays mounted under it); the revealed
  auto-hide sidebar (`useGlobalKeydown` dismisses it on Escape and deliberately
  does not stop the event); a `[role="dialog"]`/`.ate` target; any typing target.
- The overlay check is read off the OVERLAY, not the event target, because
  Vuetify's `VMenu` only pulls focus into its content on a later `focusin`: a
  menu opened with the mouse leaves focus on its activator, so a target-only
  test would let the shelf's own Sort, Show and verb menus close *and* drop the
  selection in one press.
- Tests: the gap is pinned by a keydown dispatched at `document.body` (it fails
  against the old binding), plus one test per guard and one for listener
  teardown. Existing Escape tests now attach the wrapper, because a detached
  wrapper's keydown bubbles into nothing and would pass for the wrong reason.
  Each new guard was mutation-checked: deleting any one of them turns the suite
  red. Full frontend suite: 3135 passing.
- `docs/frontend_architecture.md` — the shelf keyboard paragraph now states the
  binding, the precedence and why each check is shaped the way it is.

## Answering the review points I disagree with

An adversarial pass over the diff raised three things I did not change:

- **"Use capture phase, per the create-person precedent."** That precedent runs
  the other way: it exists so a dialog can claim Escape *before* an ancestor.
  Here every listed owner is meant to resolve the key first, so bubble phase is
  the correct one; capture would take the key from them.
- **`onBeforeUnmount`/`onDeactivated` for `<KeepAlive>`.** The shelf is
  `v-else-if`'d, never kept alive; `onUnmounted` is covered by a test.
- **`ownsEscape` gating on `ShelfSelectionBar`'s `Esc` keycap.** The keycap is
  *more* truthful after this change, not less — it now describes a key that
  works from everywhere rather than only from inside the shelf.

I also dropped the `preventDefault()`: it stops no other handler at window level
and only risks suppressing native behaviour.

## Known gap, out of scope here

The shelf has no live region for selection changes at all — clicking rows and the
bar's own Clear button are equally silent — so a screen-reader user whose focus
is outside the shelf gets no confirmation that Escape cleared anything. That is
pre-existing and wider than this card; worth its own issue.
