### PR TITLE
Drop the no-destruction promise from the CLI docstring

### DIFF
--- a/pixlstash/cli.py
+++ b/pixlstash/cli.py
@@ -9,9 +9,6 @@ folder.
 the hub file *is* the credential, the same model as ``psql`` or ``docker``.
 There is no login here and no stored credential; Docker deployments reach it
 with ``docker exec``.
-
-Nothing in the command set destroys data. ``detach`` deregisters a library and
-never touches its files, and there is deliberately no ``--delete`` flag.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What this changes

Removes two lines from the `pixlstash/cli.py` module docstring: the claim that "nothing in the command set destroys data" and the note that there is deliberately no `--delete` flag. No behaviour changes.

## Why

`plugins remove` in #958 deletes the installed file or folder, so the blanket promise stops being true the moment that lands. Better to retire it now than to leave a docstring the command set contradicts.

Nothing factual is lost. `detach`'s own subparser help already carries the specific guarantee that matters: "Forget a library. No files are removed and nothing in the folder changes." The removed paragraph was the only place in the codebase making the blanket claim.

The narrower guarantees that replace it are scoped to plugin removal and belong with that work, not here: containment inside the two plugin user directories, built-ins remaining out of reach, and confirmation before deleting.

## How it was verified

The diff is three deleted lines in a docstring, nothing else. `git diff --stat` shows `1 file changed, 3 deletions(-)`.

- The file still parses, and `grep` finds no reference to the removed text anywhere in `pixlstash/`, `tests/` or `docs/`.
- `tests/test_hub_registry.py` and `tests/test_library_backup.py` import `pixlstash.cli.main`, and neither asserts anything about the module docstring.
- I did not run the suite: it needs the full runtime dependencies, which this environment does not have. Given a docstring-only deletion I judged that acceptable, but say so if you would rather see a green local run before merging.
- `ruff check` was not meaningful here either: `pyproject.toml` pins `ruff<0.16` deliberately, and the version available to me is newer, so its one finding is a pre-existing `UP035` on an import line this PR does not touch. Worth knowing the pin is doing its job; not worth acting on in this PR.

## Contributor licence agreement

Required only for changes under `pixlstash/**` (the backend). Tick the box
yourself; nobody can tick it on your behalf. The check wants this exact line
with an `x` in it, so edit the box rather than rewriting the sentence.

- [ ] I have read and agree to the CLA in `pixlstash/CLA.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHK2xatgUmuo2nN3Q1Zc8r

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHK2xatgUmuo2nN3Q1Zc8r)_